### PR TITLE
feat(sdk/python): typed data models and config modules (MK-024, MK-027)

### DIFF
--- a/sdk/python/meerkat_mobkit_sdk/__init__.py
+++ b/sdk/python/meerkat_mobkit_sdk/__init__.py
@@ -21,6 +21,13 @@ from .helpers import (
     define_module_spec,
     define_module_tool,
 )
+from .models import DiscoverySpec, PreSpawnData, SessionBuildOptions, SessionQuery
+from . import config
+
+# Make config submodules accessible as meerkat_mobkit_sdk.auth, etc.
+auth = config.auth
+memory = config.memory
+session_store = config.session_store
 
 __all__ = [
     "MobkitAsyncTypedClient",
@@ -42,4 +49,11 @@ __all__ = [
     "define_module",
     "define_module_spec",
     "define_module_tool",
+    "DiscoverySpec",
+    "PreSpawnData",
+    "SessionBuildOptions",
+    "SessionQuery",
+    "auth",
+    "memory",
+    "session_store",
 ]

--- a/sdk/python/meerkat_mobkit_sdk/config/__init__.py
+++ b/sdk/python/meerkat_mobkit_sdk/config/__init__.py
@@ -1,0 +1,4 @@
+"""Configuration modules for MobKit runtime."""
+from . import auth, memory, session_store
+
+__all__ = ["auth", "memory", "session_store"]

--- a/sdk/python/meerkat_mobkit_sdk/config/auth.py
+++ b/sdk/python/meerkat_mobkit_sdk/config/auth.py
@@ -1,0 +1,53 @@
+"""Auth configuration for MobKit runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GoogleAuthConfig:
+    """Google OIDC auth configuration."""
+
+    client_id: str
+    discovery_url: str = "https://accounts.google.com/.well-known/openid-configuration"
+    audience: str | None = None
+    leeway_seconds: int = 60
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": "google",
+            "client_id": self.client_id,
+            "discovery_url": self.discovery_url,
+            "audience": self.audience or self.client_id,
+            "leeway_seconds": self.leeway_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class JwtAuthConfig:
+    """JWT shared-secret auth configuration."""
+
+    shared_secret: str
+    issuer: str | None = None
+    audience: str | None = None
+    leeway_seconds: int = 60
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": "jwt",
+            "shared_secret": self.shared_secret,
+            "issuer": self.issuer,
+            "audience": self.audience,
+            "leeway_seconds": self.leeway_seconds,
+        }
+
+
+def google(client_id: str, **kwargs: Any) -> GoogleAuthConfig:
+    """Create Google OIDC auth configuration."""
+    return GoogleAuthConfig(client_id=client_id, **kwargs)
+
+
+def jwt(shared_secret: str, **kwargs: Any) -> JwtAuthConfig:
+    """Create JWT shared-secret auth configuration."""
+    return JwtAuthConfig(shared_secret=shared_secret, **kwargs)

--- a/sdk/python/meerkat_mobkit_sdk/config/memory.py
+++ b/sdk/python/meerkat_mobkit_sdk/config/memory.py
@@ -1,0 +1,30 @@
+"""Memory backend configuration for MobKit runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ElephantMemoryConfig:
+    """Elephant memory backend configuration."""
+
+    endpoint: str
+    space_id: str | None = None
+    collection: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "backend": "elephant",
+            "endpoint": self.endpoint,
+        }
+        if self.space_id:
+            result["space_id"] = self.space_id
+        if self.collection:
+            result["collection"] = self.collection
+        return result
+
+
+def elephant(endpoint: str, **kwargs: Any) -> ElephantMemoryConfig:
+    """Create Elephant memory backend configuration."""
+    return ElephantMemoryConfig(endpoint=endpoint, **kwargs)

