### PR TITLE
feat: add mobkit/call_tool RPC + MobHandle.call_tool()

### DIFF
--- a/crates/meerkat-mobkit-core/src/rpc.rs
+++ b/crates/meerkat-mobkit-core/src/rpc.rs
@@ -202,7 +202,8 @@ pub fn handle_mobkit_rpc_json(
                     "mobkit/gating/evaluate",
                     "mobkit/gating/pending",
                     "mobkit/gating/decide",
-                    "mobkit/gating/audit"
+                    "mobkit/gating/audit",
+                    "mobkit/call_tool"
                 ],
                 "loaded_modules": runtime.loaded_modules()
             })),
@@ -693,6 +694,64 @@ pub fn handle_mobkit_rpc_json(
                 }),
             },
         },
+        "mobkit/call_tool" => {
+            let module_id = request.params.get("module_id").and_then(Value::as_str);
+            let tool = request.params.get("tool").and_then(Value::as_str);
+            let arguments = request.params.get("arguments").cloned().unwrap_or(serde_json::json!({}));
+
+            match (module_id, tool) {
+                (Some(module_id), Some(tool)) if !module_id.is_empty() && !tool.is_empty() => {
+                    let route = route_module_call(
+                        runtime,
+                        &ModuleRouteRequest {
+                            module_id: module_id.to_string(),
+                            method: tool.to_string(),
+                            params: arguments,
+                        },
+                        timeout,
+                    );
+                    match route {
+                        Ok(response) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: Some(serde_json::json!({
+                                "module_id": response.module_id,
+                                "tool": response.method,
+                                "result": response.payload
+                            })),
+                            error: None,
+                        },
+                        Err(ModuleRouteError::UnloadedModule(mid)) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32601,
+                                message: format!("Module '{mid}' not loaded"),
+                            }),
+                        },
+                        Err(err) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32000,
+                                message: format!("Tool call failed: {err:?}"),
+                            }),
+                        },
+                    }
+                }
+                _ => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Invalid params: module_id and tool required".to_string(),
+                    }),
+                },
+            }
+        }
         method if method.contains('/') && !method.starts_with("mobkit/") => {
             let module_id = method
                 .split('/')
@@ -862,7 +921,8 @@ pub async fn handle_unified_rpc_json(
                     "mobkit/gating/evaluate",
                     "mobkit/gating/pending",
                     "mobkit/gating/decide",
-                    "mobkit/gating/audit"
+                    "mobkit/gating/audit",
+                    "mobkit/call_tool"
                 ],
                 "loaded_modules": runtime.loaded_modules()
             })),
@@ -1404,6 +1464,63 @@ pub async fn handle_unified_rpc_json(
                 }),
             },
         },
