### PR TITLE
feat(auth): JWKS cache + Bearer auth middleware

### DIFF
--- a/crates/meerkat-mobkit-core/src/auth.rs
+++ b/crates/meerkat-mobkit-core/src/auth.rs
@@ -1,3 +1,7 @@
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use hmac::{Hmac, Mac};
@@ -5,6 +9,7 @@ use ring::signature::{self, RsaPublicKeyComponents, UnparsedPublicKey};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::Sha256;
+use tokio::sync::RwLock;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -476,4 +481,180 @@ fn extract_audiences(claims: &Value) -> Vec<String> {
             .collect(),
         _ => Vec::new(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// JwksCache — runtime JWKS cache with discovery, rotation, kid-miss refresh
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum JwksCacheError {
+    Discovery(OidcContractError),
+    Http(String),
+    Validation(JwtValidationError),
+    NoMatchingKey,
+    NotInitialized,
+}
+
+impl Display for JwksCacheError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Discovery(err) => write!(f, "OIDC discovery error: {err:?}"),
+            Self::Http(msg) => write!(f, "HTTP fetch error: {msg}"),
+            Self::Validation(err) => write!(f, "JWT validation error: {err:?}"),
+            Self::NoMatchingKey => write!(f, "no matching JWK for token"),
+            Self::NotInitialized => write!(f, "JWKS cache not initialized"),
+        }
+    }
+}
+
+impl std::error::Error for JwksCacheError {}
+
+#[derive(Debug, Clone)]
+pub struct JwksCacheConfig {
+    pub discovery_url: String,
+    pub refresh_interval: Duration,
+    pub http_timeout: Duration,
+    pub issuer: Option<String>,
+    pub audience: Option<String>,
+    pub leeway_seconds: u64,
+}
+
+impl JwksCacheConfig {
+    pub fn new(discovery_url: String) -> Self {
+        Self {
+            discovery_url,
+            refresh_interval: Duration::from_secs(3600),
+            http_timeout: Duration::from_secs(10),
+            issuer: None,
+            audience: None,
+            leeway_seconds: 60,
+        }
+    }
+}
+
+struct JwksCacheInner {
+    jwks: Option<JwksDocument>,
+    last_refresh: Option<Instant>,
+}
+
+#[derive(Clone)]
+pub struct JwksCache {
+    inner: Arc<RwLock<JwksCacheInner>>,
+    config: Arc<JwksCacheConfig>,
+    http_client: reqwest::Client,
+}
+
+impl JwksCache {
+    pub fn new(config: JwksCacheConfig) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(config.http_timeout)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            inner: Arc::new(RwLock::new(JwksCacheInner {
+                jwks: None,
+                last_refresh: None,
+            })),
+            config: Arc::new(config),
+            http_client,
+        }
+    }
+
+    /// Fetch OIDC discovery document and JWKS keys. Called on first use or periodic refresh.
+    pub async fn refresh(&self) -> Result<(), JwksCacheError> {
+        let discovery_json = fetch_json(&self.http_client, &self.config.discovery_url).await?;
+        let discovery =
+            parse_oidc_discovery_json(&discovery_json).map_err(JwksCacheError::Discovery)?;
+
+        let jwks_json = fetch_json(&self.http_client, &discovery.jwks_uri).await?;
+        let jwks = parse_jwks_json(&jwks_json).map_err(JwksCacheError::Discovery)?;
+
+        let mut inner = self.inner.write().await;
+        inner.jwks = Some(jwks);
+        inner.last_refresh = Some(Instant::now());
+        Ok(())
+    }
+
+    /// Validate a JWT token using cached JWKS. Refreshes on kid miss.
+    pub async fn validate_token(&self, token: &str) -> Result<ValidatedJwt, JwksCacheError> {
+        self.maybe_refresh().await?;
+
+        let header = inspect_jwt_header(token).map_err(JwksCacheError::Validation)?;
+
+        // First attempt: try to find key in current cache.
+        match self.try_validate(token, &header).await {
+            Ok(jwt) => return Ok(jwt),
+            Err(JwksCacheError::NoMatchingKey) => {
+                // Kid miss — force refresh and retry once.
+            }
+            Err(err) => return Err(err),
+        }
+
+        self.refresh().await?;
+        self.try_validate(token, &header).await
+    }
+
+    async fn try_validate(
+        &self,
+        token: &str,
+        header: &JwtHeaderView,
+    ) -> Result<ValidatedJwt, JwksCacheError> {
+        let inner = self.inner.read().await;
+        let jwks = inner.jwks.as_ref().ok_or(JwksCacheError::NotInitialized)?;
+
+        let jwk = select_jwk_for_token(jwks, header.kid.as_deref(), &header.alg)
+            .map_err(|_| JwksCacheError::NoMatchingKey)?;
+
+        let verification_key =
+            build_jwt_verification_key(jwk, &header.alg).map_err(JwksCacheError::Discovery)?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let claims_config = JwtClaimsValidationConfig {
+            issuer: self.config.issuer.clone(),
+            audience: self.config.audience.clone(),
+            now_epoch_seconds: now,
+            leeway_seconds: self.config.leeway_seconds,
+        };
+
+        validate_jwt_with_verification_key(token, &verification_key, &claims_config)
+            .map_err(JwksCacheError::Validation)
+    }
+
+    /// Check if cache needs periodic refresh and refresh if needed.
+    async fn maybe_refresh(&self) -> Result<(), JwksCacheError> {
+        let needs_refresh = {
+            let inner = self.inner.read().await;
+            match inner.last_refresh {
+                Some(last) => last.elapsed() >= self.config.refresh_interval,
+                None => true,
+            }
+        };
+        if needs_refresh {
+            self.refresh().await?;
+        }
+        Ok(())
+    }
+}
+
+async fn fetch_json(client: &reqwest::Client, url: &str) -> Result<String, JwksCacheError> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| JwksCacheError::Http(format!("{err}")))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(JwksCacheError::Http(format!(
+            "HTTP {status} from {url}"
+        )));
+    }
+    response
+        .text()
+        .await
+        .map_err(|err| JwksCacheError::Http(format!("{err}")))
 }

