### PR TITLE
fix: switch module_runtime to tokio::sync::Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "gix",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "dirs",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4737,8 +4737,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[patch.unused]]
 name = "meerkat-rest"
-version = "0.4.5"
+version = "0.4.6"
 
 [[patch.unused]]
 name = "meerkat-rpc"
-version = "0.4.5"
+version = "0.4.6"

--- a/crates/meerkat-mobkit-core/examples/library_mode_reference.rs
+++ b/crates/meerkat-mobkit-core/examples/library_mode_reference.rs
@@ -46,13 +46,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     runtime.reconcile(reference_member_specs()).await?;
-    runtime.subscribe_events(SubscribeRequest::default())?;
+    runtime.subscribe_events(SubscribeRequest::default()).await?;
     let empty_schedules = Vec::<ScheduleDefinition>::new();
     runtime
         .dispatch_schedule_tick(&empty_schedules, 60_000)
         .await?;
-    let _ = runtime.reconcile_modules(Vec::new(), std::time::Duration::from_secs(1));
-    let loaded_modules = runtime.loaded_modules();
+    let _ = runtime.reconcile_modules(Vec::new(), std::time::Duration::from_secs(1)).await;
+    let loaded_modules = runtime.loaded_modules().await;
     if loaded_modules.iter().any(|module| module == "router")
         && loaded_modules.iter().any(|module| module == "delivery")
     {
@@ -63,13 +63,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 retry_max: Some(1),
                 backoff_ms: Some(250),
                 rate_limit_per_minute: Some(2),
-            })
+            }).await
         {
             let _ = runtime.send_delivery(meerkat_mobkit_core::runtime::DeliverySendRequest {
                 resolution,
                 payload: serde_json::json!({"message":"reference-app smoke"}),
                 idempotency_key: Some("reference-app-smoke".to_string()),
-            });
+            }).await;
         }
     }
 

--- a/crates/meerkat-mobkit-core/src/bin/phase0b_rpc_gateway.rs
+++ b/crates/meerkat-mobkit-core/src/bin/phase0b_rpc_gateway.rs
@@ -580,7 +580,7 @@ external_addressable = true
     });
 
     // 8. Send init response via stdout channel
