### PR TITLE
fix: remove all unwrap()/expect() from production code

### DIFF
--- a/crates/meerkat-mobkit-core/src/bin/phase0b_rpc_gateway.rs
+++ b/crates/meerkat-mobkit-core/src/bin/phase0b_rpc_gateway.rs
@@ -396,7 +396,7 @@ async fn run_persistent() {
                 "id": null,
                 "error": { "code": -32700, "message": format!("Parse error: {e}") }
             });
-            println!("{}", serde_json::to_string(&error_response).unwrap());
+            println!("{}", serde_json::to_string(&error_response).unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()));
             std::process::exit(1);
         }
     };
@@ -412,7 +412,7 @@ async fn run_persistent() {
             "id": request_id,
             "error": { "code": -32600, "message": format!("Expected mobkit/init, got {method}") }
         });
-        println!("{}", serde_json::to_string(&error_response).unwrap());
+        println!("{}", serde_json::to_string(&error_response).unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()));
         std::process::exit(1);
     }
 
@@ -442,7 +442,7 @@ external_addressable = true
             "id": request_id,
             "error": { "code": -32602, "message": format!("Invalid mob_config TOML: {e}") }
         });
-        println!("{}", serde_json::to_string(&error_response).unwrap());
+        println!("{}", serde_json::to_string(&error_response).unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()));
         std::process::exit(1);
     });
 
@@ -553,7 +553,7 @@ external_addressable = true
                 "error": { "code": -32603, "message": format!("Runtime bootstrap failed: {e}") }
             });
             let mut stdout = std::io::stdout().lock();
-            let _ = writeln!(stdout, "{}", serde_json::to_string(&error_response).unwrap());
+            let _ = writeln!(stdout, "{}", serde_json::to_string(&error_response).unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()));
             let _ = stdout.flush();
             std::process::exit(1);
         });
@@ -590,7 +590,7 @@ external_addressable = true
         }
     });
     let _ = stdout_tx
-        .send(serde_json::to_string(&init_response).unwrap())
+        .send(serde_json::to_string(&init_response).unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()))
         .await;
 
     // 9. RPC dispatch loop: process queued requests from the stdin reader task

--- a/crates/meerkat-mobkit-core/src/mob_handle_runtime.rs
+++ b/crates/meerkat-mobkit-core/src/mob_handle_runtime.rs
@@ -262,6 +262,7 @@ impl RealMobRuntime {
         self.handle
             .send_message(MeerkatId::from(member_id), message)
             .await
+            .map(|_session_id| ())
             .map_err(Into::into)
     }
 

