### PR TITLE
feat(sse): per-agent and mob-merged SSE endpoints (MK-005, MK-006)

### DIFF
--- a/crates/meerkat-mobkit-core/Cargo.toml
+++ b/crates/meerkat-mobkit-core/Cargo.toml
@@ -20,6 +20,7 @@ chrono-tz = "0.10"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "process"] }
 axum = { version = "0.7", features = ["json"] }
 async-stream = "0.3"
+futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 meerkat-core = "0.4.1"
 meerkat-client = "0.4.1"

--- a/crates/meerkat-mobkit-core/src/http_sse.rs
+++ b/crates/meerkat-mobkit-core/src/http_sse.rs
@@ -5,13 +5,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_stream::stream;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
+use futures::StreamExt;
+use meerkat_core::comms::EventStream;
+use meerkat_core::event::agent_event_type;
 use meerkat_core::AgentEvent;
+use meerkat_mob::MobEventRouterHandle;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -202,4 +206,121 @@ fn runtime_inject_fn(runtime: RealMobRuntime) -> InteractionSseInjectFn {
         let runtime = runtime.clone();
         Box::pin(async move { runtime.inject_and_subscribe(&member_id, message).await })
     })
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: Per-agent persistent SSE  (MK-005)
+// ---------------------------------------------------------------------------
+
+/// Future type returned by an agent event subscribe function.
+pub type AgentEventSubscribeFuture =
+    Pin<Box<dyn Future<Output = Result<EventStream, MobRuntimeError>> + Send>>;
+
+/// Function type that, given an agent id, returns a stream of that agent's events.
+pub type AgentEventSubscribeFn =
+    Arc<dyn Fn(String) -> AgentEventSubscribeFuture + Send + Sync>;
+
+#[derive(Clone)]
+struct AgentSseState {
+    subscribe_fn: AgentEventSubscribeFn,
+}
+
+/// Build an axum router serving `GET /agents/:agent_id/events` as persistent SSE.
+pub fn agent_events_sse_router(subscribe_fn: AgentEventSubscribeFn) -> Router {
+    Router::new()
+        .route("/agents/:agent_id/events", get(agent_events_sse_handler))
+        .with_state(AgentSseState { subscribe_fn })
+}
+
+async fn agent_events_sse_handler(
+    State(state): State<AgentSseState>,
+    Path(agent_id): Path<String>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let agent_id = agent_id.trim().to_string();
+    if agent_id.is_empty() {
+        return Err(http_error(StatusCode::BAD_REQUEST, "agent_id must not be empty"));
+    }
+
+    let event_stream = (state.subscribe_fn)(agent_id.clone())
+        .await
+        .map_err(map_runtime_error)?;
+
+    let stream = stream! {
+        let mut seq = 0_u64;
+        tokio::pin!(event_stream);
+        while let Some(envelope) = event_stream.next().await {
+            let event_name = agent_event_type(&envelope.payload).to_string();
+            let payload = serde_json::to_string(&envelope.payload)
+                .unwrap_or_else(|_| "{}".to_string());
+            yield Ok::<Event, Infallible>(
+                Event::default()
+                    .id(format!("{agent_id}:{seq}"))
+                    .event(event_name)
+                    .data(payload),
+            );
+            seq += 1;
+        }
+    };
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(DEFAULT_KEEP_ALIVE_INTERVAL)
+            .text(KEEP_ALIVE_TEXT),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3: Mob-merged SSE  (MK-006)
+// ---------------------------------------------------------------------------
+
+/// Future type returned by a mob event subscribe function.
+pub type MobEventSubscribeFuture =
+    Pin<Box<dyn Future<Output = MobEventRouterHandle> + Send>>;
+
+/// Function that creates a new mob event subscription each time it is called.
+pub type MobEventSubscribeFn = Arc<dyn Fn() -> MobEventSubscribeFuture + Send + Sync>;
+
+#[derive(Clone)]
+struct MobSseState {
+    subscribe_fn: MobEventSubscribeFn,
+}
+
+/// Build an axum router serving `GET /mob/events` as a merged SSE stream
+/// of all agent events tagged with their source agent id.
+pub fn mob_events_sse_router(subscribe_fn: MobEventSubscribeFn) -> Router {
+    Router::new()
+        .route("/mob/events", get(mob_events_sse_handler))
+        .with_state(MobSseState { subscribe_fn })
+}
+
+async fn mob_events_sse_handler(
+    State(state): State<MobSseState>,
+) -> impl IntoResponse {
+    let mut router_handle = (state.subscribe_fn)().await;
+
+    // `router_handle` is moved into this stream closure, keeping the event
+    // router task alive for the lifetime of the SSE connection.
+    let stream = stream! {
+        let mut seq = 0_u64;
+        while let Some(attributed) = router_handle.event_rx.recv().await {
+            let event_name = agent_event_type(&attributed.envelope.payload).to_string();
+            let data = json!({
+                "agent_id": attributed.source.to_string(),
+                "event": attributed.envelope.payload,
+            });
+            yield Ok::<Event, Infallible>(
+                Event::default()
+                    .id(format!("mob:{seq}"))
+                    .event(event_name)
+                    .data(data.to_string()),
+            );
+            seq += 1;
+        }
+    };
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(DEFAULT_KEEP_ALIVE_INTERVAL)
+            .text(KEEP_ALIVE_TEXT),
+    )
 }