+        "mobkit/call_tool" => {
+            let module_id = request.params.get("module_id").and_then(Value::as_str);
+            let tool = request.params.get("tool").and_then(Value::as_str);
+            let arguments = request.params.get("arguments").cloned().unwrap_or(serde_json::json!({}));
+
+            match (module_id, tool) {
+                (Some(module_id), Some(tool)) if !module_id.is_empty() && !tool.is_empty() => {
+                    let route = runtime.route_module_call(
+                        &ModuleRouteRequest {
+                            module_id: module_id.to_string(),
+                            method: tool.to_string(),
+                            params: arguments,
+                        },
+                        timeout,
+                    );
+                    match route {
+                        Ok(response) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: Some(serde_json::json!({
+                                "module_id": response.module_id,
+                                "tool": response.method,
+                                "result": response.payload
+                            })),
+                            error: None,
+                        },
+                        Err(ModuleRouteError::UnloadedModule(mid)) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32601,
+                                message: format!("Module '{mid}' not loaded"),
+                            }),
+                        },
+                        Err(err) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32000,
+                                message: format!("Tool call failed: {err:?}"),
+                            }),
+                        },
+                    }
+                }
+                _ => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Invalid params: module_id and tool required".to_string(),
+                    }),
+                },
+            }
+        }
         method if method.contains('/') && !method.starts_with("mobkit/") => {
             let module_id = method
                 .split('/')

--- a/sdk/python/meerkat_mobkit/__init__.py
+++ b/sdk/python/meerkat_mobkit/__init__.py
@@ -37,6 +37,7 @@ from .errors import (
 
 # Typed return models
 from .types import (
+    CallToolResult,
     CapabilitiesResult,
     DeliveryResult,
     EventEnvelope,
@@ -87,6 +88,7 @@ __all__ = [
     "RoutingResolution",
     "DeliveryResult",
     "MemoryQueryResult",
+    "CallToolResult",
     # Typed events
     "MobEvent",
     "AgentEvent",

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -17,6 +17,7 @@ from ._sse import SseEvent, parse_sse_stream
 from ._transport import PersistentTransport
 from .models import DiscoverySpec
 from .types import (
+    CallToolResult,
     CapabilitiesResult,
     DeliveryResult,
     MemoryQueryResult,
@@ -274,6 +275,16 @@ class MobHandle:
     async def memory_query(self, query: str, **kwargs: Any) -> MemoryQueryResult:
         raw = await self._runtime._rpc("mobkit/memory/query", {"query": query, **kwargs})
         return MemoryQueryResult.from_dict(raw)
+
+    async def call_tool(
+        self, module_id: str, tool: str, arguments: dict[str, Any] | None = None
+    ) -> CallToolResult:
+        """Call an MCP tool on a loaded module."""
+        params: dict[str, Any] = {"module_id": module_id, "tool": tool}
+        if arguments:
+            params["arguments"] = arguments
+        raw = await self._runtime._rpc("mobkit/call_tool", params)
+        return CallToolResult.from_dict(raw)
 
     async def inject_and_subscribe(self, target: str, message: str) -> AsyncIterator[InteractionEvent]:
         bridge = self._runtime.sse_bridge()

--- a/sdk/python/meerkat_mobkit/types.py
+++ b/sdk/python/meerkat_mobkit/types.py
@@ -158,3 +158,19 @@ class MemoryQueryResult:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MemoryQueryResult:
         return cls(results=list(data.get("results", [])))
+
+
+@dataclass(frozen=True)
+class CallToolResult:
+    """Result of calling an MCP tool on a loaded module."""
+    module_id: str
+    tool: str
+    result: Any
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CallToolResult:
+        return cls(
+            module_id=data.get("module_id", ""),
+            tool=data.get("tool", ""),
+            result=data.get("result"),
+        )

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -13,7 +13,7 @@ class TestNewSymbolsExist:
         "StatusResult", "CapabilitiesResult", "ReconcileResult",
         "SpawnResult", "SpawnMemberResult", "SubscribeResult",
         "KeepAliveConfig", "EventEnvelope",
-        "RoutingResolution", "DeliveryResult", "MemoryQueryResult",
+        "RoutingResolution", "DeliveryResult", "MemoryQueryResult", "CallToolResult",
         "MobEvent", "AgentEvent", "InteractionEvent", "EventStream",
         "auth", "memory", "session_store",
     ])

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -1,5 +1,6 @@
 """Tests for typed return models (from_dict)."""
 from meerkat_mobkit.types import (
+    CallToolResult,
     CapabilitiesResult,
     DeliveryResult,
     EventEnvelope,
@@ -148,3 +149,15 @@ class TestMemoryQueryResult:
     def test_from_dict(self):
         r = MemoryQueryResult.from_dict({"results": [{"key": "val"}]})
         assert r.results == [{"key": "val"}]
+
+
+class TestCallToolResult:
+    def test_from_dict(self):
+        r = CallToolResult.from_dict({
+            "module_id": "gmail",
+            "tool": "gmail_search",
+            "result": {"messages": [{"id": "1", "subject": "Hello"}]},
+        })
+        assert r.module_id == "gmail"
+        assert r.tool == "gmail_search"
+        assert r.result == {"messages": [{"id": "1", "subject": "Hello"}]}


### PR DESCRIPTION
## Summary

- **Rust**: Add `mobkit/call_tool` JSON-RPC handler (both sync and async dispatch) that routes `{module_id, tool, arguments}` through existing `route_module_call` → MCP tool dispatch
- **Python**: Add `MobHandle.call_tool(module_id, tool, arguments)` returning typed `CallToolResult`
- **Public surface**: Export `CallToolResult` from `meerkat_mobkit`

This enables connectors (e.g. HomeCore `app.py:113`) to call MCP tools on loaded modules:
```python
result = await mob_handle.call_tool("gmail", "gmail_search", {"query": "is:unread"})
```

## Test plan

- [x] `cargo check -p meerkat-mobkit-core` passes
- [x] 95 Python tests pass
- [ ] Integration test with running module

🤖 Generated with [Claude Code](https://claude.com/claude-code)