### PR TITLE
fix: forward session store through MobBootstrapSpec::ephemeral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
  "meerkat-mob",
  "meerkat-models",
  "meerkat-session",
+ "meerkat-store",
  "reqwest",
  "ring",
  "serde",

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -38,6 +38,7 @@ meerkat-mcp = "0.4.11"
 meerkat-models = "0.4.11"
 meerkat = { version = "0.4.11", features = ["comms", "sub-agents", "skills", "mcp", "memory-store"] }
 meerkat-session = "0.4.11"
+meerkat-store = "0.4.11"
 tempfile = "3"
 async-trait = "0.1"
 

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, anyhow};
-use meerkat::{AgentFactory, Config, EphemeralSessionService, FactoryAgentBuilder};
 use meerkat_mob::{MeerkatId, MobDefinition, MobStorage, ProfileName, SpawnMemberSpec};
 use meerkat_mobkit::{
     AuthPolicy, BigQueryNaming, ConsolePolicy, ConventionalPaths, MOBKIT_CONTRACT_VERSION,
@@ -399,20 +397,18 @@ async fn run() -> anyhow::Result<()> {
     let (definition, used_workspace_config) = load_definition(&workspace_root, &key, &paths)?;
     let runtime_id = definition.id.to_string();
 
-    let factory = AgentFactory::new(&workspace_root)
-        .comms(true)
-        .subagents(true)
-        .mob(true);
-    let mut config = Config::default();
-    config.comms.auto_enable_for_subagents = true;
-    let builder = FactoryAgentBuilder::new(factory, config);
-    let session_service = Arc::new(EphemeralSessionService::new(builder, 64));
-    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
-        .with_options(MobBootstrapOptions {
-            allow_ephemeral_sessions: true,
-            notify_orchestrator_on_resume: true,
-            default_llm_client: None,
-        });
+    let mob_spec = MobBootstrapSpec::ephemeral(
+        definition,
+        MobStorage::in_memory(),
+        workspace_root.clone(),
+        64,
+        None,
+    )
+    .with_options(MobBootstrapOptions {
+        allow_ephemeral_sessions: true,
+        notify_orchestrator_on_resume: true,
+        default_llm_client: None,
+    });
 
     let runtime = UnifiedRuntime::bootstrap(
         mob_spec,

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -1,13 +1,17 @@
 //! Mob member lifecycle management — bootstrap, spawn, reconcile, and roster queries.
 
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use meerkat::{AgentFactory, Config, FactoryAgentBuilder, SessionStore};
 use meerkat_client::LlmClient;
+use meerkat_core::AgentSessionStore;
 use meerkat_mob::{
     MeerkatId, MemberRef, MemberState, MobBuilder, MobDefinition, MobError, MobHandle,
     MobSessionService, MobState, MobStorage, RosterEntry, SpawnMemberSpec,
 };
+use meerkat_store::StoreAdapter;
 use serde::{Deserialize, Serialize};
 
 /// Member state constant for active members.
@@ -52,6 +56,64 @@ impl MobBootstrapSpec {
     pub fn with_options(mut self, options: MobBootstrapOptions) -> Self {
         self.options = options;
         self
+    }
+
+    /// Build an ephemeral session service with a correctly wired `AgentFactory`.
+    ///
+    /// If `session_store` is provided, it is set on the `FactoryAgentBuilder` so
+    /// that agents use the given store instead of falling back to JSONL.
+    pub fn ephemeral(
+        definition: MobDefinition,
+        storage: MobStorage,
+        store_path: PathBuf,
+        max_sessions: usize,
+        session_store: Option<Arc<dyn AgentSessionStore>>,
+    ) -> Self {
+        let factory = AgentFactory::new(&store_path)
+            .comms(true)
+            .subagents(true)
+            .mob(true);
+        let mut config = Config::default();
+        config.comms.auto_enable_for_subagents = true;
+        let mut builder = FactoryAgentBuilder::new(factory, config);
+        if let Some(store) = session_store {
+            builder.default_session_store = Some(store);
+        }
+        let session_service = Arc::new(meerkat_session::EphemeralSessionService::new(
+            builder,
+            max_sessions,
+        ));
+        Self::new(definition, storage, session_service)
+    }
+
+    /// Build a persistent session service with a correctly wired `AgentFactory`.
+    ///
+    /// The `session_store` is used in two places:
+    /// 1. As the persistence backend for `PersistentSessionService` (checkpoint/restore).
+    /// 2. Adapted via `StoreAdapter` and set on `FactoryAgentBuilder.default_session_store`
+    ///    so that agents use it directly instead of falling back to JSONL.
+    pub fn persistent(
+        definition: MobDefinition,
+        storage: MobStorage,
+        store_path: PathBuf,
+        max_sessions: usize,
+        session_store: Arc<dyn SessionStore>,
+    ) -> Self {
+        let factory = AgentFactory::new(&store_path)
+            .comms(true)
+            .subagents(true)
+            .mob(true);
+        let mut config = Config::default();
+        config.comms.auto_enable_for_subagents = true;
+        let mut builder = FactoryAgentBuilder::new(factory, config);
+        builder.default_session_store = Some(Arc::new(StoreAdapter::new(session_store.clone())));
+        let session_service = Arc::new(meerkat_session::PersistentSessionService::new(
+            builder,
+            max_sessions,
+            session_store,
+            None,
+        ));
+        Self::new(definition, storage, session_service)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes: FactoryAgentBuilder doesn't forward custom SessionStore to AgentFactory — forces JSONL fallback

Two new convenience constructors on `MobBootstrapSpec`:

### `MobBootstrapSpec::ephemeral` (for ephemeral sessions)
```rust
let mob_spec = MobBootstrapSpec::ephemeral(
    definition, storage, workspace_root, 64,
    Some(my_agent_session_store),  // forwarded to FactoryAgentBuilder
);
```

### `MobBootstrapSpec::persistent` (for OB3/PersistentSessionService)
```rust
let mob_spec = MobBootstrapSpec::persistent(
    definition, storage, workspace_root, 64,
    my_bigquery_store,  // Arc<dyn SessionStore> — used for both persistence AND agent factory
);
```

The `persistent` helper:
1. Passes the `SessionStore` to `PersistentSessionService` for checkpoint/restore
2. Wraps it in `StoreAdapter` and sets it on `FactoryAgentBuilder.default_session_store` so agents skip JSONL

This eliminates the JSONL fallback, redb lock contention, and duplicate persistence described in the bug report.

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run` — 118 passed, 0 failed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)