### PR TITLE
docs: refresh for Python SDK v0.2.0 + add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# MobKit
+
+Companion orchestration platform for the [Meerkat](https://github.com/lukacf/meerkat) multi-agent runtime. Handles startup orchestration, module routing, operational subsystems, session persistence, and admin console.
+
+## Key paths
+
+| Area | Path |
+|------|------|
+| Rust core | `crates/meerkat-mobkit-core/` |
+| Gateway binary | `crates/meerkat-mobkit-core/src/bin/phase0b_rpc_gateway.rs` |
+| Python SDK | `sdk/python/meerkat_mobkit/` |
+| Python tests | `sdk/python/tests/` |
+| TypeScript SDK | `sdk/typescript/` |
+| Docs (Mintlify) | `docs/` |
+
+## Python SDK (v0.2.0)
+
+Package: `meerkat-mobkit` (import as `meerkat_mobkit`).
+
+Public surface — `__init__.py` exports:
+- **Builder/Runtime**: `MobKit`, `MobKitBuilder`, `MobKitRuntime`
+- **Models**: `DiscoverySpec`, `PreSpawnData`, `SessionBuildOptions`, `SessionQuery`
+- **Protocol**: `SessionAgentBuilder`
+- **Errors**: `MobKitError`, `TransportError`, `RpcError`, `NotConnectedError`, `CapabilityUnavailableError`, `ContractMismatchError`
+- **Typed results**: `StatusResult`, `CapabilitiesResult`, `ReconcileResult`, `SpawnResult`, `SpawnMemberResult`, `SubscribeResult`, `KeepAliveConfig`, `EventEnvelope`, `RoutingResolution`, `DeliveryResult`, `MemoryQueryResult`
+- **Events**: `MobEvent`, `AgentEvent`, `InteractionEvent`, `EventStream`
+- **Config**: `auth`, `memory`, `session_store`
+
+Module authoring helpers (`ModuleSpec`, `define_module`, etc.) live in `meerkat_mobkit.helpers` — not top-level.
+
+Private internals (underscore-prefixed): `_client.py`, `_transport.py`, `_sse.py`.
+
+## Build and test
+
+```bash
+# Rust
+cargo check --workspace
+cargo nextest run --workspace -E 'not test(phase0_governance)' --no-fail-fast
+
+# Python
+PYTHONPATH=sdk/python python3 -m pytest sdk/python/tests/ -v
+```
+
+## Branch conventions
+
+- `main` — stable, PRs merge here
+- Feature branches: `feat/<name>`, `fix/<name>`, `docs/<name>`, `refactor/<name>`

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -30,7 +30,7 @@ description: "Bootstrap a MobKit runtime with modules and a Meerkat mob. Single 
   </Tab>
   <Tab title="Python">
     ```bash
-    pip install meerkat-mobkit-sdk
+    pip install meerkat-mobkit
     ```
   </Tab>
 </Tabs>
@@ -92,12 +92,13 @@ The fastest way to get a running system is `start_mobkit_runtime`. It takes a mo
   </Tab>
   <Tab title="Python">
     ```python
-    from meerkat_mobkit_sdk import MobkitAsyncTypedClient
+    from meerkat_mobkit import MobKit
 
-    client = MobkitAsyncTypedClient.from_http("http://localhost:8080/rpc")
-    status = await client.status()
-    print("Running:", status["running"])
-    print("Modules:", status["loaded_modules"])
+    async with await MobKit.builder().gateway("./mobkit-rpc").build() as rt:
+        handle = rt.mob_handle()
+        status = await handle.status()
+        print("Running:", status.running)
+        print("Modules:", status.loaded_modules)
     ```
   </Tab>
 </Tabs>

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -90,20 +90,42 @@ All `MobHandle` methods return typed dataclasses instead of raw dicts:
 | `status()` | `StatusResult` | `contract_version`, `running`, `loaded_modules` |
 | `capabilities()` | `CapabilitiesResult` | `contract_version`, `methods`, `loaded_modules` |
 | `reconcile(modules)` | `ReconcileResult` | `accepted`, `reconciled_modules`, `added` |
-| `spawn(spec)` | `SpawnResult` | `accepted`, `module_id` |
-| `spawn_member(module_id)` | `SpawnMemberResult` | `accepted`, `module_id` |
-| `subscribe_events(...)` | `SubscribeResult` | `scope`, `events`, `event_frames` |
+| `spawn(spec: DiscoverySpec)` | `SpawnResult` | `accepted`, `module_id`, `meerkat_id`, `profile` |
+| `spawn_member(module_id)` | `SpawnResult` | `accepted`, `module_id` |
+| `subscribe_events(...)` | `SubscribeResult` | `scope`, `keep_alive: KeepAliveConfig`, `events: list[EventEnvelope]` |
 | `resolve_routing(recipient)` | `RoutingResolution` | `recipient`, `route` |
 | `send_delivery(...)` | `DeliveryResult` | `delivered`, `delivery_id` |
 | `memory_query(query)` | `MemoryQueryResult` | `results` |
+| `inject_and_subscribe(target, message)` | `AsyncIterator[InteractionEvent]` | `event_id`, `event_type`, `data` |
 
 ```python
-from meerkat_mobkit.types import StatusResult
+from meerkat_mobkit.types import StatusResult, SpawnResult, SubscribeResult
 
 status = await handle.status()
 print(status.running)           # bool
 print(status.loaded_modules)    # list[str]
 print(status.contract_version)  # str
+
+# SubscribeResult has fully typed nested objects
+sub = await handle.subscribe_events(scope="mob")
+print(sub.keep_alive.interval_ms)  # int
+for env in sub.events:
+    print(env.event_id, env.source, env.timestamp_ms)
+```
+
+### SpawnResult
+
+`spawn(spec: DiscoverySpec)` and `spawn_member(module_id)` both return `SpawnResult`. The discovery-path spawn includes additional fields:
+
+```python
+from meerkat_mobkit import DiscoverySpec
+
+spec = DiscoverySpec(profile="assistant", meerkat_id="agent-1")
+result = await handle.spawn(spec)
+print(result.accepted)     # bool
+print(result.module_id)    # str
+print(result.meerkat_id)   # str | None (set for discovery spawns)
+print(result.profile)      # str | None (set for discovery spawns)
 ```
 
 ## Error hierarchy
@@ -138,7 +160,7 @@ except RpcError as exc:
 Typed event classes for SSE streaming:
 
 ```python
-from meerkat_mobkit.events import MobEvent, AgentEvent, InteractionEvent
+from meerkat_mobkit.events import MobEvent, AgentEvent, InteractionEvent, EventStream
 ```
 
 ```python
@@ -160,12 +182,55 @@ class MyBuilder(SessionAgentBuilder):
         options.add_tools(["search", "calculator"])  # list[str] enforced
 ```
 
-## Module authoring
+## Configuration helpers
 
-Define MobKit modules as Python subprocesses:
+The SDK provides factory functions for common configuration objects:
+
+### Authentication
 
 ```python
-from meerkat_mobkit import build_module_spec, define_module, define_module_tool
+from meerkat_mobkit import auth
+
+# Google OAuth
+google = auth.google(client_id="your-client-id.apps.googleusercontent.com")
+
+# JWT with shared secret
+jwt = auth.jwt(shared_secret="your-secret", issuer="my-app")
+
+rt = await MobKit.builder().auth(google).build()
+```
+
+### Memory
+
+```python
+from meerkat_mobkit import memory
+
+elephant = memory.elephant(
+    endpoint="http://localhost:8000",
+    space_id="my-space",
+)
+
+rt = await MobKit.builder().memory(elephant).build()
+```
+
+### Session store
+
+```python
+from meerkat_mobkit import session_store
+
+# Local JSON file store
+local = session_store.json(path="./sessions")
+
+# BigQuery production store
+bq = session_store.bigquery(dataset="my_dataset", table="sessions")
+```
+
+## Module authoring
+
+Module authoring helpers are available via `meerkat_mobkit.helpers`:
+
+```python
+from meerkat_mobkit.helpers import build_module_spec, define_module, define_module_tool
 
 spec = build_module_spec(
     module_id="router",
@@ -182,26 +247,6 @@ tool = define_module_tool(
 
 module = define_module(spec=spec, tools=[tool])
 ```
-
-## BREAKING CHANGES from v0.1.0
-
-This release replaces the entire public API surface. Key changes:
-
-| Removed (v0.1) | Replacement (v0.2) |
-|----------------|-------------------|
-| `MobkitTypedClient` | `MobKit.builder()...build()` → `MobKitRuntime` |
-| `MobkitAsyncTypedClient` | `MobKit.builder()...build()` → `MobKitRuntime` |
-| `MobkitRpcError` | `meerkat_mobkit.errors.RpcError` |
-| `create_gateway_sync_transport` | Internal: `_client.py` |
-| `create_gateway_async_transport` | Internal: `_client.py` |
-| `create_http_transport` | Internal: `_client.py` |
-| `PersistentTransport` | Internal: `_transport.py` |
-| `SseEvent`, `SseEventStream` | Internal: `_sse.py` |
-| `MobHandle` (public) | `runtime.mob_handle()` (internal) |
-| `SseBridge` (public) | `runtime.sse_bridge()` (internal) |
-| `dict[str, Any]` returns | Typed dataclasses (`StatusResult`, etc.) |
-| `RuntimeError` / `ValueError` | Typed errors (`RpcError`, `TransportError`, etc.) |
-| `SessionBuildOptions.add_tools(list[Any])` | `SessionBuildOptions.add_tools(list[str])` |
 
 ## See also
 


### PR DESCRIPTION
## Summary

- **quickstart.mdx**: Replace stale Python tab (`MobkitAsyncTypedClient`, dict access, old package name) with v0.2.0 builder API
- **sdks/python.mdx**: Update typed models table (DiscoverySpec param, SpawnResult.meerkat_id/profile, KeepAliveConfig, EventEnvelope), fix helpers import path, add config helpers section, add inject_and_subscribe, remove stale BREAKING CHANGES
- **CLAUDE.md**: New repo-level project context — key paths, SDK public surface, build/test commands, branch conventions

## Test plan

- [x] `grep -r "meerkat_mobkit_sdk\|MobkitAsyncTypedClient" docs/ --include="*.mdx"` returns no matches
- [x] Python import verified: `from meerkat_mobkit import MobKit` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)