### PR TITLE
feat: add rediscover() — reset mob + replay boot sequence

### DIFF
--- a/crates/meerkat-mobkit-core/src/lib.rs
+++ b/crates/meerkat-mobkit-core/src/lib.rs
@@ -89,7 +89,7 @@ pub use types::{
 };
 pub use config_convention::ConventionalPaths;
 pub use unified_runtime::{
-    discovery_spec_to_spawn_spec, DesiredPeerEdge, DesiredPeerEdgeError, Discovery,
+    discovery_spec_to_spawn_spec, DesiredPeerEdge, DesiredPeerEdgeError, Discovery, RediscoverReport,
     EdgeDiscovery, EdgeReconcileFailure, PostReconcileHook, PostSpawnHook, PreSpawnContext,
     PreSpawnHook,
     ShutdownDrainReport, UnifiedRuntime, UnifiedRuntimeBootstrapError, UnifiedRuntimeBuilder,

--- a/crates/meerkat-mobkit-core/src/rpc.rs
+++ b/crates/meerkat-mobkit-core/src/rpc.rs
@@ -926,7 +926,8 @@ pub async fn handle_unified_rpc_json(
                     "mobkit/send_message",
                     "mobkit/find_members",
                     "mobkit/ensure_member",
-                    "mobkit/reconcile_edges"
+                    "mobkit/reconcile_edges",
+                    "mobkit/rediscover"
                 ],
                 "loaded_modules": runtime.loaded_modules()
             })),
