### PR TITLE
feat: expose mob_handle + post-spawn/reconcile hooks

### DIFF
--- a/crates/meerkat-mobkit-core/src/lib.rs
+++ b/crates/meerkat-mobkit-core/src/lib.rs
@@ -84,8 +84,10 @@ pub use types::{
     RestartPolicy, UnifiedEvent,
 };
 pub use unified_runtime::{
-    UnifiedRuntime, UnifiedRuntimeBootstrapError, UnifiedRuntimeBuilder,
-    UnifiedRuntimeBuilderError, UnifiedRuntimeBuilderField, UnifiedRuntimeError,
-    UnifiedRuntimeReconcileError, UnifiedRuntimeReconcileReport,
+    PostReconcileHook, PostSpawnHook, UnifiedRuntime, UnifiedRuntimeBootstrapError,
+    UnifiedRuntimeBuilder, UnifiedRuntimeBuilderError, UnifiedRuntimeBuilderField,
+    UnifiedRuntimeError, UnifiedRuntimeReconcileError, UnifiedRuntimeReconcileReport,
     UnifiedRuntimeReconcileRoutingReport, UnifiedRuntimeRunReport, UnifiedRuntimeShutdownReport,
 };
+
+pub use meerkat_mob::MobHandle;

--- a/crates/meerkat-mobkit-core/src/unified_runtime.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime.rs
@@ -1,13 +1,16 @@
 use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::routing::get;
 use axum::Router;
 use meerkat_core::event::agent_event_type;
-use meerkat_mob::{AttributedEvent, MemberRef, MobEventRouterHandle, MobState, SpawnMemberSpec};
+use meerkat_mob::{
+    AttributedEvent, MemberRef, MobEventRouterHandle, MobHandle, MobState, SpawnMemberSpec,
+};
 use serde_json::json;
 use tokio::runtime::RuntimeFlavor;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -29,6 +32,15 @@ use crate::runtime::{
     ScheduleValidationError, SubscribeError, SubscribeRequest, SubscribeResponse,
 };
 use crate::types::{EventEnvelope, MobKitConfig, ModuleEvent, UnifiedEvent};
+
+/// Called after members are spawned. Receives the list of spawned member IDs.
+pub type PostSpawnHook =
+    Arc<dyn Fn(Vec<String>) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+/// Called after reconcile completes. Receives the reconcile report.
+pub type PostReconcileHook = Arc<
+    dyn Fn(UnifiedRuntimeReconcileReport) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+>;
 
 const ROSTER_ROUTE_PREFIX: &str = "mob.member.";
 const ROSTER_ROUTE_CHANNEL: &str = "notification";