--- a/crates/meerkat-mobkit-core/src/lib.rs
+++ b/crates/meerkat-mobkit-core/src/lib.rs
@@ -39,7 +39,9 @@ pub use http_console::{
     console_json_handler, console_json_router, console_json_router_with_runtime, ConsoleJsonState,
 };
 pub use http_sse::{
-    agent_event_sse, interaction_sse_handler, interaction_sse_router, InjectSseRequest,
+    agent_event_sse, agent_events_sse_router, interaction_sse_handler, interaction_sse_router,
+    mob_events_sse_router, AgentEventSubscribeFn, AgentEventSubscribeFuture, InjectSseRequest,
+    MobEventSubscribeFn, MobEventSubscribeFuture,
 };
 pub use mob_handle_runtime::{
     MobBootstrapOptions, MobBootstrapSpec, MobMemberSnapshot, MobReconcileOptions,

--- a/crates/meerkat-mobkit-core/src/unified_runtime.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use axum::routing::get;
 use axum::Router;
 use meerkat_core::event::agent_event_type;
-use meerkat_mob::{AttributedEvent, MemberRef, MobEventRouterHandle, MobState, SpawnMemberSpec};
+use meerkat_mob::{
+    AttributedEvent, MeerkatId, MemberRef, MobEventRouterHandle, MobState, SpawnMemberSpec,
+};
 use serde_json::json;
 use tokio::runtime::RuntimeFlavor;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -15,7 +17,10 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
 
 use crate::http_console::{console_frontend_router, console_json_router_with_runtime};
-use crate::http_sse::interaction_sse_router_with_injector;
+use crate::http_sse::{
+    agent_events_sse_router, interaction_sse_router_with_injector, mob_events_sse_router,
+    AgentEventSubscribeFn, MobEventSubscribeFn,
+};
 use crate::mob_handle_runtime::{
     MobBootstrapSpec, MobReconcileReport, MobRuntimeError, RealInteractionSubscription,
     RealMobRuntime,
@@ -482,12 +487,44 @@ impl UnifiedRuntime {
         }))
     }
 
