### PR TITLE
fix: BQ correctness + Python SDK consolidation

### DIFF
--- a/crates/meerkat-mobkit-core/src/runtime/session_store.rs
+++ b/crates/meerkat-mobkit-core/src/runtime/session_store.rs
@@ -19,12 +19,18 @@ pub struct SessionStoreContract {
     pub bigquery_table: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionPersistenceRow {
+    #[serde(default)]
     pub session_id: String,
+    #[serde(default)]
     pub updated_at_ms: u64,
+    #[serde(default)]
     pub deleted: bool,
+    #[serde(default)]
     pub payload: Value,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -358,18 +364,21 @@ impl BigQuerySessionStoreAdapter {
         );
 
         let mut request_rows = Vec::with_capacity(rows.len());
-        for (idx, row) in rows.iter().enumerate() {
+        for row in rows.iter() {
             let payload_json = serde_json::to_string(&row.payload)
                 .map_err(|err| BigQuerySessionStoreError::Serialize(err.to_string()))?;
-            request_rows.push(serde_json::json!({
-                "insertId": format!("{}-{}-{idx}", row.session_id, row.updated_at_ms),
-                "json": {
-                    "session_id": row.session_id,
-                    "updated_at_ms": row.updated_at_ms.to_string(),
-                    "deleted": row.deleted,
-                    "payload": payload_json,
-                },
-            }));
+            let mut row_json = serde_json::json!({
+                "session_id": row.session_id,
+                "updated_at_ms": row.updated_at_ms.to_string(),
+                "deleted": row.deleted,
+                "payload": payload_json,
+            });
+            if !row.labels.is_empty() {
+                let labels_json = serde_json::to_string(&row.labels)
+                    .map_err(|err| BigQuerySessionStoreError::Serialize(err.to_string()))?;
+                row_json["labels_json"] = serde_json::Value::String(labels_json);
+            }
+            request_rows.push(serde_json::json!({ "json": row_json }));
         }
         let request = serde_json::json!({
             "ignoreUnknownValues": false,
@@ -399,11 +408,10 @@ impl BigQuerySessionStoreAdapter {
     pub fn read_rows(&self) -> Result<Vec<SessionPersistenceRow>, BigQuerySessionStoreError> {
         let project_id = self.resolve_project_id()?;
         let access_token = self.resolve_access_token()?;
+        let table_ref = self.table_ref();
         let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
         let query = format!(
-            "SELECT session_id, updated_at_ms, deleted, payload FROM `{}.{}` ORDER BY updated_at_ms ASC",
-            project_id,
-            self.table_ref()
+            "SELECT session_id, updated_at_ms, deleted, payload, labels_json FROM `{project_id}.{table_ref}` ORDER BY updated_at_ms ASC"
         );
         let request = serde_json::json!({
             "query": query,
@@ -423,13 +431,105 @@ impl BigQuerySessionStoreAdapter {
     pub fn read_latest_rows(
         &self,
     ) -> Result<Vec<SessionPersistenceRow>, BigQuerySessionStoreError> {
-        let rows = self.read_rows()?;
-        Ok(materialize_latest_session_rows(&rows))
+        let project_id = self.resolve_project_id()?;
+        let access_token = self.resolve_access_token()?;
+        let table_ref = self.table_ref();
+        let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
+        let query = format!(
+            "SELECT session_id, updated_at_ms, deleted, payload, labels_json \
+             FROM `{project_id}.{table_ref}` \
+             QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY updated_at_ms DESC) = 1"
+        );
+        let request = serde_json::json!({
+            "query": query,
+            "useLegacySql": false,
+            "maxResults": 10000,
+        });
+        let response = self.send_json_request(
+            reqwest::Method::POST,
+            &endpoint,
+            &access_token,
+            Some(&request),
+        )?;
+        parse_bigquery_query_rows(&response)
     }
 
     pub fn read_live_rows(&self) -> Result<Vec<SessionPersistenceRow>, BigQuerySessionStoreError> {
-        let rows = self.read_rows()?;
-        Ok(materialize_live_session_rows(&rows))
+        let project_id = self.resolve_project_id()?;
+        let access_token = self.resolve_access_token()?;
+        let table_ref = self.table_ref();
+        let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
+        let query = format!(
+            "SELECT session_id, updated_at_ms, deleted, payload, labels_json \
+             FROM `{project_id}.{table_ref}` \
+             WHERE deleted = false \
+             QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY updated_at_ms DESC) = 1"
+        );
+        let request = serde_json::json!({
+            "query": query,
+            "useLegacySql": false,
+            "maxResults": 10000,
+        });
+        let response = self.send_json_request(
+            reqwest::Method::POST,
+            &endpoint,
+            &access_token,
+            Some(&request),
+        )?;
+        parse_bigquery_query_rows(&response)
+    }
+
+    /// Delete all rows except the latest per session_id.
+    /// Returns the number of deleted rows.
+    pub fn gc_superseded_rows(&self) -> Result<u64, BigQuerySessionStoreError> {
+        let project_id = self.resolve_project_id()?;
+        let access_token = self.resolve_access_token()?;
+        let table_ref = self.table_ref();
+        let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
+        let query = format!(
+            "DELETE FROM `{project_id}.{table_ref}` AS t \
+             WHERE STRUCT(t.session_id, t.updated_at_ms) NOT IN ( \
+               SELECT AS STRUCT session_id, MAX(updated_at_ms) \
+               FROM `{project_id}.{table_ref}` \
+               GROUP BY session_id \
+             )"
+        );
+        let request = serde_json::json!({
+            "query": query,
+            "useLegacySql": false,
+        });
+        let response = self.send_json_request(
+            reqwest::Method::POST,
+            &endpoint,
+            &access_token,
+            Some(&request),
+        )?;
+        let affected = response
+            .get("numDmlAffectedRows")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+        Ok(affected)
+    }
+
+    /// Admin reset: truncate the entire session table.
+    pub fn truncate_sessions(&self) -> Result<(), BigQuerySessionStoreError> {
+        let project_id = self.resolve_project_id()?;
+        let access_token = self.resolve_access_token()?;
+        let table_ref = self.table_ref();
+        let endpoint = format!("{}/projects/{project_id}/queries", self.api_base_url());
+        let query = format!("TRUNCATE TABLE `{project_id}.{table_ref}`");
+        let request = serde_json::json!({
+            "query": query,
+            "useLegacySql": false,
+        });
+        self.send_json_request(
+            reqwest::Method::POST,
+            &endpoint,
+            &access_token,
+            Some(&request),
+        )?;
+        Ok(())
     }
 
     fn api_base_url(&self) -> &str {
@@ -570,12 +670,18 @@ fn parse_bigquery_query_row(
     let updated_at_ms = parse_bigquery_u64_cell(&fields[1], "updated_at_ms")?;
     let deleted = parse_bigquery_bool_cell(&fields[2], "deleted")?;
     let payload = parse_bigquery_payload_cell(&fields[3], "payload")?;
+    let labels = if fields.len() > 4 {
+        parse_bigquery_labels_cell(&fields[4])?
+    } else {
+        BTreeMap::new()
+    };
 
     Ok(SessionPersistenceRow {
         session_id,
         updated_at_ms,
         deleted,
         payload,
+        labels,
     })
 }
 
@@ -646,6 +752,26 @@ fn parse_bigquery_payload_cell(
             })
         }
         _ => Ok(value.clone()),
+    }
+}
+
+fn parse_bigquery_labels_cell(
+    cell: &Value,
+) -> Result<BTreeMap<String, String>, BigQuerySessionStoreError> {
+    let value = bigquery_cell_value(cell);
+    match value {
+        Value::Null => Ok(BTreeMap::new()),
+        Value::String(s) => {
+            if s.trim().is_empty() {
+                return Ok(BTreeMap::new());
+            }
+            serde_json::from_str::<BTreeMap<String, String>>(s).map_err(|_| {
+                BigQuerySessionStoreError::InvalidQueryResponse(
+                    "query column labels_json parse failed".to_string(),
+                )
+            })
+        }
+        _ => Ok(BTreeMap::new()),
     }
 }
 

--- a/crates/meerkat-mobkit-core/tests/phase3c_targets.rs
+++ b/crates/meerkat-mobkit-core/tests/phase3c_targets.rs
@@ -1145,32 +1145,35 @@ fn e2e_501_session_persistence_target_defined_red() {
             updated_at_ms: 1_000,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s1".to_string(),
             updated_at_ms: 2_000,
             deleted: true,
             payload: json!({}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 1_500,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         },
     ];
+    // BQ mock returns server-side deduped results (QUALIFY ROW_NUMBER already applied)
+    // read_live_rows sends WHERE deleted=false QUALIFY, so mock returns only live latest rows
     let query_rows = json!({
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
         ]
     });
     let bq_server = MockHttpServer::start(vec![
@@ -1227,8 +1230,8 @@ fn e2e_501_session_persistence_target_defined_red() {
         .as_str()
         .expect("query text should be present");
     assert!(
-        bq_query_text.contains("SELECT session_id, updated_at_ms, deleted, payload"),
-        "query request should include concrete read-path SQL"
+        bq_query_text.contains("SELECT session_id, updated_at_ms, deleted, payload, labels_json"),
+        "query request should include labels_json column: {bq_query_text}"
     );
     assert!(
         bq_query_text.contains("phase3c-project.phase3c_dataset.phase3c_table"),
@@ -1257,14 +1260,14 @@ fn e2e_501_session_persistence_target_defined_red() {
                 {"store":"json_file","dedup":true,"tombstones":true}
             ],
             "latest": [
-                {"session_id":"s1","updated_at_ms":2000,"deleted":true,"payload":{}},
-                {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2}}
+                {"session_id":"s1","updated_at_ms":2000,"deleted":true,"payload":{},"labels":{}},
+                {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2},"labels":{}}
             ],
             "live": [
-                {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2}}
+                {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2},"labels":{}}
             ],
             "bq_live": [
-                {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2}}
+                {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2},"labels":{}}
             ]
         }),
         "E2E-501: concrete JSON + BigQuery backend paths preserve dedup-by-latest-row and tombstone filtering semantics"

--- a/crates/meerkat-mobkit-core/tests/phase5.rs
+++ b/crates/meerkat-mobkit-core/tests/phase5.rs
@@ -42,6 +42,7 @@ fn phase5_json_store_recovers_stale_lock_and_persists_rows() {
         updated_at_ms: 100,
         deleted: false,
         payload: json!({"step":"create"}),
+    ..Default::default()
     }];
     store
         .append_rows(&writes)
@@ -78,6 +79,7 @@ fn phase5_json_store_blocks_on_fresh_lock() {
             updated_at_ms: 200,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         }])
         .expect_err("fresh lock should block writer");
 