@@ -111,6 +123,8 @@ pub struct UnifiedRuntimeBuilder {
     module_agent_events: Vec<EventEnvelope<UnifiedEvent>>,
     timeout: Option<Duration>,
     options: RuntimeOptions,
+    post_spawn_hook: Option<PostSpawnHook>,
+    post_reconcile_hook: Option<PostReconcileHook>,
 }
 
 impl UnifiedRuntimeBuilder {
@@ -139,6 +153,16 @@ impl UnifiedRuntimeBuilder {
         self
     }
 
+    pub fn post_spawn_hook(mut self, hook: PostSpawnHook) -> Self {
+        self.post_spawn_hook = Some(hook);
+        self
+    }
+
+    pub fn post_reconcile_hook(mut self, hook: PostReconcileHook) -> Self {
+        self.post_reconcile_hook = Some(hook);
+        self
+    }
+
     pub async fn build(self) -> Result<UnifiedRuntime, UnifiedRuntimeBuilderError> {
         let mob_spec = self
             .mob_spec
@@ -155,7 +179,7 @@ impl UnifiedRuntimeBuilder {
             .ok_or(UnifiedRuntimeBuilderError::MissingRequiredField(
                 UnifiedRuntimeBuilderField::Timeout,
             ))?;
-        UnifiedRuntime::bootstrap_with_options(
+        let mut runtime = UnifiedRuntime::bootstrap_with_options(
             mob_spec,
             module_config,
             self.module_agent_events,
@@ -163,7 +187,10 @@ impl UnifiedRuntimeBuilder {
             self.options,
         )
         .await
-        .map_err(UnifiedRuntimeBuilderError::Bootstrap)
+        .map_err(UnifiedRuntimeBuilderError::Bootstrap)?;
+        runtime.post_spawn_hook = self.post_spawn_hook;
+        runtime.post_reconcile_hook = self.post_reconcile_hook;
+        Ok(runtime)
     }
 }
 
@@ -270,6 +297,8 @@ pub struct UnifiedRuntime {
     module_runtime: MobkitRuntimeHandle,
     mob_event_ingress: Option<MobEventIngress>,
     shutting_down: bool,
+    post_spawn_hook: Option<PostSpawnHook>,
+    post_reconcile_hook: Option<PostReconcileHook>,
 }
 
 enum MobEventIngress {
@@ -340,6 +369,8 @@ impl UnifiedRuntime {
             module_runtime,
             mob_event_ingress,
             shutting_down: false,
+            post_spawn_hook: None,
+            post_reconcile_hook: None,
         }
     }
 
@@ -390,8 +421,17 @@ impl UnifiedRuntime {
         self.mob_runtime.status()
     }
 
+    pub fn mob_handle(&self) -> MobHandle {
+        self.mob_runtime.handle()
+    }
+
     pub async fn spawn(&self, spec: SpawnMemberSpec) -> Result<MemberRef, MobRuntimeError> {
-        self.mob_runtime.spawn(spec).await
+        let member_id = spec.meerkat_id.to_string();
+        let member_ref = self.mob_runtime.spawn(spec).await?;
+        if let Some(hook) = &self.post_spawn_hook {
+            hook(vec![member_id]).await;
+        }
+        Ok(member_ref)
     }
 
     pub async fn reconcile(
@@ -411,7 +451,11 @@ impl UnifiedRuntime {
             .map(|member| member.meerkat_id)
             .collect::<Vec<_>>();
         let routing = self.reconcile_routing_wiring(active_members)?;
-        Ok(UnifiedRuntimeReconcileReport { mob, routing })
+        let report = UnifiedRuntimeReconcileReport { mob, routing };
+        if let Some(hook) = &self.post_reconcile_hook {
+            hook(report.clone()).await;
+        }
+        Ok(report)
     }
 
     pub async fn inject_and_subscribe(

--- a/crates/meerkat-mobkit-core/tests/hooks.rs
+++ b/crates/meerkat-mobkit-core/tests/hooks.rs
@@ -1,0 +1,218 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use meerkat::{build_ephemeral_service, AgentFactory, Config};
+use meerkat_client::TestClient;
+use meerkat_mob::{MobDefinition, MobSessionService, MobState, MobStorage, SpawnMemberSpec};
+use meerkat_mobkit_core::{
+    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobHandle, MobKitConfig,
+    PostReconcileHook, PostSpawnHook, UnifiedRuntime, UnifiedRuntimeReconcileReport,
+};
+use tokio::sync::Mutex;
+
+fn spawn_spec(profile: &str, member_id: &str) -> SpawnMemberSpec {
+    SpawnMemberSpec::from_wire(
+        profile.to_string(),
+        member_id.to_string(),
+        Some(format!("You are {member_id}. Keep responses concise.")),
+        None,
+        None,
+    )
+}
+
+fn build_session_service(temp_dir: &tempfile::TempDir) -> Arc<dyn MobSessionService> {
+    let session_path = temp_dir.path().join("sessions");
+    std::fs::create_dir_all(&session_path).expect("session path");
+    let factory = AgentFactory::new(&session_path).comms(true);
+    Arc::new(build_ephemeral_service(factory, Config::default(), 16))
+}
+
+fn build_mob_spec(temp_dir: &tempfile::TempDir) -> MobBootstrapSpec {
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "hooks-test-mob"
+
+[profiles.worker]
+model = "gpt-5.2"
+external_addressable = true
+
+[profiles.worker.tools]
+comms = true
+"#,
+    )
+    .expect("parse mob definition");
+
+    MobBootstrapSpec::new(
+        definition,
+        MobStorage::in_memory(),
+        build_session_service(temp_dir),
+    )
+    .with_options(MobBootstrapOptions {
+        allow_ephemeral_sessions: true,
+        notify_orchestrator_on_resume: true,
+        default_llm_client: Some(Arc::new(TestClient::default())),
+    })
+}
+
+fn empty_module_config() -> MobKitConfig {
+    MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "hooks-test".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    }
+}
+
+#[tokio::test]
+async fn post_spawn_hook_receives_spawned_member_id() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let spawned_ids: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured = spawned_ids.clone();
+
+    let hook: PostSpawnHook = Arc::new(move |ids| {
+        let captured = captured.clone();
+        Box::pin(async move {
+            captured.lock().await.push(ids);
+        })
+    });
+
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(empty_module_config())
+        .timeout(Duration::from_secs(2))
+        .post_spawn_hook(hook)
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    assert_eq!(runtime.status(), MobState::Running);
+
+    runtime
+        .spawn(spawn_spec("worker", "hook-worker-1"))
+        .await
+        .expect("spawn member");
+
+    let captured = spawned_ids.lock().await;
+    assert_eq!(captured.len(), 1, "post-spawn hook should be called once");
+    assert_eq!(
+        captured[0],
+        vec!["hook-worker-1".to_string()],
+        "post-spawn hook should receive the spawned member id"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn post_reconcile_hook_receives_reconcile_report() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let reports: Arc<Mutex<Vec<UnifiedRuntimeReconcileReport>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let captured = reports.clone();
+
+    let hook: PostReconcileHook = Arc::new(move |report| {
+        let captured = captured.clone();
+        Box::pin(async move {
+            captured.lock().await.push(report);
+        })
+    });
+
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(empty_module_config())
+        .timeout(Duration::from_secs(2))
+        .post_reconcile_hook(hook)
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    let desired = vec![
+        spawn_spec("worker", "reconcile-a"),
+        spawn_spec("worker", "reconcile-b"),
+    ];
+    let report = runtime
+        .reconcile(desired)
+        .await
+        .expect("reconcile should succeed");
+
+    let captured = reports.lock().await;
+    assert_eq!(
+        captured.len(),
+        1,
+        "post-reconcile hook should be called once"
+    );
+    assert_eq!(
+        captured[0], report,
+        "post-reconcile hook should receive the same report returned by reconcile"
+    );
+    assert_eq!(captured[0].mob.spawned.len(), 2);
+    assert!(captured[0].mob.spawned.contains(&"reconcile-a".to_string()));
+    assert!(captured[0].mob.spawned.contains(&"reconcile-b".to_string()));
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn mob_handle_returns_working_handle() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(empty_module_config())
+        .timeout(Duration::from_secs(2))
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    let handle: MobHandle = runtime.mob_handle();
+
+    // The handle should report running state
+    assert_eq!(handle.status(), MobState::Running);
+
+    // Spawn via the handle directly
+    handle
+        .spawn_spec(spawn_spec("worker", "handle-worker-1"))
+        .await
+        .expect("spawn via mob_handle");
+
+    // Verify the member is visible through the handle
+    let members = handle.list_members().await;
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].meerkat_id.to_string(), "handle-worker-1");
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn no_hook_still_works() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(empty_module_config())
+        .timeout(Duration::from_secs(2))
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    // spawn without hooks set should work fine
+    runtime
+        .spawn(spawn_spec("worker", "no-hook-worker"))
+        .await
+        .expect("spawn without hook");
+
+    // reconcile without hooks set should work fine
+    let report = runtime
+        .reconcile(vec![
+            spawn_spec("worker", "no-hook-worker"),
+            spawn_spec("worker", "no-hook-worker-2"),
+        ])
+        .await
+        .expect("reconcile without hook");
+
+    assert_eq!(report.mob.spawned.len(), 1);
+    assert!(report.mob.spawned.contains(&"no-hook-worker-2".to_string()));
+
+    runtime.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- Expose `mob_handle()` on `UnifiedRuntime` so callers can access the underlying `MobHandle` for `wire()`, `run_flow()`, and other Meerkat APIs directly
- Define `PostSpawnHook` and `PostReconcileHook` async callback types, wired through `UnifiedRuntimeBuilder`
- Re-export `MobHandle`, `PostSpawnHook`, and `PostReconcileHook` from `lib.rs`
- Add integration tests verifying hook invocation and mob_handle functionality

## Test plan
- [x] `post_spawn_hook_receives_spawned_member_id` -- verifies hook fires after spawn with correct member ID
- [x] `post_reconcile_hook_receives_reconcile_report` -- verifies hook fires after reconcile with correct report
- [x] `mob_handle_returns_working_handle` -- verifies mob_handle() returns a functional MobHandle
- [x] `no_hook_still_works` -- verifies spawn/reconcile work correctly when no hooks are set
- [x] `cargo test --workspace` passes (pre-existing governance failures unrelated)

Backlog: MK-003, MK-004, MK-017 | Phase P1

🤖 Generated with [Claude Code](https://claude.com/claude-code)