--- a/crates/meerkat-mobkit-core/src/rpc.rs
+++ b/crates/meerkat-mobkit-core/src/rpc.rs
@@ -1606,17 +1606,22 @@ pub async fn handle_unified_rpc_json(
                         .map(|arr| arr.iter().filter_map(Value::as_str).map(String::from).collect::<Vec<_>>())
                         .and_then(|v| if v.is_empty() { None } else { Some(v) });
 
-                    let spec = meerkat_mob::SpawnMemberSpec {
-                        profile_name: meerkat_mob::ProfileName::from(profile),
-                        meerkat_id: meerkat_mob::MeerkatId::from(meerkat_id),
-                        initial_message: None,
-                        runtime_mode: None,
-                        backend: None,
-                        context,
-                        labels,
-                        resume_session_id,
-                        additional_instructions,
-                    };
+                    let mut spec = meerkat_mob::SpawnMemberSpec::new(
+                        meerkat_mob::ProfileName::from(profile),
+                        meerkat_mob::MeerkatId::from(meerkat_id),
+                    );
+                    if let Some(context) = context {
+                        spec = spec.with_context(context);
+                    }
+                    if let Some(labels) = labels {
+                        spec = spec.with_labels(labels);
+                    }
+                    if let Some(sid) = resume_session_id {
+                        spec = spec.with_resume_session_id(sid);
+                    }
+                    if let Some(instructions) = additional_instructions {
+                        spec = spec.with_additional_instructions(instructions);
+                    }
                     match runtime.ensure_member(spec).await {
                         Ok(snapshot) => JsonRpcResponse {
                             jsonrpc: JSONRPC_VERSION.to_string(),

--- a/crates/meerkat-mobkit-core/src/rpc/session_store_methods.rs
+++ b/crates/meerkat-mobkit-core/src/rpc/session_store_methods.rs
@@ -175,6 +175,7 @@ pub(super) fn run_bigquery_session_store_request(
     match request.operation {
         BigQuerySessionStoreOperation::StreamInsert => {
             block_on_bq(store.stream_insert_rows(&request.rows))
+                .and_then(|inner| inner)
                 .map_err(BigQuerySessionStoreRpcError::Store)?;
             Ok(serde_json::json!({
                 "operation": "stream_insert_rows",
@@ -184,6 +185,7 @@ pub(super) fn run_bigquery_session_store_request(
         }
         BigQuerySessionStoreOperation::ReadAll => {
             let rows = block_on_bq(store.read_rows())
+                .and_then(|inner| inner)
                 .map_err(BigQuerySessionStoreRpcError::Store)?;
             Ok(serde_json::json!({
                 "operation": "read_rows",
@@ -192,6 +194,7 @@ pub(super) fn run_bigquery_session_store_request(
         }
         BigQuerySessionStoreOperation::ReadLatest => {
             let rows = block_on_bq(store.read_latest_rows())
+                .and_then(|inner| inner)
                 .map_err(BigQuerySessionStoreRpcError::Store)?;
             Ok(serde_json::json!({
                 "operation": "read_latest_rows",
@@ -200,6 +203,7 @@ pub(super) fn run_bigquery_session_store_request(
         }
         BigQuerySessionStoreOperation::ReadLive => {
             let rows = block_on_bq(store.read_live_rows())
+                .and_then(|inner| inner)
                 .map_err(BigQuerySessionStoreRpcError::Store)?;
             Ok(serde_json::json!({
                 "operation": "read_live_rows",
@@ -212,20 +216,30 @@ pub(super) fn run_bigquery_session_store_request(
 /// Run an async BQ future from a synchronous RPC context.
 /// Spawns a dedicated thread with its own tokio runtime to avoid
 /// nesting runtimes when the RPC handler runs inside an existing one.
-fn block_on_bq<F: std::future::Future + Send>(future: F) -> F::Output
+fn block_on_bq<F: std::future::Future + Send>(
+    future: F,
+) -> Result<F::Output, BigQuerySessionStoreError>
 where
     F::Output: Send,
 {
     std::thread::scope(|s| {
         s.spawn(|| {
-            tokio::runtime::Builder::new_current_thread()
+            let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .expect("create async runtime for BQ")
-                .block_on(future)
+                .map_err(|err| {
+                    BigQuerySessionStoreError::Io(format!(
+                        "failed to create async runtime for BigQuery: {err}"
+                    ))
+                })?;
+            Ok(rt.block_on(future))
         })
         .join()
-        .expect("BQ async thread panicked")
+        .map_err(|_| {
+            BigQuerySessionStoreError::Io(
+                "BigQuery async worker thread panicked".to_string(),
+            )
+        })?
     })
 }
 

--- a/crates/meerkat-mobkit-core/src/runtime/scheduling.rs
+++ b/crates/meerkat-mobkit-core/src/runtime/scheduling.rs
@@ -10,33 +10,42 @@ pub fn evaluate_schedules_at_tick(
 ) -> Result<ScheduleEvaluation, ScheduleValidationError> {
     validate_schedule_tick_ms_supported(tick_ms)?;
     validate_schedules(schedules)?;
-    let mut due_triggers = schedules
-        .iter()
-        .filter(|schedule| schedule.enabled)
-        .filter_map(|schedule| {
-            let canonical_schedule_id = canonical_schedule_id(&schedule.schedule_id);
-            let interval =
-                parse_schedule_interval(&schedule.interval).expect("validated schedule interval");
-            let timezone =
-                parse_schedule_timezone(&schedule.timezone).expect("validated schedule timezone");
-            let due_tick_ms = latest_due_tick_at_or_before(
-                &canonical_schedule_id,
-                &interval,
-                &timezone,
-                schedule.jitter_ms,
-                tick_ms,
-            )?;
-            if due_tick_ms != tick_ms {
-                return None;
-            }
-            Some(ScheduleTrigger {
-                schedule_id: canonical_schedule_id,
-                interval: schedule.interval.clone(),
-                timezone: schedule.timezone.clone(),
-                due_tick_ms,
-            })
-        })
-        .collect::<Vec<_>>();
+    let mut due_triggers = Vec::new();
+    for schedule in schedules.iter().filter(|s| s.enabled) {
+        let canonical_schedule_id = canonical_schedule_id(&schedule.schedule_id);
+        let interval =
+            parse_schedule_interval(&schedule.interval).ok_or_else(|| {
+                ScheduleValidationError::InvalidInterval {
+                    schedule_id: canonical_schedule_id.clone(),
+                    interval: schedule.interval.clone(),
+                }
+            })?;
+        let timezone =
+            parse_schedule_timezone(&schedule.timezone).ok_or_else(|| {
+                ScheduleValidationError::InvalidTimezone {
+                    schedule_id: canonical_schedule_id.clone(),
+                    timezone: schedule.timezone.clone(),
+                }
+            })?;
+        let Some(due_tick_ms) = latest_due_tick_at_or_before(
+            &canonical_schedule_id,
+            &interval,
+            &timezone,
+            schedule.jitter_ms,
+            tick_ms,
+        ) else {
+            continue;
+        };
+        if due_tick_ms != tick_ms {
+            continue;
+        }
+        due_triggers.push(ScheduleTrigger {
+            schedule_id: canonical_schedule_id,
+            interval: schedule.interval.clone(),
+            timezone: schedule.timezone.clone(),
+            due_tick_ms,
+        });
+    }
 
     due_triggers.sort_by(|left, right| {
         left.due_tick_ms
@@ -179,38 +188,43 @@ impl MobkitRuntimeHandle {
         validate_schedules(schedules)?;
         self.prune_schedule_claims(tick_ms);
         self.prune_scheduling_last_due_ticks(tick_ms);
-        let mut due_triggers = schedules
-            .iter()
-            .filter(|schedule| schedule.enabled)
-            .filter_map(|schedule| {
-                let canonical_schedule_id = canonical_schedule_id(&schedule.schedule_id);
-                let interval = parse_schedule_interval(&schedule.interval)
-                    .expect("validated schedule interval");
-                let timezone = parse_schedule_timezone(&schedule.timezone)
-                    .expect("validated schedule timezone");
-                let due_tick_ms = latest_due_tick_at_or_before(
-                    &canonical_schedule_id,
-                    &interval,
-                    &timezone,
-                    schedule.jitter_ms,
-                    tick_ms,
-                )?;
-                let last_due_tick = self
-                    .scheduling_last_due_ticks
-                    .get(&canonical_schedule_id)
-                    .copied();
-                if schedule.catch_up {
-                    if last_due_tick.is_some_and(|last| last >= due_tick_ms) {
-                        return None;
-                    }
-                } else if last_due_tick
-                    .is_some_and(|last| last >= due_tick_ms && due_tick_ms != tick_ms)
-                {
-                    return None;
+        let mut due_triggers = Vec::new();
+        for schedule in schedules.iter().filter(|s| s.enabled) {
+            let canonical_schedule_id = canonical_schedule_id(&schedule.schedule_id);
+            let interval = parse_schedule_interval(&schedule.interval)
+                .ok_or_else(|| ScheduleValidationError::InvalidInterval {
+                    schedule_id: canonical_schedule_id.clone(),
+                    interval: schedule.interval.clone(),
+                })?;
+            let timezone = parse_schedule_timezone(&schedule.timezone)
+                .ok_or_else(|| ScheduleValidationError::InvalidTimezone {
+                    schedule_id: canonical_schedule_id.clone(),
+                    timezone: schedule.timezone.clone(),
+                })?;
+            let Some(due_tick_ms) = latest_due_tick_at_or_before(
+                &canonical_schedule_id,
+                &interval,
+                &timezone,
+                schedule.jitter_ms,
+                tick_ms,
+            ) else {
+                continue;
+            };
+            let last_due_tick = self
+                .scheduling_last_due_ticks
+                .get(&canonical_schedule_id)
+                .copied();
+            if schedule.catch_up {
+                if last_due_tick.is_some_and(|last| last >= due_tick_ms) {
+                    continue;
                 }
-                Some((schedule, canonical_schedule_id, due_tick_ms))
-            })
-            .collect::<Vec<_>>();
+            } else if last_due_tick
+                .is_some_and(|last| last >= due_tick_ms && due_tick_ms != tick_ms)
+            {
+                continue;
+            }
+            due_triggers.push((schedule, canonical_schedule_id, due_tick_ms));
+        }
         due_triggers.sort_by(
             |(left_schedule, left_schedule_id, left_due_tick),
              (right_schedule, right_schedule_id, right_due_tick)| {

--- a/crates/meerkat-mobkit-core/src/runtime/session_store.rs
+++ b/crates/meerkat-mobkit-core/src/runtime/session_store.rs
@@ -624,10 +624,16 @@ pub fn run_periodic_gc(
     config: BigQueryGcConfig,
 ) -> impl FnOnce() {
     move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
+        let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .expect("create async runtime for BQ GC");
+        {
+            Ok(rt) => rt,
+            Err(err) => {
+                eprintln!("[mobkit-gc] failed to create async runtime for BQ GC: {err}");
+                return;
+            }
+        };
         loop {
             std::thread::sleep(config.interval);
             match rt.block_on(adapter.gc_superseded_rows()) {

--- a/crates/meerkat-mobkit-core/src/unified_runtime/edge_reconcile.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/edge_reconcile.rs
@@ -227,7 +227,7 @@ impl UnifiedRuntime {
         active_members.sort();
         active_members.dedup();
 
-        let mut rt = self.module_runtime.lock().unwrap();
+        let mut rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
         let router_module_loaded = rt
             .loaded_modules()
             .iter()

--- a/crates/meerkat-mobkit-core/src/unified_runtime/lifecycle.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/lifecycle.rs
@@ -135,7 +135,7 @@ impl UnifiedRuntime {
         self.close_event_router().await;
 
         // Phase 3: Shutdown modules and mob
-        let module_shutdown = self.module_runtime.lock().unwrap().shutdown();
+        let module_shutdown = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).shutdown();
         let mob_stop = self.mob_runtime.stop().await;
         UnifiedRuntimeShutdownReport {
             drain,
@@ -156,7 +156,7 @@ impl UnifiedRuntime {
         loop {
             match Self::try_recv_ingress_event(ingress) {
                 Some(Ok(unified_event)) => {
-                    self.module_runtime.lock().unwrap().append_normalized_event(unified_event)?
+                    self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).append_normalized_event(unified_event)?
                 }
                 Some(Err(TryRecvError::Empty)) => break,
                 Some(Err(TryRecvError::Disconnected)) => {
@@ -225,7 +225,7 @@ impl UnifiedRuntime {
 
             match injection_result {
                 Ok(()) => {
-                    self.module_runtime.lock().unwrap().append_normalized_event(EventEnvelope {
+                    self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).append_normalized_event(EventEnvelope {
                         event_id: format!("{}-executed", runtime_injection.injection_event_id),
                         source: "module".to_string(),
                         timestamp_ms: dispatch.tick_ms,
@@ -243,7 +243,7 @@ impl UnifiedRuntime {
                 }
                 Err(error) => {
                     dispatch.runtime_injection_error = Some(format!("mob injection failed: {error}"));
-                    self.module_runtime.lock().unwrap().append_normalized_event(EventEnvelope {
+                    self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).append_normalized_event(EventEnvelope {
                         event_id: format!("{}-failed", runtime_injection.injection_event_id),
                         source: "module".to_string(),
                         timestamp_ms: dispatch.tick_ms,
@@ -277,7 +277,7 @@ impl UnifiedRuntime {
             .is_ok_and(|handle| handle.runtime_flavor() == RuntimeFlavor::MultiThread)
         {
             tokio::task::block_in_place(|| {
-                let mut rt = self.module_runtime.lock().unwrap();
+                let mut rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
                 Self::dispatch_schedule_tick_in_joined_thread(
                     &mut rt,
                     schedules,
@@ -285,7 +285,7 @@ impl UnifiedRuntime {
                 )
             })
         } else {
-            let mut rt = self.module_runtime.lock().unwrap();
+            let mut rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
             Self::dispatch_schedule_tick_in_joined_thread(
                 &mut rt,
                 schedules,

--- a/crates/meerkat-mobkit-core/src/unified_runtime/mob_ops.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/mob_ops.rs
@@ -76,17 +76,11 @@ impl UnifiedRuntime {
         meerkat_id: &str,
         labels: BTreeMap<String, String>,
     ) -> Result<MobMemberSnapshot, MobRuntimeError> {
-        let spec = SpawnMemberSpec {
-            profile_name: meerkat_mob::ProfileName::from(profile),
-            meerkat_id: meerkat_mob::MeerkatId::from(meerkat_id),
-            initial_message: None,
-            runtime_mode: None,
-            backend: None,
-            context: None,
-            labels: Some(labels),
-            resume_session_id: None,
-            additional_instructions: None,
-        };
+        let spec = SpawnMemberSpec::new(
+            meerkat_mob::ProfileName::from(profile),
+            meerkat_mob::MeerkatId::from(meerkat_id),
+        )
+        .with_labels(labels);
         self.ensure_member(spec).await
     }
 }

--- a/crates/meerkat-mobkit-core/src/unified_runtime/mod.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/mod.rs
@@ -71,17 +71,23 @@ pub fn discovery_spec_to_spawn_spec(spec: &AgentDiscoverySpec) -> SpawnMemberSpe
     } else {
         Some(spec.additional_instructions.clone())
     };
-    SpawnMemberSpec {
-        profile_name: meerkat_mob::ProfileName::from(spec.profile.as_str()),
-        meerkat_id: MeerkatId::from(spec.meerkat_id.as_str()),
-        initial_message: None,
-        runtime_mode: None,
-        backend: None,
-        context: spec.context.clone(),
-        labels: spec.labels.clone(),
-        resume_session_id,
-        additional_instructions,
+    let mut spawn = SpawnMemberSpec::new(
+        meerkat_mob::ProfileName::from(spec.profile.as_str()),
+        MeerkatId::from(spec.meerkat_id.as_str()),
+    );
+    if let Some(context) = spec.context.clone() {
+        spawn = spawn.with_context(context);
     }
+    if let Some(labels) = spec.labels.clone() {
+        spawn = spawn.with_labels(labels);
+    }
+    if let Some(sid) = resume_session_id {
+        spawn = spawn.with_resume_session_id(sid);
+    }
+    if let Some(instructions) = additional_instructions {
+        spawn = spawn.with_additional_instructions(instructions);
+    }
+    spawn
 }
 
 pub struct UnifiedRuntime {

--- a/crates/meerkat-mobkit-core/src/unified_runtime/module_ops.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/module_ops.rs
@@ -18,11 +18,11 @@ use super::UnifiedRuntime;
 
 impl UnifiedRuntime {
     pub fn module_is_running(&self) -> bool {
-        self.module_runtime.lock().unwrap().is_running()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).is_running()
     }
 
     pub fn loaded_modules(&self) -> Vec<String> {
-        self.module_runtime.lock().unwrap().loaded_modules()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).loaded_modules()
     }
 
     pub fn reconcile_modules(
@@ -30,21 +30,21 @@ impl UnifiedRuntime {
         modules: Vec<String>,
         timeout: Duration,
     ) -> Result<usize, RuntimeMutationError> {
-        self.module_runtime.lock().unwrap().reconcile_modules(modules, timeout)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).reconcile_modules(modules, timeout)
     }
 
     pub fn resolve_routing(
         &self,
         request: RoutingResolveRequest,
     ) -> Result<RoutingResolution, RoutingResolveError> {
-        self.module_runtime.lock().unwrap().resolve_routing(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).resolve_routing(request)
     }
 
     pub fn send_delivery(
         &self,
         request: DeliverySendRequest,
     ) -> Result<DeliveryRecord, DeliverySendError> {
-        self.module_runtime.lock().unwrap().send_delivery(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).send_delivery(request)
     }
 
     pub fn evaluate_schedule_tick(
@@ -52,66 +52,66 @@ impl UnifiedRuntime {
         schedules: &[ScheduleDefinition],
         tick_ms: u64,
     ) -> Result<ScheduleEvaluation, ScheduleValidationError> {
-        self.module_runtime.lock().unwrap().evaluate_schedule_tick(schedules, tick_ms)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).evaluate_schedule_tick(schedules, tick_ms)
     }
 
     pub fn list_runtime_routes(&self) -> Vec<RuntimeRoute> {
-        self.module_runtime.lock().unwrap().list_runtime_routes()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).list_runtime_routes()
     }
 
     pub fn add_runtime_route(
         &self,
         route: RuntimeRoute,
     ) -> Result<RuntimeRoute, RuntimeRouteMutationError> {
-        self.module_runtime.lock().unwrap().add_runtime_route(route)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).add_runtime_route(route)
     }
 
     pub fn delete_runtime_route(
         &self,
         route_key: &str,
     ) -> Result<RuntimeRoute, RuntimeRouteMutationError> {
-        self.module_runtime.lock().unwrap().delete_runtime_route(route_key)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).delete_runtime_route(route_key)
     }
 
     pub fn delivery_history(&self, request: DeliveryHistoryRequest) -> DeliveryHistoryResponse {
-        self.module_runtime.lock().unwrap().delivery_history(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).delivery_history(request)
     }
 
     pub fn memory_stores(&self) -> Vec<MemoryStoreInfo> {
-        self.module_runtime.lock().unwrap().memory_stores()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).memory_stores()
     }
 
     pub fn memory_index(
         &self,
         request: MemoryIndexRequest,
     ) -> Result<MemoryIndexResult, MemoryIndexError> {
-        self.module_runtime.lock().unwrap().memory_index(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).memory_index(request)
     }
 
     pub fn memory_query(&self, request: MemoryQueryRequest) -> MemoryQueryResult {
-        self.module_runtime.lock().unwrap().memory_query(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).memory_query(request)
     }
 
     pub fn evaluate_gating_action(
         &self,
         request: GatingEvaluateRequest,
     ) -> GatingEvaluateResult {
-        self.module_runtime.lock().unwrap().evaluate_gating_action(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).evaluate_gating_action(request)
     }
 
     pub fn list_gating_pending(&self) -> Vec<GatingPendingEntry> {
-        self.module_runtime.lock().unwrap().list_gating_pending()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).list_gating_pending()
     }
 
     pub fn decide_gating_action(
         &self,
         request: GatingDecideRequest,
     ) -> Result<GatingDecisionResult, GatingDecideError> {
-        self.module_runtime.lock().unwrap().decide_gating_action(request)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).decide_gating_action(request)
     }
 
     pub fn gating_audit_entries(&self, limit: usize) -> Vec<GatingAuditEntry> {
-        self.module_runtime.lock().unwrap().gating_audit_entries(limit)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).gating_audit_entries(limit)
     }
 
     pub fn spawn_member(
@@ -119,7 +119,7 @@ impl UnifiedRuntime {
         module_id: &str,
         timeout: Duration,
     ) -> Result<(), RuntimeMutationError> {
-        self.module_runtime.lock().unwrap().spawn_member(module_id, timeout)
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).spawn_member(module_id, timeout)
     }
 
     pub fn route_module_call(
@@ -127,20 +127,20 @@ impl UnifiedRuntime {
         request: &ModuleRouteRequest,
         timeout: Duration,
     ) -> Result<ModuleRouteResponse, ModuleRouteError> {
-        let rt = self.module_runtime.lock().unwrap();
+        let rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
         route_module_call(&rt, request, timeout)
     }
 
     pub fn module_lifecycle_events(&self) -> Vec<LifecycleEvent> {
-        self.module_runtime.lock().unwrap().lifecycle_events.clone()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).lifecycle_events.clone()
     }
 
     pub fn module_health_transitions(&self) -> Vec<ModuleHealthTransition> {
-        self.module_runtime.lock().unwrap().supervisor_report.transitions.clone()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).supervisor_report.transitions.clone()
     }
 
     pub fn module_events(&self) -> Vec<EventEnvelope<UnifiedEvent>> {
-        self.module_runtime.lock().unwrap().merged_events().to_vec()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).merged_events().to_vec()
     }
 
     pub fn subscribe_events(
@@ -148,7 +148,7 @@ impl UnifiedRuntime {
         request: SubscribeRequest,
     ) -> Result<SubscribeResponse, UnifiedRuntimeError> {
         self.drain_mob_agent_events()?;
-        self.module_runtime.lock().unwrap()
+        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner())
             .subscribe_events(request)
             .map_err(UnifiedRuntimeError::Subscribe)
     }


### PR DESCRIPTION
## Summary

- Replace 30 `module_runtime.lock().unwrap()` with `.unwrap_or_else(|e| e.into_inner())` for mutex poison recovery instead of panicking
- Replace BQ runtime `.expect()` in session_store_methods with proper error propagation through JSON-RPC error responses (code `-32011`)
- Replace BQ GC runtime `.expect()` in session_store with graceful degradation (log to stderr, skip GC cycle)
- Replace scheduling `.expect("validated ...")` with proper error returns via existing `ScheduleValidationError` variants
- Replace gateway `serde_json::to_string().unwrap()` with fallback error strings
- Adapt to upstream meerkat-mob 0.4.6 changes: `SpawnMemberSpec` builder pattern (`#[non_exhaustive]` + `shell_env` field), `send_message` return type (`SessionId`)

Only startup `expect()` calls remain in the gateway binary (env vars, port binding, tempdir) — appropriate for binary entry points. Zero `unwrap()`/`expect()` in library code.

## Test plan

- [x] `cargo check -p meerkat-mobkit-core` — zero warnings, zero errors
- [x] `cargo nextest run --workspace -E 'not test(phase0_governance)'` — 225/225 passed
- [x] `rg '.unwrap()|.expect(' src/ | grep -v test | grep -v bin/` — returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)