### PR TITLE
feat: meerkat 0.4.13 — full multimodal support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a5f454e4e86f0b94e3425e70bd00729607a4681884e5aaa5806502cdbfebff"
+checksum = "6d6187a5b8999edb4062c822ae6e76fc0968f8328cdedb968ae3f340ba199bfb"
 dependencies = [
  "async-trait",
  "futures",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dab9569cc3a919ddc38106e4def5360c16b543ff17f53563f07a905f375138"
+checksum = "18b144dacaf5775fab2501acb4eefcf852dea58de543e3bbc594df6285298c6a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eede88744ec25ece22a99caa6accae7c97689a2a3dbc0fe98405d69e1b5a398"
+checksum = "d079839edce79f319fe3e2a76df1cf7a62ac07b53bd3180c35e31ce9ac39a3a0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b85c1f86cee4856edbc0fe5b55d262c58e49035af17e8693e1cd1bdc69019a"
+checksum = "271b2709e94962ae6c3723e479d2d243d525bb23b76f5dfcb454acdced97c44c"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749402f56c147f4ce48ef3d109a50ad4913358ccbd84b3bc11364c2f61e46273"
+checksum = "8ec02280555ce691b4f4b2a12533c1af896600a4c62a5f48dc70459d71249ccd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2281,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0cbd3f648a551081eb31a1ee17145eaa99b76f95c49171898bc6bbbccdcbdc"
+checksum = "55c4281307693823d054154c03d6a1403aeacce5f80af7c5b6ce29f84dead2b5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2302,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ddd36574e8f588ca1e7498ede27ba53513e8fadbb9622998b0078947b7eb0b"
+checksum = "705b70181a8fa40122e2ac4de6f18e8be63a00089d2c92c2d3a17bc111ae4950"
 dependencies = [
  "async-trait",
  "futures",
@@ -2325,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d79dd3396d080c1b694c0dc4c33cef189322346866e77f0b2a9e5e22aaf0402"
+checksum = "39bce930bc4cef17081f783d0a373df1e25ac26e2150c6bf4281bc033a1cc84e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0308ed1196dfd6c971bd30962d468d3c42f5a2c6aa7f6ce25dadb5e354242da"
+checksum = "b531e9b8245b21ae958ecb089983c62c624810135bd8bfb83230c5b11048ee91"
 dependencies = [
  "schemars",
  "serde",
@@ -2399,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb82d400c442a688fd54e4748649cac0a91a47f612749b4f8bdaa8e9ab1d1ec1"
+checksum = "e91293926093a118d19895ed89ad45b8a8b1c624ad597684d0775d9435601100"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2419,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01463ee8e68d87c03876f85aff00e1ee56b9313bbe1d67ebcfa820e012351e6"
+checksum = "96be004e1301d883f484106efe2e008ddc9dbebaf9d9ec6cb8bcd1005f1a0d0d"
 dependencies = [
  "async-trait",
  "futures",
@@ -2444,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc832673e4ba8e6ff02d42f7aebe03f24ec7a49dea6237e0fe9307ea4f017aee"
+checksum = "11348e33c15c3860932ee4debcd17ae407b8880cd961d5d0fcc3b40f5108e8fe"
 dependencies = [
  "async-trait",
  "gix",
@@ -2468,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6102e89e5673d00e1568f464b6fa9eed00ee222e475151a0474485973234fadd"
+checksum = "cb9f1224f8165e7ee79c72cfd358f5f0e00ee5c9caf52adb824f44574a98d12b"
 dependencies = [
  "async-trait",
  "dirs",
@@ -2487,11 +2487,12 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffc755317a1d0a6b204873682cda282b07e2454e117879587a097ba2727b7de"
+checksum = "8c9eacace143068aad92d30faeb7518c14896f32faf8d91fd1a1626f4999353d"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "ciborium",
  "futures",

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -31,14 +31,14 @@ axum = { version = "0.7", features = ["json"] }
 async-stream = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 futures = "0.3"
-meerkat-core = "0.4.11"
-meerkat-client = "0.4.11"
-meerkat-mob = "0.4.11"
-meerkat-mcp = "0.4.11"
-meerkat-models = "0.4.11"
-meerkat = { version = "0.4.11", features = ["comms", "sub-agents", "skills", "mcp", "memory-store"] }
-meerkat-session = "0.4.11"
-meerkat-store = "0.4.11"
+meerkat-core = "0.4.13"
+meerkat-client = "0.4.13"
+meerkat-mob = "0.4.13"
+meerkat-mcp = "0.4.13"
+meerkat-models = "0.4.13"
+meerkat = { version = "0.4.13", features = ["comms", "sub-agents", "skills", "mcp", "memory-store"] }
+meerkat-session = "0.4.13"
+meerkat-store = "0.4.13"
 tempfile = "3"
 async-trait = "0.1"
 

--- a/meerkat-mobkit/examples/real_mob_llm_smoke.rs
+++ b/meerkat-mobkit/examples/real_mob_llm_smoke.rs
@@ -59,14 +59,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn(
             ProfileName::from("lead"),
             MeerkatId::from("lead-1"),
-            Some("You are the lead. Keep responses brief and direct.".to_string()),
+            Some(meerkat_core::ContentInput::Text(
+                "You are the lead. Keep responses brief and direct.".to_string(),
+            )),
         )
         .await?;
     handle
         .spawn(
             ProfileName::from("worker"),
             MeerkatId::from("worker-1"),
-            Some("You are a worker. Help the lead when asked.".to_string()),
+            Some(meerkat_core::ContentInput::Text(
+                "You are a worker. Help the lead when asked.".to_string(),
+            )),
         )
         .await?;
     handle

--- a/meerkat-mobkit/examples/streaming_smoke.rs
+++ b/meerkat-mobkit/examples/streaming_smoke.rs
@@ -53,14 +53,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn(
             ProfileName::from("lead"),
             MeerkatId::from("lead-1"),
-            Some("You are concise. 1 short paragraph max.".to_string()),
+            Some(meerkat_core::ContentInput::Text(
+                "You are concise. 1 short paragraph max.".to_string(),
+            )),
         )
         .await?;
     handle
         .spawn(
             ProfileName::from("worker"),
             MeerkatId::from("worker-1"),
-            Some("You are a helper worker.".to_string()),
+            Some(meerkat_core::ContentInput::Text(
+                "You are a helper worker.".to_string(),
+            )),
         )
         .await?;
     handle

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -36,6 +36,7 @@ use meerkat::{
     FactoryAgentBuilder, SessionAgentBuilder, SessionError,
 };
 use meerkat_core::AgentToolDispatcher;
+use meerkat_core::ContentBlock;
 use meerkat_core::error::{AgentError, ToolError};
 use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
 use meerkat_mob::{MobDefinition, MobStorage};
@@ -253,7 +254,7 @@ impl AgentToolDispatcher for CallbackToolDispatcher {
         });
         match self.bridge.call("callback/call_tool", params).await {
             Ok(result) => {
-                let content = result
+                let text = result
                     .get("content")
                     .map(|v| {
                         if let Some(s) = v.as_str() {
@@ -265,13 +266,15 @@ impl AgentToolDispatcher for CallbackToolDispatcher {
                     .unwrap_or_else(|| serde_json::to_string(&result).unwrap_or_default());
                 Ok(ToolResult {
                     tool_use_id: call.id.to_string(),
-                    content,
+                    content: vec![ContentBlock::Text { text }],
                     is_error: false,
                 })
             }
             Err(err) => Ok(ToolResult {
                 tool_use_id: call.id.to_string(),
-                content: format!("Tool execution failed: {err}"),
+                content: vec![ContentBlock::Text {
+                    text: format!("Tool execution failed: {err}"),
+                }],
                 is_error: true,
             }),
         }

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -354,16 +354,17 @@ impl RealMobRuntime {
     pub async fn send_message(
         &self,
         member_id: &str,
-        message: String,
+        content: impl Into<meerkat_core::ContentInput>,
     ) -> Result<String, MobRuntimeError> {
         if member_id.trim().is_empty() {
             return Err(MobRuntimeError::InvalidInput("member_id must not be empty"));
         }
-        if message.trim().is_empty() {
+        let content = content.into();
+        if content.text_content().is_empty() {
             return Err(MobRuntimeError::InvalidInput("message must not be empty"));
         }
         self.handle
-            .send_message(MeerkatId::from(member_id), message)
+            .send_message(MeerkatId::from(member_id), content)
             .await
             .map(|session_id| session_id.to_string())
             .map_err(Into::into)

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -234,25 +234,12 @@ pub fn handle_mobkit_rpc_json(
             })),
             error: None,
         },
-        "mobkit/models/catalog" => {
-            let entries: Vec<serde_json::Value> = meerkat_models::catalog()
-                .iter()
-                .filter_map(|e| serde_json::to_value(e).ok())
-                .collect();
-            let defaults: Vec<serde_json::Value> = meerkat_models::provider_defaults()
-                .iter()
-                .filter_map(|d| serde_json::to_value(d).ok())
-                .collect();
-            JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id,
-                result: Some(serde_json::json!({
-                    "models": entries,
-                    "provider_defaults": defaults,
-                })),
-                error: None,
-            }
-        }
+        "mobkit/models/catalog" => JsonRpcResponse {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: response_id,
+            result: Some(build_models_catalog_result()),
+            error: None,
+        },
         "mobkit/reconcile" => {
             let modules = match params::required_string_array(&request.params, "modules") {
                 Ok(m) => m,
@@ -1634,25 +1621,12 @@ pub async fn handle_unified_rpc_json(
                 },
             }
         }
-        "mobkit/models/catalog" => {
-            let entries: Vec<serde_json::Value> = meerkat_models::catalog()
-                .iter()
-                .filter_map(|e| serde_json::to_value(e).ok())
-                .collect();
-            let defaults: Vec<serde_json::Value> = meerkat_models::provider_defaults()
-                .iter()
-                .filter_map(|d| serde_json::to_value(d).ok())
-                .collect();
-            JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: response_id,
-                result: Some(serde_json::json!({
-                    "models": entries,
-                    "provider_defaults": defaults,
-                })),
-                error: None,
-            }
-        }
+        "mobkit/models/catalog" => JsonRpcResponse {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: response_id,
+            result: Some(build_models_catalog_result()),
+            error: None,
+        },
         "mobkit/send_message" => {
             mob_methods::handle_send_message(runtime, response_id, &request.params).await
         }
@@ -1739,6 +1713,29 @@ pub async fn handle_unified_rpc_json(
     } else {
         serialize_response(&response)
     }
+}
+
+fn build_models_catalog_result() -> Value {
+    let entries: Vec<Value> = meerkat_models::catalog()
+        .iter()
+        .filter_map(|e| {
+            let mut val = serde_json::to_value(e).ok()?;
+            if let Some(profile) = meerkat_models::profile_for(e.provider, e.id)
+                && let Ok(p) = serde_json::to_value(&profile)
+            {
+                val["profile"] = p;
+            }
+            Some(val)
+        })
+        .collect();
+    let defaults: Vec<Value> = meerkat_models::provider_defaults()
+        .iter()
+        .filter_map(|d| serde_json::to_value(d).ok())
+        .collect();
+    serde_json::json!({
+        "models": entries,
+        "provider_defaults": defaults,
+    })
 }
 
 fn serialize_response(response: &JsonRpcResponse) -> String {

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -1,10 +1,33 @@
 //! RPC handler implementations for mob member operations.
 
+use meerkat_core::ContentInput;
 use serde_json::Value;
 
 use crate::unified_runtime::UnifiedRuntime;
 
 use super::{JSONRPC_VERSION, JsonRpcError, JsonRpcResponse};
+
+/// Extract content from params as `ContentInput`.
+///
+/// Accepts either:
+/// - `"message": "plain text"` (string — backwards-compatible)
+/// - `"content": "plain text"` (string shorthand)
+/// - `"content": [{"type":"text","text":"..."},{"type":"image",...}]` (multimodal blocks)
+///
+/// `message` takes precedence if both are present.
+fn extract_content(params: &Value) -> Option<ContentInput> {
+    if let Some(s) = params.get("message").and_then(Value::as_str)
+        && !s.is_empty()
+    {
+        return Some(ContentInput::Text(s.to_string()));
+    }
+    if let Some(content_val) = params.get("content")
+        && let Ok(input) = serde_json::from_value::<ContentInput>(content_val.clone())
+    {
+        return Some(input);
+    }
+    None
+}
 
 pub(super) async fn handle_send_message(
     runtime: &UnifiedRuntime,
@@ -12,11 +35,11 @@ pub(super) async fn handle_send_message(
     params: &Value,
 ) -> JsonRpcResponse {
     let member_id = params.get("member_id").and_then(Value::as_str);
-    let message = params.get("message").and_then(Value::as_str);
+    let content = extract_content(params);
 
-    match (member_id, message) {
-        (Some(member_id), Some(message)) if !member_id.is_empty() && !message.is_empty() => {
-            match runtime.send_message(member_id, message.to_string()).await {
+    match (member_id, content) {
+        (Some(member_id), Some(content)) if !member_id.is_empty() => {
+            match runtime.send_message(member_id, content).await {
                 Ok(session_id) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id,
@@ -44,7 +67,7 @@ pub(super) async fn handle_send_message(
             result: None,
             error: Some(JsonRpcError {
                 code: -32602,
-                message: "Invalid params: member_id and message required".to_string(),
+                message: "Invalid params: member_id and message (or content) required".to_string(),
             }),
         },
     }

--- a/meerkat-mobkit/src/runtime/module_boundary.rs
+++ b/meerkat-mobkit/src/runtime/module_boundary.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use meerkat_core::ContentBlock;
 use meerkat_mcp::{McpConnection, McpError, McpServerConfig};
 use serde_json::Value;
 use tokio::time::timeout;
@@ -187,6 +188,33 @@ async fn list_tools_with_timeout(
         .map_err(|error| mcp_list_tools_error(module_id, error))
 }
 
+/// Flatten `Vec<ContentBlock>` to a single text string for MobKit's JSON pipeline.
+///
+/// MCP module tools return text in practice. If the result contains only
+/// text blocks, concatenate them. If non-text blocks are present, serialize
+/// the full block list to JSON and log a warning — this is lossy and will
+/// be replaced when the pipeline supports multimodal content natively.
+fn content_blocks_to_text(blocks: Vec<ContentBlock>) -> String {
+    let all_text = blocks
+        .iter()
+        .all(|b| matches!(b, ContentBlock::Text { .. }));
+    if all_text {
+        blocks
+            .into_iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text),
+                _ => None,
+            })
+            .collect::<String>()
+    } else {
+        eprintln!(
+            "WARN mobkit: MCP tool returned multimodal content blocks; \
+             serializing to JSON string (lossy) until pipeline supports native multimodal"
+        );
+        serde_json::to_string(&blocks).unwrap_or_default()
+    }
+}
+
 async fn call_tool_with_timeout(
     module_id: &str,
     tool_name: &str,
@@ -194,7 +222,7 @@ async fn call_tool_with_timeout(
     args: &Value,
     timeout_duration: Duration,
 ) -> Result<String, RuntimeBoundaryError> {
-    timeout(timeout_duration, connection.call_tool(tool_name, args))
+    let blocks = timeout(timeout_duration, connection.call_tool(tool_name, args))
         .await
         .map_err(|_| {
             mcp_timeout_error(
@@ -203,7 +231,8 @@ async fn call_tool_with_timeout(
                 timeout_duration,
             )
         })?
-        .map_err(|error| mcp_tool_call_error(module_id, tool_name, error))
+        .map_err(|error| mcp_tool_call_error(module_id, tool_name, error))?;
+    Ok(content_blocks_to_text(blocks))
 }
 
 async fn close_with_timeout(

--- a/meerkat-mobkit/src/unified_runtime/mob_ops.rs
+++ b/meerkat-mobkit/src/unified_runtime/mob_ops.rs
@@ -56,9 +56,9 @@ impl UnifiedRuntime {
     pub async fn send_message(
         &self,
         member_id: &str,
-        message: String,
+        content: impl Into<meerkat_core::ContentInput>,
     ) -> Result<String, MobRuntimeError> {
-        self.mob_runtime.send_message(member_id, message).await
+        self.mob_runtime.send_message(member_id, content).await
     }
 
     /// Find members matching a label key-value pair.

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -428,12 +428,33 @@ class MobHandle:
         raw = await self._runtime._rpc("mobkit/reconcile_edges")
         return ReconcileEdgesReport.from_dict(raw)
 
-    async def send(self, member_id: str, message: str) -> SendMessageResult:
-        """Send a message to a mob member and return the accepting session."""
-        raw = await self._runtime._rpc(
-            "mobkit/send_message",
-            {"member_id": member_id, "message": message},
-        )
+    async def send(
+        self,
+        member_id: str,
+        message: str | None = None,
+        *,
+        content: list[dict[str, Any]] | None = None,
+    ) -> SendMessageResult:
+        """Send a message to a mob member and return the accepting session.
+
+        Args:
+            member_id: Target member ID.
+            message: Plain text message (simple path).
+            content: Multimodal content blocks, e.g.
+                ``[{"type": "text", "text": "describe this"},
+                  {"type": "image", "media_type": "image/png", "data": "<base64>"}]``
+
+        Either ``message`` or ``content`` must be provided. If both are given,
+        ``message`` takes precedence.
+        """
+        params: dict[str, Any] = {"member_id": member_id}
+        if message is not None:
+            params["message"] = message
+        elif content is not None:
+            params["content"] = content
+        else:
+            raise ValueError("either message or content must be provided")
+        raw = await self._runtime._rpc("mobkit/send_message", params)
         return SendMessageResult.from_dict(raw)
 
     async def query_events(

--- a/sdk/python/meerkat_mobkit/types.py
+++ b/sdk/python/meerkat_mobkit/types.py
@@ -548,9 +548,12 @@ class CatalogEntry:
     tier: str
     context_window: int | None = None
     max_output_tokens: int | None = None
+    vision: bool = False
+    image_tool_results: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CatalogEntry:
+        profile = data.get("profile", {})
         return cls(
             id=data["id"],
             display_name=data["display_name"],
@@ -558,6 +561,8 @@ class CatalogEntry:
             tier=data["tier"],
             context_window=data.get("context_window"),
             max_output_tokens=data.get("max_output_tokens"),
+            vision=profile.get("vision", False),
+            image_tool_results=profile.get("image_tool_results", False),
         )
 
 


### PR DESCRIPTION
## Summary

Bump meerkat crates to 0.4.13. Multimodal content now flows end-to-end through the send_message pipeline — no more text extraction or silent dropping.

### Multimodal send_message (end-to-end)
- `mobkit/send_message` accepts `"message"` (string) or `"content"` (ContentInput blocks including images)
- `ContentInput` passes directly through: RPC → UnifiedRuntime → RealMobRuntime → MobHandle::send_message(impl Into\<ContentInput\>)
- Images reach the agent session intact — no lossy flattening
- Python SDK `MobHandle.send(content=[...])` fully functional:
  ```python
  await mob.send("agent-1", content=[
      {"type": "text", "text": "describe this image"},
      {"type": "image", "media_type": "image/png", "data": "<base64>"},
  ])
  ```

### Compile fixes (0.4.12 → 0.4.13)
- `McpConnection::call_tool` returns `Vec<ContentBlock>` — `content_blocks_to_text()` flattens for MobKit's JSON pipeline
- `ToolResult.content` now `Vec<ContentBlock>` — updated `CallbackToolDispatcher`
- `SpawnMemberSpec` system_prompt now `ContentInput` — fixed examples

### Enriched models/catalog
- Each model includes inline `profile` with `vision` and `image_tool_results` capability flags
- Python SDK `CatalogEntry` gains `vision`/`image_tool_results` fields

## Test plan
- [x] `cargo check --workspace --examples` — clean
- [x] `cargo nextest run` — 118 passed
- [x] Python SDK — 202 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)