### PR TITLE
feat: label-based roster queries + Rust-side ensure_member

### DIFF
--- a/crates/meerkat-mobkit-core/src/mob_handle_runtime.rs
+++ b/crates/meerkat-mobkit-core/src/mob_handle_runtime.rs
@@ -78,6 +78,8 @@ pub struct MobMemberSnapshot {
     pub profile: String,
     pub state: String,
     pub wired_to: Vec<String>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub labels: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -152,6 +154,7 @@ impl RealMobRuntime {
                         MemberState::Retiring => MEMBER_STATE_RETIRING.to_string(),
                     },
                     wired_to,
+                    labels: entry.labels,
                 }
             })
             .collect()
@@ -260,5 +263,71 @@ impl RealMobRuntime {
             .send_message(MeerkatId::from(member_id), message)
             .await
             .map_err(Into::into)
+    }
+
+    /// Find members matching a label key-value pair.
+    pub async fn find_members(
+        &self,
+        label_key: &str,
+        label_value: &str,
+    ) -> Vec<MobMemberSnapshot> {
+        self.discover()
+            .await
+            .into_iter()
+            .filter(|m| m.labels.get(label_key).map_or(false, |v| v == label_value))
+            .collect()
+    }
+
+    /// Ensure a member exists, spawning from spec if missing.
+    ///
+    /// Idempotent — returns Ok if the member already exists.
+    pub async fn ensure_member(
+        &self,
+        spec: SpawnMemberSpec,
+    ) -> Result<MobMemberSnapshot, MobRuntimeError> {
+        let meerkat_id = spec.meerkat_id.clone();
+        // Check roster first
+        if let Some(entry) = self.handle.get_member(&meerkat_id).await {
+            let mut wired_to: Vec<String> =
+                entry.wired_to.into_iter().map(|p| p.to_string()).collect();
+            wired_to.sort();
+            return Ok(MobMemberSnapshot {
+                meerkat_id: entry.meerkat_id.to_string(),
+                profile: entry.profile.to_string(),
+                state: match entry.state {
+                    MemberState::Active => MEMBER_STATE_ACTIVE.to_string(),
+                    MemberState::Retiring => MEMBER_STATE_RETIRING.to_string(),
+                },
+                wired_to,
+                labels: entry.labels,
+            });
+        }
+        // Spawn
+        match self.handle.spawn_spec(spec).await {
+            Ok(_member_ref) => {}
+            Err(MobError::MeerkatAlreadyExists(_)) => {
+                // Concurrent spawn — fine
+            }
+            Err(err) => return Err(err.into()),
+        }
+        // Return current state
+        let entry = self
+            .handle
+            .get_member(&meerkat_id)
+            .await
+            .ok_or(MobRuntimeError::Mob(MobError::MeerkatNotFound(meerkat_id)))?;
+        let mut wired_to: Vec<String> =
+            entry.wired_to.into_iter().map(|p| p.to_string()).collect();
+        wired_to.sort();
+        Ok(MobMemberSnapshot {
+            meerkat_id: entry.meerkat_id.to_string(),
+            profile: entry.profile.to_string(),
+            state: match entry.state {
+                MemberState::Active => MEMBER_STATE_ACTIVE.to_string(),
+                MemberState::Retiring => MEMBER_STATE_RETIRING.to_string(),
+            },
+            wired_to,
+            labels: entry.labels,
+        })
     }
 }

--- a/crates/meerkat-mobkit-core/src/rpc.rs
+++ b/crates/meerkat-mobkit-core/src/rpc.rs
@@ -923,7 +923,9 @@ pub async fn handle_unified_rpc_json(
                     "mobkit/gating/decide",
                     "mobkit/gating/audit",
                     "mobkit/call_tool",
-                    "mobkit/send_message"
+                    "mobkit/send_message",
+                    "mobkit/find_members",
+                    "mobkit/ensure_member"
                 ],
                 "loaded_modules": runtime.loaded_modules()
             })),