@@ -112,6 +114,7 @@ fn phase5_json_store_does_not_evict_aged_lock_with_live_owner() {
             updated_at_ms: 250,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         }])
         .expect_err("aged lock with live owner should block writer");
 
@@ -135,39 +138,57 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
             updated_at_ms: 1_000,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s1".to_string(),
             updated_at_ms: 2_000,
             deleted: true,
             payload: json!({}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 1_500,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         },
     ];
     let query_rows = serde_json::json!({
         "jobComplete": true,
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"},{"v":"{}"}]},
+            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"},{"v":"{}"}]},
+            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"},{"v":"{}"}]},
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
+        ]
+    });
+    let _ = query_rows; // all rows not used directly; server-side dedup returns subsets
+    // Server-side QUALIFY dedup: read_latest_rows returns latest per session
+    let latest_rows = json!({
+        "rows": [
+            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"},{"v":"{}"}]},
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
+        ]
+    });
+    // Server-side QUALIFY + WHERE deleted=false: read_live_rows returns live latest
+    let live_rows = json!({
+        "rows": [
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
         ]
     });
     let mock_server = MockHttpServer::start(vec![
         MockHttpResponse::json(serde_json::json!({})),
-        MockHttpResponse::json(query_rows.clone()),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(latest_rows),
+        MockHttpResponse::json(live_rows),
     ]);
 
     let store = BigQuerySessionStoreAdapter::new_native("phase5_dataset", "phase5_table")
@@ -200,10 +221,15 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
     );
     let query_body: serde_json::Value =
         serde_json::from_str(&requests[1].body).expect("parse query request");
-    assert!(query_body["query"]
-        .as_str()
-        .expect("query text")
-        .contains("SELECT session_id, updated_at_ms, deleted, payload"));
+    let query_text = query_body["query"].as_str().expect("query text");
+    assert!(
+        query_text.contains("SELECT session_id, updated_at_ms, deleted, payload, labels_json"),
+        "query should select labels_json column: {query_text}"
+    );
+    assert!(
+        query_text.contains("QUALIFY ROW_NUMBER()"),
+        "read_latest_rows should use server-side QUALIFY dedup: {query_text}"
+    );
 
     assert_eq!(
         latest,
@@ -213,12 +239,14 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
                 updated_at_ms: 2_000,
                 deleted: true,
                 payload: json!({}),
+            ..Default::default()
             },
             SessionPersistenceRow {
                 session_id: "s2".to_string(),
                 updated_at_ms: 3_000,
                 deleted: false,
                 payload: json!({"step":"update","version":2}),
+            ..Default::default()
             },
         ]
     );
@@ -229,6 +257,7 @@ fn phase5_bigquery_adapter_process_path_and_dedup_tombstone_semantics() {
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         }]
     );
 }

--- a/crates/meerkat-mobkit-core/tests/phase_f.rs
+++ b/crates/meerkat-mobkit-core/tests/phase_f.rs
@@ -23,6 +23,7 @@ fn sample_write_rows() -> Vec<SessionPersistenceRow> {
         updated_at_ms: 10_000,
         deleted: false,
         payload: json!({"step":"create"}),
+    ..Default::default()
     }]
 }
 
@@ -63,40 +64,50 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
             updated_at_ms: 1_000,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s1".to_string(),
             updated_at_ms: 2_000,
             deleted: true,
             payload: json!({}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 1_500,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         },
     ];
-    let query_rows = json!({
+    // Server-side QUALIFY dedup: read_latest_rows returns latest per session
+    let latest_rows = json!({
         "jobComplete": true,
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"},{"v":"{}"}]},
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
+        ]
+    });
+    // Server-side QUALIFY + WHERE deleted=false: read_live_rows returns live latest
+    let live_rows = json!({
+        "jobComplete": true,
+        "rows": [
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
         ]
     });
 
     let server = MockHttpServer::start(vec![
         MockHttpResponse::json(json!({})),
-        MockHttpResponse::json(query_rows.clone()),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(latest_rows),
+        MockHttpResponse::json(live_rows),
     ]);
     let store = BigQuerySessionStoreAdapter::new_native("phase_f_dataset", "phase_f_table")
         .with_project_id("phase-f-project")
@@ -117,12 +128,14 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
                 updated_at_ms: 2_000,
                 deleted: true,
                 payload: json!({}),
+            ..Default::default()
             },
             SessionPersistenceRow {
                 session_id: "s2".to_string(),
                 updated_at_ms: 3_000,
                 deleted: false,
                 payload: json!({"step":"update","version":2}),
+            ..Default::default()
             },
         ]
     );
@@ -133,6 +146,7 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         }]
     );
 
@@ -185,7 +199,7 @@ fn phase_f_contract_native_bigquery_transport_request_shape_and_query_parsing() 
 fn phase_f_rpc_builtin_bigquery_path_uses_native_adapter() {
     let query_rows = json!({
         "rows": [
-            {"f":[{"v":"rpc-session"},{"v":"1234"},{"v":"false"},{"v":"{\"kind\":\"rpc\"}"}]}
+            {"f":[{"v":"rpc-session"},{"v":"1234"},{"v":"false"},{"v":"{\"kind\":\"rpc\"}"},{"v":"{}"}]}
         ]
     });
     let server = MockHttpServer::start(vec![MockHttpResponse::json(query_rows)]);
@@ -216,7 +230,8 @@ fn phase_f_rpc_builtin_bigquery_path_uses_native_adapter() {
             "session_id":"rpc-session",
             "updated_at_ms":1234,
             "deleted":false,
-            "payload":{"kind":"rpc"}
+            "payload":{"kind":"rpc"},
+            "labels":{}
         }])
     );
 
@@ -263,12 +278,14 @@ fn phase_f_rpc_bigquery_stream_insert_rows_issues_insert_all_request() {
             updated_at_ms: 101,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "rpc-s1".to_string(),
             updated_at_ms: 202,
             deleted: true,
             payload: json!({}),
+        ..Default::default()
         },
     ];
 