+    /// Build an axum router for per-agent persistent SSE at `GET /agents/:agent_id/events`.
+    pub fn build_agent_sse_router(&self) -> Router {
+        let handle = self.mob_runtime.handle();
+        let subscribe_fn: AgentEventSubscribeFn =
+            Arc::new(move |agent_id: String| {
+                let handle = handle.clone();
+                Box::pin(async move {
+                    handle
+                        .subscribe_agent_events(&MeerkatId::from(agent_id))
+                        .await
+                        .map_err(MobRuntimeError::Mob)
+                })
+            });
+        agent_events_sse_router(subscribe_fn)
+    }
+
+    /// Build an axum router for mob-merged SSE at `GET /mob/events`.
+    ///
+    /// Each incoming connection creates a new mob event subscription, so
+    /// multiple clients receive independent streams. The returned router
+    /// keeps the event router handle alive for the lifetime of the stream.
+    pub fn build_mob_sse_router(&self) -> Router {
+        let mob_handle = self.mob_runtime.handle();
+        let subscribe_fn: MobEventSubscribeFn = Arc::new(move || {
+            let mob_handle = mob_handle.clone();
+            Box::pin(async move { mob_handle.subscribe_mob_events() })
+        });
+        mob_events_sse_router(subscribe_fn)
+    }
+
     pub fn build_reference_app_router(&self, decisions: RuntimeDecisionState) -> Router {
         Router::new()
             .route("/healthz", get(|| async { "ok" }))
             .merge(self.build_console_frontend_router())
             .merge(self.build_console_json_router(decisions))
             .merge(self.build_interaction_sse_router())
+            .merge(self.build_agent_sse_router())
+            .merge(self.build_mob_sse_router())
     }
 
     pub async fn serve(

--- a/crates/meerkat-mobkit-core/tests/phase_mk005_006.rs
+++ b/crates/meerkat-mobkit-core/tests/phase_mk005_006.rs
@@ -1,0 +1,381 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use meerkat::{build_ephemeral_service, AgentFactory, Config};
+use meerkat_client::TestClient;
+use meerkat_core::AgentEvent;
+use meerkat_mob::{MobDefinition, MobState, MobStorage, SpawnMemberSpec};
+use meerkat_mobkit_core::{
+    agent_event_sse, agent_events_sse_router, mob_events_sse_router, AgentEventSubscribeFn,
+    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobEventSubscribeFn, MobKitConfig,
+    UnifiedRuntime,
+};
+use tower::ServiceExt;
+
+fn build_mob_spec(temp_dir: &tempfile::TempDir) -> MobBootstrapSpec {
+    let session_path = temp_dir.path().join("sessions");
+    std::fs::create_dir_all(&session_path).expect("session path");
+
+    let factory = AgentFactory::new(&session_path).comms(true);
+    let session_service = Arc::new(build_ephemeral_service(factory, Config::default(), 16));
+
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "mk005-006-test-mob"
+
+[profiles.lead]
+model = "gpt-5.2"
+external_addressable = true
+
+[profiles.lead.tools]
+comms = true
+"#,
+    )
+    .expect("parse mob definition");
+
+    MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service).with_options(
+        MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        },
+    )
+}
+
+fn spawn_spec(profile: &str, member_id: &str) -> SpawnMemberSpec {
+    SpawnMemberSpec::from_wire(
+        profile.to_string(),
+        member_id.to_string(),
+        Some(format!("You are {member_id}.")),
+        None,
+        None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// MK-005: agent_event_sse format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mk005_agent_event_sse_formats_event_with_id_and_type() {
+    let event = AgentEvent::TextDelta {
+        delta: "hello".to_string(),
+    };
+    let sse_event = agent_event_sse("agent-1", 0, &event);
+
+    // The axum SSE Event does not expose its fields publicly, but we can
+    // verify it was created without panicking. The interaction SSE tests
+    // already cover the wire format via real HTTP; here we verify the helper
+    // produces a value for each variant we care about.
+    let _ = sse_event;
+
+    let complete_event = AgentEvent::TextComplete {
+        content: "done".to_string(),
+    };
+    let sse_complete = agent_event_sse("agent-1", 1, &complete_event);
+    let _ = sse_complete;
+}
+
+// ---------------------------------------------------------------------------
+// MK-005: agent_events_sse_router construction
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mk005_agent_events_sse_router_returns_404_for_unknown_agent() {
+    use meerkat_mob::MobError;
+    use meerkat_mobkit_core::MobRuntimeError;
+
+    let subscribe_fn: AgentEventSubscribeFn = Arc::new(|_agent_id: String| {
+        Box::pin(async {
+            Err(MobRuntimeError::Mob(MobError::MeerkatNotFound(
+                meerkat_mob::MeerkatId::from("unknown"),
+            )))
+        })
+    });
+
+    let router = agent_events_sse_router(subscribe_fn);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/agents/unknown-agent/events")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn mk005_agent_events_sse_router_returns_400_for_empty_agent_id() {
+    let subscribe_fn: AgentEventSubscribeFn = Arc::new(|_agent_id: String| {
+        Box::pin(async { unreachable!("should not be called for empty id") })
+    });
+
+    let router = agent_events_sse_router(subscribe_fn);
+
+    // The axum path extractor will match the literal " " as an agent_id.
+    // Our handler trims it, so it should return 400.
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/agents/%20/events")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn mk005_agent_events_sse_router_returns_sse_content_type_on_success() {
+    use futures::stream;
+    use meerkat_core::EventEnvelope;
+
+    let subscribe_fn: AgentEventSubscribeFn = Arc::new(|_agent_id: String| {
+        Box::pin(async {
+            let event = AgentEvent::TextDelta {
+                delta: "hello".to_string(),
+            };
+            let envelope = EventEnvelope::new("test-source", 0, None, event);
+            let event_stream: meerkat_core::EventStream =
+                Box::pin(stream::iter(vec![envelope]));
+            Ok(event_stream)
+        })
+    });
+
+    let router = agent_events_sse_router(subscribe_fn);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/agents/agent-1/events")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "expected text/event-stream content type, got: {content_type}"
+    );
+
+    let body = tokio::time::timeout(
+        Duration::from_secs(5),
+        to_bytes(response.into_body(), 1024 * 1024),
+    )
+    .await
+    .expect("body timeout")
+    .expect("read body");
+    let body_text = String::from_utf8(body.to_vec()).expect("utf8 body");
+
+    assert!(
+        body_text.contains("event: text_delta"),
+        "expected text_delta event in body: {body_text}"
+    );
+    assert!(
+        body_text.contains("id: agent-1:0"),
+        "expected agent-1:0 id in body: {body_text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MK-006: mob_events_sse_router construction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mk006_mob_events_sse_router_type_signature_compiles() {
+    // MobEventRouterHandle has a private cancel field, so we cannot
+    // construct one in a unit test. Instead we verify the type signature
+    // compiles and test the full path through the unified runtime below.
+    fn _assert_compiles(subscribe_fn: MobEventSubscribeFn) {
+        let _ = mob_events_sse_router(subscribe_fn);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified Runtime: build_agent_sse_router and build_mob_sse_router
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mk005_unified_runtime_build_agent_sse_router_returns_router() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(MobKitConfig {
+            modules: vec![],
+            discovery: DiscoverySpec {
+                namespace: "mk005-agent-sse-router".to_string(),
+                modules: vec![],
+            },
+            pre_spawn: vec![],
+        })
+        .timeout(Duration::from_secs(1))
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    assert_eq!(runtime.status(), MobState::Running);
+
+    runtime
+        .spawn(spawn_spec("lead", "agent-mk005"))
+        .await
+        .expect("spawn agent");
+
+    let agent_sse_router = runtime.build_agent_sse_router();
+
+    // Request events for the spawned agent - should get SSE content type
+    let response = agent_sse_router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/agents/agent-mk005/events")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "expected SSE content type, got: {content_type}"
+    );
+
+    let shutdown = runtime.shutdown().await;
+    shutdown.mob_stop.expect("mob runtime should stop cleanly");
+}
+
+#[tokio::test]
+async fn mk005_unified_runtime_build_agent_sse_router_returns_404_for_unknown_agent() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(MobKitConfig {
+            modules: vec![],
+            discovery: DiscoverySpec {
+                namespace: "mk005-agent-sse-404".to_string(),
+                modules: vec![],
+            },
+            pre_spawn: vec![],
+        })
+        .timeout(Duration::from_secs(1))
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    let agent_sse_router = runtime.build_agent_sse_router();
+
+    let response = agent_sse_router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/agents/nonexistent/events")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let shutdown = runtime.shutdown().await;
+    shutdown.mob_stop.expect("mob runtime should stop cleanly");
+}
+
+#[tokio::test]
+async fn mk006_unified_runtime_build_mob_sse_router_returns_sse_stream() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let mut runtime = UnifiedRuntime::builder()
+        .mob_spec(build_mob_spec(&temp_dir))
+        .module_config(MobKitConfig {
+            modules: vec![],
+            discovery: DiscoverySpec {
+                namespace: "mk006-mob-sse-router".to_string(),
+                modules: vec![],
+            },
+            pre_spawn: vec![],
+        })
+        .timeout(Duration::from_secs(1))
+        .build()
+        .await
+        .expect("build unified runtime");
+
+    assert_eq!(runtime.status(), MobState::Running);
+
+    let mob_sse_router = runtime.build_mob_sse_router();
+
+    let response = mob_sse_router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/mob/events")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "expected SSE content type, got: {content_type}"
+    );
+
+    let shutdown = runtime.shutdown().await;
+    shutdown.mob_stop.expect("mob runtime should stop cleanly");
+}
+
+// ---------------------------------------------------------------------------
+// Source-level contract: reference_app_router merges agent and mob SSE
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mk005_mk006_reference_app_router_merges_agent_and_mob_sse_routers() {
+    let source = include_str!("../src/unified_runtime.rs");
+    assert!(
+        source.contains(".merge(self.build_agent_sse_router())"),
+        "reference app router should merge agent SSE router"
+    );
+    assert!(
+        source.contains(".merge(self.build_mob_sse_router())"),
+        "reference app router should merge mob SSE router"
+    );
+}
+
+#[test]
+fn mk005_mk006_http_sse_exports_new_types() {
+    let source = include_str!("../src/lib.rs");
+    assert!(source.contains("agent_events_sse_router"));
+    assert!(source.contains("mob_events_sse_router"));
+    assert!(source.contains("AgentEventSubscribeFn"));
+    assert!(source.contains("MobEventSubscribeFn"));
+}


### PR DESCRIPTION
## Summary
- **MK-005**: Add `GET /agents/:agent_id/events` persistent SSE endpoint that streams a single agent's session-level events via `subscribe_agent_events`
- **MK-006**: Add `GET /mob/events` merged SSE endpoint that streams all agent events tagged with source `agent_id` via `subscribe_mob_events`, creating an independent subscription per client connection
- Add `build_agent_sse_router()` and `build_mob_sse_router()` builder methods to `UnifiedRuntime`, merged into `build_reference_app_router()`
- Export `AgentEventSubscribeFn`, `MobEventSubscribeFn`, and router constructor functions from `lib.rs`
- 10 new tests covering router construction, error responses (400/404), SSE content type, event format verification, and source-level contracts

## Test plan
- [x] `cargo check` compiles cleanly (no warnings)
- [x] `cargo test --test phase_mk005_006` — all 10 new tests pass
- [x] `cargo test --test phase2` — all 7 existing SSE/unified runtime tests pass (no regressions)
- [x] `cargo test --workspace` — only pre-existing governance failures (missing `.rct/spec.yaml` in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)