-    let loaded_modules = runtime.loaded_modules();
+    let loaded_modules = runtime.loaded_modules().await;
     let init_response = json!({
         "jsonrpc": "2.0",
         "id": request_id,

--- a/crates/meerkat-mobkit-core/src/rpc.rs
+++ b/crates/meerkat-mobkit-core/src/rpc.rs
@@ -877,10 +877,12 @@ pub async fn handle_unified_rpc_json(
     let response = match request.method.as_str() {
         "mobkit/status" => {
             let mob_state = runtime.status();
+            let is_running = runtime.module_is_running().await;
+            let loaded = runtime.loaded_modules().await;
             let mut result = serde_json::json!({
                 "contract_version": MOBKIT_CONTRACT_VERSION,
-                "running": runtime.module_is_running(),
-                "loaded_modules": runtime.loaded_modules(),
+                "running": is_running,
+                "loaded_modules": loaded,
                 "mob_state": format!("{mob_state:?}"),
             });
             if let Some(url) = http_base_url {
@@ -893,46 +895,49 @@ pub async fn handle_unified_rpc_json(
                 error: None,
             }
         }
-        "mobkit/capabilities" => JsonRpcResponse {
-            jsonrpc: JSONRPC_VERSION.to_string(),
-            id: response_id.clone(),
-            result: Some(serde_json::json!({
-                "contract_version": MOBKIT_CONTRACT_VERSION,
-                "runtime_type": "unified",
-                "methods": [
-                    "mobkit/init",
-                    "mobkit/status",
-                    "mobkit/capabilities",
-                    "mobkit/reconcile",
-                    "mobkit/spawn_member",
-                    "mobkit/scheduling/evaluate",
-                    "mobkit/scheduling/dispatch",
-                    "mobkit/routing/resolve",
-                    "mobkit/routing/routes/list",
-                    "mobkit/routing/routes/add",
-                    "mobkit/routing/routes/delete",
-                    "mobkit/delivery/send",
-                    "mobkit/delivery/history",
-                    "mobkit/events/subscribe",
-                    "mobkit/memory/stores",
-                    "mobkit/memory/index",
-                    "mobkit/memory/query",
-                    "mobkit/session_store/bigquery",
-                    "mobkit/gating/evaluate",
-                    "mobkit/gating/pending",
-                    "mobkit/gating/decide",
-                    "mobkit/gating/audit",
-                    "mobkit/call_tool",
-                    "mobkit/send_message",
-                    "mobkit/find_members",
-                    "mobkit/ensure_member",
-                    "mobkit/reconcile_edges",
-                    "mobkit/rediscover"
-                ],
-                "loaded_modules": runtime.loaded_modules()
-            })),
-            error: None,
-        },
+        "mobkit/capabilities" => {
+            let loaded = runtime.loaded_modules().await;
+            JsonRpcResponse {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: response_id.clone(),
+                result: Some(serde_json::json!({
+                    "contract_version": MOBKIT_CONTRACT_VERSION,
+                    "runtime_type": "unified",
+                    "methods": [
+                        "mobkit/init",
+                        "mobkit/status",
+                        "mobkit/capabilities",
+                        "mobkit/reconcile",
+                        "mobkit/spawn_member",
+                        "mobkit/scheduling/evaluate",
+                        "mobkit/scheduling/dispatch",
+                        "mobkit/routing/resolve",
+                        "mobkit/routing/routes/list",
+                        "mobkit/routing/routes/add",
+                        "mobkit/routing/routes/delete",
+                        "mobkit/delivery/send",
+                        "mobkit/delivery/history",
+                        "mobkit/events/subscribe",
+                        "mobkit/memory/stores",
+                        "mobkit/memory/index",
+                        "mobkit/memory/query",
+                        "mobkit/session_store/bigquery",
+                        "mobkit/gating/evaluate",
+                        "mobkit/gating/pending",
+                        "mobkit/gating/decide",
+                        "mobkit/gating/audit",
+                        "mobkit/call_tool",
+                        "mobkit/send_message",
+                        "mobkit/find_members",
+                        "mobkit/ensure_member",
+                        "mobkit/reconcile_edges",
+                        "mobkit/rediscover"
+                    ],
+                    "loaded_modules": loaded
+                })),
+                error: None,
+            }
+        }
         "mobkit/reconcile" => {
             let modules = request
                 .params
@@ -946,7 +951,7 @@ pub async fn handle_unified_rpc_json(
                 })
                 .unwrap_or_default();
 
-            match runtime.reconcile_modules(modules.clone(), timeout) {
+            match runtime.reconcile_modules(modules.clone(), timeout).await {
                 Ok(added) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -987,7 +992,7 @@ pub async fn handle_unified_rpc_json(
                         }),
                     }
                 } else {
-                    match runtime.spawn_member(module_id, timeout) {
+                    match runtime.spawn_member(module_id, timeout).await {
                         Ok(()) => JsonRpcResponse {
                             jsonrpc: JSONRPC_VERSION.to_string(),
                             id: response_id.clone(),
@@ -1055,26 +1060,28 @@ pub async fn handle_unified_rpc_json(
             }
         }
         "mobkit/scheduling/evaluate" => match parse_scheduling_params(&request.params) {
-            Ok((schedules, tick_ms)) => match runtime.evaluate_schedule_tick(&schedules, tick_ms) {
-                Ok(evaluation) => JsonRpcResponse {
-                    jsonrpc: JSONRPC_VERSION.to_string(),
-                    id: response_id.clone(),
-                    result: Some(serde_json::to_value(evaluation).unwrap_or(Value::Null)),
-                    error: None,
-                },
-                Err(err) => JsonRpcResponse {
-                    jsonrpc: JSONRPC_VERSION.to_string(),
-                    id: response_id.clone(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32602,
-                        message: format!(
-                            "Invalid params: {}",
-                            format_schedule_validation_error(err)
-                        ),
-                    }),
-                },
-            },
+            Ok((schedules, tick_ms)) => {
+                match runtime.evaluate_schedule_tick(&schedules, tick_ms).await {
+                    Ok(evaluation) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id.clone(),
+                        result: Some(serde_json::to_value(evaluation).unwrap_or(Value::Null)),
+                        error: None,
+                    },
+                    Err(err) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id.clone(),
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32602,
+                            message: format!(
+                                "Invalid params: {}",
+                                format_schedule_validation_error(err)
+                            ),
+                        }),
+                    },
+                }
+            }
             Err(message) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1116,11 +1123,14 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/routing/resolve" => {
-            match parse_routing_resolve_params(&request.params).and_then(|resolve_request| {
-                runtime
+            let resolve_result = match parse_routing_resolve_params(&request.params) {
+                Ok(resolve_request) => runtime
                     .resolve_routing(resolve_request)
-                    .map_err(RoutingDeliveryParamsError::Routing)
-            }) {
+                    .await
+                    .map_err(RoutingDeliveryParamsError::Routing),
+                Err(e) => Err(e),
+            };
+            match resolve_result {
                 Ok(resolution) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -1139,14 +1149,17 @@ pub async fn handle_unified_rpc_json(
             }
         }
         "mobkit/routing/routes/list" => match parse_routing_routes_list_params(&request.params) {
-            Ok(()) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(serde_json::json!({
-                    "routes": runtime.list_runtime_routes()
-                })),
-                error: None,
-            },
+            Ok(()) => {
+                let routes = runtime.list_runtime_routes().await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::json!({
+                        "routes": routes
+                    })),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1157,34 +1170,41 @@ pub async fn handle_unified_rpc_json(
                 }),
             },
         },
-        "mobkit/routing/routes/add" => match parse_routing_route_add_params(&request.params)
-            .and_then(|route| {
-                runtime
+        "mobkit/routing/routes/add" => {
+            let add_result = match parse_routing_route_add_params(&request.params) {
+                Ok(route) => runtime
                     .add_runtime_route(route)
-                    .map_err(RoutingDeliveryParamsError::RouteMutation)
-            }) {
-            Ok(route) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(serde_json::json!({ "route": route })),
-                error: None,
-            },
-            Err(err) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32602,
-                    message: format!("Invalid params: {}", err.message()),
-                }),
-            },
-        },
+                    .await
+                    .map_err(RoutingDeliveryParamsError::RouteMutation),
+                Err(e) => Err(e),
+            };
+            match add_result {
+                Ok(route) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::json!({ "route": route })),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: format!("Invalid params: {}", err.message()),
+                    }),
+                },
+            }
+        }
         "mobkit/routing/routes/delete" => {
-            match parse_routing_route_delete_params(&request.params).and_then(|route_key| {
-                runtime
+            let delete_result = match parse_routing_route_delete_params(&request.params) {
+                Ok(route_key) => runtime
                     .delete_runtime_route(&route_key)
-                    .map_err(RoutingDeliveryParamsError::RouteMutation)
-            }) {
+                    .await
+                    .map_err(RoutingDeliveryParamsError::RouteMutation),
+                Err(e) => Err(e),
+            };
+            match delete_result {
                 Ok(route) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -1203,11 +1223,14 @@ pub async fn handle_unified_rpc_json(
             }
         }
         "mobkit/delivery/send" => {
-            match parse_delivery_send_params(&request.params).and_then(|send_request| {
-                runtime
+            let send_result = match parse_delivery_send_params(&request.params) {
+                Ok(send_request) => runtime
                     .send_delivery(send_request)
-                    .map_err(RoutingDeliveryParamsError::Delivery)
-            }) {
+                    .await
+                    .map_err(RoutingDeliveryParamsError::Delivery),
+                Err(e) => Err(e),
+            };
+            match send_result {
                 Ok(record) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -1226,15 +1249,18 @@ pub async fn handle_unified_rpc_json(
             }
         }
         "mobkit/delivery/history" => match parse_delivery_history_params(&request.params) {
-            Ok(history_request) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(
-                    serde_json::to_value(runtime.delivery_history(history_request))
-                        .unwrap_or(Value::Null),
-                ),
-                error: None,
-            },
+            Ok(history_request) => {
+                let history = runtime.delivery_history(history_request).await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(
+                        serde_json::to_value(history)
+                            .unwrap_or(Value::Null),
+                    ),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1246,7 +1272,7 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/events/subscribe" => match parse_subscribe_request(&request.params) {
-            Ok(subscribe_request) => match runtime.subscribe_events(subscribe_request) {
+            Ok(subscribe_request) => match runtime.subscribe_events(subscribe_request).await {
                 Ok(subscribe_result) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -1274,14 +1300,17 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/memory/stores" => match parse_memory_stores_params(&request.params) {
-            Ok(()) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(serde_json::json!({
-                    "stores": runtime.memory_stores(),
-                })),
-                error: None,
-            },
+            Ok(()) => {
+                let stores = runtime.memory_stores().await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::json!({
+                        "stores": stores,
+                    })),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1293,7 +1322,7 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/memory/index" => match parse_memory_index_params(&request.params) {
-            Ok(index_request) => match runtime.memory_index(index_request) {
+            Ok(index_request) => match runtime.memory_index(index_request).await {
                 Ok(indexed) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -1336,15 +1365,18 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/memory/query" => match parse_memory_query_params(&request.params) {
-            Ok(query_request) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(
-                    serde_json::to_value(runtime.memory_query(query_request))
-                        .unwrap_or(Value::Null),
-                ),
-                error: None,
-            },
+            Ok(query_request) => {
+                let query_result = runtime.memory_query(query_request).await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(
+                        serde_json::to_value(query_result)
+                            .unwrap_or(Value::Null),
+                    ),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1389,15 +1421,18 @@ pub async fn handle_unified_rpc_json(
             }
         }
         "mobkit/gating/evaluate" => match parse_gating_evaluate_params(&request.params) {
-            Ok(gating_request) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(
-                    serde_json::to_value(runtime.evaluate_gating_action(gating_request))
-                        .unwrap_or(Value::Null),
-                ),
-                error: None,
-            },
+            Ok(gating_request) => {
+                let gating_result = runtime.evaluate_gating_action(gating_request).await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(
+                        serde_json::to_value(gating_result)
+                            .unwrap_or(Value::Null),
+                    ),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1409,14 +1444,17 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/gating/pending" => match parse_gating_pending_params(&request.params) {
-            Ok(()) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(serde_json::json!({
-                    "pending": runtime.list_gating_pending(),
-                })),
-                error: None,
-            },
+            Ok(()) => {
+                let pending = runtime.list_gating_pending().await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::json!({
+                        "pending": pending,
+                    })),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1428,11 +1466,14 @@ pub async fn handle_unified_rpc_json(
             },
         },
         "mobkit/gating/decide" => {
-            match parse_gating_decide_params(&request.params).and_then(|decide_request| {
-                runtime
+            let decide_result = match parse_gating_decide_params(&request.params) {
+                Ok(decide_request) => runtime
                     .decide_gating_action(decide_request)
-                    .map_err(GatingParamsError::Decision)
-            }) {
+                    .await
+                    .map_err(GatingParamsError::Decision),
+                Err(e) => Err(e),
+            };
+            match decide_result {
                 Ok(result) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id.clone(),
@@ -1451,14 +1492,17 @@ pub async fn handle_unified_rpc_json(
             }
         }
         "mobkit/gating/audit" => match parse_gating_audit_params(&request.params) {
-            Ok(limit) => JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id.clone(),
-                result: Some(serde_json::json!({
-                    "entries": runtime.gating_audit_entries(limit),
-                })),
-                error: None,
-            },
+            Ok(limit) => {
+                let entries = runtime.gating_audit_entries(limit).await;
+                JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id.clone(),
+                    result: Some(serde_json::json!({
+                        "entries": entries,
+                    })),
+                    error: None,
+                }
+            }
             Err(err) => JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id.clone(),
@@ -1483,7 +1527,7 @@ pub async fn handle_unified_rpc_json(
                             params: arguments,
                         },
                         timeout,
-                    );
+                    ).await;
                     match route {
                         Ok(response) => JsonRpcResponse {
                             jsonrpc: JSONRPC_VERSION.to_string(),
@@ -1700,7 +1744,7 @@ pub async fn handle_unified_rpc_json(
                     params: request.params,
                 },
                 timeout,
-            );
+            ).await;
             match route {
                 Ok(response) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),

--- a/crates/meerkat-mobkit-core/src/unified_runtime/edge_reconcile.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/edge_reconcile.rs
@@ -35,7 +35,7 @@ impl UnifiedRuntime {
             .reconcile_edges_from_members(active_snapshots)
             .await;
         // 5. Routing reconcile
-        let routing = self.reconcile_routing_wiring(active_member_ids)?;
+        let routing = self.reconcile_routing_wiring(active_member_ids).await?;
         let report = UnifiedRuntimeReconcileReport { mob, edges, routing };
         if let Some(hook) = &self.post_reconcile_hook {
             hook(report.clone()).await;
@@ -220,14 +220,14 @@ impl UnifiedRuntime {
         report
     }
 
-    pub(super) fn reconcile_routing_wiring(
+    pub(super) async fn reconcile_routing_wiring(
         &self,
         mut active_members: Vec<String>,
     ) -> Result<UnifiedRuntimeReconcileRoutingReport, UnifiedRuntimeReconcileError> {
         active_members.sort();
         active_members.dedup();
 
-        let mut rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
+        let mut rt = self.module_runtime.lock().await;
         let router_module_loaded = rt
             .loaded_modules()
             .iter()

--- a/crates/meerkat-mobkit-core/src/unified_runtime/lifecycle.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/lifecycle.rs
@@ -109,7 +109,7 @@ impl UnifiedRuntime {
         let mut drained_count = 0_usize;
         let drain_result = tokio::time::timeout(self.drain_timeout, async {
             loop {
-                if self.drain_mob_agent_events().is_err() {
+                if self.drain_mob_agent_events().await.is_err() {
                     break;
                 }
                 let ingress = self.mob_event_ingress.lock().await;
@@ -135,7 +135,7 @@ impl UnifiedRuntime {
         self.close_event_router().await;
 
         // Phase 3: Shutdown modules and mob
-        let module_shutdown = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).shutdown();
+        let module_shutdown = self.module_runtime.lock().await.shutdown();
         let mob_stop = self.mob_runtime.stop().await;
         UnifiedRuntimeShutdownReport {
             drain,
@@ -144,7 +144,7 @@ impl UnifiedRuntime {
         }
     }
 
-    pub(super) fn drain_mob_agent_events(&self) -> Result<(), UnifiedRuntimeError> {
+    pub(super) async fn drain_mob_agent_events(&self) -> Result<(), UnifiedRuntimeError> {
         let mut disconnected = false;
         let mut ingress_guard = self.mob_event_ingress.try_lock()
             .map_err(|_| UnifiedRuntimeError::RuntimeShuttingDown)?;
@@ -156,7 +156,7 @@ impl UnifiedRuntime {
         loop {
             match Self::try_recv_ingress_event(ingress) {
                 Some(Ok(unified_event)) => {
-                    self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).append_normalized_event(unified_event)?
+                    self.module_runtime.lock().await.append_normalized_event(unified_event)?
                 }
                 Some(Err(TryRecvError::Empty)) => break,
                 Some(Err(TryRecvError::Disconnected)) => {
@@ -208,7 +208,7 @@ impl UnifiedRuntime {
         if self.shutting_down.load(Ordering::SeqCst) {
             return Err(UnifiedRuntimeError::RuntimeShuttingDown);
         }
-        let mut dispatch_report = self.dispatch_schedule_tick_blocking(schedules, tick_ms)?;
+        let mut dispatch_report = self.dispatch_schedule_tick_blocking(schedules, tick_ms).await?;
 
         for dispatch in &mut dispatch_report.dispatched {
             let Some(runtime_injection) = dispatch.runtime_injection.clone() else {
@@ -225,7 +225,7 @@ impl UnifiedRuntime {
 
             match injection_result {
                 Ok(()) => {
-                    self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).append_normalized_event(EventEnvelope {
+                    self.module_runtime.lock().await.append_normalized_event(EventEnvelope {
                         event_id: format!("{}-executed", runtime_injection.injection_event_id),
                         source: "module".to_string(),
                         timestamp_ms: dispatch.tick_ms,
@@ -243,7 +243,7 @@ impl UnifiedRuntime {
                 }
                 Err(error) => {
                     dispatch.runtime_injection_error = Some(format!("mob injection failed: {error}"));
-                    self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).append_normalized_event(EventEnvelope {
+                    self.module_runtime.lock().await.append_normalized_event(EventEnvelope {
                         event_id: format!("{}-failed", runtime_injection.injection_event_id),
                         source: "module".to_string(),
                         timestamp_ms: dispatch.tick_ms,
@@ -264,20 +264,21 @@ impl UnifiedRuntime {
             }
         }
 
-        self.drain_mob_agent_events()?;
+        self.drain_mob_agent_events().await?;
         Ok(dispatch_report)
     }
 
-    fn dispatch_schedule_tick_blocking(
+    async fn dispatch_schedule_tick_blocking(
         &self,
         schedules: &[ScheduleDefinition],
         tick_ms: u64,
     ) -> Result<ScheduleDispatchReport, UnifiedRuntimeError> {
+        let mut rt = self.module_runtime.lock().await;
+
         let dispatch_result = if tokio::runtime::Handle::try_current()
             .is_ok_and(|handle| handle.runtime_flavor() == RuntimeFlavor::MultiThread)
         {
             tokio::task::block_in_place(|| {
-                let mut rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
                 Self::dispatch_schedule_tick_in_joined_thread(
                     &mut rt,
                     schedules,
@@ -285,7 +286,6 @@ impl UnifiedRuntime {
                 )
             })
         } else {
-            let mut rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
             Self::dispatch_schedule_tick_in_joined_thread(
                 &mut rt,
                 schedules,

--- a/crates/meerkat-mobkit-core/src/unified_runtime/mod.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/mod.rs
@@ -100,7 +100,7 @@ pub struct UnifiedRuntime {
     edge_discovery: Option<Box<dyn EdgeDiscovery>>,
 
     // Fine-grained interior mutability
-    module_runtime: std::sync::Mutex<MobkitRuntimeHandle>,
+    module_runtime: tokio::sync::Mutex<MobkitRuntimeHandle>,
     managed_dynamic_edges: tokio::sync::RwLock<BTreeSet<(String, String)>>,
     shutting_down: AtomicBool,
     mob_event_ingress: tokio::sync::Mutex<Option<MobEventIngress>>,
@@ -135,7 +135,7 @@ impl UnifiedRuntime {
             drain_timeout: DEFAULT_DRAIN_TIMEOUT,
             discovery: None,
             edge_discovery: None,
-            module_runtime: std::sync::Mutex::new(module_runtime),
+            module_runtime: tokio::sync::Mutex::new(module_runtime),
             managed_dynamic_edges: tokio::sync::RwLock::new(BTreeSet::new()),
             shutting_down: AtomicBool::new(false),
             mob_event_ingress: tokio::sync::Mutex::new(mob_event_ingress),
@@ -190,8 +190,8 @@ impl UnifiedRuntime {
     ///
     /// Inspect after `build()` to detect incomplete startup topology.
     /// Returns `None` if no edge discovery was configured.
-    pub fn bootstrap_edges_report(&self) -> Option<UnifiedRuntimeReconcileEdgesReport> {
-        self.bootstrap_edges_report.blocking_read().clone()
+    pub async fn bootstrap_edges_report(&self) -> Option<UnifiedRuntimeReconcileEdgesReport> {
+        self.bootstrap_edges_report.read().await.clone()
     }
 
     fn create_event_ingress(router: MobEventRouterHandle) -> MobEventIngress {

--- a/crates/meerkat-mobkit-core/src/unified_runtime/module_ops.rs
+++ b/crates/meerkat-mobkit-core/src/unified_runtime/module_ops.rs
@@ -16,139 +16,164 @@ use crate::{route_module_call, ModuleRouteError, ModuleRouteRequest, ModuleRoute
 use super::types::UnifiedRuntimeError;
 use super::UnifiedRuntime;
 
+/// Run a blocking closure on a dedicated thread to isolate it from the
+/// tokio runtime. MCP boundary calls check `Handle::try_current()` and
+/// refuse to block inside an active runtime, so `block_in_place` is not
+/// sufficient — we need a thread that has no runtime handle at all.
+///
+/// Uses `std::thread::scope` so the closure can borrow from the caller.
+fn run_blocking<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send,
+    R: Send,
+{
+    std::thread::scope(|scope| {
+        scope.spawn(f).join().unwrap_or_else(|e| std::panic::resume_unwind(e))
+    })
+}
+
 impl UnifiedRuntime {
-    pub fn module_is_running(&self) -> bool {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).is_running()
+    pub async fn module_is_running(&self) -> bool {
+        self.module_runtime.lock().await.is_running()
     }
 
-    pub fn loaded_modules(&self) -> Vec<String> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).loaded_modules()
+    pub async fn loaded_modules(&self) -> Vec<String> {
+        self.module_runtime.lock().await.loaded_modules()
     }
 
-    pub fn reconcile_modules(
+    /// Reconcile modules — runs blocking subprocess I/O via `block_in_place`.
+    pub async fn reconcile_modules(
         &self,
         modules: Vec<String>,
         timeout: Duration,
     ) -> Result<usize, RuntimeMutationError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).reconcile_modules(modules, timeout)
+        let mut rt = self.module_runtime.lock().await;
+        run_blocking(|| rt.reconcile_modules(modules, timeout))
     }
 
-    pub fn resolve_routing(
+    /// Resolve routing — runs blocking MCP boundary call via `block_in_place`.
+    pub async fn resolve_routing(
         &self,
         request: RoutingResolveRequest,
     ) -> Result<RoutingResolution, RoutingResolveError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).resolve_routing(request)
+        let mut rt = self.module_runtime.lock().await;
+        run_blocking(|| rt.resolve_routing(request))
     }
 
-    pub fn send_delivery(
+    /// Send delivery — runs blocking MCP boundary call via `block_in_place`.
+    pub async fn send_delivery(
         &self,
         request: DeliverySendRequest,
     ) -> Result<DeliveryRecord, DeliverySendError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).send_delivery(request)
+        let mut rt = self.module_runtime.lock().await;
+        run_blocking(|| rt.send_delivery(request))
     }
 
-    pub fn evaluate_schedule_tick(
+    pub async fn evaluate_schedule_tick(
         &self,
         schedules: &[ScheduleDefinition],
         tick_ms: u64,
     ) -> Result<ScheduleEvaluation, ScheduleValidationError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).evaluate_schedule_tick(schedules, tick_ms)
+        self.module_runtime.lock().await.evaluate_schedule_tick(schedules, tick_ms)
     }
 
-    pub fn list_runtime_routes(&self) -> Vec<RuntimeRoute> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).list_runtime_routes()
+    pub async fn list_runtime_routes(&self) -> Vec<RuntimeRoute> {
+        self.module_runtime.lock().await.list_runtime_routes()
     }
 
-    pub fn add_runtime_route(
+    pub async fn add_runtime_route(
         &self,
         route: RuntimeRoute,
     ) -> Result<RuntimeRoute, RuntimeRouteMutationError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).add_runtime_route(route)
+        self.module_runtime.lock().await.add_runtime_route(route)
     }
 
-    pub fn delete_runtime_route(
+    pub async fn delete_runtime_route(
         &self,
         route_key: &str,
     ) -> Result<RuntimeRoute, RuntimeRouteMutationError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).delete_runtime_route(route_key)
+        self.module_runtime.lock().await.delete_runtime_route(route_key)
     }
 
-    pub fn delivery_history(&self, request: DeliveryHistoryRequest) -> DeliveryHistoryResponse {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).delivery_history(request)
+    pub async fn delivery_history(&self, request: DeliveryHistoryRequest) -> DeliveryHistoryResponse {
+        self.module_runtime.lock().await.delivery_history(request)
     }
 
-    pub fn memory_stores(&self) -> Vec<MemoryStoreInfo> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).memory_stores()
+    pub async fn memory_stores(&self) -> Vec<MemoryStoreInfo> {
+        self.module_runtime.lock().await.memory_stores()
     }
 
-    pub fn memory_index(
+    pub async fn memory_index(
         &self,
         request: MemoryIndexRequest,
     ) -> Result<MemoryIndexResult, MemoryIndexError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).memory_index(request)
+        self.module_runtime.lock().await.memory_index(request)
     }
 
-    pub fn memory_query(&self, request: MemoryQueryRequest) -> MemoryQueryResult {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).memory_query(request)
+    pub async fn memory_query(&self, request: MemoryQueryRequest) -> MemoryQueryResult {
+        self.module_runtime.lock().await.memory_query(request)
     }
 
-    pub fn evaluate_gating_action(
+    pub async fn evaluate_gating_action(
         &self,
         request: GatingEvaluateRequest,
     ) -> GatingEvaluateResult {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).evaluate_gating_action(request)
+        self.module_runtime.lock().await.evaluate_gating_action(request)
     }
 
-    pub fn list_gating_pending(&self) -> Vec<GatingPendingEntry> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).list_gating_pending()
+    pub async fn list_gating_pending(&self) -> Vec<GatingPendingEntry> {
+        self.module_runtime.lock().await.list_gating_pending()
     }
 
-    pub fn decide_gating_action(
+    pub async fn decide_gating_action(
         &self,
         request: GatingDecideRequest,
     ) -> Result<GatingDecisionResult, GatingDecideError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).decide_gating_action(request)
+        self.module_runtime.lock().await.decide_gating_action(request)
     }
 
-    pub fn gating_audit_entries(&self, limit: usize) -> Vec<GatingAuditEntry> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).gating_audit_entries(limit)
+    pub async fn gating_audit_entries(&self, limit: usize) -> Vec<GatingAuditEntry> {
+        self.module_runtime.lock().await.gating_audit_entries(limit)
     }
 
-    pub fn spawn_member(
+    /// Spawn a module member — runs blocking subprocess I/O via `block_in_place`.
+    pub async fn spawn_member(
         &self,
         module_id: &str,
         timeout: Duration,
     ) -> Result<(), RuntimeMutationError> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).spawn_member(module_id, timeout)
+        let mut rt = self.module_runtime.lock().await;
+        run_blocking(|| rt.spawn_member(module_id, timeout))
     }
 
-    pub fn route_module_call(
+    /// Route a module call — runs blocking MCP boundary call via `block_in_place`.
+    pub async fn route_module_call(
         &self,
         request: &ModuleRouteRequest,
         timeout: Duration,
     ) -> Result<ModuleRouteResponse, ModuleRouteError> {
-        let rt = self.module_runtime.lock().unwrap_or_else(|e| e.into_inner());
-        route_module_call(&rt, request, timeout)
+        let rt = self.module_runtime.lock().await;
+        run_blocking(|| route_module_call(&rt, request, timeout))
     }
 
-    pub fn module_lifecycle_events(&self) -> Vec<LifecycleEvent> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).lifecycle_events.clone()
+    pub async fn module_lifecycle_events(&self) -> Vec<LifecycleEvent> {
+        self.module_runtime.lock().await.lifecycle_events.clone()
     }
 
-    pub fn module_health_transitions(&self) -> Vec<ModuleHealthTransition> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).supervisor_report.transitions.clone()
+    pub async fn module_health_transitions(&self) -> Vec<ModuleHealthTransition> {
+        self.module_runtime.lock().await.supervisor_report.transitions.clone()
     }
 
-    pub fn module_events(&self) -> Vec<EventEnvelope<UnifiedEvent>> {
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner()).merged_events().to_vec()
+    pub async fn module_events(&self) -> Vec<EventEnvelope<UnifiedEvent>> {
+        self.module_runtime.lock().await.merged_events().to_vec()
     }
 
-    pub fn subscribe_events(
+    pub async fn subscribe_events(
         &self,
         request: SubscribeRequest,
     ) -> Result<SubscribeResponse, UnifiedRuntimeError> {
-        self.drain_mob_agent_events()?;
-        self.module_runtime.lock().unwrap_or_else(|e| e.into_inner())
+        self.drain_mob_agent_events().await?;
+        self.module_runtime.lock().await
             .subscribe_events(request)
             .map_err(UnifiedRuntimeError::Subscribe)
     }

--- a/crates/meerkat-mobkit-core/tests/phase1.rs
+++ b/crates/meerkat-mobkit-core/tests/phase1.rs
@@ -795,8 +795,8 @@ async fn req_001_unified_owner_starts_and_shuts_down_from_single_object() {
 
     let fixture = build_unified_runtime_fixture(config).await;
     assert_eq!(fixture.runtime.status(), MobState::Running);
-    assert!(fixture.runtime.module_is_running());
-    assert_eq!(fixture.runtime.loaded_modules(), vec!["mod-a".to_string()]);
+    assert!(fixture.runtime.module_is_running().await);
+    assert_eq!(fixture.runtime.loaded_modules().await, vec!["mod-a".to_string()]);
 
     let shutdown = fixture.runtime.shutdown().await;
     assert_eq!(shutdown.module_shutdown.orphan_processes, 0);
@@ -805,7 +805,7 @@ async fn req_001_unified_owner_starts_and_shuts_down_from_single_object() {
         vec!["mod-a".to_string()]
     );
     assert!(shutdown.mob_stop.is_ok());
-    assert!(!fixture.runtime.module_is_running());
+    assert!(!fixture.runtime.module_is_running().await);
     assert_eq!(fixture.runtime.status(), MobState::Stopped);
 }
 
@@ -845,6 +845,7 @@ async fn choke_001_unified_subscribe_merges_module_and_agent_events() {
                 last_event_id: None,
                 agent_id: None,
             })
+            .await
             .expect("subscribe should succeed");
         let has_agent = response.events.iter().any(|event| {
             matches!(&event.event, UnifiedEvent::Agent { agent_id, .. } if agent_id == "worker-1")
@@ -885,6 +886,7 @@ async fn choke_001_unified_subscribe_merges_module_and_agent_events() {
                 last_event_id: None,
                 agent_id: None,
             })
+            .await
             .expect("subscribe should succeed");
         let has_module = response
             .events
@@ -961,7 +963,7 @@ async fn choke_002_unified_dispatch_executes_mob_runtime_injection_success_path(
     assert!(dispatch.dispatched[0].runtime_injection.is_some());
     assert!(dispatch.dispatched[0].runtime_injection_error.is_none());
 
-    let merged = fixture.runtime.module_events();
+    let merged = fixture.runtime.module_events().await;
     let executed = merged
         .iter()
         .find(|event| {
@@ -1026,7 +1028,7 @@ async fn choke_003_unified_dispatch_surfaces_mob_runtime_injection_failure() {
     assert!(dispatch.dispatched[0].runtime_injection.is_some());
     assert!(dispatch.dispatched[0].runtime_injection_error.is_some());
 
-    let merged = fixture.runtime.module_events();
+    let merged = fixture.runtime.module_events().await;
     let failed = merged
         .iter()
         .find(|event| {
@@ -1072,6 +1074,7 @@ async fn req_001_reference_entrypoint_real_listener_graceful_shutdown_stops_runt
     let module_pid = fixture
         .runtime
         .module_events()
+        .await
         .iter()
         .find_map(|event| match &event.event {
             UnifiedEvent::Module(module) if module.module == "listener-mod" => {
@@ -1128,7 +1131,7 @@ async fn req_001_reference_entrypoint_real_listener_graceful_shutdown_stops_runt
         vec!["listener-mod".to_string()]
     );
     assert!(shutdown.mob_stop.is_ok());
-    assert!(!fixture.runtime.module_is_running());
+    assert!(!fixture.runtime.module_is_running().await);
     assert_eq!(fixture.runtime.status(), MobState::Stopped);
 
     let kill_status = Command::new("sh")

--- a/crates/meerkat-mobkit-core/tests/phase2.rs
+++ b/crates/meerkat-mobkit-core/tests/phase2.rs
@@ -206,7 +206,7 @@ async fn req_002_builder_returns_unified_runtime_and_reference_app_is_unified_on
         .await
         .expect("builder should return unified runtime");
     assert_eq!(runtime.status(), MobState::Running);
-    assert!(runtime.module_is_running());
+    assert!(runtime.module_is_running().await);
 
     let example_source = include_str!("../examples/library_mode_reference.rs");
     assert!(example_source.contains("UnifiedRuntime::builder()"));
@@ -425,10 +425,11 @@ async fn req_008_reconcile_updates_routing_wiring_when_router_module_is_loaded()
     assert!(
         runtime
             .loaded_modules()
+            .await
             .iter()
             .any(|module_id| module_id == "router"),
         "router should be loaded for reconcile routing test; got {:?}",
-        runtime.loaded_modules()
+        runtime.loaded_modules().await
     );
 
     let first_reconcile = runtime

--- a/crates/meerkat-mobkit-core/tests/phase5_lifecycle.rs
+++ b/crates/meerkat-mobkit-core/tests/phase5_lifecycle.rs
@@ -299,6 +299,7 @@ async fn e2e_003_failure_path_module_crash_during_active_sse_stream_recovers_and
 
     let added = runtime
         .reconcile_modules(vec!["forced-crash".to_string()], Duration::from_secs(1))
+        .await
         .expect("reconcile_modules should recover forced-crash module");
     assert_eq!(added, 1);
     assert_eq!(
@@ -310,6 +311,7 @@ async fn e2e_003_failure_path_module_crash_during_active_sse_stream_recovers_and
 
     let forced_crash_transitions = runtime
         .module_health_transitions()
+        .await
         .into_iter()
         .filter(|transition| transition.module_id == "forced-crash")
         .map(|transition| transition.to)
@@ -337,6 +339,7 @@ async fn e2e_003_failure_path_module_crash_during_active_sse_stream_recovers_and
     assert_eq!(
         runtime
             .module_lifecycle_events()
+            .await
             .iter()
             .map(|event| event.stage.clone())
             .collect::<Vec<_>>(),
@@ -403,9 +406,9 @@ fn e2e_004_happy_path_full_lifecycle_startup_reconcile_dispatch_route_delivery_s
     });
 
     assert_eq!(runtime.status(), MobState::Running);
-    assert!(runtime.module_is_running());
+    assert!(tokio_runtime.block_on(runtime.module_is_running()));
     assert_eq!(
-        runtime.loaded_modules(),
+        tokio_runtime.block_on(runtime.loaded_modules()),
         vec![
             "delivery".to_string(),
             "router".to_string(),
@@ -470,7 +473,7 @@ fn e2e_004_happy_path_full_lifecycle_startup_reconcile_dispatch_route_delivery_s
         assert_eq!(dispatch.dispatched.len(), 1);
         assert!(dispatch.dispatched[0].runtime_injection.is_some());
         assert!(dispatch.dispatched[0].runtime_injection_error.is_none());
-        assert!(runtime.module_events().iter().any(|event| {
+        assert!(runtime.module_events().await.iter().any(|event| {
             matches!(
                 &event.event,
                 UnifiedEvent::Module(module_event)
@@ -489,24 +492,24 @@ fn e2e_004_happy_path_full_lifecycle_startup_reconcile_dispatch_route_delivery_s
             .expect("reference app should shut down cleanly");
     });
 
-    let resolution = runtime
+    let resolution = tokio_runtime.block_on(runtime
         .resolve_routing(RoutingResolveRequest {
             recipient: "user@example.com".to_string(),
             channel: Some("transactional".to_string()),
             retry_max: Some(1),
             backoff_ms: Some(125),
             rate_limit_per_minute: Some(10),
-        })
+        }))
         .expect("routing resolve");
     assert_eq!(resolution.target_module, "delivery");
     assert_eq!(resolution.sink, "email");
 
-    let delivery = runtime
+    let delivery = tokio_runtime.block_on(runtime
         .send_delivery(DeliverySendRequest {
             resolution: resolution.clone(),
             payload: json!({"message":"phase5 lifecycle happy path"}),
             idempotency_key: Some("phase5-e2e-004".to_string()),
-        })
+        }))
         .expect("delivery send");
     assert_eq!(delivery.route_id, resolution.route_id);
     assert_eq!(delivery.status, "sent");
@@ -534,8 +537,8 @@ fn e2e_004_happy_path_full_lifecycle_startup_reconcile_dispatch_route_delivery_s
         .expect("mob runtime should stop cleanly at lifecycle end");
 
     assert_eq!(
-        runtime
-            .module_lifecycle_events()
+        tokio_runtime.block_on(runtime
+            .module_lifecycle_events())
             .iter()
             .map(|event| event.stage.clone())
             .collect::<Vec<_>>(),


### PR DESCRIPTION
## Summary

- Switch `module_runtime` from `std::sync::Mutex` to `tokio::sync::Mutex` — fixes panics when locking from async contexts (edge reconciliation at boot, RPC handlers)
- All `module_ops` methods become `async fn` with `.lock().await`
- Methods that do blocking MCP boundary I/O (`resolve_routing`, `send_delivery`, `route_module_call`, `reconcile_modules`, `spawn_member`) use `std::thread::scope` to run on a dedicated thread, isolating from the tokio runtime so MCP boundary checks don't panic
- Fix `bootstrap_edges_report()` which used `blocking_read()` on a `tokio::sync::RwLock` — same class of bug
- Update all callers in `rpc.rs`, test files, and examples to `.await` the now-async methods

## Test plan

- [x] `cargo check -p meerkat-mobkit-core --tests` — zero errors
- [x] `cargo nextest run -p meerkat-mobkit-core -E 'not test(phase0_governance)'` — 225/225 passed
- [x] `phase5_lifecycle::e2e_003` (crash recovery) — passes (was panicking with `block_in_place` on current-thread runtime)
- [x] `phase5_lifecycle::e2e_004` (happy path with MCP routing) — passes (was panicking with "cannot execute blocking MCP boundary call inside an active tokio runtime")

🤖 Generated with [Claude Code](https://claude.com/claude-code)