--- a/crates/meerkat-mobkit-core/src/http_auth.rs
+++ b/crates/meerkat-mobkit-core/src/http_auth.rs
@@ -1,0 +1,50 @@
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::Response;
+use axum::Router;
+
+use crate::auth::JwksCache;
+
+/// Axum middleware that validates Bearer tokens using a [`JwksCache`].
+///
+/// On success the [`ValidatedJwt`] is inserted into request extensions so
+/// downstream handlers can extract it via `Extension<ValidatedJwt>`.
+///
+/// On failure the middleware short-circuits with `401 Unauthorized`.
+pub async fn auth_middleware(
+    axum::extract::State(cache): axum::extract::State<JwksCache>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let token = extract_bearer_token(&request).ok_or(StatusCode::UNAUTHORIZED)?;
+
+    let validated_jwt = cache
+        .validate_token(token)
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+    request.extensions_mut().insert(validated_jwt);
+    Ok(next.run(request).await)
+}
+
+/// Wrap a router with Bearer-token authentication backed by a JWKS cache.
+pub fn with_auth_layer(router: Router, jwks_cache: JwksCache) -> Router {
+    router.layer(axum::middleware::from_fn_with_state(
+        jwks_cache,
+        auth_middleware,
+    ))
+}
+
+fn extract_bearer_token(request: &Request) -> Option<&str> {
+    let header_value = request
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = header_value.strip_prefix("Bearer ")?;
+    if token.is_empty() {
+        return None;
+    }
+    Some(token)
+}

--- a/crates/meerkat-mobkit-core/src/lib.rs
+++ b/crates/meerkat-mobkit-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod baseline;
 pub mod decisions;
 pub mod governance;
+pub mod http_auth;
 pub mod http_console;
 pub mod http_sse;
 pub mod mob_handle_runtime;
@@ -15,10 +16,11 @@ pub mod unified_runtime;
 
 pub use auth::{
     extract_hs256_shared_secret, inspect_jwt_header, parse_jwks_json, parse_oidc_discovery_json,
-    select_jwk_for_token, validate_jwt_locally, Jwk, JwksDocument, JwtHeaderView,
-    JwtValidationConfig, JwtValidationError, OidcContractError, OidcDiscoveryDocument,
-    ValidatedJwt,
+    select_jwk_for_token, validate_jwt_locally, Jwk, JwksCache, JwksCacheConfig, JwksCacheError,
+    JwksDocument, JwtHeaderView, JwtValidationConfig, JwtValidationError, OidcContractError,
+    OidcDiscoveryDocument, ValidatedJwt,
 };
