### PR TITLE
chore: release workflow, binary builds, and registry publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,290 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_release_packages:
+        description: "Publish Rust/Python/TypeScript artifacts to registries"
+        required: false
+        default: false
+        type: boolean
+      registry_dry_run:
+        description: "Run registry publish steps in dry-run mode"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Required GitHub Actions secrets for full release:
+#   CARGO_REGISTRY_TOKEN  - crates.io API token
+#   PYPI_API_TOKEN        - PyPI API token (scoped to meerkat-mobkit package)
+#   NPM_TOKEN             - npm access token (scoped to @rkat org)
+
+jobs:
+  release_validate:
+    name: Validate release state
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Verify version parity
+        run: make verify-version-parity
+
+      - name: Verify tag matches version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: make verify-version
+
+      - name: Check formatting
+        run: make fmt-check
+
+  build_binaries:
+    name: Build gateway binary (${{ matrix.target }})
+    needs: [release_validate]
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive_ext: tar.gz
+          - runs-on: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            archive_ext: tar.gz
+          - runs-on: macos-15
+            target: aarch64-apple-darwin
+            archive_ext: tar.gz
+          - runs-on: macos-15-large
+            target: x86_64-apple-darwin
+            archive_ext: tar.gz
+          - runs-on: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive_ext: zip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add release target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build gateway binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p meerkat-mobkit --release --target "${{ matrix.target }}"
+
+      - name: Package artifacts
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ github.ref_name }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+        run: |
+          set -euo pipefail
+          BINARIES=("phase0b_rpc_gateway")
+          mkdir -p dist
+          VERSION="${VERSION#v}"
+          VERSION="${VERSION//\//-}"
+
+          for bin in "${BINARIES[@]}"; do
+            if [[ "${RUNNER_OS}" == "Windows" ]]; then
+              src="target/${TARGET}/release/${bin}.exe"
+            else
+              src="target/${TARGET}/release/${bin}"
+            fi
+            artifact_name="mobkit-gateway-${VERSION}-${TARGET}.${ARCHIVE_EXT}"
+
+            if [[ ! -f "$src" ]]; then
+              echo "Missing expected binary at $src" >&2
+              exit 1
+            fi
+
+            if [[ "$ARCHIVE_EXT" == "zip" ]]; then
+              7z a -tzip "${GITHUB_WORKSPACE}/dist/${artifact_name}" "$(cygpath -w "$src")"
+            else
+              tar -czf "dist/${artifact_name}" -C "$(dirname "$src")" "$(basename "$src")"
+            fi
+            echo "packaged=${bin} -> dist/${artifact_name}"
+          done
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobkit-${{ matrix.target }}-${{ matrix.runs-on }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish_github_release:
+    name: Publish GitHub release assets
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build_binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Build checksum manifest
+        working-directory: release-artifacts
+        run: |
+          set -euo pipefail
+          find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | sort > manifest_files.txt
+          if [[ ! -s manifest_files.txt ]]; then
+            echo "No release artifacts found" >&2
+            exit 1
+          fi
+          xargs sha256sum < manifest_files.txt > checksums.sha256
+          python3 - <<'PY'
+          import os
+          import json
+          from pathlib import Path
+
+          paths = [
+              p.as_posix().lstrip("./")
+              for p in sorted(Path(".").rglob("*"))
+              if p.is_file() and (p.name.endswith(".tar.gz") or p.name.endswith(".zip"))
+          ]
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          manifest = {
+              "version": tag.lstrip("v"),
+              "tag": tag,
+              "artifacts": paths,
+              "checksums": "checksums.sha256",
+          }
+
+          with open("index.json", "w", encoding="utf-8") as f:
+              json.dump(manifest, f, indent=2)
+          PY
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-artifacts/**/*.tar.gz
+            release-artifacts/**/*.zip
+            release-artifacts/checksums.sha256
+            release-artifacts/index.json
+          draft: false
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+  publish_registries:
+    name: Publish crate + SDK packages
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release_packages == 'true')
+    needs: [release_validate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Python + Node tooling
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Python publishing tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Publish Rust crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}"
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Running cargo publish in dry-run mode"
+            cargo publish -p meerkat-mobkit --locked --dry-run
+          else
+            echo "Publishing meerkat-mobkit to crates.io"
+            output=$(cargo publish -p meerkat-mobkit --locked 2>&1) && true
+            rc=$?
+            if [[ $rc -eq 0 ]]; then
+              echo "  meerkat-mobkit: published"
+            elif echo "$output" | grep -q "already exists\|already uploaded"; then
+              echo "  meerkat-mobkit: already published, skipping"
+            else
+              echo "$output" >&2
+              exit $rc
+            fi
+          fi
+
+      - name: Publish Python SDK
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        working-directory: sdk/python
+        run: |
+          set -euo pipefail
+          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}"
+          python -m pip install --upgrade build twine
+          rm -rf dist
+          python -m build
+          python -m twine check dist/*
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Python SDK dry-run: skipping upload"
+          else
+            python -m twine upload --skip-existing dist/*
+          fi
+
+      - name: Publish TypeScript SDK
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: sdk/typescript
+        run: |
+          set -euo pipefail
+          DRY_RUN="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.registry_dry_run == 'true' }}"
+          npm install --ignore-scripts
+          npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
+          npm run build
+          if [[ "$DRY_RUN" == "true" ]]; then
+            npm publish --access public --dry-run
+          else
+            npm publish --access public
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # MobKit internal
 .rct/
+.release-hook-done
 /.rct-legacy/
 /.rct-legacy-*/
 docs/rct/traceability.legacy-*.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,5 +94,6 @@ shared-version = true
 tag-name = "v{{version}}"
 pre-release-commit-message = "chore: release v{{version}}"
 tag-message = "Release v{{version}}"