@@ -1652,6 +1653,33 @@ pub async fn handle_unified_rpc_json(
                 id: response_id.clone(),
                 result: Some(serde_json::to_value(&report).unwrap_or(Value::Null)),
                 error: None,
+            }
+        }
+        "mobkit/rediscover" => {
+            match runtime.rediscover().await {
+                Ok(Some(report)) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::to_value(&report).unwrap_or(Value::Null)),
+                    error: None,
+                },
+                Ok(None) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::json!({
+                        "status": "no_discovery_configured"
+                    })),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32000,
+                        message: format!("rediscover failed: {err}"),
+                    }),
+                },
             }
         }
         method if method.contains('/') && !method.starts_with("mobkit/") => {

--- a/crates/meerkat-mobkit-core/src/unified_runtime.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime.rs
@@ -392,6 +392,7 @@ impl UnifiedRuntimeBuilder {
         runtime.post_spawn_hook = self.post_spawn_hook;
         runtime.post_reconcile_hook = self.post_reconcile_hook;
         runtime.drain_timeout = self.drain_timeout.unwrap_or(DEFAULT_DRAIN_TIMEOUT);
+        runtime.discovery = self.discovery;
         runtime.edge_discovery = self.edge_discovery;
 
         let pre_spawn_context = if let Some(hook) = self.pre_spawn_hook {
@@ -405,7 +406,7 @@ impl UnifiedRuntimeBuilder {
         } else {
             serde_json::Value::Null
         };
-        if let Some(discovery) = self.discovery {
+        if let Some(ref discovery) = runtime.discovery {
             let specs = discovery.discover(pre_spawn_context).await;
             let spawn_specs: Vec<SpawnMemberSpec> =
                 specs.iter().map(discovery_spec_to_spawn_spec).collect();
@@ -492,6 +493,15 @@ pub struct UnifiedRuntimeRunReport {
     pub shutdown: UnifiedRuntimeShutdownReport,
 }
 
+/// Report from a rediscover operation (reset + re-run discovery + reconcile edges).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RediscoverReport {
+    /// Number of members spawned by discovery.
+    pub spawned: Vec<String>,
+    /// Edge reconciliation report (if EdgeDiscovery is configured).
+    pub edges: UnifiedRuntimeReconcileEdgesReport,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnifiedRuntimeReconcileRoutingReport {
     pub router_module_loaded: bool,
@@ -543,6 +553,7 @@ pub struct UnifiedRuntime {
     post_spawn_hook: Option<PostSpawnHook>,
     post_reconcile_hook: Option<PostReconcileHook>,
     drain_timeout: Duration,
+    discovery: Option<Box<dyn Discovery>>,
     edge_discovery: Option<Box<dyn EdgeDiscovery>>,
     /// Dynamic edges managed by edge reconciliation. Only edges in this set
     /// can be unwired by the reconciler — static/preexisting edges are safe.
@@ -582,6 +593,7 @@ impl UnifiedRuntime {
             post_spawn_hook: None,
             post_reconcile_hook: None,
             drain_timeout: DEFAULT_DRAIN_TIMEOUT,
+            discovery: None,
             edge_discovery: None,
             managed_dynamic_edges: BTreeSet::new(),
             bootstrap_edges_report: None,
@@ -899,6 +911,57 @@ impl UnifiedRuntime {
         spec: SpawnMemberSpec,
     ) -> Result<MobMemberSnapshot, MobRuntimeError> {
         self.mob_runtime.ensure_member(spec).await
+    }
+
+    /// Reset the mob and re-run discovery + edge reconciliation.
+    ///
+    /// Sequence:
+    /// 1. `MobHandle::reset()` — retires all members, clears projections,
+    ///    restarts MCP servers, returns mob to Running state
+    /// 2. Re-runs the stored `Discovery` (with `Value::Null` context since
+    ///    `PreSpawnHook` is consumed at boot and cannot be replayed)
+    /// 3. Spawns discovered members via `spawn_many`
+    /// 4. Clears managed dynamic edges (stale after reset)
+    /// 5. Runs edge reconciliation if `EdgeDiscovery` is configured
+    ///
+    /// Returns `None` if no `Discovery` is configured (nothing to rediscover).
+    pub async fn rediscover(&mut self) -> Result<Option<RediscoverReport>, MobRuntimeError> {
+        let discovery = match &self.discovery {
+            Some(d) => d,
+            None => return Ok(None),
+        };
+
+        // 1. Reset the mob — retires all, clears state, returns to Running
+        self.mob_runtime
+            .handle()
+            .reset()
+            .await
+            .map_err(MobRuntimeError::Mob)?;
+
+        // 2. Re-run discovery (no pre-spawn context — PreSpawnHook is FnOnce)
+        let specs = discovery.discover(serde_json::Value::Null).await;
+        let spawn_specs: Vec<SpawnMemberSpec> =
+            specs.iter().map(discovery_spec_to_spawn_spec).collect();
+        let spawned: Vec<String> = spawn_specs
+            .iter()
+            .map(|s| s.meerkat_id.to_string())
+            .collect();
+
+        // 3. Spawn discovered members
+        self.mob_runtime
+            .spawn_many(spawn_specs)
+            .await?;
+        if let Some(hook) = &self.post_spawn_hook {
+            hook(spawned.clone()).await;
+        }
+
+        // 4. Clear stale managed edges (old topology is gone after reset)
+        self.managed_dynamic_edges.clear();
+
+        // 5. Reconcile edges
+        let edges = self.reconcile_edges().await;
+
+        Ok(Some(RediscoverReport { spawned, edges }))
     }
 
     pub fn module_is_running(&self) -> bool {

--- a/sdk/python/meerkat_mobkit/__init__.py
+++ b/sdk/python/meerkat_mobkit/__init__.py
@@ -40,6 +40,7 @@ from .types import (
     CallToolResult,
     CapabilitiesResult,
     ReconcileEdgesReport,
+    RediscoverReport,
     DeliveryResult,
     EventEnvelope,
     KeepAliveConfig,
@@ -108,6 +109,7 @@ __all__ = [
     "MemoryQueryResult",
     "CallToolResult",
     "ReconcileEdgesReport",
+    "RediscoverReport",
     "ToolCaller",
     # Typed events
     "Event",

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -23,6 +23,7 @@ from .types import (
     MemoryQueryResult,
     ReconcileEdgesReport,
     ReconcileResult,
+    RediscoverReport,
     RoutingResolution,
     SpawnResult,
     StatusResult,
@@ -354,20 +355,21 @@ class MobHandle:
         )
         return raw if isinstance(raw, list) else []
 
-    async def rediscover(self) -> dict[str, Any]:
+    async def rediscover(self) -> RediscoverReport | None:
         """Reset the mob and re-run discovery + edge reconciliation.
 
         Sequence: reset mob (retire all, clear state) → re-run Discovery →
         spawn discovered members → reconcile edges.
 
-        Returns a report with ``spawned`` (list of member IDs) and ``edges``
-        (edge reconciliation report). Returns ``{"status": "no_discovery_configured"}``
-        if no Discovery was configured on the builder.
+        Returns ``None`` if no Discovery was configured on the builder.
 
         Use for "nuke everything and start fresh" scenarios — e.g. a config
         reload, admin reset command, or recovery from a bad state.
         """
-        return await self._runtime._rpc("mobkit/rediscover")
+        raw = await self._runtime._rpc("mobkit/rediscover")
+        if isinstance(raw, dict) and "status" in raw:
+            return None
+        return RediscoverReport.from_dict(raw)
 
     async def reconcile_edges(self) -> ReconcileEdgesReport:
         """Re-run edge discovery and reconcile dynamic peer edges.

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -354,6 +354,21 @@ class MobHandle:
         )
         return raw if isinstance(raw, list) else []
 
+    async def rediscover(self) -> dict[str, Any]:
+        """Reset the mob and re-run discovery + edge reconciliation.
+
+        Sequence: reset mob (retire all, clear state) → re-run Discovery →
+        spawn discovered members → reconcile edges.
+
+        Returns a report with ``spawned`` (list of member IDs) and ``edges``
+        (edge reconciliation report). Returns ``{"status": "no_discovery_configured"}``
+        if no Discovery was configured on the builder.
+
+        Use for "nuke everything and start fresh" scenarios — e.g. a config
+        reload, admin reset command, or recovery from a bad state.
+        """
+        return await self._runtime._rpc("mobkit/rediscover")
+
     async def reconcile_edges(self) -> ReconcileEdgesReport:
         """Re-run edge discovery and reconcile dynamic peer edges.
 

--- a/sdk/python/meerkat_mobkit/types.py
+++ b/sdk/python/meerkat_mobkit/types.py
@@ -177,6 +177,20 @@ class CallToolResult:
 
 
 @dataclass(frozen=True)
+class RediscoverReport:
+    """Report from a rediscover operation (reset + re-run discovery)."""
+    spawned: list[str]
+    edges: ReconcileEdgesReport
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RediscoverReport:
+        return cls(
+            spawned=list(data.get("spawned", [])),
+            edges=ReconcileEdgesReport.from_dict(data.get("edges", {})),
+        )
+
+
+@dataclass(frozen=True)
 class ReconcileEdgesReport:
     """Report from dynamic edge reconciliation."""
     desired_edges: list[dict[str, Any]]

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -14,7 +14,7 @@ class TestNewSymbolsExist:
         "SpawnResult", "SpawnMemberResult", "SubscribeResult",
         "KeepAliveConfig", "EventEnvelope",
         "RoutingResolution", "DeliveryResult", "MemoryQueryResult", "CallToolResult",
-        "ReconcileEdgesReport", "ToolCaller",
+        "ReconcileEdgesReport", "RediscoverReport", "ToolCaller",
         "Event", "MobEvent", "AgentEvent", "EventStream",
         "RunStarted", "RunCompleted", "RunFailed",
         "TurnStarted", "TextDelta", "TextComplete",


### PR DESCRIPTION
Adds a lifecycle operation that resets the mob and replays the boot sequence (discovery + spawn + edge reconciliation).

## What it does

```python
report = await handle.rediscover()
# report["spawned"] → ["agent-1", "agent-2", ...]
# report["edges"] → edge reconciliation report
```

Sequence:
1. `MobHandle::reset()` — retires all, clears projections, restarts MCP servers
2. Re-runs the stored `Discovery` with null context
3. `spawn_many()` for discovered members
4. Clears stale managed dynamic edges
5. `reconcile_edges()` if EdgeDiscovery is configured

## Design change

`Discovery` is now stored on `UnifiedRuntime` instead of being consumed during `build()`. This enables rediscover without providing a new Discovery instance. The Discovery trait takes `&self` so it was always re-invocable — it just wasn't kept around.

`PreSpawnHook` remains `FnOnce` and is NOT replayed on rediscover (consumed at boot). Rediscover passes `Value::Null` as the pre-spawn context.

## Test results
- cargo check clean
- 144 Python tests pass