### PR TITLE
feat(bq): remove insertId and add server-side QUALIFY dedup (MK-008, MK-009)

### DIFF
--- a/crates/meerkat-mobkit-core/src/runtime/session_store.rs
+++ b/crates/meerkat-mobkit-core/src/runtime/session_store.rs
@@ -358,11 +358,10 @@ impl BigQuerySessionStoreAdapter {
         );
 
         let mut request_rows = Vec::with_capacity(rows.len());
-        for (idx, row) in rows.iter().enumerate() {
+        for row in rows {
             let payload_json = serde_json::to_string(&row.payload)
                 .map_err(|err| BigQuerySessionStoreError::Serialize(err.to_string()))?;
             request_rows.push(serde_json::json!({
-                "insertId": format!("{}-{}-{idx}", row.session_id, row.updated_at_ms),
                 "json": {
                     "session_id": row.session_id,
                     "updated_at_ms": row.updated_at_ms.to_string(),
@@ -423,13 +422,55 @@ impl BigQuerySessionStoreAdapter {
     pub fn read_latest_rows(
         &self,
     ) -> Result<Vec<SessionPersistenceRow>, BigQuerySessionStoreError> {
-        let rows = self.read_rows()?;
-        Ok(materialize_latest_session_rows(&rows))
+        let project_id = self.resolve_project_id()?;
+        let access_token = self.resolve_access_token()?;
+        let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
+        let query = format!(
+            "SELECT session_id, updated_at_ms, deleted, payload \
+             FROM `{}.{}` \
+             QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY updated_at_ms DESC) = 1",
+            project_id,
+            self.table_ref()
+        );
+        let request = serde_json::json!({
+            "query": query,
+            "useLegacySql": false,
+            "maxResults": 10000,
+        });
+        let response = self.send_json_request(
+            reqwest::Method::POST,
+            &endpoint,
+            &access_token,
+            Some(&request),
+        )?;
+        parse_bigquery_query_rows(&response)
     }
 
     pub fn read_live_rows(&self) -> Result<Vec<SessionPersistenceRow>, BigQuerySessionStoreError> {
-        let rows = self.read_rows()?;
-        Ok(materialize_live_session_rows(&rows))
+        let project_id = self.resolve_project_id()?;
+        let access_token = self.resolve_access_token()?;
+        let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
+        let query = format!(
+            "SELECT session_id, updated_at_ms, deleted, payload FROM (\
+               SELECT session_id, updated_at_ms, deleted, payload \
+               FROM `{}.{}` \
+               QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY updated_at_ms DESC) = 1\
+             ) WHERE deleted = false",
+            project_id,
+            self.table_ref()
+        );
+        let request = serde_json::json!({
+            "query": query,
+            "useLegacySql": false,
+            "maxResults": 10000,
+        });
+        let response = self.send_json_request(
+            reqwest::Method::POST,
+            &endpoint,
+            &access_token,
+            Some(&request),
+        )?;
+        parse_bigquery_query_rows(&response)
     }
 
     fn api_base_url(&self) -> &str {

--- a/crates/meerkat-mobkit-core/tests/phase3c_targets.rs
+++ b/crates/meerkat-mobkit-core/tests/phase3c_targets.rs
@@ -1165,17 +1165,15 @@ fn e2e_501_session_persistence_target_defined_red() {
             payload: json!({"step":"update","version":2}),
         },
     ];
-    let query_rows = json!({
+    // read_live_rows uses server-side QUALIFY dedup + WHERE deleted = false
+    let live_query_rows = json!({
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
             {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
         ]
     });
     let bq_server = MockHttpServer::start(vec![
         MockHttpResponse::json(json!({})),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(live_query_rows),
     ]);
 
     let json_store = JsonFileSessionStore::new(&sessions_path)

--- a/crates/meerkat-mobkit-core/tests/phase5.rs
+++ b/crates/meerkat-mobkit-core/tests/phase5.rs
@@ -155,19 +155,25 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
             payload: json!({"step":"update","version":2}),
         },
     ];
-    let query_rows = serde_json::json!({
+    // read_latest_rows uses server-side QUALIFY dedup, so mock returns already-deduped rows
+    let latest_query_rows = serde_json::json!({
         "jobComplete": true,
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
             {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+        ]
+    });
+    // read_live_rows uses server-side QUALIFY dedup + WHERE deleted = false
+    let live_query_rows = serde_json::json!({
+        "jobComplete": true,
+        "rows": [
             {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
         ]
     });
     let mock_server = MockHttpServer::start(vec![
         MockHttpResponse::json(serde_json::json!({})),
-        MockHttpResponse::json(query_rows.clone()),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(latest_query_rows),
+        MockHttpResponse::json(live_query_rows),
     ]);
 
     let store = BigQuerySessionStoreAdapter::new_native("phase5_dataset", "phase5_table")
@@ -193,6 +199,13 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
         .as_array()
         .expect("insert request rows array");
     assert_eq!(insert_rows.len(), writes.len());
+    // insertId must not be present (MK-008)
+    for row in insert_rows {
+        assert!(
+            row.get("insertId").is_none(),
+            "insertId must be removed from BQ streaming inserts"
+        );
+    }
     assert_eq!(requests[1].method, "POST");
     assert_eq!(
         requests[1].path,
@@ -200,10 +213,29 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
     );
     let query_body: serde_json::Value =
         serde_json::from_str(&requests[1].body).expect("parse query request");
-    assert!(query_body["query"]
+    let query_text = query_body["query"]
         .as_str()
-        .expect("query text")
-        .contains("SELECT session_id, updated_at_ms, deleted, payload"));
+        .expect("query text");
+    assert!(query_text.contains("SELECT session_id, updated_at_ms, deleted, payload"));
+    // read_latest_rows must use server-side QUALIFY dedup (MK-009)
+    assert!(
+        query_text.contains("QUALIFY ROW_NUMBER()"),
+        "read_latest_rows query must use QUALIFY for server-side dedup"
+    );
+    // Verify read_live_rows query uses QUALIFY + WHERE deleted = false
+    let live_query_body: serde_json::Value =
+        serde_json::from_str(&requests[2].body).expect("parse live query request");
+    let live_query_text = live_query_body["query"]
+        .as_str()
+        .expect("live query text");
+    assert!(
+        live_query_text.contains("QUALIFY ROW_NUMBER()"),
+        "read_live_rows query must use QUALIFY for server-side dedup"
+    );
+    assert!(
+        live_query_text.contains("deleted = false"),
+        "read_live_rows query must filter deleted rows server-side"
+    );
 
     assert_eq!(
         latest,

--- a/crates/meerkat-mobkit-core/tests/phase_f.rs
+++ b/crates/meerkat-mobkit-core/tests/phase_f.rs
@@ -83,20 +83,26 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
             payload: json!({"step":"update","version":2}),
         },
     ];
-    let query_rows = json!({
+    // read_latest_rows uses server-side QUALIFY dedup, so mock returns already-deduped rows
+    let latest_query_rows = json!({
         "jobComplete": true,
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
             {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+        ]
+    });
+    // read_live_rows uses server-side QUALIFY dedup + WHERE deleted = false
+    let live_query_rows = json!({
+        "jobComplete": true,
+        "rows": [
             {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
         ]
     });
 
     let server = MockHttpServer::start(vec![
         MockHttpResponse::json(json!({})),
-        MockHttpResponse::json(query_rows.clone()),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(latest_query_rows),
+        MockHttpResponse::json(live_query_rows),
     ]);
     let store = BigQuerySessionStoreAdapter::new_native("phase_f_dataset", "phase_f_table")
         .with_project_id("phase-f-project")
@@ -158,6 +164,13 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
         .as_array()
         .expect("insert request rows array");
     assert_eq!(inserted_rows.len(), writes.len());
+    // insertId must not be present (MK-008)
+    for row in inserted_rows {
+        assert!(
+            row.get("insertId").is_none(),
+            "insertId must be removed from BQ streaming inserts"
+        );
+    }
     assert_eq!(
         insert_body["rows"][0]["json"]["session_id"],
         Value::String("s1".to_string())
@@ -179,6 +192,11 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
     let query_text = query_body["query"].as_str().expect("query body query text");
     assert!(query_text.contains("SELECT session_id, updated_at_ms, deleted, payload"));
     assert!(query_text.contains("phase-f-project.phase_f_dataset.phase_f_table"));
+    // read_latest_rows must use server-side QUALIFY dedup (MK-009)
+    assert!(
+        query_text.contains("QUALIFY ROW_NUMBER()"),
+        "read_latest_rows query must use QUALIFY for server-side dedup"
+    );
 }
 
 #[test]
@@ -306,7 +324,15 @@ fn phase_f_rpc_bigquery_stream_insert_rows_issues_insert_all_request() {
     );
     let insert_body: Value =
         serde_json::from_str(&requests[0].body).expect("parse insert request body");
-    assert_eq!(insert_body["rows"].as_array().map_or(0, Vec::len), 2);
+    let inserted_rows = insert_body["rows"].as_array().expect("insert rows array");
+    assert_eq!(inserted_rows.len(), 2);
+    // insertId must not be present (MK-008)
+    for row in inserted_rows {
+        assert!(
+            row.get("insertId").is_none(),
+            "insertId must be removed from BQ streaming inserts"
+        );
+    }
     assert_eq!(insert_body["rows"][0]["json"]["session_id"], "rpc-s1");
     assert_eq!(insert_body["rows"][0]["json"]["updated_at_ms"], "101");
     assert_eq!(
@@ -318,7 +344,8 @@ fn phase_f_rpc_bigquery_stream_insert_rows_issues_insert_all_request() {
 
 #[test]
 fn phase_f_rpc_bigquery_read_rows_and_read_live_rows_semantics() {
-    let query_rows = json!({
+    // read_rows returns all raw rows (no server-side dedup)
+    let all_query_rows = json!({
         "rows": [
             {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
             {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
@@ -326,9 +353,15 @@ fn phase_f_rpc_bigquery_read_rows_and_read_live_rows_semantics() {
             {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
         ]
     });
+    // read_live_rows uses server-side QUALIFY dedup + WHERE deleted = false
+    let live_query_rows = json!({
+        "rows": [
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+        ]
+    });
     let server = MockHttpServer::start(vec![
-        MockHttpResponse::json(query_rows.clone()),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(all_query_rows),
+        MockHttpResponse::json(live_query_rows),
     ]);
     let mut runtime = start_phase_f_rpc_runtime();
 


### PR DESCRIPTION
## Summary
- Remove `insertId` from BigQuery streaming inserts to prevent silent data loss from BQ's 1-hour dedup window
- Replace client-side `materialize_latest_session_rows` with server-side `QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY updated_at_ms DESC) = 1` in `read_latest_rows()` and `read_live_rows()`
- Keep `materialize_*` functions for JsonFileSessionStore path

## Test plan
- [ ] Verify BQ insert requests no longer contain insertId field
- [ ] Verify read_latest_rows uses QUALIFY query
- [ ] Verify read_live_rows uses QUALIFY + WHERE deleted = false

🤖 Generated with [Claude Code](https://claude.com/claude-code)