+pub use http_auth::{auth_middleware, with_auth_layer};
 pub use baseline::{
     verify_meerkat_baseline_symbols, BaselineVerificationError, BaselineVerificationReport,
     DEFAULT_MEERKAT_REPO, REQUIRED_MEERKAT_SYMBOLS,

--- a/crates/meerkat-mobkit-core/tests/jwks_cache_and_auth.rs
+++ b/crates/meerkat-mobkit-core/tests/jwks_cache_and_auth.rs
@@ -1,0 +1,405 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use axum::http::{header, StatusCode};
+use axum::routing::get;
+use axum::{Extension, Router};
+use serde_json::json;
+use tower::ServiceExt;
+
+use meerkat_mobkit_core::{JwksCache, JwksCacheConfig, ValidatedJwt, with_auth_layer};
+
+// ---------------------------------------------------------------------------
+// Inline mock HTTP server that supports pre-allocated ports
+// ---------------------------------------------------------------------------
+
+struct OidcMockServer {
+    base_url: String,
+    _join_handle: thread::JoinHandle<()>,
+    captured_requests: Arc<Mutex<Vec<String>>>,
+}
+
+impl OidcMockServer {
+    /// Start a mock OIDC server that serves discovery then JWKS responses in order.
+    /// The `build_responses` closure receives the base_url so jwks_uri can reference it.
+    fn start(build_responses: impl FnOnce(&str) -> Vec<(u16, String)>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.set_nonblocking(true).expect("set nonblocking");
+        let addr = listener.local_addr().expect("local addr");
+        let base_url = format!("http://{addr}");
+
+        let responses = build_responses(&base_url);
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let thread_captured = Arc::clone(&captured_requests);
+
+        let join_handle = thread::spawn(move || {
+            for (status, body) in responses {
+                let mut stream = wait_for_connection(&listener, Duration::from_secs(5));
+                let request_line = read_request_line(&mut stream);
+                thread_captured
+                    .lock()
+                    .expect("lock")
+                    .push(request_line);
+                let response = format!(
+                    "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream.write_all(response.as_bytes()).expect("write");
+                stream.flush().expect("flush");
+            }
+        });
+
+        OidcMockServer {
+            base_url,
+            _join_handle: join_handle,
+            captured_requests,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn request_count(&self) -> usize {
+        self.captured_requests.lock().expect("lock").len()
+    }
+}
+
+fn wait_for_connection(listener: &TcpListener, timeout: Duration) -> TcpStream {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => return stream,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                assert!(Instant::now() < deadline, "timed out waiting for connection");
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(e) => panic!("accept failed: {e}"),
+        }
+    }
+}
+
+fn read_request_line(stream: &mut TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set timeout");
+    let mut buf = vec![0u8; 4096];
+    let n = stream.read(&mut buf).expect("read");
+    let text = String::from_utf8_lossy(&buf[..n]);
+    text.lines().next().unwrap_or("").to_string()
+}
+
+fn json_body(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).expect("serialize")
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build an HS256-signed JWT with the `jsonwebtoken` dev-dependency
+// ---------------------------------------------------------------------------
+
+fn build_hs256_token(secret: &[u8], kid: Option<&str>, claims: &serde_json::Value) -> String {
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    let mut header = Header::new(jsonwebtoken::Algorithm::HS256);
+    header.kid = kid.map(ToString::to_string);
+    encode(&header, claims, &EncodingKey::from_secret(secret)).expect("encode test JWT")
+}
+
+fn hs256_secret() -> Vec<u8> {
+    b"super-secret-test-key-32-bytes!!".to_vec()
+}
+
+fn hs256_jwk_json(secret: &[u8], kid: &str) -> serde_json::Value {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let k = URL_SAFE_NO_PAD.encode(secret);
+    json!({
+        "kty": "oct",
+        "kid": kid,
+        "alg": "HS256",
+        "k": k,
+    })
+}
+
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+/// Build a standard pair of discovery + JWKS response bodies.
+fn discovery_jwks_responses(
+    base_url: &str,
+    secret: &[u8],
+    kid: &str,
+) -> Vec<(u16, String)> {
+    vec![
+        (
+            200,
+            json_body(&json!({
+                "issuer": "https://test-issuer.example.com",
+                "jwks_uri": format!("{base_url}/jwks"),
+            })),
+        ),
+        (
+            200,
+            json_body(&json!({
+                "keys": [hs256_jwk_json(secret, kid)]
+            })),
+        ),
+    ]
+}
+
+fn make_cache(base_url: &str) -> JwksCache {
+    let config = JwksCacheConfig {
+        discovery_url: format!("{base_url}/.well-known/openid-configuration"),
+        refresh_interval: Duration::from_secs(3600),
+        http_timeout: Duration::from_secs(5),
+        issuer: None,
+        audience: None,
+        leeway_seconds: 60,
+    };
+    JwksCache::new(config)
+}
+
+fn make_cache_with_issuer(base_url: &str, issuer: &str) -> JwksCache {
+    let config = JwksCacheConfig {
+        discovery_url: format!("{base_url}/.well-known/openid-configuration"),
+        refresh_interval: Duration::from_secs(3600),
+        http_timeout: Duration::from_secs(5),
+        issuer: Some(issuer.to_string()),
+        audience: None,
+        leeway_seconds: 60,
+    };
+    JwksCache::new(config)
+}
+
+// ---------------------------------------------------------------------------
+// JwksCache tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn jwks_cache_refresh_and_validate_token() {
+    let secret = hs256_secret();
+    let claims = json!({
+        "sub": "user-1",
+        "iss": "https://test-issuer.example.com",
+        "exp": now_epoch() + 3600,
+    });
+    let token = build_hs256_token(&secret, Some("key-1"), &claims);
+
+    let mock = OidcMockServer::start(|base_url| {
+        discovery_jwks_responses(base_url, &secret, "key-1")
+    });
+
+    let cache = make_cache_with_issuer(mock.base_url(), "https://test-issuer.example.com");
+    let jwt = cache
+        .validate_token(&token)
+        .await
+        .expect("token validation should succeed");
+    assert_eq!(jwt.subject.as_deref(), Some("user-1"));
+    assert_eq!(
+        jwt.issuer.as_deref(),
+        Some("https://test-issuer.example.com")
+    );
+}
+
+#[tokio::test]
+async fn jwks_cache_kid_miss_triggers_refresh() {
+    let secret = hs256_secret();
+    let claims = json!({
+        "sub": "user-2",
+        "exp": now_epoch() + 3600,
+    });
+    let token = build_hs256_token(&secret, Some("key-2"), &claims);
+
+    let mock = OidcMockServer::start(|base_url| {
+        let base = base_url.to_string();
+        vec![
+            // Initial refresh — discovery
+            (
+                200,
+                json_body(&json!({
+                    "issuer": "https://test-issuer.example.com",
+                    "jwks_uri": format!("{base}/jwks"),
+                })),
+            ),
+            // Initial refresh — JWKS with key-1 only (kid miss)
+            (
+                200,
+                json_body(&json!({
+                    "keys": [hs256_jwk_json(&secret, "key-1")]
+                })),
+            ),
+            // Kid-miss refresh — discovery
+            (
+                200,
+                json_body(&json!({
+                    "issuer": "https://test-issuer.example.com",
+                    "jwks_uri": format!("{base}/jwks"),
+                })),
+            ),
+            // Kid-miss refresh — JWKS with key-2
+            (
+                200,
+                json_body(&json!({
+                    "keys": [hs256_jwk_json(&secret, "key-2")]
+                })),
+            ),
+        ]
+    });
+
+    let cache = make_cache(mock.base_url());
+    let jwt = cache
+        .validate_token(&token)
+        .await
+        .expect("should succeed after kid-miss refresh");
+    assert_eq!(jwt.subject.as_deref(), Some("user-2"));
+
+    // Verify 4 HTTP requests were made (2 refresh cycles of discovery+JWKS).
+    assert_eq!(
+        mock.request_count(),
+        4,
+        "expected 4 HTTP requests (2 refresh cycles)"
+    );
+}
+
+#[tokio::test]
+async fn jwks_cache_returns_error_on_invalid_token() {
+    let secret = hs256_secret();
+    let mock = OidcMockServer::start(|base_url| {
+        discovery_jwks_responses(base_url, &secret, "key-1")
+    });
+
+    let cache = make_cache(mock.base_url());
+    let result = cache.validate_token("not.a.valid-token").await;
+    assert!(result.is_err(), "invalid token should fail validation");
+}
+
+#[tokio::test]
+async fn jwks_cache_expired_token_rejected() {
+    let secret = hs256_secret();
+    let claims = json!({
+        "sub": "expired-user",
+        "exp": now_epoch() - 3600,
+    });
+    let token = build_hs256_token(&secret, Some("key-1"), &claims);
+
+    let mock = OidcMockServer::start(|base_url| {
+        discovery_jwks_responses(base_url, &secret, "key-1")
+    });
+
+    let cache = make_cache(mock.base_url());
+    let result = cache.validate_token(&token).await;
+    assert!(result.is_err(), "expired token should be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware tests
+// ---------------------------------------------------------------------------
+
+async fn echo_identity(Extension(jwt): Extension<ValidatedJwt>) -> axum::Json<serde_json::Value> {
+    axum::Json(json!({
+        "sub": jwt.subject,
+        "email": jwt.email,
+    }))
+}
+
+fn build_test_app(cache: JwksCache) -> Router {
+    let inner = Router::new().route("/protected", get(echo_identity));
+    with_auth_layer(inner, cache)
+}
+
+#[tokio::test]
+async fn auth_middleware_returns_401_without_token() {
+    let secret = hs256_secret();
+    let mock = OidcMockServer::start(|base_url| {
+        discovery_jwks_responses(base_url, &secret, "key-1")
+    });
+
+    let app = build_test_app(make_cache(mock.base_url()));
+
+    let request = axum::http::Request::builder()
+        .uri("/protected")
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn auth_middleware_returns_401_with_invalid_token() {
+    let secret = hs256_secret();
+    let mock = OidcMockServer::start(|base_url| {
+        let base = base_url.to_string();
+        vec![
+            // Initial refresh
+            (
+                200,
+                json_body(&json!({
+                    "issuer": "https://test-issuer.example.com",
+                    "jwks_uri": format!("{base}/jwks"),
+                })),
+            ),
+            (
+                200,
+                json_body(&json!({
+                    "keys": [hs256_jwk_json(&secret, "key-1")]
+                })),
+            ),
+        ]
+    });
+
+    let app = build_test_app(make_cache(mock.base_url()));
+
+    // Token signed with wrong secret
+    let wrong_secret = b"wrong-secret-key-also-32-bytes!!";
+    let claims = json!({ "sub": "hacker", "exp": now_epoch() + 3600 });
+    let bad_token = build_hs256_token(wrong_secret, Some("key-1"), &claims);
+
+    let request = axum::http::Request::builder()
+        .uri("/protected")
+        .header(header::AUTHORIZATION, format!("Bearer {bad_token}"))
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn auth_middleware_passes_valid_token_and_injects_identity() {
+    let secret = hs256_secret();
+    let claims = json!({
+        "sub": "user-42",
+        "email": "user42@example.com",
+        "exp": now_epoch() + 3600,
+    });
+    let token = build_hs256_token(&secret, Some("key-1"), &claims);
+
+    let mock = OidcMockServer::start(|base_url| {
+        discovery_jwks_responses(base_url, &secret, "key-1")
+    });
+
+    let app = build_test_app(make_cache(mock.base_url()));
+
+    let request = axum::http::Request::builder()
+        .uri("/protected")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["sub"], "user-42");
+    assert_eq!(json["email"], "user42@example.com");
+}


### PR DESCRIPTION
## Summary
- Add `JwksCache` to `auth.rs` with OIDC discovery, periodic JWKS refresh, and kid-miss retry
- Add `http_auth.rs` with axum Bearer-token middleware that validates tokens via `JwksCache` and propagates `ValidatedJwt` through request extensions
- Export new types (`JwksCache`, `JwksCacheConfig`, `JwksCacheError`, `auth_middleware`, `with_auth_layer`) from `lib.rs`
- Add 7 integration tests covering cache refresh, kid-miss rotation, expired token rejection, and middleware 401/200 behavior

## Test plan
- [x] `cargo test -p meerkat-mobkit-core --test jwks_cache_and_auth` — all 7 tests pass
- [x] `cargo build -p meerkat-mobkit-core` — clean build, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)