+pre-release-hook = ["bash", "-c", "$(git rev-parse --show-toplevel)/scripts/release-hook.sh {{version}}"]
 publish = false
 push = true

--- a/Makefile
+++ b/Makefile
@@ -134,19 +134,57 @@ verify-version-parity: ## Verify version strings are in sync
 bump-sdk-versions: ## Bump SDK version strings
 	@scripts/bump-sdk-versions.sh
 
+verify-version: ## Verify Cargo.toml version matches git tag
+	@VERSION=$$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "meerkat-mobkit") | .version'); \
+	TAG=$$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//'); \
+	if [ -z "$$TAG" ]; then \
+		echo "$(YELLOW)No tag found on current commit$(NC)"; \
+	elif [ "$$VERSION" != "$$TAG" ]; then \
+		echo "$(RED)Version mismatch: Cargo.toml has $$VERSION but tag is $$TAG$(NC)"; \
+		exit 1; \
+	else \
+		echo "$(GREEN)Version $$VERSION matches tag$(NC)"; \
+	fi
+
+publish-dry-run: ## Dry-run cargo publish
+	@echo "$(YELLOW)Dry-run cargo publish…$(NC)"
+	cargo publish -p meerkat-mobkit --dry-run
+	@echo "$(GREEN)Cargo dry-run succeeded.$(NC)"
+
 publish-dry-run-python: ## Dry-run Python package build + twine check
 	@echo "$(YELLOW)Building Python package (dry run)…$(NC)"
-	cd sdk/python && \
-		pip install --quiet build twine && \
+	@cd sdk/python && \
+		python3 -m pip install --quiet build twine && \
+		rm -rf dist && \
 		python3 -m build && \