@@ -1556,6 +1558,88 @@ pub async fn handle_unified_rpc_json(
                     error: Some(JsonRpcError {
                         code: -32602,
                         message: "Invalid params: member_id and message required".to_string(),
+                    }),
+                },
+            }
+        }
+        "mobkit/find_members" => {
+            let label_key = request.params.get("label_key").and_then(Value::as_str);
+            let label_value = request.params.get("label_value").and_then(Value::as_str);
+
+            match (label_key, label_value) {
+                (Some(key), Some(value)) if !key.is_empty() => {
+                    let members = runtime.find_members(key, value).await;
+                    JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id.clone(),
+                        result: Some(serde_json::to_value(&members).unwrap_or(Value::Null)),
+                        error: None,
+                    }
+                }
+                _ => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Invalid params: label_key and label_value required".to_string(),
+                    }),
+                },
+            }
+        }
+        "mobkit/ensure_member" => {
+            let profile = request.params.get("profile").and_then(Value::as_str);
+            let meerkat_id = request.params.get("meerkat_id").and_then(Value::as_str);
+
+            match (profile, meerkat_id) {
+                (Some(profile), Some(meerkat_id)) if !profile.is_empty() && !meerkat_id.is_empty() => {
+                    let labels = request.params.get("labels")
+                        .and_then(|v| serde_json::from_value::<std::collections::BTreeMap<String, String>>(v.clone()).ok());
+                    let context = request.params.get("context").cloned();
+                    let resume_session_id = request.params.get("resume_session_id")
+                        .and_then(Value::as_str)
+                        .and_then(|s| meerkat_core::types::SessionId::parse(s).ok());
+                    let additional_instructions = request.params.get("additional_instructions")
+                        .and_then(Value::as_array)
+                        .map(|arr| arr.iter().filter_map(Value::as_str).map(String::from).collect::<Vec<_>>())
+                        .and_then(|v| if v.is_empty() { None } else { Some(v) });
+
+                    let spec = meerkat_mob::SpawnMemberSpec {
+                        profile_name: meerkat_mob::ProfileName::from(profile),
+                        meerkat_id: meerkat_mob::MeerkatId::from(meerkat_id),
+                        initial_message: None,
+                        runtime_mode: None,
+                        backend: None,
+                        context,
+                        labels,
+                        resume_session_id,
+                        additional_instructions,
+                    };
+                    match runtime.ensure_member(spec).await {
+                        Ok(snapshot) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: Some(serde_json::to_value(&snapshot).unwrap_or(Value::Null)),
+                            error: None,
+                        },
+                        Err(err) => JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id.clone(),
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32602,
+                                message: format!("ensure_member failed: {err}"),
+                            }),
+                        },
+                    }
+                }
+                _ => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Invalid params: profile and meerkat_id required".to_string(),
                     }),
                 },
             }

--- a/crates/meerkat-mobkit-core/src/unified_runtime.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime.rs
@@ -884,6 +884,23 @@ impl UnifiedRuntime {
             .await
     }
 
+    /// Find members matching a label key-value pair.
+    pub async fn find_members(
+        &self,
+        label_key: &str,
+        label_value: &str,
+    ) -> Vec<MobMemberSnapshot> {
+        self.mob_runtime.find_members(label_key, label_value).await
+    }
+
+    /// Ensure a member exists, spawning from spec if missing. Idempotent.
+    pub async fn ensure_member(
+        &self,
+        spec: SpawnMemberSpec,
+    ) -> Result<MobMemberSnapshot, MobRuntimeError> {
+        self.mob_runtime.ensure_member(spec).await
+    }
+
     pub fn module_is_running(&self) -> bool {
         self.module_runtime.is_running()
     }

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -302,35 +302,56 @@ class MobHandle:
 
     async def ensure_member(
         self, member_id: str, profile: str, **kwargs: Any
-    ) -> SpawnResult:
+    ) -> dict[str, Any]:
         """Ensure a mob member exists, spawning it if missing.
 
-        Idempotent — if the member already exists, returns success without
-        error. Use before ``send()`` when handling first contact from an
-        unknown user (e.g. new Slack DM).
+        Idempotent — returns the member snapshot whether it was just spawned
+        or already existed. Use before ``send()`` when handling first contact
+        from an unknown user (e.g. new Slack DM).
 
         Args:
             member_id: Meerkat ID for the member.
             profile: Profile name from mob.toml to spawn with.
-            **kwargs: Optional fields passed to DiscoverySpec (labels, context,
-                      resume_session_id, additional_instructions).
+            **kwargs: Optional fields (labels, context, resume_session_id,
+                      additional_instructions).
+
+        Returns:
+            Member snapshot dict with meerkat_id, profile, state, labels, wired_to.
         """