@@ -318,17 +335,22 @@ fn phase_f_rpc_bigquery_stream_insert_rows_issues_insert_all_request() {
 
 #[test]
 fn phase_f_rpc_bigquery_read_rows_and_read_live_rows_semantics() {
-    let query_rows = json!({
+    let all_rows = json!({
         "rows": [
-            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"}]},
-            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"}]},
-            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"}]}
+            {"f":[{"v":"s1"},{"v":"1000"},{"v":"false"},{"v":"{\"step\":\"create\"}"},{"v":"{}"}]},
+            {"f":[{"v":"s1"},{"v":"2000"},{"v":"true"},{"v":"{}"},{"v":"{}"}]},
+            {"f":[{"v":"s2"},{"v":"1500"},{"v":"false"},{"v":"{\"step\":\"create\"}"},{"v":"{}"}]},
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
+        ]
+    });
+    let live_rows = json!({
+        "rows": [
+            {"f":[{"v":"s2"},{"v":"3000"},{"v":"false"},{"v":"{\"step\":\"update\",\"version\":2}"},{"v":"{}"}]}
         ]
     });
     let server = MockHttpServer::start(vec![
-        MockHttpResponse::json(query_rows.clone()),
-        MockHttpResponse::json(query_rows),
+        MockHttpResponse::json(all_rows),
+        MockHttpResponse::json(live_rows),
     ]);
     let mut runtime = start_phase_f_rpc_runtime();
 
@@ -375,10 +397,10 @@ fn phase_f_rpc_bigquery_read_rows_and_read_live_rows_semantics() {
     assert_eq!(
         read_all["result"]["rows"],
         json!([
-            {"session_id":"s1","updated_at_ms":1000,"deleted":false,"payload":{"step":"create"}},
-            {"session_id":"s1","updated_at_ms":2000,"deleted":true,"payload":{}},
-            {"session_id":"s2","updated_at_ms":1500,"deleted":false,"payload":{"step":"create"}},
-            {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2}}
+            {"session_id":"s1","updated_at_ms":1000,"deleted":false,"payload":{"step":"create"},"labels":{}},
+            {"session_id":"s1","updated_at_ms":2000,"deleted":true,"payload":{},"labels":{}},
+            {"session_id":"s2","updated_at_ms":1500,"deleted":false,"payload":{"step":"create"},"labels":{}},
+            {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2},"labels":{}}
         ])
     );
 
@@ -390,7 +412,7 @@ fn phase_f_rpc_bigquery_read_rows_and_read_live_rows_semantics() {
     assert_eq!(
         read_live["result"]["rows"],
         json!([
-            {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2}}
+            {"session_id":"s2","updated_at_ms":3000,"deleted":false,"payload":{"step":"update","version":2},"labels":{}}
         ])
     );
 
@@ -618,7 +640,7 @@ fn phase_f_bigquery_malformed_query_rows_and_payloads_return_parse_failures() {
 
     let malformed_payload_server = MockHttpServer::start(vec![MockHttpResponse::json(json!({
         "rows": [
-            {"f":[{"v":"s1"},{"v":"2000"},{"v":"false"},{"v":"{not-json}"}]}
+            {"f":[{"v":"s1"},{"v":"2000"},{"v":"false"},{"v":"{not-json}"},{"v":"{}"}]}
         ]
     }))]);
     let malformed_payload_store =
@@ -748,24 +770,28 @@ fn phase_f_real_bigquery_integration_streaming_dedup_tombstone_semantics() {
             updated_at_ms: 1_000,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s1".to_string(),
             updated_at_ms: 2_000,
             deleted: true,
             payload: json!({}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 1_500,
             deleted: false,
             payload: json!({"step":"create"}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         },
     ];
 
@@ -779,12 +805,14 @@ fn phase_f_real_bigquery_integration_streaming_dedup_tombstone_semantics() {
             updated_at_ms: 2_000,
             deleted: true,
             payload: json!({}),
+        ..Default::default()
         },
         SessionPersistenceRow {
             session_id: "s2".to_string(),
             updated_at_ms: 3_000,
             deleted: false,
             payload: json!({"step":"update","version":2}),
+        ..Default::default()
         },
     ];
     let expected_live = vec![SessionPersistenceRow {
@@ -792,6 +820,7 @@ fn phase_f_real_bigquery_integration_streaming_dedup_tombstone_semantics() {
         updated_at_ms: 3_000,
         deleted: false,
         payload: json!({"step":"update","version":2}),
+    ..Default::default()
     }];
 
     let deadline = Instant::now() + Duration::from_secs(60);

--- a/sdk/python/examples/h2_reference_app.py
+++ b/sdk/python/examples/h2_reference_app.py
@@ -11,10 +11,10 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 try:
-    from meerkat_mobkit_sdk import MobkitAsyncTypedClient, MobkitRpcError
+    from meerkat_mobkit import MobkitAsyncTypedClient, MobkitRpcError
 except ModuleNotFoundError:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from meerkat_mobkit_sdk import (  # type: ignore[no-redef]
+    from meerkat_mobkit import (  # type: ignore[no-redef]
         MobkitAsyncTypedClient,
         MobkitRpcError,
     )

--- a/sdk/python/meerkat_mobkit/__init__.py
+++ b/sdk/python/meerkat_mobkit/__init__.py
@@ -1,0 +1,103 @@
+"""MobKit Python SDK.
+
+All imports come from this package:
+    from meerkat_mobkit import MobKit, auth, memory, session_store
+    from meerkat_mobkit import DiscoverySpec, PreSpawnData, SessionQuery
+    from meerkat_mobkit import SessionAgentBuilder, SessionBuildOptions
+"""
+from __future__ import annotations
+
+# Builder + Runtime
+from .builder import MobKit, MobKitBuilder
+from .runtime import MobHandle, MobKitRuntime, SseBridge
+
+# Data models
+from .models import DiscoverySpec, PreSpawnData, SessionBuildOptions, SessionQuery
+
+# Agent builder protocol
+from .agent_builder import CallbackDispatcher, SessionAgentBuilder
+
+# SSE bridge
+from .sse import SseEvent, SseEventStream, parse_sse_stream
+
+# Transport
+from .transport import PersistentTransport, create_persistent_transport
+
+# Config modules (importable as meerkat_mobkit.auth, etc.)
+from .config import auth, memory, session_store
+
+# Typed RPC clients (low-level)
+from .client import (
+    MobkitAsyncTypedClient,
+    MobkitRpcError,
+    MobkitTypedClient,
+    create_gateway_async_transport,
+    create_gateway_sync_transport,
+    create_http_transport,
+)
+
+# Module authoring helpers
+from .helpers import (
+    ModuleDefinition,
+    ModuleSpec,
+    ModuleTool,
+    build_console_experience_route,
+    build_console_modules_route,
+    build_console_route,
+    build_console_routes,
+    build_module_spec,
+    decorate_module_spec,
+    decorate_module_tool,
+    define_module,
+    define_module_spec,
+    define_module_tool,
+)
+
+__all__ = [
+    # Builder + Runtime
+    "MobKit",
+    "MobKitBuilder",
+    "MobKitRuntime",
+    "MobHandle",
+    "SseBridge",
+    # Data models
+    "DiscoverySpec",
+    "PreSpawnData",
+    "SessionBuildOptions",
+    "SessionQuery",
+    # Agent builder
+    "CallbackDispatcher",
+    "SessionAgentBuilder",
+    # SSE
+    "SseEvent",
+    "SseEventStream",
+    "parse_sse_stream",
+    # Transport
+    "PersistentTransport",
+    "create_persistent_transport",
+    # Config modules
+    "auth",
+    "memory",
+    "session_store",
+    # Typed RPC clients
+    "MobkitAsyncTypedClient",
+    "MobkitRpcError",
+    "MobkitTypedClient",
+    "create_gateway_async_transport",
+    "create_gateway_sync_transport",
+    "create_http_transport",
+    # Module authoring
+    "ModuleDefinition",
+    "ModuleSpec",
+    "ModuleTool",
+    "build_console_experience_route",
+    "build_console_modules_route",
+    "build_console_route",
+    "build_console_routes",
+    "build_module_spec",
+    "decorate_module_spec",
+    "decorate_module_tool",
+    "define_module",
+    "define_module_spec",
+    "define_module_tool",
+]

--- a/sdk/python/meerkat_mobkit/agent_builder.py
+++ b/sdk/python/meerkat_mobkit/agent_builder.py
@@ -1,0 +1,51 @@
+"""SessionAgentBuilder protocol — imperative mutation pattern matching HomeCore."""
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .models import SessionBuildOptions
+
+
+@runtime_checkable
+class SessionAgentBuilder(Protocol):
+    """Protocol for building agents during session creation.
+
+    Uses the imperative mutation pattern: build_agent receives a mutable
+    SessionBuildOptions and modifies it (sets profile_name, calls add_tools).
+
+    Example:
+        class MyAgentBuilder(SessionAgentBuilder):
+            async def build_agent(self, opts: SessionBuildOptions) -> None:
+                opts.profile_name = "assistant"
+                opts.additional_instructions = "Be helpful."
+                opts.add_tools([search_tool, calc_tool])
+    """
+
+    async def build_agent(self, options: SessionBuildOptions) -> None:
+        """Build an agent by mutating the given options.
+
+        Args:
+            options: Mutable SessionBuildOptions. Set profile_name,
+                    additional_instructions, and call add_tools().
+        """
+        ...
+
+
+class CallbackDispatcher:
+    """Routes incoming JSON-RPC callback requests from the Rust runtime
+    to the registered SessionAgentBuilder."""
+
+    def __init__(self) -> None:
+        self._builder: SessionAgentBuilder | None = None
+
+    def register_builder(self, builder: SessionAgentBuilder) -> None:
+        self._builder = builder
+
+    async def handle_callback(self, method: str, params: dict[str, Any]) -> Any:
+        if method == "callback/build_agent":
+            if self._builder is None:
+                raise ValueError("no SessionAgentBuilder registered")
+            opts = SessionBuildOptions(**(params.get("options", {})))
+            await self._builder.build_agent(opts)
+            return opts.to_dict()
+        raise ValueError(f"unknown callback method: {method}")

--- a/sdk/python/meerkat_mobkit/builder.py
+++ b/sdk/python/meerkat_mobkit/builder.py
@@ -1,0 +1,97 @@
+"""MobKit builder chain — matches HomeCore's app.py patterns."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Sequence
+
+
+@dataclass
+class MobKitBuilderConfig:
+    mob_config_path: str | None = None
+    session_builder: Any | None = None
+    session_store: Any | None = None
+    discovery_callback: Any | None = None
+    pre_spawn_callback: Any | None = None
+    gating_config_path: str | None = None
+    routing_config_path: str | None = None
+    scheduling_files: list[str] = field(default_factory=list)
+    memory_config: Any | None = None
+    auth_config: Any | None = None
+    gateway_bin: str | None = None
+    modules: list[dict[str, Any]] = field(default_factory=list)
+    extra_routes: Any | None = None
+
+
+class MobKitBuilder:
+    """Chainable builder for MobKit runtime configuration.
+
+    Usage:
+        runtime = await (
+            MobKit.builder()
+            .mob("config/mob.toml")
+            .session_service(builder, store)
+            .discovery(discover_fn)
+            .scheduling("schedules/a.toml", "schedules/b.toml")
+            .build()
+        )
+    """
+
+    def __init__(self) -> None:
+        self._config = MobKitBuilderConfig()
+
+    def mob(self, config_path: str) -> MobKitBuilder:
+        self._config.mob_config_path = config_path
+        return self
+
+    def session_service(self, builder: Any, store: Any = None) -> MobKitBuilder:
+        self._config.session_builder = builder
+        self._config.session_store = store
+        return self
+
+    def discovery(self, callback: Any) -> MobKitBuilder:
+        self._config.discovery_callback = callback
+        return self
+
+    def pre_spawn(self, callback: Any) -> MobKitBuilder:
+        self._config.pre_spawn_callback = callback
+        return self
+
+    def gating(self, config_path: str) -> MobKitBuilder:
+        self._config.gating_config_path = config_path
+        return self
+
+    def routing(self, config_path: str) -> MobKitBuilder:
+        self._config.routing_config_path = config_path
+        return self
+
+    def scheduling(self, *schedule_files: str) -> MobKitBuilder:
+        """Set schedule config files (accepts multiple positional args)."""
+        self._config.scheduling_files = list(schedule_files)
+        return self
+
+    def memory(self, config: Any = None, *, stores: list[str] | None = None) -> MobKitBuilder:
+        """Set memory config. Accepts config object or stores=["knowledge_graph", ...]."""
+        self._config.memory_config = config or {"stores": stores or []}
+        return self
+
+    def auth(self, config: Any) -> MobKitBuilder:
+        self._config.auth_config = config
+        return self
+
+    def gateway(self, bin_path: str) -> MobKitBuilder:
+        self._config.gateway_bin = bin_path
+        return self
+
+    def modules(self, module_specs: list[dict[str, Any]]) -> MobKitBuilder:
+        self._config.modules = module_specs
+        return self
+
+    async def build(self) -> MobKitRuntime:
+        from .runtime import MobKitRuntime
+        return await MobKitRuntime._create(self._config)
+
+
+class MobKit:
+    @staticmethod
+    def builder() -> MobKitBuilder:
+        return MobKitBuilder()

--- a/sdk/python/meerkat_mobkit/client.py
+++ b/sdk/python/meerkat_mobkit/client.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+from typing import Any, Callable, Literal, Mapping, Protocol, TypedDict, cast
+from urllib import request as urllib_request
+from urllib.error import HTTPError, URLError
+
+
+class JsonRpcRequest(TypedDict):
+    jsonrpc: Literal["2.0"]
+    id: str
+    method: str
+    params: dict[str, Any]
+
+
+class JsonRpcSuccess(TypedDict):
+    jsonrpc: Literal["2.0"]
+    id: str
+    result: Any
+
+
+class JsonRpcErrorBody(TypedDict):
+    code: int
+    message: str
+
+
+class JsonRpcErrorResponse(TypedDict):
+    jsonrpc: Literal["2.0"]
+    id: str
+    error: JsonRpcErrorBody
+
+
+JsonRpcResponse = JsonRpcSuccess | JsonRpcErrorResponse
+
+
+class MobkitStatusResult(TypedDict):
+    contract_version: str
+    running: bool
+    loaded_modules: list[str]
+
+
+class MobkitCapabilitiesResult(TypedDict):
+    contract_version: str
+    methods: list[str]
+    loaded_modules: list[str]
+
+
+class MobkitReconcileResult(TypedDict):
+    accepted: bool
+    reconciled_modules: list[str]
+    added: int
+
+
+class MobkitSpawnMemberResult(TypedDict):
+    accepted: bool
+    module_id: str
+
+
+class MobkitSubscribeKeepAlive(TypedDict):
+    interval_ms: int
+    event: str
+
+
+class MobkitSubscribeEventEnvelope(TypedDict):
+    event_id: str
+    source: str
+    timestamp_ms: int
+    event: Any
+
+
+class MobkitSubscribeResult(TypedDict):
+    scope: Literal["mob", "agent", "interaction"]
+    replay_from_event_id: str | None
+    keep_alive: MobkitSubscribeKeepAlive
+    keep_alive_comment: str
+    event_frames: list[str]
+    events: list[MobkitSubscribeEventEnvelope]
+
+
+class MobkitSubscribeParams(TypedDict, total=False):
+    scope: Literal["mob", "agent", "interaction"]
+    last_event_id: str
+    agent_id: str
+
+
+class AsyncRpcTransport(Protocol):
+    async def __call__(self, request: JsonRpcRequest) -> Any:
+        ...
+
+
+class SyncRpcTransport(Protocol):
+    def __call__(self, request: JsonRpcRequest) -> Any:
+        ...
+
+
+class MobkitRpcError(RuntimeError):
+    def __init__(self, code: int, message: str, request_id: str, method: str):
+        super().__init__(message)
+        self.code = code
+        self.request_id = request_id
+        self.method = method
+
+
+def create_gateway_sync_transport(gateway_bin: str) -> SyncRpcTransport:
+    def transport(request: JsonRpcRequest) -> Any:
+        request_json = json.dumps(request)
+        proc = subprocess.run(
+            [gateway_bin],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "MOBKIT_RPC_REQUEST": request_json},
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"gateway failed (status={proc.returncode}): {proc.stderr.strip()}"
+            )
+
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise ValueError("gateway returned non-JSON response") from exc
+
+    return transport
+
+
+def create_gateway_async_transport(gateway_bin: str) -> AsyncRpcTransport:
+    async def transport(request: JsonRpcRequest) -> Any:
+        request_json = json.dumps(request)
+        proc = await asyncio.create_subprocess_exec(
+            gateway_bin,
+            env={**os.environ, "MOBKIT_RPC_REQUEST": request_json},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            stderr_text = stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(
+                f"gateway failed (status={proc.returncode}): {stderr_text}"
+            )
+
+        try:
+            return json.loads(stdout.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError("gateway returned non-JSON response") from exc
+
+    return transport
+
+
+def create_http_transport(
+    endpoint: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    timeout_seconds: float = 10.0,
+) -> AsyncRpcTransport:
+    base_headers = {"content-type": "application/json", "accept": "application/json"}
+    if headers:
+        base_headers.update(dict(headers))
+
+    async def transport(request: JsonRpcRequest) -> Any:
+        request_bytes = json.dumps(request).encode("utf-8")
+        http_request = urllib_request.Request(
+            endpoint,
+            data=request_bytes,
+            method="POST",
+            headers=base_headers,
+        )
+        try:
+            body = await asyncio.to_thread(_read_http_body, http_request, timeout_seconds)
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"http transport failed (status={exc.code}): {body}"
+            ) from exc
+        except URLError as exc:
+            raise RuntimeError(f"http transport failed: {exc.reason}") from exc
+
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise ValueError("http transport returned non-JSON response") from exc
+
+    return transport
+
+
+class MobkitTypedClient:
+    def __init__(self, gateway_bin: str):
+        self.gateway_bin = gateway_bin
+        self._sync_transport = create_gateway_sync_transport(gateway_bin)
+
+    def rpc(
+        self, request_id: str, method: str, params: Mapping[str, Any] | None = None
+    ) -> JsonRpcResponse:
+        payload = self._sync_transport(_build_request(request_id, method, params))
+        return _parse_json_rpc_response(payload, request_id)
+
+    def status(self, request_id: str = "status") -> MobkitStatusResult:
+        return cast(
+            MobkitStatusResult,
+            _unwrap_typed_result(
+                self.rpc(request_id, "mobkit/status", {}),
+                request_id,
+                "mobkit/status",
+                _is_status_result,
+            ),
+        )
+
+    def capabilities(self, request_id: str = "capabilities") -> MobkitCapabilitiesResult:
+        return cast(
+            MobkitCapabilitiesResult,
+            _unwrap_typed_result(
+                self.rpc(request_id, "mobkit/capabilities", {}),
+                request_id,
+                "mobkit/capabilities",
+                _is_capabilities_result,
+            ),
+        )
+
+    def reconcile(
+        self, modules: list[str], request_id: str = "reconcile"
+    ) -> MobkitReconcileResult:
+        return cast(
+            MobkitReconcileResult,
+            _unwrap_typed_result(
+                self.rpc(request_id, "mobkit/reconcile", {"modules": modules}),
+                request_id,
+                "mobkit/reconcile",
+                _is_reconcile_result,
+            ),
+        )
+
+    def spawn_member(
+        self, module_id: str, request_id: str = "spawn_member"
+    ) -> MobkitSpawnMemberResult:
+        return cast(
+            MobkitSpawnMemberResult,
+            _unwrap_typed_result(
+                self.rpc(request_id, "mobkit/spawn_member", {"module_id": module_id}),
+                request_id,
+                "mobkit/spawn_member",
+                _is_spawn_member_result,
+            ),
+        )
+
+    def subscribe_events(
+        self,
+        params: MobkitSubscribeParams | None = None,
+        request_id: str = "events_subscribe",
+    ) -> MobkitSubscribeResult:
+        return cast(
+            MobkitSubscribeResult,
+            _unwrap_typed_result(
+                self.rpc(
+                    request_id,
+                    "mobkit/events/subscribe",
+                    dict(params) if params is not None else {},
+                ),
+                request_id,
+                "mobkit/events/subscribe",
+                _is_subscribe_result,
+            ),
+        )
+
+
+class MobkitAsyncTypedClient:
+    def __init__(self, transport: AsyncRpcTransport):
+        self._transport = transport
+
+    @classmethod
+    def from_gateway_bin(cls, gateway_bin: str) -> "MobkitAsyncTypedClient":
+        return cls(create_gateway_async_transport(gateway_bin))
+
+    @classmethod
+    def from_http(
+        cls,
+        endpoint: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        timeout_seconds: float = 10.0,
+    ) -> "MobkitAsyncTypedClient":
+        return cls(
+            create_http_transport(
+                endpoint,
+                headers=headers,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+
+    async def rpc(
+        self, request_id: str, method: str, params: Mapping[str, Any] | None = None
+    ) -> JsonRpcResponse:
+        payload = await self._transport(_build_request(request_id, method, params))
+        return _parse_json_rpc_response(payload, request_id)
+
+    async def request(
+        self,
+        request_id: str,
+        method: str,
+        params: Mapping[str, Any] | None,
+        validator: Callable[[Any], bool],
+    ) -> Any:
+        response = await self.rpc(request_id, method, params)
+        return _unwrap_typed_result(response, request_id, method, validator)
+
+    async def status(self, request_id: str = "status") -> MobkitStatusResult:
+        return cast(
+            MobkitStatusResult,
+            await self.request(request_id, "mobkit/status", {}, _is_status_result),
+        )
+
+    async def capabilities(
+        self, request_id: str = "capabilities"
+    ) -> MobkitCapabilitiesResult:
+        return cast(
+            MobkitCapabilitiesResult,
+            await self.request(
+                request_id,
+                "mobkit/capabilities",
+                {},
+                _is_capabilities_result,
+            ),
+        )
+
+    async def reconcile(
+        self, modules: list[str], request_id: str = "reconcile"
+    ) -> MobkitReconcileResult:
+        return cast(
+            MobkitReconcileResult,
+            await self.request(
+                request_id,
+                "mobkit/reconcile",
+                {"modules": modules},
+                _is_reconcile_result,
+            ),
+        )
+
+    async def spawn_member(
+        self, module_id: str, request_id: str = "spawn_member"
+    ) -> MobkitSpawnMemberResult:
+        return cast(
+            MobkitSpawnMemberResult,
+            await self.request(
+                request_id,
+                "mobkit/spawn_member",
+                {"module_id": module_id},
+                _is_spawn_member_result,
+            ),
+        )
+
+    async def subscribe_events(
+        self,
+        params: MobkitSubscribeParams | None = None,
+        request_id: str = "events_subscribe",
+    ) -> MobkitSubscribeResult:
+        return cast(
+            MobkitSubscribeResult,
+            await self.request(
+                request_id,
+                "mobkit/events/subscribe",
+                dict(params) if params is not None else {},
+                _is_subscribe_result,
+            ),
+        )
+
+
+def _read_http_body(http_request: urllib_request.Request, timeout_seconds: float) -> str:
+    with urllib_request.urlopen(http_request, timeout=timeout_seconds) as response:
+        return response.read().decode("utf-8")
+
+
+def _build_request(
+    request_id: str,
+    method: str,
+    params: Mapping[str, Any] | None,
+) -> JsonRpcRequest:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": dict(params) if params is not None else {},
+    }
+
+
+def _parse_json_rpc_response(payload: Any, request_id: str) -> JsonRpcResponse:
+    if not isinstance(payload, dict):
+        raise ValueError("invalid JSON-RPC response envelope")
+    if payload.get("jsonrpc") != "2.0" or payload.get("id") != request_id:
+        raise ValueError("invalid JSON-RPC response envelope")
+
+    has_result = "result" in payload
+    has_error = "error" in payload
+    if has_result == has_error:
+        raise ValueError("invalid JSON-RPC response envelope")
+
+    if has_error:
+        error = payload.get("error")
+        if not isinstance(error, dict):
+            raise ValueError("invalid JSON-RPC response envelope")
+        code = error.get("code")
+        message = error.get("message")
+        if not isinstance(code, int) or isinstance(code, bool):
+            raise ValueError("invalid JSON-RPC response envelope")
+        if not isinstance(message, str):
+            raise ValueError("invalid JSON-RPC response envelope")
+
+    return cast(JsonRpcResponse, payload)
+
+
+def _unwrap_typed_result(
+    response: JsonRpcResponse,
+    request_id: str,
+    method: str,
+    validator: Callable[[Any], bool],
+) -> Any:
+    if "error" in response:
+        error = response["error"]
+        raise MobkitRpcError(error["code"], error["message"], request_id, method)
+
+    result = response["result"]
+    if not validator(result):
+        raise ValueError(f"invalid result payload for {method}")
+    return result
+
+
+def _is_status_result(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("contract_version"), str)
+        and isinstance(value.get("running"), bool)
+        and _is_string_list(value.get("loaded_modules"))
+    )
+
+
+def _is_capabilities_result(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("contract_version"), str)
+        and _is_string_list(value.get("methods"))
+        and _is_string_list(value.get("loaded_modules"))
+    )
+
+
+def _is_reconcile_result(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("accepted"), bool)
+        and _is_string_list(value.get("reconciled_modules"))
+        and isinstance(value.get("added"), int)
+        and not isinstance(value.get("added"), bool)
+    )
+
+
+def _is_spawn_member_result(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("accepted"), bool)
+        and isinstance(value.get("module_id"), str)
+    )
+
+
+def _is_subscribe_result(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    scope = value.get("scope")
+    if scope not in {"mob", "agent", "interaction"}:
+        return False
+
+    replay = value.get("replay_from_event_id")
+    if replay is not None and not isinstance(replay, str):
+        return False
+
+    keep_alive = value.get("keep_alive")
+    if not isinstance(keep_alive, dict):
+        return False
+
+    interval = keep_alive.get("interval_ms")
+    if not isinstance(interval, int) or isinstance(interval, bool):
+        return False
+    if not isinstance(keep_alive.get("event"), str):
+        return False
+
+    if not isinstance(value.get("keep_alive_comment"), str):
+        return False
+
+    if not _is_string_list(value.get("event_frames")):
+        return False
+
+    events = value.get("events")
+    if not isinstance(events, list):
+        return False
+
+    for event in events:
+        if not isinstance(event, dict):
+            return False
+        timestamp = event.get("timestamp_ms")
+        if (
+            not isinstance(event.get("event_id"), str)
+            or not isinstance(event.get("source"), str)
+            or not isinstance(timestamp, int)
+            or isinstance(timestamp, bool)
+            or "event" not in event
+        ):
+            return False
+
+    return True
+
+
+def _is_string_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)

--- a/sdk/python/meerkat_mobkit/config/__init__.py
+++ b/sdk/python/meerkat_mobkit/config/__init__.py
@@ -1,0 +1,4 @@
+"""Configuration modules for MobKit runtime."""
+from . import auth, memory, session_store
+
+__all__ = ["auth", "memory", "session_store"]

--- a/sdk/python/meerkat_mobkit/config/auth.py
+++ b/sdk/python/meerkat_mobkit/config/auth.py
@@ -1,0 +1,47 @@
+"""Auth configuration for MobKit runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GoogleAuthConfig:
+    client_id: str
+    discovery_url: str = "https://accounts.google.com/.well-known/openid-configuration"
+    audience: str | None = None
+    leeway_seconds: int = 60
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": "google",
+            "client_id": self.client_id,
+            "discovery_url": self.discovery_url,
+            "audience": self.audience or self.client_id,
+            "leeway_seconds": self.leeway_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class JwtAuthConfig:
+    shared_secret: str
+    issuer: str | None = None
+    audience: str | None = None
+    leeway_seconds: int = 60
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": "jwt",
+            "shared_secret": self.shared_secret,
+            "issuer": self.issuer,
+            "audience": self.audience,
+            "leeway_seconds": self.leeway_seconds,
+        }
+
+
+def google(client_id: str, **kwargs: Any) -> GoogleAuthConfig:
+    return GoogleAuthConfig(client_id=client_id, **kwargs)
+
+
+def jwt(shared_secret: str, **kwargs: Any) -> JwtAuthConfig:
+    return JwtAuthConfig(shared_secret=shared_secret, **kwargs)

--- a/sdk/python/meerkat_mobkit/config/memory.py
+++ b/sdk/python/meerkat_mobkit/config/memory.py
@@ -1,0 +1,30 @@
+"""Memory backend configuration for MobKit runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ElephantMemoryConfig:
+    endpoint: str
+    space_id: str | None = None
+    collection: str | None = None
+    stores: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "backend": "elephant",
+            "endpoint": self.endpoint,
+        }
+        if self.space_id:
+            result["space_id"] = self.space_id
+        if self.collection:
+            result["collection"] = self.collection
+        if self.stores:
+            result["stores"] = self.stores
+        return result
+
+
+def elephant(endpoint: str, **kwargs: Any) -> ElephantMemoryConfig:
+    return ElephantMemoryConfig(endpoint=endpoint, **kwargs)

--- a/sdk/python/meerkat_mobkit/config/session_store.py
+++ b/sdk/python/meerkat_mobkit/config/session_store.py
@@ -1,0 +1,45 @@
+"""Session store configuration for MobKit runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class JsonSessionStoreConfig:
+    path: str
+    stale_lock_threshold_seconds: int = 30
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "store": "json_file",
+            "path": self.path,
+            "stale_lock_threshold_seconds": self.stale_lock_threshold_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class BigQuerySessionStoreConfig:
+    dataset: str
+    table: str
+    project_id: str | None = None
+    gc_interval_hours: int = 6
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "store": "bigquery",
+            "dataset": self.dataset,
+            "table": self.table,
+            "gc_interval_hours": self.gc_interval_hours,
+        }
+        if self.project_id:
+            result["project_id"] = self.project_id
+        return result
+
+
+def json(path: str, **kwargs: Any) -> JsonSessionStoreConfig:
+    return JsonSessionStoreConfig(path=path, **kwargs)
+
+
+def bigquery(dataset: str, table: str, **kwargs: Any) -> BigQuerySessionStoreConfig:
+    return BigQuerySessionStoreConfig(dataset=dataset, table=table, **kwargs)

--- a/sdk/python/meerkat_mobkit/helpers.py
+++ b/sdk/python/meerkat_mobkit/helpers.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Literal, Sequence
+from urllib.parse import quote
+
+RestartPolicy = Literal["never", "always", "on_failure"]
+
+
+def build_console_route(
+    path: Literal["/console/modules", "/console/experience"],
+    auth_token: str | None = None,
+) -> str:
+    if not auth_token:
+        return path
+    joiner = "&" if "?" in path else "?"
+    return f"{path}{joiner}auth_token={quote(auth_token, safe='')}"
+
+
+def build_console_modules_route(auth_token: str | None = None) -> str:
+    return build_console_route("/console/modules", auth_token)
+
+
+def build_console_experience_route(auth_token: str | None = None) -> str:
+    return build_console_route("/console/experience", auth_token)
+
+
+def build_console_routes(auth_token: str | None = None) -> dict[str, str]:
+    return {
+        "modules": build_console_modules_route(auth_token),
+        "experience": build_console_experience_route(auth_token),
+    }
+
+
+@dataclass(frozen=True)
+class ModuleSpec:
+    id: str
+    command: str
+    args: tuple[str, ...]
+    restart_policy: RestartPolicy = "never"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "command": self.command,
+            "args": list(self.args),
+            "restart_policy": self.restart_policy,
+        }
+
+
+ModuleSpecDecorator = Callable[[ModuleSpec], ModuleSpec]
+ModuleToolHandler = Callable[[Any, dict[str, Any]], Awaitable[Any] | Any]
+ModuleToolDecorator = Callable[[ModuleToolHandler], ModuleToolHandler]
+
+
+@dataclass(frozen=True)
+class ModuleTool:
+    name: str
+    handler: ModuleToolHandler
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class ModuleDefinition:
+    spec: ModuleSpec
+    tools: tuple[ModuleTool, ...]
+    description: str | None = None
+
+
+def build_module_spec(
+    *,
+    module_id: str,
+    command: str,
+    args: Sequence[str] | None = None,
+    restart_policy: RestartPolicy = "never",
+) -> ModuleSpec:
+    return ModuleSpec(
+        id=module_id,
+        command=command,
+        args=tuple(args or ()),
+        restart_policy=restart_policy,
+    )
+
+
+def define_module_spec(
+    *,
+    module_id: str,
+    command: str,
+    args: list[str] | None = None,
+    restart_policy: RestartPolicy = "never",
+) -> dict[str, object]:
+    return build_module_spec(
+        module_id=module_id,
+        command=command,
+        args=args,
+        restart_policy=restart_policy,
+    ).to_dict()
+
+
+def decorate_module_spec(spec: ModuleSpec, *decorators: ModuleSpecDecorator) -> ModuleSpec:
+    current = ModuleSpec(
+        id=spec.id,
+        command=spec.command,
+        args=tuple(spec.args),
+        restart_policy=spec.restart_policy,
+    )
+    for decorate in decorators:
+        current = decorate(current)
+    return current
+
+
+def decorate_module_tool(
+    handler: ModuleToolHandler, *decorators: ModuleToolDecorator
+) -> ModuleToolHandler:
+    wrapped = handler
+    for decorate in reversed(decorators):
+        wrapped = decorate(wrapped)
+    return wrapped
+
+
+def define_module_tool(
+    *,
+    name: str,
+    handler: ModuleToolHandler,
+    description: str | None = None,
+    decorators: Sequence[ModuleToolDecorator] | None = None,
+) -> ModuleTool:
+    wrapped = decorate_module_tool(handler, *(decorators or ()))
+    return ModuleTool(name=name, handler=wrapped, description=description)
+
+
+def define_module(
+    *,
+    spec: ModuleSpec,
+    tools: Sequence[ModuleTool] | None = None,
+    description: str | None = None,
+) -> ModuleDefinition:
+    return ModuleDefinition(
+        spec=ModuleSpec(
+            id=spec.id,
+            command=spec.command,
+            args=tuple(spec.args),
+            restart_policy=spec.restart_policy,
+        ),
+        tools=tuple(tools or ()),
+        description=description,
+    )

--- a/sdk/python/meerkat_mobkit/models.py
+++ b/sdk/python/meerkat_mobkit/models.py
@@ -1,0 +1,120 @@
+"""Typed data models for MobKit SDK — matches HomeCore import surface."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class DiscoverySpec:
+    """Agent discovery specification.
+
+    Maps to Rust SpawnMemberSpec fields via the MobKit discovery pipeline.
+    """
+
+    profile: str
+    meerkat_id: str
+    labels: dict[str, str] = field(default_factory=dict)
+    app_context: Any | None = None
+    additional_instructions: str | None = None
+    resume_session_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "profile": self.profile,
+            "meerkat_id": self.meerkat_id,
+        }
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        if self.app_context is not None:
+            result["app_context"] = self.app_context
+        if self.additional_instructions is not None:
+            result["additional_instructions"] = self.additional_instructions
+        if self.resume_session_id is not None:
+            result["resume_session_id"] = self.resume_session_id
+        return result
+
+
+@dataclass
+class PreSpawnData:
+    """Pre-spawn data for session resume and cache warming.
+
+    The resume_map maps meerkat_id -> session_id for agents that should
+    resume existing sessions instead of creating new ones.
+    """
+
+    resume_map: dict[str, str] = field(default_factory=dict)
+    module_id: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.resume_map:
+            result["resume_map"] = dict(self.resume_map)
+        if self.module_id is not None:
+            result["module_id"] = self.module_id
+        if self.env:
+            result["env"] = list(self.env.items())
+        return result
+
+
+@dataclass
+class SessionQuery:
+    """Query parameters for session lookup."""
+
+    agent_type: str | None = None
+    owner_id: str | None = None
+    labels: dict[str, str] = field(default_factory=dict)
+    include_deleted: bool = False
+    limit: int = 100
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.agent_type is not None:
+            result["agent_type"] = self.agent_type
+        if self.owner_id is not None:
+            result["owner_id"] = self.owner_id
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        result["include_deleted"] = self.include_deleted
+        result["limit"] = self.limit
+        return result
+
+
+@dataclass
+class SessionBuildOptions:
+    """Options passed to SessionAgentBuilder.build_agent().
+
+    Mutable — the builder mutates fields during agent construction.
+    """
+
+    app_context: Any | None = None
+    additional_instructions: str | None = None
+    session_id: str | None = None
+    labels: dict[str, str] = field(default_factory=dict)
+    profile_name: str | None = None
+    _tools: list[Any] = field(default_factory=list, repr=False)
+
+    def add_tools(self, tools: list[Any]) -> None:
+        """Add tools to the agent being built."""
+        self._tools.extend(tools)
+
+    @property
+    def tools(self) -> list[Any]:
+        return list(self._tools)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.app_context is not None:
+            result["app_context"] = self.app_context
+        if self.additional_instructions is not None:
+            result["additional_instructions"] = self.additional_instructions
+        if self.session_id is not None:
+            result["session_id"] = self.session_id
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        if self.profile_name is not None:
+            result["profile_name"] = self.profile_name
+        if self._tools:
+            result["tools"] = self._tools
+        return result

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -1,0 +1,110 @@
+"""MobKit runtime object — the running instance returned by the builder."""
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+from .agent_builder import CallbackDispatcher, SessionAgentBuilder
+from .transport import PersistentTransport
+
+
+class MobKitRuntime:
+    """Running MobKit runtime instance.
+
+    Created by MobKit.builder().build(). Manages the persistent
+    mobkit-rpc subprocess and exposes the runtime API surface.
+    """
+
+    def __init__(self, config: Any, transport: PersistentTransport | None = None):
+        self._config = config
+        self._transport = transport
+        self._running = False
+        self._dispatcher = CallbackDispatcher()
+
+    @classmethod
+    async def _create(cls, config: Any) -> MobKitRuntime:
+        runtime = cls(config)
+        await runtime._bootstrap()
+        return runtime
+
+    async def _bootstrap(self) -> None:
+        if self._config.gateway_bin:
+            self._transport = PersistentTransport(self._config.gateway_bin)
+            self._transport.start()
+        if self._config.session_builder and isinstance(
+            self._config.session_builder, SessionAgentBuilder
+        ):
+            self._dispatcher.register_builder(self._config.session_builder)
+        self._running = True
+
+    def mob_handle(self) -> MobHandle:
+        return MobHandle(self)
+
+    def sse_bridge(self) -> SseBridge:
+        return SseBridge(self)
+
+    def asgi(
+        self,
+        *,
+        console: bool = True,
+        auth: Any | None = None,
+        extra_routes: Any | None = None,
+    ) -> Any:
+        """Build an ASGI app. Accepts extra_routes for app-defined endpoints."""
+        # Future: construct Starlette/FastAPI app
+        return None
+
+    async def serve(
+        self,
+        app: Any = None,
+        *,
+        host: str = "0.0.0.0",
+        port: int = 8080,
+    ) -> None:
+        if app is None:
+            app = self.asgi()
+        # Future: uvicorn.run(app, host=host, port=port)
+
+    async def shutdown(self) -> None:
+        self._running = False
+        if self._transport is not None:
+            self._transport.stop()
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+
+class MobHandle:
+    """Proxy for the Meerkat MobHandle API."""
+
+    def __init__(self, runtime: MobKitRuntime):
+        self._runtime = runtime
+
+    async def wire(self, source_id: str, target_id: str) -> None:
+        # Future: send RPC
+        pass
+
+    async def inject(self, member_id: str, message: str) -> str:
+        # Future: send RPC
+        return ""
+
+    async def discover(self) -> list[dict[str, Any]]:
+        # Future: send RPC
+        return []
+
+
+class SseBridge:
+    """Bridge for streaming SSE events from the Rust runtime."""
+
+    def __init__(self, runtime: MobKitRuntime):
+        self._runtime = runtime
+
+    async def agent_events(self, agent_id: str) -> AsyncIterator[dict[str, Any]]:
+        # Future: connect to per-agent SSE endpoint
+        return
+        yield  # type: ignore[misc]
+
+    async def mob_events(self) -> AsyncIterator[dict[str, Any]]:
+        # Future: connect to mob SSE endpoint
+        return
+        yield  # type: ignore[misc]

--- a/sdk/python/meerkat_mobkit/sse.py
+++ b/sdk/python/meerkat_mobkit/sse.py
@@ -1,0 +1,110 @@
+"""SSE streaming bridge for ASGI integration."""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, AsyncIterator
+
+
+class SseEvent:
+    __slots__ = ("id", "event", "data")
+
+    def __init__(self, *, id: str | None = None, event: str = "message", data: str = ""):
+        self.id = id
+        self.event = event
+        self.data = data
+
+    def encode(self) -> str:
+        lines: list[str] = []
+        if self.id is not None:
+            lines.append(f"id: {self.id}")
+        if self.event != "message":
+            lines.append(f"event: {self.event}")
+        for line in self.data.split("\n"):
+            lines.append(f"data: {line}")
+        lines.append("")
+        lines.append("")
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"event": self.event, "data": self.data}
+        if self.id is not None:
+            result["id"] = self.id
+        return result
+
+
+class SseEventStream:
+    """Async iterator yielding SSE-formatted strings.
+
+    Use with StreamingResponse(stream, media_type="text/event-stream").
+    """
+
+    def __init__(
+        self,
+        source: AsyncIterator[dict[str, Any]],
+        *,
+        keep_alive_interval: float = 15.0,
+    ):
+        self._source = source
+        self._keep_alive_interval = keep_alive_interval
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        source_iter = self._source.__aiter__()
+        while True:
+            try:
+                event_data = await asyncio.wait_for(
+                    source_iter.__anext__(),
+                    timeout=self._keep_alive_interval,
+                )
+                data_str = (
+                    json.dumps(event_data.get("data", {}))
+                    if not isinstance(event_data.get("data"), str)
+                    else event_data.get("data", "")
+                )
+                event = SseEvent(
+                    id=event_data.get("id"),
+                    event=event_data.get("event", "message"),
+                    data=data_str,
+                )
+                yield event.encode()
+            except asyncio.TimeoutError:
+                yield ": keep-alive\n\n"
+            except StopAsyncIteration:
+                break
+
+
+async def parse_sse_stream(
+    response_body: AsyncIterator[bytes],
+) -> AsyncIterator[SseEvent]:
+    """Parse an SSE byte stream into SseEvent objects."""
+    buffer = ""
+    current_id: str | None = None
+    current_event = "message"
+    current_data: list[str] = []
+
+    async for chunk in response_body:
+        buffer += chunk.decode("utf-8", errors="replace")
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            line = line.rstrip("\r")
+
+            if not line:
+                if current_data:
+                    yield SseEvent(
+                        id=current_id,
+                        event=current_event,
+                        data="\n".join(current_data),
+                    )
+                current_id = None
+                current_event = "message"
+                current_data = []
+            elif line.startswith(":"):
+                continue
+            elif line.startswith("id: "):
+                current_id = line[4:]
+            elif line.startswith("event: "):
+                current_event = line[7:]
+            elif line.startswith("data: "):
+                current_data.append(line[6:])
+            elif line.startswith("data:"):
+                current_data.append(line[5:])

--- a/sdk/python/meerkat_mobkit/transport.py
+++ b/sdk/python/meerkat_mobkit/transport.py
@@ -1,0 +1,86 @@
+"""Persistent subprocess transport for MobKit JSON-RPC."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import threading
+from typing import Any
+
+
+class PersistentTransport:
+    """Long-lived mobkit-rpc subprocess communicating over stdin/stdout JSON-RPC.
+
+    Unlike the per-call subprocess transport, this keeps the process alive
+    so mob state persists across calls. stderr is sent to devnull to avoid
+    backpressure deadlocks.
+    """
+
+    def __init__(self, gateway_bin: str, *, env: dict[str, str] | None = None):
+        self.gateway_bin = gateway_bin
+        self._env = {**os.environ, **(env or {})}
+        self._process: subprocess.Popen[bytes] | None = None
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        if self._process is not None and self._process.poll() is None:
+            return
+        self._process = subprocess.Popen(
+            [self.gateway_bin, "--persistent"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=self._env,
+        )
+
+    def stop(self) -> None:
+        if self._process is None:
+            return
+        try:
+            if self._process.stdin:
+                self._process.stdin.close()
+            self._process.wait(timeout=5)
+        except Exception:
+            self._process.kill()
+        finally:
+            self._process = None
+
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def send_sync(self, request: dict[str, Any]) -> Any:
+        with self._lock:
+            self._ensure_running()
+            assert self._process is not None
+            assert self._process.stdin is not None
+            assert self._process.stdout is not None
+
+            request_line = json.dumps(request) + "\n"
+            self._process.stdin.write(request_line.encode("utf-8"))
+            self._process.stdin.flush()
+
+            response_line = self._process.stdout.readline()
+            if not response_line:
+                raise RuntimeError("persistent transport: subprocess closed stdout")
+
+            try:
+                return json.loads(response_line.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                raise ValueError("persistent transport: non-JSON response") from exc
+
+    async def send_async(self, request: dict[str, Any]) -> Any:
+        return await asyncio.to_thread(self.send_sync, request)
+
+    def _ensure_running(self) -> None:
+        if not self.is_running():
+            self.start()
+
+    def __del__(self) -> None:
+        self.stop()
+
+
+def create_persistent_transport(gateway_bin: str, **kwargs: Any) -> PersistentTransport:
+    transport = PersistentTransport(gateway_bin, **kwargs)
+    transport.start()
+    return transport

--- a/sdk/python/meerkat_mobkit_sdk/__init__.py
+++ b/sdk/python/meerkat_mobkit_sdk/__init__.py
@@ -1,12 +1,8 @@
-from .client import (
+"""Deprecated — use meerkat_mobkit instead."""
+from meerkat_mobkit import (  # noqa: F401
     MobkitAsyncTypedClient,
     MobkitRpcError,
     MobkitTypedClient,
-    create_gateway_async_transport,
-    create_gateway_sync_transport,
-    create_http_transport,
-)
-from .helpers import (
     ModuleDefinition,
     ModuleSpec,
     ModuleTool,
@@ -15,31 +11,12 @@ from .helpers import (
     build_console_route,
     build_console_routes,
     build_module_spec,
+    create_gateway_async_transport,
+    create_gateway_sync_transport,
+    create_http_transport,
     decorate_module_spec,
     decorate_module_tool,
     define_module,
     define_module_spec,
     define_module_tool,
 )
-
-__all__ = [
-    "MobkitAsyncTypedClient",
-    "MobkitRpcError",
-    "MobkitTypedClient",
-    "create_gateway_async_transport",
-    "create_gateway_sync_transport",
-    "create_http_transport",
-    "ModuleDefinition",
-    "ModuleSpec",
-    "ModuleTool",
-    "build_console_experience_route",
-    "build_console_modules_route",
-    "build_console_route",
-    "build_console_routes",
-    "build_module_spec",
-    "decorate_module_spec",
-    "decorate_module_tool",
-    "define_module",
-    "define_module_spec",
-    "define_module_tool",
-]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -3,7 +3,11 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "meerkat-mobkit-sdk"
+name = "meerkat-mobkit"
 version = "0.1.0"
-description = "Minimal Meerkat MobKit Python SDK artifacts for parity tests"
+description = "Meerkat MobKit Python SDK"
 requires-python = ">=3.10"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["meerkat_mobkit*"]

--- a/sdk/python/scripts/parity.py
+++ b/sdk/python/scripts/parity.py
@@ -9,14 +9,14 @@ from pathlib import Path
 from typing import Any, Callable
 
 try:
-    from meerkat_mobkit_sdk import (
+    from meerkat_mobkit import (
         MobkitTypedClient,
         build_console_modules_route,
         define_module_spec,
     )
 except ModuleNotFoundError:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from meerkat_mobkit_sdk import (  # type: ignore[no-redef]
+    from meerkat_mobkit import (  # type: ignore[no-redef]
         MobkitTypedClient,
         build_console_modules_route,
         define_module_spec,

--- a/sdk/python/scripts/productization.py
+++ b/sdk/python/scripts/productization.py
@@ -12,7 +12,7 @@ from typing import Any, Awaitable, Callable, cast
 from urllib.error import URLError
 
 try:
-    from meerkat_mobkit_sdk import (
+    from meerkat_mobkit import (
         MobkitAsyncTypedClient,
         MobkitRpcError,
         ModuleSpec,
@@ -28,7 +28,7 @@ try:
     )
 except ModuleNotFoundError:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from meerkat_mobkit_sdk import (  # type: ignore[no-redef]
+    from meerkat_mobkit import (  # type: ignore[no-redef]
         MobkitAsyncTypedClient,
         MobkitRpcError,
         ModuleSpec,


### PR DESCRIPTION
## Summary
- Remove BQ insertId (MK-008), add QUALIFY dedup (MK-009), add label columns (MK-010)
- Add gc_superseded_rows + truncate_sessions (MK-011/012)
- Consolidate Python SDK: everything in `meerkat_mobkit`, `meerkat_mobkit_sdk` is thin shim
- Fix all HomeCore contract mismatches: app_context, resume_map, mutable SessionBuildOptions, builder signatures
- Fix PersistentTransport stderr backpressure (DEVNULL)

## Not yet addressed (separate PRs needed)
- BQ async client (MK-013) — significant refactor, ripples through RPC handler
- Shutdown drain polls "active" state not in-flight turns (PR #14)
- Discovery additional_instructions → initial_message mapping (PR #7)
- SSE replay re-injection risk on POST (PR #12)
- Callback dispatcher wiring into transport loop

## Test plan
- [x] BQ mock tests pass (phase5, phase_f, phase3c_targets)
- [x] Python parity test passes (phase11)
- [x] All imports from meerkat_mobkit verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)