--- a/sdk/python/meerkat_mobkit_sdk/config/session_store.py
+++ b/sdk/python/meerkat_mobkit_sdk/config/session_store.py
@@ -1,0 +1,51 @@
+"""Session store configuration for MobKit runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class JsonSessionStoreConfig:
+    """JSON file session store configuration."""
+
+    path: str
+    stale_lock_threshold_seconds: int = 30
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "store": "json_file",
+            "path": self.path,
+            "stale_lock_threshold_seconds": self.stale_lock_threshold_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class BigQuerySessionStoreConfig:
+    """BigQuery session store configuration."""
+
+    dataset: str
+    table: str
+    project_id: str | None = None
+    gc_interval_hours: int = 6
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "store": "bigquery",
+            "dataset": self.dataset,
+            "table": self.table,
+            "gc_interval_hours": self.gc_interval_hours,
+        }
+        if self.project_id:
+            result["project_id"] = self.project_id
+        return result
+
+
+def json(path: str, **kwargs: Any) -> JsonSessionStoreConfig:
+    """Create JSON file session store configuration."""
+    return JsonSessionStoreConfig(path=path, **kwargs)
+
+
+def bigquery(dataset: str, table: str, **kwargs: Any) -> BigQuerySessionStoreConfig:
+    """Create BigQuery session store configuration."""
+    return BigQuerySessionStoreConfig(dataset=dataset, table=table, **kwargs)

--- a/sdk/python/meerkat_mobkit_sdk/models.py
+++ b/sdk/python/meerkat_mobkit_sdk/models.py
@@ -1,0 +1,103 @@
+"""Typed data models for MobKit SDK."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DiscoverySpec:
+    """Specification for discovering an agent to spawn.
+
+    Maps to Rust SpawnMemberSpec fields via the MobKit discovery pipeline.
+    """
+
+    profile: str
+    meerkat_id: str
+    labels: dict[str, str] = field(default_factory=dict)
+    context: Any | None = None
+    additional_instructions: str | None = None
+    resume_session_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "profile": self.profile,
+            "meerkat_id": self.meerkat_id,
+        }
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        if self.context is not None:
+            result["context"] = self.context
+        if self.additional_instructions is not None:
+            result["additional_instructions"] = self.additional_instructions
+        if self.resume_session_id is not None:
+            result["resume_session_id"] = self.resume_session_id
+        return result
+
+
+@dataclass(frozen=True)
+class PreSpawnData:
+    """Data passed to modules before agent spawning.
+
+    Maps to Rust PreSpawnData.
+    """
+
+    module_id: str
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "module_id": self.module_id,
+            "env": list(self.env.items()),
+        }
+
+
+@dataclass(frozen=True)
+class SessionQuery:
+    """Query parameters for session lookup.
+
+    Used to filter sessions by labels or other criteria.
+    """
+
+    agent_type: str | None = None
+    owner_id: str | None = None
+    labels: dict[str, str] = field(default_factory=dict)
+    include_deleted: bool = False
+    limit: int = 100
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.agent_type is not None:
+            result["agent_type"] = self.agent_type
+        if self.owner_id is not None:
+            result["owner_id"] = self.owner_id
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        result["include_deleted"] = self.include_deleted
+        result["limit"] = self.limit
+        return result
+
+
+@dataclass(frozen=True)
+class SessionBuildOptions:
+    """Options passed to SessionAgentBuilder.build_agent().
+
+    Carries application context and instructions for agent construction.
+    """
+
+    app_context: Any | None = None
+    additional_instructions: str | None = None
+    session_id: str | None = None
+    labels: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.app_context is not None:
+            result["app_context"] = self.app_context
+        if self.additional_instructions is not None:
+            result["additional_instructions"] = self.additional_instructions
+        if self.session_id is not None:
+            result["session_id"] = self.session_id
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        return result


### PR DESCRIPTION
## Summary
- Add `models.py` with typed frozen dataclasses (`DiscoverySpec`, `PreSpawnData`, `SessionQuery`, `SessionBuildOptions`) matching Rust structs, each with `to_dict()` serialization
- Add `config/` package with `auth`, `memory`, and `session_store` submodules providing factory functions for runtime configuration (Google OIDC, JWT, Elephant memory, JSON file store, BigQuery store)
- Wire all exports through `__init__.py` so HomeCore can import directly: `from meerkat_mobkit_sdk import DiscoverySpec, auth, memory, session_store`

## Test plan
- [x] All six new Python files compile cleanly (`python3 -m py_compile`)
- [x] E2E import test passes: `from meerkat_mobkit_sdk import DiscoverySpec, auth, memory, session_store`
- [x] Functional tests verify `to_dict()` output, frozen immutability, and factory function behavior
- [x] No `.pyc` artifacts included in commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)