-		twine check dist/* && \
+		python3 -m twine check dist/* && \
 		rm -rf dist build *.egg-info
 	@echo "$(GREEN)Python dry-run publish succeeded.$(NC)"
+
+publish-dry-run-typescript: ## Dry-run TypeScript SDK build + npm pack
+	@echo "$(YELLOW)Building TypeScript SDK (dry run)…$(NC)"
+	@cd sdk/typescript && \
+		npm install --ignore-scripts && \
+		npm run build && \
+		npm publish --access public --dry-run && \
+		rm -rf dist
+	@echo "$(GREEN)TypeScript dry-run publish succeeded.$(NC)"
 
 release-preflight: ci ## Pre-release checks (full CI + CHANGELOG)
 	@grep -q '\[Unreleased\]' CHANGELOG.md || \
 		(echo "$(RED)CHANGELOG.md missing [Unreleased] section$(NC)" && exit 1)
 	@echo "$(GREEN)Release preflight passed — ready to ship.$(NC)"
+
+release-preflight-smoke: ci-smoke ## Smoke pre-release checks
+	@grep -q '\[Unreleased\]' CHANGELOG.md || \
+		(echo "$(RED)CHANGELOG.md missing [Unreleased] section$(NC)" && exit 1)
+	@echo "$(GREEN)Smoke preflight passed.$(NC)"
+
+release-dry-run: release-preflight publish-dry-run publish-dry-run-python publish-dry-run-typescript ## Full dry-run release (no uploads)
+	@echo "$(GREEN)Full release dry-run passed.$(NC)"
+
+release-dry-run-smoke: release-preflight-smoke publish-dry-run publish-dry-run-python publish-dry-run-typescript ## Smoke dry-run release
+	@echo "$(GREEN)Smoke release dry-run passed.$(NC)"
 
 # ── help ──────────────────────────────────────────────────────
 

--- a/scripts/release-hook.sh
+++ b/scripts/release-hook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Pre-release hook for cargo-release.
+# Called with the new version as the first argument.
+# Bumps SDK versions and stages the changes for the release commit.
+
+set -euo pipefail
+
+VERSION="${1:?usage: release-hook.sh <version>}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Prevent duplicate execution within the same release
+SENTINEL="$ROOT/.release-hook-done"
+if [ -f "$SENTINEL" ] && [ "$(cat "$SENTINEL")" = "$VERSION" ]; then
+  echo "release-hook: already ran for $VERSION, skipping"
+  exit 0
+fi
+
+echo "release-hook: bumping SDK versions to $VERSION"
+"$ROOT/scripts/bump-sdk-versions.sh" "$VERSION"
+
+echo "release-hook: verifying version parity"
+"$ROOT/scripts/verify-version-parity.sh"
+
+echo "release-hook: staging SDK version files"
+git add \
+  "$ROOT/sdk/python/pyproject.toml" \
+  "$ROOT/sdk/typescript/package.json"
+
+echo "$VERSION" > "$SENTINEL"
+echo "release-hook: done ($VERSION)"


### PR DESCRIPTION
## Summary

Adds complete release infrastructure matching Meerkat's pattern, enabling `cargo release` to trigger the full pipeline.

**Release workflow** (`.github/workflows/release.yml`):
- **release_validate** — version parity, tag match, formatting
- **build_binaries** — `phase0b_rpc_gateway` for 5 platforms (linux x86/arm, macOS x86/arm, Windows) with build provenance attestation
- **publish_github_release** — SHA256 checksums, index.json manifest, auto-generated release notes
- **publish_registries** — crates.io (`meerkat-mobkit`), PyPI (`meerkat-mobkit`), npm (`@rkat/mobkit-sdk`)
- Supports `workflow_dispatch` with dry-run mode for recovery/testing

**Release automation**:
- `scripts/release-hook.sh` — cargo-release pre-release hook (bumps SDK versions, verifies parity, stages files)
- `pre-release-hook` added to `[workspace.metadata.release]`

**Makefile targets**:
- `verify-version` — check Cargo version matches git tag
- `publish-dry-run` — cargo publish dry-run
- `publish-dry-run-typescript` — npm build + publish dry-run
- `release-preflight-smoke` — fast pre-release checks
- `release-dry-run` / `release-dry-run-smoke` — full dry-run pipelines

**Required secrets** (to configure in GitHub repo settings):
- `CARGO_REGISTRY_TOKEN`
- `PYPI_API_TOKEN`
- `NPM_TOKEN`

## Release process

```bash
# 1. Preflight
make release-preflight-smoke

# 2. Release (bumps version, tags, pushes — triggers workflow)
cargo release patch  # or minor/major

# 3. Workflow does the rest:
#    - Validates
#    - Builds binaries for 5 platforms
#    - Publishes GitHub release with checksums
#    - Publishes to crates.io, PyPI, npm
```

## Test plan

- [x] `make verify-version-parity` — passes
- [x] `make help` — all new targets listed
- [x] `cargo publish --dry-run` — crate is publishable (after commit)
- [x] All pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)