-        spec = DiscoverySpec(profile=profile, meerkat_id=member_id, **kwargs)
-        try:
-            return await self.spawn(spec)
-        except RpcError as exc:
-            # Meerkat returns MeerkatAlreadyExists when the member is already
-            # in the roster or has a pending spawn. The Rust Debug format is
-            # 'MeerkatAlreadyExists(MeerkatId("..."))' which flows through
-            # the RPC error message as 'Invalid params: MeerkatAlreadyExists(...)'.
-            if exc.code == -32602 and "MeerkatAlreadyExists" in str(exc):
-                return SpawnResult.from_dict({
-                    "accepted": True,
-                    "module_id": "",
-                    "meerkat_id": member_id,
-                    "profile": profile,
-                })
-            raise
+        params: dict[str, Any] = {"profile": profile, "meerkat_id": member_id}
+        if "labels" in kwargs:
+            params["labels"] = kwargs["labels"]
+        if "context" in kwargs:
+            params["context"] = kwargs["context"]
+        if "resume_session_id" in kwargs:
+            params["resume_session_id"] = kwargs["resume_session_id"]
+        if "additional_instructions" in kwargs:
+            params["additional_instructions"] = kwargs["additional_instructions"]
+        return await self._runtime._rpc("mobkit/ensure_member", params)
+
+    async def find_members(
+        self, label_key: str, label_value: str
+    ) -> list[dict[str, Any]]:
+        """Find members matching a label key-value pair.
+
+        Returns a list of member snapshot dicts with meerkat_id, profile,
+        state, labels, and wired_to.
+
+        Example::
+
+            # Find all initiative agents
+            initiatives = await handle.find_members("agent_type", "initiative")
+
+            # Find the agent for a specific owner
+            agents = await handle.find_members("owner_id", "user-123")
+            if agents:
+                meerkat_id = agents[0]["meerkat_id"]
+        """
+        raw = await self._runtime._rpc(
+            "mobkit/find_members",
+            {"label_key": label_key, "label_value": label_value},
+        )
+        return raw if isinstance(raw, list) else []
 
     async def send(self, member_id: str, message: str) -> None:
         """Send a message to a mob member. Pure delivery, fire-and-forget."""


### PR DESCRIPTION
Three features that eliminate app-layer boilerplate (OB3 list_agents, owner_to_meerkat map, manual SpawnMemberSpec construction):

## 1. Labels on MobMemberSnapshot
MobMemberSnapshot now includes `labels: BTreeMap<String, String>` from the roster. Labels are first-class data in all roster queries.

## 2. find_members(label_key, label_value)
Query the roster by label. Returns matching member snapshots with full metadata.
```python
agents = await handle.find_members("owner_id", "user-123")
initiatives = await handle.find_members("agent_type", "initiative")
```

## 3. ensure_member (Rust-side atomic)
Atomic check-roster-then-spawn on the Rust side. Handles concurrent callers via MeerkatAlreadyExists. Python SDK delegates to the RPC method (was client-side).
```python
snapshot = await handle.ensure_member("user-123", profile="personal",
                                       labels={"owner_id": "user-123"})
```

## Test results
- cargo check clean
- 137 Python tests pass