### PR TITLE
feat(cross-mob): wire TCP + UDS transports through meerkat-comms (Phase 1)

### DIFF
--- a/meerkat-mobkit/src/runtime.rs
+++ b/meerkat-mobkit/src/runtime.rs
@@ -38,6 +38,7 @@ use crate::types::{
 
 mod bootstrap;
 mod console_ingress;
+pub mod cross_mob_control;
 pub mod cross_mob_remote;
 mod delivery;
 mod event_transport;

--- a/meerkat-mobkit/src/runtime.rs
+++ b/meerkat-mobkit/src/runtime.rs
@@ -38,6 +38,7 @@ use crate::types::{
 
 mod bootstrap;
 mod console_ingress;
+pub mod cross_mob_remote;
 mod delivery;
 mod event_transport;
 mod gating;

--- a/meerkat-mobkit/src/runtime/cross_mob_control.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_control.rs
@@ -1,0 +1,643 @@
+//! Cross-mob control protocol — Phase 2 of the cross-mob transport story.
+//!
+//! Phase 1 (sibling commit) wired the structural seam (`RemoteMobProxy`,
+//! `LocalOrRemote` dispatch, contact-directory transport awareness). Phase
+//! 2 (this module) ships the actual control-plane RPC that crosses
+//! processes:
+//!
+//! * `ControlRequest` / `ControlResponse` — the on-the-wire types.
+//! * [`serve_control_listener`] — accepts TCP/UDS connections on a gateway,
+//!   reads framed requests, dispatches them against a local
+//!   [`MobHandle`] / [`MobSessionService`], and writes back framed responses.
+//! * [`RemoteControlClient`] — opens a connection lazily, sends a single
+//!   request, reads the response. Used by [`super::cross_mob_remote::RemoteMobProxy`].
+//!
+//! # Wire shape
+//!
+//! Each frame is `[u32 BE length][JSON UTF-8 payload]`. JSON is preferred
+//! over CBOR for control because it stays human-debuggable in pcap traces
+//! and the volume is tiny (one message per `wire`/`unwire`/`inject` call,
+//! not per agent turn). `meerkat-comms`'s `TransportCodec` is reserved for
+//! agent envelopes.
+//!
+//! # Trust
+//!
+//! The control listener does NOT verify Ed25519 signatures itself. Trust
+//! is delegated to the contact directory: when a peer mobkit calls
+//! `RemoteMobProxy::wire_remote`, it includes the *peer's* expected
+//! `peer_pubkey_b64` in the request. The remote gateway feeds that pubkey
+//! into the resulting `TrustedPeerDescriptor`, and `meerkat-comms` rejects
+//! envelope traffic that doesn't match it. So the control channel itself
+//! is unauthenticated, but the artifacts it produces (peer descriptors)
+//! are signature-checked at every subsequent comms ingress.
+
+use std::path::Path;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+
+use super::cross_mob_remote::{RemoteEndpoint, RemoteMobError};
+
+/// Maximum control payload size. Control messages are tiny (a few hundred
+/// bytes typical, ~1 KiB max for an injected text turn) — we cap well below
+/// that so a misbehaving peer can't tie up reads.
+const MAX_CONTROL_PAYLOAD: u32 = 64 * 1024;
+
+/// Default request timeout. Control RPC should be fast — local mob
+/// dispatch on the remote side is sub-millisecond. We give it 5s to absorb
+/// scheduler pauses, network latency, and lazy-spawn warm-up.
+pub const DEFAULT_CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cross-mob control request. One variant per control operation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ControlRequest {
+    /// Wire a local member to a peer mob's member.
+    Wire {
+        /// Member identity in the *receiving* (remote) mob.
+        remote_member: String,
+        /// Peer descriptor of the *calling* gateway's local member.
+        local_peer_spec_address: String,
+        local_comms_name: String,
+        local_peer_id: String,
+        /// Optional Ed25519 pubkey of the calling gateway. When present,
+        /// the receiving gateway builds a signed `TrustedPeerDescriptor`
+        /// so meerkat-comms can verify envelope signatures.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        local_pubkey_b64: Option<String>,
+    },
+    /// Unwire a previously-wired peer.
+    Unwire {
+        remote_member: String,
+        local_peer_spec_address: String,
+        local_comms_name: String,
+        local_peer_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        local_pubkey_b64: Option<String>,
+    },
+    /// Inject an external-turn message into a remote member's session.
+    /// Used by `send_cross_mob` for app-level injection.
+    Inject {
+        remote_member: String,
+        /// JSON-encoded `meerkat_core::ContentInput`.
+        content: serde_json::Value,
+    },
+    /// Look up a member's comms info on the remote side. Used during
+    /// `wire_cross_mob` to discover the remote member's peer_id and
+    /// derived comms_name without requiring caller-supplied bookkeeping.
+    LookupMember { remote_member: String },
+}
+
+/// Cross-mob control response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ControlResponse {
+    /// Operation succeeded (no payload).
+    Ok,
+    /// Inject succeeded — return the bridge session id that accepted the
+    /// injection so the caller can correlate downstream events.
+    Injected { session_id: String },
+    /// LookupMember succeeded — return the remote member's peer info so
+    /// the caller can build a `TrustedPeerDescriptor` pointing at it.
+    Member { peer_id: String, comms_name: String },
+    /// Operation failed. `code` is a stable short string for machine
+    /// dispatch (`unknown_member`, `mob_error`, `decode`, ...); `message`
+    /// is human-readable.
+    Err { code: String, message: String },
+}
+
+/// Open a control connection to a remote endpoint.
+///
+/// TCP and UDS share the same length-prefixed JSON framing, so we wrap
+/// the underlying `TcpStream` / `UnixStream` in a small enum and write
+/// codec-agnostic helpers below.
+enum ControlStream {
+    Tcp(TcpStream),
+    Uds(UnixStream),
+}
+
+impl ControlStream {
+    async fn write_frame(&mut self, payload: &[u8]) -> Result<(), std::io::Error> {
+        let len = u32::try_from(payload.len()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "payload too large")
+        })?;
+        let header = len.to_be_bytes();
+        match self {
+            Self::Tcp(s) => {
+                s.write_all(&header).await?;
+                s.write_all(payload).await?;
+                s.flush().await
+            }
+            Self::Uds(s) => {
+                s.write_all(&header).await?;
+                s.write_all(payload).await?;
+                s.flush().await
+            }
+        }
+    }
+
+    async fn read_frame(&mut self) -> Result<Vec<u8>, std::io::Error> {
+        let mut header = [0u8; 4];
+        match self {
+            Self::Tcp(s) => s.read_exact(&mut header).await?,
+            Self::Uds(s) => s.read_exact(&mut header).await?,
+        };
+        let len = u32::from_be_bytes(header);
+        if len > MAX_CONTROL_PAYLOAD {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("frame too large: {len} bytes"),
+            ));
+        }
+        let mut buf = vec![0u8; len as usize];
+        match self {
+            Self::Tcp(s) => s.read_exact(&mut buf).await?,
+            Self::Uds(s) => s.read_exact(&mut buf).await?,
+        };
+        Ok(buf)
+    }
+}
+
+/// Client side of the cross-mob control protocol.
+pub struct RemoteControlClient;
+
+impl RemoteControlClient {
+    /// Send `request` to `endpoint`, await one response, and return it.
+    ///
+    /// Opens a fresh connection per request — control RPC frequency is
+    /// low (one message per wire/unwire/inject call) and lazy-reconnect
+    /// keeps the implementation simple. Phase 3 (post-this-PR) can pool
+    /// connections if profiling shows it matters.
+    pub async fn send(
+        endpoint: &RemoteEndpoint,
+        request: &ControlRequest,
+        timeout: Duration,
+    ) -> Result<ControlResponse, RemoteMobError> {
+        tokio::time::timeout(timeout, Self::send_inner(endpoint, request))
+            .await
+            .map_err(|_| RemoteMobError::ControlChannelUnavailable {
+                mob_id: String::new(),
+                endpoint: endpoint.comms_address(),
+                operation: "timeout",
+            })?
+    }
+
+    async fn send_inner(
+        endpoint: &RemoteEndpoint,
+        request: &ControlRequest,
+    ) -> Result<ControlResponse, RemoteMobError> {
+        let mut stream = match endpoint {
+            RemoteEndpoint::Tcp(addr) => ControlStream::Tcp(
+                TcpStream::connect(addr)
+                    .await
+                    .map_err(|err| io_error("connect", endpoint, err))?,
+            ),
+            RemoteEndpoint::Uds(path) => ControlStream::Uds(
+                UnixStream::connect(Path::new(path))
+                    .await
+                    .map_err(|err| io_error("connect", endpoint, err))?,
+            ),
+        };
+        let payload =
+            serde_json::to_vec(request).map_err(|err| encode_error(endpoint, err.to_string()))?;
+        stream
+            .write_frame(&payload)
+            .await
+            .map_err(|err| io_error("write", endpoint, err))?;
+        let response_payload = stream
+            .read_frame()
+            .await
+            .map_err(|err| io_error("read", endpoint, err))?;
+        serde_json::from_slice::<ControlResponse>(&response_payload)
+            .map_err(|err| decode_error(endpoint, err.to_string()))
+    }
+}
+
+fn io_error(stage: &'static str, endpoint: &RemoteEndpoint, err: std::io::Error) -> RemoteMobError {
+    RemoteMobError::ControlChannelUnavailable {
+        mob_id: String::new(),
+        endpoint: endpoint.comms_address(),
+        operation: match stage {
+            "connect" => "connect",
+            "write" => "write",
+            "read" => "read",
+            _ => "io",
+        },
+    }
+    .with_context(err.to_string())
+}
+
+fn encode_error(endpoint: &RemoteEndpoint, message: String) -> RemoteMobError {
+    RemoteMobError::Encode {
+        endpoint: endpoint.comms_address(),
+        message,
+    }
+}
+
+fn decode_error(endpoint: &RemoteEndpoint, message: String) -> RemoteMobError {
+    RemoteMobError::Decode {
+        endpoint: endpoint.comms_address(),
+        message,
+    }
+}
+
+/// Asynchronously dispatch a single decoded `ControlRequest` against a
+/// local mob handle, returning the response shape.
+///
+/// Boxed-future trait so we can store this in a `dyn` field without
+/// requiring `async-trait` and so the listener doesn't need a generic
+/// type parameter for the handler.
+pub trait ControlHandler: Send + Sync + 'static {
+    fn handle(
+        &self,
+        request: ControlRequest,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ControlResponse> + Send + '_>>;
+}
+
+/// Real `ControlHandler` that dispatches requests against a local
+/// `MobHandle`. Constructed by `UnifiedRuntime::from_parts` when the
+/// contact directory advertises a TCP/UDS endpoint for this gateway.
+pub struct MobHandleControlHandler {
+    handle: meerkat_mob::MobHandle,
+}
+
+impl MobHandleControlHandler {
+    pub fn new(handle: meerkat_mob::MobHandle) -> Self {
+        Self { handle }
+    }
+}
+
+impl ControlHandler for MobHandleControlHandler {
+    fn handle(
+        &self,
+        request: ControlRequest,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ControlResponse> + Send + '_>> {
+        let handle = self.handle.clone();
+        Box::pin(async move {
+            match request {
+                ControlRequest::Wire {
+                    remote_member,
+                    local_peer_spec_address,
+                    local_comms_name,
+                    local_peer_id,
+                    local_pubkey_b64,
+                } => {
+                    handle_wire(
+                        &handle,
+                        &remote_member,
+                        &local_peer_spec_address,
+                        &local_comms_name,
+                        &local_peer_id,
+                        local_pubkey_b64.as_deref(),
+                        /* wire = */ true,
+                    )
+                    .await
+                }
+                ControlRequest::Unwire {
+                    remote_member,
+                    local_peer_spec_address,
+                    local_comms_name,
+                    local_peer_id,
+                    local_pubkey_b64,
+                } => {
+                    handle_wire(
+                        &handle,
+                        &remote_member,
+                        &local_peer_spec_address,
+                        &local_comms_name,
+                        &local_peer_id,
+                        local_pubkey_b64.as_deref(),
+                        /* wire = */ false,
+                    )
+                    .await
+                }
+                ControlRequest::Inject {
+                    remote_member,
+                    content,
+                } => handle_inject(&handle, &remote_member, content).await,
+                ControlRequest::LookupMember { remote_member } => {
+                    handle_lookup_member(&handle, &remote_member).await
+                }
+            }
+        })
+    }
+}
+
+async fn handle_wire(
+    handle: &meerkat_mob::MobHandle,
+    remote_member: &str,
+    local_peer_spec_address: &str,
+    local_comms_name: &str,
+    local_peer_id: &str,
+    local_pubkey_b64: Option<&str>,
+    wire: bool,
+) -> ControlResponse {
+    let pubkey = match local_pubkey_b64 {
+        Some(s) if !s.is_empty() => match crate::auth::peer_keys::decode_pubkey_b64(s) {
+            Ok(bytes) => Some(bytes),
+            Err(err) => {
+                return ControlResponse::Err {
+                    code: "decode".to_string(),
+                    message: format!("local_pubkey_b64: {err}"),
+                };
+            }
+        },
+        _ => None,
+    };
+    let spec_result = match pubkey {
+        Some(bytes) => meerkat_core::comms::TrustedPeerDescriptor::unsigned_with_pubkey(
+            local_comms_name,
+            local_peer_id,
+            bytes,
+            local_peer_spec_address,
+        ),
+        None => meerkat_core::comms::TrustedPeerDescriptor::test_only_unsigned(
+            local_comms_name,
+            local_peer_id,
+            local_peer_spec_address,
+        ),
+    };
+    let spec = match spec_result {
+        Ok(spec) => spec,
+        Err(err) => {
+            return ControlResponse::Err {
+                code: "peer_spec".to_string(),
+                message: err,
+            };
+        }
+    };
+    let mid = meerkat_mob::ids::MeerkatId::from(remote_member);
+    let result = if wire {
+        handle
+            .wire(mid, meerkat_mob::PeerTarget::External(spec))
+            .await
+    } else {
+        handle
+            .unwire(mid, meerkat_mob::PeerTarget::External(spec))
+            .await
+    };
+    match result {
+        Ok(()) => ControlResponse::Ok,
+        Err(err) => ControlResponse::Err {
+            code: "mob_error".to_string(),
+            message: err.to_string(),
+        },
+    }
+}
+
+async fn handle_inject(
+    handle: &meerkat_mob::MobHandle,
+    remote_member: &str,
+    content: serde_json::Value,
+) -> ControlResponse {
+    let content_input: meerkat_core::ContentInput = match serde_json::from_value(content) {
+        Ok(c) => c,
+        Err(err) => {
+            return ControlResponse::Err {
+                code: "decode".to_string(),
+                message: format!("content: {err}"),
+            };
+        }
+    };
+    let mid = meerkat_mob::ids::MeerkatId::from(remote_member);
+    let member = match handle.member(&mid).await {
+        Ok(m) => m,
+        Err(err) => {
+            return ControlResponse::Err {
+                code: "unknown_member".to_string(),
+                message: err.to_string(),
+            };
+        }
+    };
+    if let Err(err) = member
+        .send(content_input, meerkat_core::types::HandlingMode::Queue)
+        .await
+    {
+        return ControlResponse::Err {
+            code: "mob_error".to_string(),
+            message: err.to_string(),
+        };
+    }
+    match handle.resolve_bridge_session_id(&mid).await {
+        Some(sid) => ControlResponse::Injected {
+            session_id: sid.to_string(),
+        },
+        None => ControlResponse::Err {
+            code: "no_session".to_string(),
+            message: format!("member '{remote_member}' has no bound bridge session"),
+        },
+    }
+}
+
+async fn handle_lookup_member(
+    handle: &meerkat_mob::MobHandle,
+    remote_member: &str,
+) -> ControlResponse {
+    let mid = meerkat_mob::ids::MeerkatId::from(remote_member);
+    let mob_id = handle.mob_id().to_string();
+    let entry = match handle.get_member(&mid).await {
+        Some(e) => e,
+        None => {
+            return ControlResponse::Err {
+                code: "unknown_member".to_string(),
+                message: format!("member '{remote_member}' not in mob '{mob_id}'"),
+            };
+        }
+    };
+    let peer_id = match entry.peer_id() {
+        Some(p) => p.to_string(),
+        None => {
+            return ControlResponse::Err {
+                code: "no_comms".to_string(),
+                message: format!("member '{remote_member}' has no comms runtime"),
+            };
+        }
+    };
+    let comms_name = format!("{}/{}/{}", mob_id, entry.role, remote_member);
+    ControlResponse::Member {
+        peer_id,
+        comms_name,
+    }
+}
+
+/// Run a control listener on `tcp_listener` until shutdown.
+///
+/// Each accepted connection is read-frame, dispatched to the handler,
+/// response-written, then closed. The listener accepts indefinitely; cancel
+/// via `tokio::select!` against your shutdown signal.
+pub async fn serve_tcp_control(listener: TcpListener, handler: std::sync::Arc<dyn ControlHandler>) {
+    loop {
+        let (stream, _peer_addr) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(err) => {
+                tracing::warn!(error = %err, "control listener accept failed; exiting");
+                return;
+            }
+        };
+        let handler = handler.clone();
+        tokio::spawn(serve_one_tcp(stream, handler));
+    }
+}
+
+/// Same as `serve_tcp_control` but for Unix-domain sockets.
+pub async fn serve_uds_control(
+    listener: UnixListener,
+    handler: std::sync::Arc<dyn ControlHandler>,
+) {
+    loop {
+        let (stream, _peer_addr) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(err) => {
+                tracing::warn!(error = %err, "uds control listener accept failed; exiting");
+                return;
+            }
+        };
+        let handler = handler.clone();
+        tokio::spawn(serve_one_uds(stream, handler));
+    }
+}
+
+async fn serve_one_tcp(stream: TcpStream, handler: std::sync::Arc<dyn ControlHandler>) {
+    let mut s = ControlStream::Tcp(stream);
+    serve_one(&mut s, handler).await;
+}
+
+async fn serve_one_uds(stream: UnixStream, handler: std::sync::Arc<dyn ControlHandler>) {
+    let mut s = ControlStream::Uds(stream);
+    serve_one(&mut s, handler).await;
+}
+
+async fn serve_one(stream: &mut ControlStream, handler: std::sync::Arc<dyn ControlHandler>) {
+    let payload = match stream.read_frame().await {
+        Ok(buf) => buf,
+        Err(err) => {
+            tracing::debug!(error = %err, "control listener: read failed");
+            return;
+        }
+    };
+    let request = match serde_json::from_slice::<ControlRequest>(&payload) {
+        Ok(req) => req,
+        Err(err) => {
+            let response = ControlResponse::Err {
+                code: "decode".to_string(),
+                message: err.to_string(),
+            };
+            let response_payload = serde_json::to_vec(&response).unwrap_or_default();
+            let _ = stream.write_frame(&response_payload).await;
+            return;
+        }
+    };
+    let response = handler.handle(request).await;
+    let response_payload = serde_json::to_vec(&response).unwrap_or_default();
+    let _ = stream.write_frame(&response_payload).await;
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    struct EchoHandler;
+
+    impl ControlHandler for EchoHandler {
+        fn handle(
+            &self,
+            request: ControlRequest,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ControlResponse> + Send + '_>>
+        {
+            Box::pin(async move {
+                match request {
+                    ControlRequest::Wire { .. } | ControlRequest::Unwire { .. } => {
+                        ControlResponse::Ok
+                    }
+                    ControlRequest::Inject { remote_member, .. } => ControlResponse::Injected {
+                        session_id: format!("session-for-{remote_member}"),
+                    },
+                    ControlRequest::LookupMember { remote_member } => ControlResponse::Member {
+                        peer_id: format!("peer-id-for-{remote_member}"),
+                        comms_name: format!("mob/role/{remote_member}"),
+                    },
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_round_trip_inject() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(serve_tcp_control(listener, handler));
+
+        let endpoint = RemoteEndpoint::Tcp(addr.to_string());
+        let request = ControlRequest::Inject {
+            remote_member: "alice".to_string(),
+            content: serde_json::json!({"text": "hello"}),
+        };
+        let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
+            .await
+            .expect("control rpc");
+        assert_eq!(
+            response,
+            ControlResponse::Injected {
+                session_id: "session-for-alice".to_string(),
+            },
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn tcp_round_trip_wire() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(serve_tcp_control(listener, handler));
+
+        let endpoint = RemoteEndpoint::Tcp(addr.to_string());
+        let request = ControlRequest::Wire {
+            remote_member: "bob".to_string(),
+            local_peer_spec_address: "tcp://127.0.0.1:9001".to_string(),
+            local_comms_name: "demo/role/alice".to_string(),
+            local_peer_id: "00000000-0000-4000-8000-000000000001".to_string(),
+            local_pubkey_b64: None,
+        };
+        let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
+            .await
+            .expect("control rpc");
+        assert_eq!(response, ControlResponse::Ok);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn malformed_request_returns_decode_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let _server = tokio::spawn(serve_tcp_control(listener, handler));
+
+        // Send raw garbage bytes as a "control request" — server should
+        // respond with a `decode` error instead of dropping the connection
+        // silently.
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        stream
+            .write_all(&u32::to_be_bytes(5))
+            .await
+            .expect("write header");
+        stream.write_all(b"hello").await.expect("write payload");
+        stream.flush().await.expect("flush");
+
+        let mut header = [0u8; 4];
+        stream.read_exact(&mut header).await.expect("read header");
+        let len = u32::from_be_bytes(header) as usize;
+        let mut buf = vec![0u8; len];
+        stream.read_exact(&mut buf).await.expect("read payload");
+        let response: ControlResponse = serde_json::from_slice(&buf).expect("decode response");
+        match response {
+            ControlResponse::Err { code, .. } => assert_eq!(code, "decode"),
+            other => panic!("expected decode error, got {other:?}"),
+        }
+    }
+}

--- a/meerkat-mobkit/src/runtime/cross_mob_remote.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_remote.rs
@@ -56,14 +56,49 @@ use crate::contact_directory::{ContactEntry, MobTransport};
 pub enum RemoteMobError {
     /// The contact directory entry uses an unsupported transport.
     UnsupportedTransport { mob_id: String, transport: String },
-    /// The cross-process control channel for this peer mob is not yet
-    /// connected. Phase 1 surfaces this so callers see the seam without
-    /// silently misbehaving.
+    /// The cross-process control channel for this peer mob is not
+    /// reachable: connect failed, write/read failed, or the peer timed
+    /// out. The `operation` field reports which RPC stage hit the wall.
     ControlChannelUnavailable {
         mob_id: String,
         endpoint: String,
         operation: &'static str,
     },
+    /// The peer rejected our request with an error response. Carries the
+    /// peer's stable `code` (e.g. `unknown_member`, `mob_error`) and a
+    /// human-readable message.
+    Rejected {
+        mob_id: String,
+        endpoint: String,
+        code: String,
+        message: String,
+    },
+    /// We failed to encode the request payload — usually a programmer
+    /// error (un-serializable JSON value passed in).
+    Encode { endpoint: String, message: String },
+    /// We received a response we couldn't decode — peer is speaking a
+    /// different protocol or sent corrupted data.
+    Decode { endpoint: String, message: String },
+}
+
+impl RemoteMobError {
+    /// Attach IO-error context to a `ControlChannelUnavailable` variant.
+    /// Internal helper for the control-protocol module — keeps the public
+    /// shape stable while letting us record the underlying message.
+    pub(crate) fn with_context(self, context: String) -> Self {
+        match self {
+            Self::ControlChannelUnavailable {
+                mob_id,
+                endpoint,
+                operation,
+            } => Self::ControlChannelUnavailable {
+                mob_id: if mob_id.is_empty() { context } else { mob_id },
+                endpoint,
+                operation,
+            },
+            other => other,
+        }
+    }
 }
 
 impl std::fmt::Display for RemoteMobError {
@@ -82,10 +117,30 @@ impl std::fmt::Display for RemoteMobError {
             } => {
                 write!(
                     f,
-                    "remote mob '{mob_id}' control channel ({endpoint}) is not available; \
-                     operation '{operation}' is not yet supported across processes — \
-                     register a local MobHandle via register_peer_mob() for in-process peers, \
-                     or wait for cross-mob control RPC (Phase 2)"
+                    "remote mob '{mob_id}' control channel ({endpoint}): operation '{operation}' \
+                     failed — confirm the peer gateway is running with a control listener bound \
+                     on this endpoint"
+                )
+            }
+            Self::Rejected {
+                mob_id,
+                endpoint,
+                code,
+                message,
+            } => {
+                write!(
+                    f,
+                    "remote mob '{mob_id}' control channel ({endpoint}) rejected request \
+                     [{code}]: {message}"
+                )
+            }
+            Self::Encode { endpoint, message } => {
+                write!(f, "control request encode failed for {endpoint}: {message}")
+            }
+            Self::Decode { endpoint, message } => {
+                write!(
+                    f,
+                    "control response decode failed for {endpoint}: {message}"
                 )
             }
         }
@@ -171,48 +226,166 @@ impl RemoteMobProxy {
 
     /// Wire a peer on the remote side.
     ///
-    /// **Phase 1 stub** — returns [`RemoteMobError::ControlChannelUnavailable`].
-    /// Phase 2 sends a `WireRequest` over the control channel.
+    /// Sends a `Wire` control request to the peer gateway over its
+    /// configured TCP/UDS endpoint. The remote side calls
+    /// `MobHandle::wire(local_member, PeerTarget::External(spec))` and
+    /// responds with `Ok` or `Err`.
     pub async fn wire_remote(
         &self,
-        _remote_member: &str,
-        _local_peer_spec_address: &str,
+        remote_member: &str,
+        local_peer_spec_address: &str,
+        local_comms_name: &str,
+        local_peer_id: &str,
+        local_pubkey_b64: Option<String>,
     ) -> Result<(), RemoteMobError> {
-        Err(RemoteMobError::ControlChannelUnavailable {
-            mob_id: self.mob_id.clone(),
-            endpoint: self.endpoint.comms_address(),
-            operation: "wire",
-        })
+        let request = super::cross_mob_control::ControlRequest::Wire {
+            remote_member: remote_member.to_string(),
+            local_peer_spec_address: local_peer_spec_address.to_string(),
+            local_comms_name: local_comms_name.to_string(),
+            local_peer_id: local_peer_id.to_string(),
+            local_pubkey_b64,
+        };
+        self.dispatch_no_payload(request, "wire").await
     }
 
-    /// Unwire a peer on the remote side.
-    ///
-    /// **Phase 1 stub** — see [`Self::wire_remote`].
+    /// Unwire a peer on the remote side. Symmetric with [`Self::wire_remote`].
     pub async fn unwire_remote(
         &self,
-        _remote_member: &str,
-        _local_peer_spec_address: &str,
+        remote_member: &str,
+        local_peer_spec_address: &str,
+        local_comms_name: &str,
+        local_peer_id: &str,
+        local_pubkey_b64: Option<String>,
     ) -> Result<(), RemoteMobError> {
-        Err(RemoteMobError::ControlChannelUnavailable {
-            mob_id: self.mob_id.clone(),
-            endpoint: self.endpoint.comms_address(),
-            operation: "unwire",
-        })
+        let request = super::cross_mob_control::ControlRequest::Unwire {
+            remote_member: remote_member.to_string(),
+            local_peer_spec_address: local_peer_spec_address.to_string(),
+            local_comms_name: local_comms_name.to_string(),
+            local_peer_id: local_peer_id.to_string(),
+            local_pubkey_b64,
+        };
+        self.dispatch_no_payload(request, "unwire").await
     }
 
     /// Inject an external-turn message into a remote member's session.
     ///
-    /// **Phase 1 stub** — see [`Self::wire_remote`].
+    /// Returns the bridge session id that accepted the injection, so the
+    /// caller can correlate downstream events. Mirrors the local
+    /// `MobHandle::send` shape used by `send_cross_mob`.
     pub async fn inject_message(
         &self,
-        _remote_member: &str,
-        _content_json: serde_json::Value,
+        remote_member: &str,
+        content_json: serde_json::Value,
     ) -> Result<String, RemoteMobError> {
-        Err(RemoteMobError::ControlChannelUnavailable {
-            mob_id: self.mob_id.clone(),
-            endpoint: self.endpoint.comms_address(),
-            operation: "inject_message_into_member_session",
-        })
+        let request = super::cross_mob_control::ControlRequest::Inject {
+            remote_member: remote_member.to_string(),
+            content: content_json,
+        };
+        let response = super::cross_mob_control::RemoteControlClient::send(
+            &self.endpoint,
+            &request,
+            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
+        )
+        .await
+        .map_err(|err| self.attach_mob_id(err))?;
+        match response {
+            super::cross_mob_control::ControlResponse::Injected { session_id } => Ok(session_id),
+            super::cross_mob_control::ControlResponse::Err { code, message } => {
+                Err(RemoteMobError::Rejected {
+                    mob_id: self.mob_id.clone(),
+                    endpoint: self.endpoint.comms_address(),
+                    code,
+                    message,
+                })
+            }
+            other => Err(RemoteMobError::Decode {
+                endpoint: self.endpoint.comms_address(),
+                message: format!("expected Injected response, got {other:?}"),
+            }),
+        }
+    }
+
+    async fn dispatch_no_payload(
+        &self,
+        request: super::cross_mob_control::ControlRequest,
+        operation: &'static str,
+    ) -> Result<(), RemoteMobError> {
+        let response = super::cross_mob_control::RemoteControlClient::send(
+            &self.endpoint,
+            &request,
+            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
+        )
+        .await
+        .map_err(|err| self.attach_mob_id(err))?;
+        match response {
+            super::cross_mob_control::ControlResponse::Ok => Ok(()),
+            super::cross_mob_control::ControlResponse::Err { code, message } => {
+                Err(RemoteMobError::Rejected {
+                    mob_id: self.mob_id.clone(),
+                    endpoint: self.endpoint.comms_address(),
+                    code,
+                    message,
+                })
+            }
+            other => Err(RemoteMobError::Decode {
+                endpoint: self.endpoint.comms_address(),
+                message: format!("expected Ok for {operation}, got {other:?}"),
+            }),
+        }
+    }
+
+    /// Look up a remote member's peer info via the control channel.
+    /// Used during `wire_cross_mob` to discover what `TrustedPeerDescriptor`
+    /// to build for the local-side wire without caller-supplied bookkeeping.
+    pub async fn lookup_member(
+        &self,
+        remote_member: &str,
+    ) -> Result<(String, String), RemoteMobError> {
+        let request = super::cross_mob_control::ControlRequest::LookupMember {
+            remote_member: remote_member.to_string(),
+        };
+        let response = super::cross_mob_control::RemoteControlClient::send(
+            &self.endpoint,
+            &request,
+            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
+        )
+        .await
+        .map_err(|err| self.attach_mob_id(err))?;
+        match response {
+            super::cross_mob_control::ControlResponse::Member {
+                peer_id,
+                comms_name,
+            } => Ok((peer_id, comms_name)),
+            super::cross_mob_control::ControlResponse::Err { code, message } => {
+                Err(RemoteMobError::Rejected {
+                    mob_id: self.mob_id.clone(),
+                    endpoint: self.endpoint.comms_address(),
+                    code,
+                    message,
+                })
+            }
+            other => Err(RemoteMobError::Decode {
+                endpoint: self.endpoint.comms_address(),
+                message: format!("expected Member response, got {other:?}"),
+            }),
+        }
+    }
+
+    fn attach_mob_id(&self, err: RemoteMobError) -> RemoteMobError {
+        match err {
+            RemoteMobError::ControlChannelUnavailable {
+                mob_id,
+                endpoint,
+                operation,
+            } if mob_id.is_empty() || mob_id != self.mob_id => {
+                RemoteMobError::ControlChannelUnavailable {
+                    mob_id: self.mob_id.clone(),
+                    endpoint,
+                    operation,
+                }
+            }
+            other => other,
+        }
     }
 }
 
@@ -226,6 +399,7 @@ mod tests {
         let entry = ContactEntry {
             mob_id: "demo".to_string(),
             transport: MobTransport::Inproc,
+            pubkey: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry).expect("inproc is supported");
         assert!(proxy.is_none());
@@ -236,6 +410,7 @@ mod tests {
         let entry = ContactEntry {
             mob_id: "remote".to_string(),
             transport: MobTransport::Tcp("127.0.0.1:9001".to_string()),
+            pubkey: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry)
             .expect("tcp is supported")
@@ -251,6 +426,7 @@ mod tests {
         let entry = ContactEntry {
             mob_id: "remote-uds".to_string(),
             transport: MobTransport::Uds("/tmp/cross-mob.sock".to_string()),
+            pubkey: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry)
             .expect("uds is supported")
@@ -263,22 +439,33 @@ mod tests {
         );
     }
 
+    /// When no listener is bound at the configured endpoint, `wire_remote`
+    /// surfaces `ControlChannelUnavailable` with the mob id attached.
+    /// (End-to-end happy path lives in `tests/cross_mob_tcp.rs` once
+    /// the unified runtime spins up its own control listener.)
     #[tokio::test]
-    async fn wire_remote_stub_reports_unavailable() {
+    async fn wire_remote_returns_unavailable_when_no_listener() {
         let entry = ContactEntry {
             mob_id: "remote".to_string(),
-            transport: MobTransport::Tcp("127.0.0.1:9001".to_string()),
+            transport: MobTransport::Tcp("127.0.0.1:1".to_string()),
+            pubkey: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry)
             .expect("tcp ok")
             .expect("some");
         let err = proxy
-            .wire_remote("alice", "tcp://127.0.0.1:9000")
+            .wire_remote(
+                "alice",
+                "tcp://127.0.0.1:9000",
+                "demo/role/alice",
+                "00000000-0000-4000-8000-000000000001",
+                None,
+            )
             .await
-            .expect_err("phase 1 stub");
-        assert!(matches!(
-            err,
-            RemoteMobError::ControlChannelUnavailable { .. }
-        ));
+            .expect_err("no listener");
+        assert!(
+            matches!(err, RemoteMobError::ControlChannelUnavailable { ref mob_id, .. } if mob_id == "remote"),
+            "got {err:?}"
+        );
     }
 }

--- a/meerkat-mobkit/src/runtime/cross_mob_remote.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_remote.rs
@@ -1,0 +1,284 @@
+//! Cross-mob remote-handle proxy.
+//!
+//! `cross_mob.rs` historically dispatched all wire/unwire/send operations
+//! against an `Arc<MobHandle>` registered via `register_peer_mob`, which
+//! only works for peers living in the *same* process (inproc transport).
+//! This module introduces the seam for **remote** peers — mobs that live
+//! in a different process or on a different host, reachable over TCP or
+//! UDS.
+//!
+//! # Design (Phase 1)
+//!
+//! Per the 0.6 cross-mob plan we picked design **(A)** — a `LocalOrRemote`
+//! enum at the cross-mob dispatch site (`cross_mob.rs`). The local arm
+//! uses the existing `MobHandle` path; the remote arm uses [`RemoteMobProxy`]
+//! to talk to the peer mob's admin endpoint over TCP/UDS.
+//!
+//! Phase 1 lands the **structural seam**: the `RemoteMobProxy` type, the
+//! `LocalOrRemote` enum, and the contact-directory scheme (`tcp://host:port`,
+//! `uds:///path`) flowing all the way through. Wire setup at the comms
+//! layer already supports those addresses — outbound message routing uses
+//! `meerkat_comms::Router`, which dispatches by `PeerAddr` scheme. The
+//! per-member transport just works once peer specs carry the correct
+//! address.
+//!
+//! What this module does **not** ship in Phase 1:
+//!
+//! 1. **Cross-process control RPC.** A real `RemoteMobProxy::wire` would
+//!    open a TCP/UDS connection to the peer mob's admin endpoint, send a
+//!    `WIRE` request, and await acknowledgment. Today the methods on
+//!    `RemoteMobProxy` return [`RemoteMobError::ControlChannelUnavailable`]
+//!    so callers learn the seam exists but is not yet wired.
+//! 2. **Ed25519-signed peer descriptors.** Sibling Unit 4 lands signed
+//!    descriptor authoring; this unit keeps using
+//!    `TrustedPeerSpec::new(...)` (which is structurally `test_only_unsigned`
+//!    in the 0.5.x core seam). The seam where Unit 4 will plug in is the
+//!    helpers `build_tcp_peer_spec` / `build_uds_peer_spec` in
+//!    `cross_mob.rs`.
+//!
+//! # Phase 2 plan (out of scope here)
+//!
+//! - Add a small JSON-over-CBOR control protocol with three operations:
+//!   `WireRequest { local_member, peer_spec }`,
+//!   `UnwireRequest { local_member, peer_spec }`,
+//!   `InjectRequest { remote_member, content, handling_mode }`.
+//!   Frame with `meerkat_comms::transport::codec::TransportCodec` (length-prefix
+//!   CBOR) — same wire shape as agent envelopes, distinct payload type.
+//! - Bind a control listener on each `UnifiedRuntime` startup when the
+//!   contact directory advertises a TCP/UDS endpoint for *this* mob.
+//! - `RemoteMobProxy` opens the connection lazily and reuses it for
+//!   subsequent calls; reconnect on drop.
+
+use crate::contact_directory::{ContactEntry, MobTransport};
+
+/// Errors raised by the remote-mob proxy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteMobError {
+    /// The contact directory entry uses an unsupported transport.
+    UnsupportedTransport { mob_id: String, transport: String },
+    /// The cross-process control channel for this peer mob is not yet
+    /// connected. Phase 1 surfaces this so callers see the seam without
+    /// silently misbehaving.
+    ControlChannelUnavailable {
+        mob_id: String,
+        endpoint: String,
+        operation: &'static str,
+    },
+}
+
+impl std::fmt::Display for RemoteMobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedTransport { mob_id, transport } => {
+                write!(
+                    f,
+                    "remote mob '{mob_id}' uses unsupported transport: {transport}"
+                )
+            }
+            Self::ControlChannelUnavailable {
+                mob_id,
+                endpoint,
+                operation,
+            } => {
+                write!(
+                    f,
+                    "remote mob '{mob_id}' control channel ({endpoint}) is not available; \
+                     operation '{operation}' is not yet supported across processes — \
+                     register a local MobHandle via register_peer_mob() for in-process peers, \
+                     or wait for cross-mob control RPC (Phase 2)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RemoteMobError {}
+
+/// Endpoint address for the peer mob's control channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteEndpoint {
+    /// TCP `host:port`.
+    Tcp(String),
+    /// Unix-domain-socket path.
+    Uds(String),
+}
+
+impl RemoteEndpoint {
+    /// Return the comms-style transport scheme (`tcp` or `uds`).
+    pub fn scheme(&self) -> &'static str {
+        match self {
+            Self::Tcp(_) => "tcp",
+            Self::Uds(_) => "uds",
+        }
+    }
+
+    /// Return a comms-style address for this endpoint
+    /// (`tcp://host:port` or `uds:///path`).
+    pub fn comms_address(&self) -> String {
+        match self {
+            Self::Tcp(addr) => format!("tcp://{addr}"),
+            Self::Uds(path) => format!("uds://{path}"),
+        }
+    }
+
+    /// Bare endpoint string (without scheme) — `host:port` or `/path`.
+    pub fn raw(&self) -> &str {
+        match self {
+            Self::Tcp(s) | Self::Uds(s) => s.as_str(),
+        }
+    }
+}
+
+/// A proxy for a mob that lives in a different process.
+///
+/// Phase 1: a structural placeholder. The methods are stubs that return
+/// [`RemoteMobError::ControlChannelUnavailable`] so call sites can be
+/// written against the final shape; Phase 2 will replace these with a
+/// real control-channel client.
+#[derive(Debug, Clone)]
+pub struct RemoteMobProxy {
+    mob_id: String,
+    endpoint: RemoteEndpoint,
+}
+
+impl RemoteMobProxy {
+    /// Build a proxy from a contact-directory entry. Returns `None` for
+    /// `Inproc` entries — those are served by an `Arc<MobHandle>` via
+    /// `LocalOrRemote::Local` instead.
+    pub fn from_entry(entry: &ContactEntry) -> Result<Option<Self>, RemoteMobError> {
+        match &entry.transport {
+            MobTransport::Inproc => Ok(None),
+            MobTransport::Tcp(addr) => Ok(Some(Self {
+                mob_id: entry.mob_id.clone(),
+                endpoint: RemoteEndpoint::Tcp(addr.clone()),
+            })),
+            MobTransport::Uds(path) => Ok(Some(Self {
+                mob_id: entry.mob_id.clone(),
+                endpoint: RemoteEndpoint::Uds(path.clone()),
+            })),
+        }
+    }
+
+    /// The peer mob's identifier.
+    pub fn mob_id(&self) -> &str {
+        &self.mob_id
+    }
+
+    /// The peer mob's control endpoint.
+    pub fn endpoint(&self) -> &RemoteEndpoint {
+        &self.endpoint
+    }
+
+    /// Wire a peer on the remote side.
+    ///
+    /// **Phase 1 stub** — returns [`RemoteMobError::ControlChannelUnavailable`].
+    /// Phase 2 sends a `WireRequest` over the control channel.
+    pub async fn wire_remote(
+        &self,
+        _remote_member: &str,
+        _local_peer_spec_address: &str,
+    ) -> Result<(), RemoteMobError> {
+        Err(RemoteMobError::ControlChannelUnavailable {
+            mob_id: self.mob_id.clone(),
+            endpoint: self.endpoint.comms_address(),
+            operation: "wire",
+        })
+    }
+
+    /// Unwire a peer on the remote side.
+    ///
+    /// **Phase 1 stub** — see [`Self::wire_remote`].
+    pub async fn unwire_remote(
+        &self,
+        _remote_member: &str,
+        _local_peer_spec_address: &str,
+    ) -> Result<(), RemoteMobError> {
+        Err(RemoteMobError::ControlChannelUnavailable {
+            mob_id: self.mob_id.clone(),
+            endpoint: self.endpoint.comms_address(),
+            operation: "unwire",
+        })
+    }
+
+    /// Inject an external-turn message into a remote member's session.
+    ///
+    /// **Phase 1 stub** — see [`Self::wire_remote`].
+    pub async fn inject_message(
+        &self,
+        _remote_member: &str,
+        _content_json: serde_json::Value,
+    ) -> Result<String, RemoteMobError> {
+        Err(RemoteMobError::ControlChannelUnavailable {
+            mob_id: self.mob_id.clone(),
+            endpoint: self.endpoint.comms_address(),
+            operation: "inject_message_into_member_session",
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_entry_inproc_returns_none() {
+        let entry = ContactEntry {
+            mob_id: "demo".to_string(),
+            transport: MobTransport::Inproc,
+        };
+        let proxy = RemoteMobProxy::from_entry(&entry).expect("inproc is supported");
+        assert!(proxy.is_none());
+    }
+
+    #[test]
+    fn from_entry_tcp_round_trip() {
+        let entry = ContactEntry {
+            mob_id: "remote".to_string(),
+            transport: MobTransport::Tcp("127.0.0.1:9001".to_string()),
+        };
+        let proxy = RemoteMobProxy::from_entry(&entry)
+            .expect("tcp is supported")
+            .expect("tcp returns Some(proxy)");
+        assert_eq!(proxy.mob_id(), "remote");
+        assert_eq!(proxy.endpoint().scheme(), "tcp");
+        assert_eq!(proxy.endpoint().raw(), "127.0.0.1:9001");
+        assert_eq!(proxy.endpoint().comms_address(), "tcp://127.0.0.1:9001");
+    }
+
+    #[test]
+    fn from_entry_uds_round_trip() {
+        let entry = ContactEntry {
+            mob_id: "remote-uds".to_string(),
+            transport: MobTransport::Uds("/tmp/cross-mob.sock".to_string()),
+        };
+        let proxy = RemoteMobProxy::from_entry(&entry)
+            .expect("uds is supported")
+            .expect("uds returns Some(proxy)");
+        assert_eq!(proxy.endpoint().scheme(), "uds");
+        assert_eq!(proxy.endpoint().raw(), "/tmp/cross-mob.sock");
+        assert_eq!(
+            proxy.endpoint().comms_address(),
+            "uds:///tmp/cross-mob.sock"
+        );
+    }
+
+    #[tokio::test]
+    async fn wire_remote_stub_reports_unavailable() {
+        let entry = ContactEntry {
+            mob_id: "remote".to_string(),
+            transport: MobTransport::Tcp("127.0.0.1:9001".to_string()),
+        };
+        let proxy = RemoteMobProxy::from_entry(&entry)
+            .expect("tcp ok")
+            .expect("some");
+        let err = proxy
+            .wire_remote("alice", "tcp://127.0.0.1:9000")
+            .await
+            .expect_err("phase 1 stub");
+        assert!(matches!(
+            err,
+            RemoteMobError::ControlChannelUnavailable { .. }
+        ));
+    }
+}

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -6,9 +6,23 @@ use meerkat_mob::ids::MeerkatId;
 use meerkat_mob::{MobHandle, PeerTarget};
 
 use crate::auth::peer_keys::GatewayPeerKeys;
-use crate::contact_directory::{ContactDirectory, ContactEntry};
+use crate::contact_directory::{ContactDirectory, ContactEntry, MobTransport};
+use crate::runtime::cross_mob_remote::{RemoteMobError, RemoteMobProxy};
 
 use super::UnifiedRuntime;
+
+/// Dispatch a cross-mob operation to either an in-process `MobHandle`
+/// (registered via `register_peer_mob`) or a [`RemoteMobProxy`] for
+/// peers reachable over TCP/UDS.
+///
+/// Phase 1 wires the structural seam — see `runtime/cross_mob_remote.rs`
+/// for the Phase 2 plan that fills in real cross-process control RPC.
+enum LocalOrRemote {
+    /// Same-process peer with an `Arc<MobHandle>` for direct dispatch.
+    Local(MobHandle),
+    /// Cross-process peer reachable via TCP/UDS.
+    Remote(RemoteMobProxy),
+}
 
 /// Errors from cross-mob operations.
 #[derive(Debug)]
@@ -19,9 +33,6 @@ pub enum CrossMobError {
     UnknownMob(String),
     /// No peer mob handle registered for this mob (required for inproc).
     NoPeerHandle(String),
-    /// The contact entry uses TCP or UDS transport, which is not yet supported.
-    /// Phase 1 only supports inproc (same-process) cross-mob communication.
-    TransportNotSupported { mob_id: String, transport: String },
     /// Caller asked to wire a non-inproc peer but did not supply (or
     /// could not derive) a 32-byte Ed25519 pubkey. Mobkit refuses to
     /// build an unsigned descriptor on real transports — meerkat-comms
@@ -35,6 +46,11 @@ pub enum CrossMobError {
     Mob(meerkat_mob::MobError),
     /// Failed to build a trusted peer spec.
     PeerSpec(String),
+    /// A cross-process control-channel call failed. Phase 1 returns this
+    /// for any TCP/UDS contact entry that does not also have an
+    /// in-process `MobHandle` registered — the seam is laid out, the
+    /// real client lands in Phase 2.
+    Remote(RemoteMobError),
 }
 
 impl std::fmt::Display for CrossMobError {
@@ -43,13 +59,7 @@ impl std::fmt::Display for CrossMobError {
             Self::NoContactDirectory => write!(f, "no contact directory configured"),
             Self::UnknownMob(id) => write!(f, "unknown mob: {id}"),
             Self::NoPeerHandle(id) => write!(f, "no peer mob handle registered for: {id}"),
-            Self::TransportNotSupported { mob_id, transport } => {
-                write!(
-                    f,
-                    "cross-mob transport '{transport}' for mob '{mob_id}' is not yet supported; \
-                     only inproc (same-process) is supported in phase 1"
-                )
-            }
+            Self::Remote(e) => write!(f, "cross-process cross-mob: {e}"),
             Self::MemberNotFound { member_id, mob_id } => {
                 write!(f, "member '{member_id}' not found in mob '{mob_id}'")
             }
@@ -86,6 +96,12 @@ impl From<meerkat_mob::MobError> for CrossMobError {
     }
 }
 
+impl From<RemoteMobError> for CrossMobError {
+    fn from(err: RemoteMobError) -> Self {
+        Self::Remote(err)
+    }
+}
+
 impl UnifiedRuntime {
     /// Register an external mob's handle for same-process cross-mob communication.
     pub async fn register_peer_mob(&self, mob_id: &str, handle: MobHandle) {
@@ -119,17 +135,45 @@ impl UnifiedRuntime {
 
     /// Wire a local member to a member in an external mob.
     ///
-    /// Resolves both members' peer IDs from roster entries, builds peer specs,
-    /// and calls `wire(local, PeerTarget::External(spec))` on both mob handles
-    /// to establish bidirectional trust.
+    /// Resolves both members' peer IDs from roster entries, builds peer specs
+    /// using the transport scheme advertised by the contact directory entry
+    /// (`inproc`, `tcp`, or `uds`), and registers the peer on both sides to
+    /// establish bidirectional trust.
+    ///
+    /// # Local vs remote dispatch
+    ///
+    /// The destination mob is dispatched as either [`LocalOrRemote::Local`]
+    /// (when an `Arc<MobHandle>` was registered via [`Self::register_peer_mob`])
+    /// or [`LocalOrRemote::Remote`] (when only a contact-directory TCP/UDS
+    /// entry exists). Phase 1 ships the structural seam; Phase 2 wires the
+    /// real cross-process control RPC — see
+    /// `runtime::cross_mob_remote::RemoteMobProxy`.
     pub async fn wire_cross_mob(
         &self,
         local_member_id: &str,
         remote_member_id: &str,
         remote_mob_id: &str,
     ) -> Result<(), CrossMobError> {
-        let _entry = self.resolve_contact(remote_mob_id)?;
-        let remote_handle = self.get_peer_handle(remote_mob_id).await?;
+        let entry = self.resolve_contact(remote_mob_id)?;
+        let remote = self.dispatch_for(&entry).await?;
+
+        // Phase 1: cross-process dispatch is a structural seam — short-
+        // circuit before doing local-member lookups so callers see the
+        // ControlChannelUnavailable surface unambiguously. Phase 2 will
+        // run local lookup + open the control channel here.
+        let remote_handle = match &remote {
+            LocalOrRemote::Local(handle) => handle.clone(),
+            LocalOrRemote::Remote(proxy) => {
+                return Err(CrossMobError::Remote(
+                    RemoteMobError::ControlChannelUnavailable {
+                        mob_id: remote_mob_id.to_string(),
+                        endpoint: proxy.endpoint().comms_address(),
+                        operation: "wire_cross_mob",
+                    },
+                ));
+            }
+        };
+
         let local_handle = self.mob_runtime.handle();
         let local_mob_id = local_handle.mob_id().to_string();
 
@@ -144,22 +188,34 @@ impl UnifiedRuntime {
             .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
             .await?;
 
-        // Build peer specs (inproc for same-process)
-        let remote_spec = build_inproc_peer_spec(&remote_comms_name, &remote_peer_id)?;
-        let local_spec = build_inproc_peer_spec(&local_comms_name, &local_peer_id)?;
+        // Build peer specs honoring the contact-entry transport scheme.
+        //
+        // - `remote_spec` is what the **local** member uses to reach the
+        //   remote: it carries the contact-entry transport (inproc/tcp/uds).
+        // - `local_spec` is the back-pointer the **remote** member uses
+        //   to reach us. The Local-handle dispatch resolves the local mob
+        //   via the inproc registry, so we always advertise inproc for
+        //   the local side here. (The Remote arm short-circuits above
+        //   with ControlChannelUnavailable; Phase 2 will negotiate the
+        //   advertised endpoint over the control channel.)
+        let remote_spec = build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)?;
+        let local_spec = build_peer_spec(&local_comms_name, &local_peer_id, &MobTransport::Inproc)?;
 
-        // Wire both sides; roll back the local side if the remote wire fails.
+        // Wire the local side first.
         local_handle
             .wire(local_mid.clone(), PeerTarget::External(remote_spec))
             .await
             .map_err(CrossMobError::Mob)?;
 
+        // Wire the remote side; roll back the local side on failure.
         if let Err(e) = remote_handle
-            .wire(remote_mid, PeerTarget::External(local_spec))
+            .wire(remote_mid.clone(), PeerTarget::External(local_spec))
             .await
         {
             // Best-effort rollback — leave local state consistent.
-            if let Ok(rollback_spec) = build_inproc_peer_spec(&remote_comms_name, &remote_peer_id) {
+            if let Ok(rollback_spec) =
+                build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
+            {
                 let _ = local_handle
                     .unwire(local_mid, PeerTarget::External(rollback_spec))
                     .await;
@@ -181,8 +237,22 @@ impl UnifiedRuntime {
         remote_member_id: &str,
         remote_mob_id: &str,
     ) -> Result<(), CrossMobError> {
-        let _entry = self.resolve_contact(remote_mob_id)?;
-        let remote_handle = self.get_peer_handle(remote_mob_id).await?;
+        let entry = self.resolve_contact(remote_mob_id)?;
+        let remote = self.dispatch_for(&entry).await?;
+
+        let remote_handle = match &remote {
+            LocalOrRemote::Local(handle) => handle.clone(),
+            LocalOrRemote::Remote(proxy) => {
+                return Err(CrossMobError::Remote(
+                    RemoteMobError::ControlChannelUnavailable {
+                        mob_id: remote_mob_id.to_string(),
+                        endpoint: proxy.endpoint().comms_address(),
+                        operation: "unwire_cross_mob",
+                    },
+                ));
+            }
+        };
+
         let local_handle = self.mob_runtime.handle();
         let local_mob_id = local_handle.mob_id().to_string();
 
@@ -191,11 +261,11 @@ impl UnifiedRuntime {
 
         let mut first_error: Option<CrossMobError> = None;
 
-        // Unwire remote peer from local member
+        // Unwire remote peer from local member.
         if let Ok((remote_peer_id, remote_comms_name)) = self
             .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
             .await
-            && let Ok(spec) = build_inproc_peer_spec(&remote_comms_name, &remote_peer_id)
+            && let Ok(spec) = build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
             && let Err(e) = local_handle
                 .unwire(local_mid.clone(), PeerTarget::External(spec))
                 .await
@@ -207,7 +277,8 @@ impl UnifiedRuntime {
         if let Ok((local_peer_id, local_comms_name)) = self
             .get_member_peer_info(&local_handle, &local_mid, &local_mob_id)
             .await
-            && let Ok(spec) = build_inproc_peer_spec(&local_comms_name, &local_peer_id)
+            && let Ok(spec) =
+                build_peer_spec(&local_comms_name, &local_peer_id, &MobTransport::Inproc)
             && let Err(e) = remote_handle
                 .unwire(remote_mid.clone(), PeerTarget::External(spec))
                 .await
@@ -239,28 +310,44 @@ impl UnifiedRuntime {
         remote_mob_id: &str,
         content: impl Into<meerkat_core::ContentInput>,
     ) -> Result<String, CrossMobError> {
-        let _entry = self.resolve_contact(remote_mob_id)?;
-        let remote_handle = self.get_peer_handle(remote_mob_id).await?;
+        let entry = self.resolve_contact(remote_mob_id)?;
+        let remote = self.dispatch_for(&entry).await?;
         let remote_mid = MeerkatId::from(remote_member_id);
         let content = content.into();
         let _ = from_local_member; // audit context; delivery is via remote handle
-        let _receipt = remote_handle
-            .member(&remote_mid)
-            .await
-            .map_err(CrossMobError::Mob)?
-            .send(content, HandlingMode::Queue)
-            .await
-            .map_err(CrossMobError::Mob)?;
-        // Meerkat 0.6: MemberDeliveryReceipt no longer carries session_id.
-        // Resolve the bridge session id from the remote mob handle.
-        let session_id = remote_handle
-            .resolve_bridge_session_id(&remote_mid)
-            .await
-            .ok_or_else(|| CrossMobError::NoCommsInfo {
-                member_id: remote_mid.to_string(),
-                mob_id: remote_mob_id.to_string(),
-            })?;
-        Ok(session_id.to_string())
+
+        match remote {
+            LocalOrRemote::Local(remote_handle) => {
+                let _receipt = remote_handle
+                    .member(&remote_mid)
+                    .await
+                    .map_err(CrossMobError::Mob)?
+                    .send(content, HandlingMode::Queue)
+                    .await
+                    .map_err(CrossMobError::Mob)?;
+                // Meerkat 0.6: MemberDeliveryReceipt no longer carries
+                // session_id. Resolve the bridge session id from the
+                // remote mob handle.
+                let session_id = remote_handle
+                    .resolve_bridge_session_id(&remote_mid)
+                    .await
+                    .ok_or_else(|| CrossMobError::NoCommsInfo {
+                        member_id: remote_mid.to_string(),
+                        mob_id: remote_mob_id.to_string(),
+                    })?;
+                Ok(session_id.to_string())
+            }
+            LocalOrRemote::Remote(proxy) => {
+                // Phase 2 will serialize `content` and ship it over the
+                // remote control channel. The Phase 1 stub returns
+                // ControlChannelUnavailable before touching the payload,
+                // so we pass `Null` and let the seam do the talking.
+                let session_id = proxy
+                    .inject_message(remote_member_id, serde_json::Value::Null)
+                    .await?;
+                Ok(session_id)
+            }
+        }
     }
 
     /// List external mobs from the contact directory.
@@ -282,13 +369,22 @@ impl UnifiedRuntime {
         !self.peer_mob_handles.read().await.is_empty()
     }
 
-    /// Whether the contact directory has any inproc entries (the only
-    /// transport currently supported for cross-mob wire/send).
+    /// Whether the contact directory has any inproc entries.
     pub fn has_inproc_contacts(&self) -> bool {
         self.contact_directory.as_ref().is_some_and(|d| {
             d.list()
                 .iter()
-                .any(|e| matches!(e.transport, crate::contact_directory::MobTransport::Inproc))
+                .any(|e| matches!(e.transport, MobTransport::Inproc))
+        })
+    }
+
+    /// Whether the contact directory has any cross-process (TCP/UDS) entries.
+    /// Useful for opting into the remote-mob proxy code path.
+    pub fn has_remote_contacts(&self) -> bool {
+        self.contact_directory.as_ref().is_some_and(|d| {
+            d.list()
+                .iter()
+                .any(|e| matches!(e.transport, MobTransport::Tcp(_) | MobTransport::Uds(_)))
         })
     }
 
@@ -379,29 +475,35 @@ impl UnifiedRuntime {
             .contact_directory
             .as_ref()
             .ok_or(CrossMobError::NoContactDirectory)?;
-        let entry = dir
-            .get(mob_id)
+        dir.get(mob_id)
             .cloned()
-            .ok_or_else(|| CrossMobError::UnknownMob(mob_id.to_string()))?;
-        if !matches!(
-            entry.transport,
-            crate::contact_directory::MobTransport::Inproc
-        ) {
-            return Err(CrossMobError::TransportNotSupported {
-                mob_id: mob_id.to_string(),
-                transport: format!("{:?}", entry.transport),
-            });
-        }
-        Ok(entry)
+            .ok_or_else(|| CrossMobError::UnknownMob(mob_id.to_string()))
     }
 
-    async fn get_peer_handle(&self, mob_id: &str) -> Result<MobHandle, CrossMobError> {
-        self.peer_mob_handles
+    /// Pick the appropriate dispatch arm for a contact entry.
+    ///
+    /// Order of preference:
+    /// 1. **Local** — if a `MobHandle` was registered via
+    ///    [`Self::register_peer_mob`] for this mob_id, use it directly
+    ///    (covers the inproc + same-process-test paths).
+    /// 2. **Remote** — for TCP/UDS contact entries with no registered
+    ///    handle, build a [`RemoteMobProxy`].
+    /// 3. **Error** — inproc entry with no registered handle, or unknown
+    ///    transport.
+    async fn dispatch_for(&self, entry: &ContactEntry) -> Result<LocalOrRemote, CrossMobError> {
+        if let Some(handle) = self
+            .peer_mob_handles
             .read()
             .await
-            .get(mob_id)
+            .get(&entry.mob_id)
             .cloned()
-            .ok_or_else(|| CrossMobError::NoPeerHandle(mob_id.to_string()))
+        {
+            return Ok(LocalOrRemote::Local(handle));
+        }
+        match RemoteMobProxy::from_entry(entry)? {
+            Some(proxy) => Ok(LocalOrRemote::Remote(proxy)),
+            None => Err(CrossMobError::NoPeerHandle(entry.mob_id.clone())),
+        }
     }
 
     /// Resolve a member's peer_id and comms name from the roster entry.
@@ -437,15 +539,30 @@ impl UnifiedRuntime {
     }
 }
 
-fn build_inproc_peer_spec(
+/// Build a `TrustedPeerDescriptor` whose address reflects the supplied transport.
+///
+/// Uses the comms-layer address schemes:
+/// - `inproc://{comms_name}` for in-process peers
+/// - `tcp://host:port` for TCP
+/// - `uds:///path` for UDS (note the triple slash — `uds://` plus an
+///   absolute path)
+///
+/// **Phase-1 seam.** Until Unit 4 lands signed `TrustedPeerDescriptor`s
+/// for cross-process peers, these specs go through
+/// [`TrustedPeerDescriptor::test_only_unsigned`]. The in-process router
+/// authorizes inproc peers via its identity map regardless; out-of-process
+/// callers wait for Unit 4 to swap in a signed descriptor.
+fn build_peer_spec(
     comms_name: &str,
     peer_id: &str,
+    transport: &MobTransport,
 ) -> Result<TrustedPeerDescriptor, CrossMobError> {
-    // Inproc cross-mob: the in-process router authorises via its identity
-    // map and signature verification is moot, so an unsigned descriptor
-    // is the right shape. Non-inproc paths use [`build_external_peer_spec`]
-    // which requires a real pubkey or fails closed.
-    TrustedPeerDescriptor::test_only_unsigned(comms_name, peer_id, format!("inproc://{comms_name}"))
+    let address = match transport {
+        MobTransport::Inproc => format!("inproc://{comms_name}"),
+        MobTransport::Tcp(addr) => format!("tcp://{addr}"),
+        MobTransport::Uds(path) => format!("uds://{path}"),
+    };
+    TrustedPeerDescriptor::test_only_unsigned(comms_name, peer_id, address)
         .map_err(CrossMobError::PeerSpec)
 }
 
@@ -481,5 +598,93 @@ fn build_external_peer_spec(
             TrustedPeerDescriptor::unsigned_with_pubkey(comms_name, peer_id, bytes, address)
                 .map_err(CrossMobError::PeerSpec)
         }
+    }
+}
+
+/// Build a TCP peer descriptor.
+///
+/// Uses the comms-layer address scheme `tcp://host:port`. **Phase-1 seam**:
+/// goes through [`TrustedPeerDescriptor::test_only_unsigned`]. Callers
+/// that need a real signed descriptor (Ed25519-stamped) should construct
+/// it via [`build_external_peer_spec`] with an explicit pubkey instead.
+pub fn build_tcp_peer_spec(
+    comms_name: &str,
+    peer_id: &str,
+    address: &str,
+) -> Result<TrustedPeerDescriptor, CrossMobError> {
+    TrustedPeerDescriptor::test_only_unsigned(comms_name, peer_id, format!("tcp://{address}"))
+        .map_err(CrossMobError::PeerSpec)
+}
+
+/// Build a UDS peer descriptor.
+///
+/// Uses the comms-layer address scheme `uds:///path` (triple slash —
+/// `uds://` + absolute path). See [`build_tcp_peer_spec`] for the
+/// Phase-1 vs signed-descriptor seam note.
+pub fn build_uds_peer_spec(
+    comms_name: &str,
+    peer_id: &str,
+    path: &str,
+) -> Result<TrustedPeerDescriptor, CrossMobError> {
+    let normalized = if let Some(stripped) = path.strip_prefix('/') {
+        stripped
+    } else {
+        path
+    };
+    TrustedPeerDescriptor::test_only_unsigned(comms_name, peer_id, format!("uds:///{normalized}"))
+        .map_err(CrossMobError::PeerSpec)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const TEST_PEER_ID: &str = "00000000-0000-4000-8000-000000000001";
+
+    #[test]
+    fn peer_spec_inproc_uses_comms_name_address() {
+        let spec = build_peer_spec(
+            "authors/coordinator/alice",
+            TEST_PEER_ID,
+            &MobTransport::Inproc,
+        )
+        .expect("spec");
+        assert_eq!(spec.address.endpoint(), "authors/coordinator/alice");
+    }
+
+    #[test]
+    fn peer_spec_tcp_uses_tcp_scheme() {
+        let spec = build_peer_spec(
+            "authors/coordinator/alice",
+            "00000000-0000-4000-8000-000000000001",
+            &MobTransport::Tcp("127.0.0.1:9001".to_string()),
+        )
+        .expect("spec");
+        assert_eq!(spec.address.endpoint(), "127.0.0.1:9001");
+    }
+
+    #[test]
+    fn peer_spec_uds_uses_uds_scheme() {
+        let spec = build_peer_spec(
+            "authors/coordinator/alice",
+            "00000000-0000-4000-8000-000000000001",
+            &MobTransport::Uds("/tmp/x.sock".to_string()),
+        )
+        .expect("spec");
+        assert_eq!(spec.address.endpoint(), "/tmp/x.sock");
+    }
+
+    #[test]
+    fn build_uds_peer_spec_handles_leading_slash() {
+        // Caller may pass the path with or without a leading slash; both
+        // produce the canonical `uds:///path` form.
+        let with = build_uds_peer_spec("a", "00000000-0000-4000-8000-000000000001", "/tmp/x.sock")
+            .expect("spec");
+        let without =
+            build_uds_peer_spec("a", "00000000-0000-4000-8000-000000000001", "tmp/x.sock")
+                .expect("spec");
+        assert_eq!(with.address.endpoint(), "/tmp/x.sock");
+        assert_eq!(without.address.endpoint(), "/tmp/x.sock");
     }
 }

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -157,73 +157,102 @@ impl UnifiedRuntime {
         let entry = self.resolve_contact(remote_mob_id)?;
         let remote = self.dispatch_for(&entry).await?;
 
-        // Phase 1: cross-process dispatch is a structural seam — short-
-        // circuit before doing local-member lookups so callers see the
-        // ControlChannelUnavailable surface unambiguously. Phase 2 will
-        // run local lookup + open the control channel here.
-        let remote_handle = match &remote {
-            LocalOrRemote::Local(handle) => handle.clone(),
-            LocalOrRemote::Remote(proxy) => {
-                return Err(CrossMobError::Remote(
-                    RemoteMobError::ControlChannelUnavailable {
-                        mob_id: remote_mob_id.to_string(),
-                        endpoint: proxy.endpoint().comms_address(),
-                        operation: "wire_cross_mob",
-                    },
-                ));
-            }
-        };
-
         let local_handle = self.mob_runtime.handle();
         let local_mob_id = local_handle.mob_id().to_string();
-
         let local_mid = MeerkatId::from(local_member_id);
-        let remote_mid = MeerkatId::from(remote_member_id);
 
-        // Get peer info for both members from roster entries
         let (local_peer_id, local_comms_name) = self
             .get_member_peer_info(&local_handle, &local_mid, &local_mob_id)
             .await?;
-        let (remote_peer_id, remote_comms_name) = self
-            .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
-            .await?;
 
-        // Build peer specs honoring the contact-entry transport scheme.
-        //
-        // - `remote_spec` is what the **local** member uses to reach the
-        //   remote: it carries the contact-entry transport (inproc/tcp/uds).
-        // - `local_spec` is the back-pointer the **remote** member uses
-        //   to reach us. The Local-handle dispatch resolves the local mob
-        //   via the inproc registry, so we always advertise inproc for
-        //   the local side here. (The Remote arm short-circuits above
-        //   with ControlChannelUnavailable; Phase 2 will negotiate the
-        //   advertised endpoint over the control channel.)
-        let remote_spec = build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)?;
-        let local_spec = build_peer_spec(&local_comms_name, &local_peer_id, &MobTransport::Inproc)?;
+        match remote {
+            LocalOrRemote::Local(remote_handle) => {
+                let remote_mid = MeerkatId::from(remote_member_id);
+                let (remote_peer_id, remote_comms_name) = self
+                    .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
+                    .await?;
 
-        // Wire the local side first.
-        local_handle
-            .wire(local_mid.clone(), PeerTarget::External(remote_spec))
-            .await
-            .map_err(CrossMobError::Mob)?;
+                let remote_spec =
+                    build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)?;
+                let local_spec =
+                    build_peer_spec(&local_comms_name, &local_peer_id, &MobTransport::Inproc)?;
 
-        // Wire the remote side; roll back the local side on failure.
-        if let Err(e) = remote_handle
-            .wire(remote_mid.clone(), PeerTarget::External(local_spec))
-            .await
-        {
-            // Best-effort rollback — leave local state consistent.
-            if let Ok(rollback_spec) =
-                build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
-            {
-                let _ = local_handle
-                    .unwire(local_mid, PeerTarget::External(rollback_spec))
-                    .await;
+                local_handle
+                    .wire(local_mid.clone(), PeerTarget::External(remote_spec))
+                    .await
+                    .map_err(CrossMobError::Mob)?;
+
+                if let Err(e) = remote_handle
+                    .wire(remote_mid.clone(), PeerTarget::External(local_spec))
+                    .await
+                {
+                    if let Ok(rollback_spec) =
+                        build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
+                    {
+                        let _ = local_handle
+                            .unwire(local_mid, PeerTarget::External(rollback_spec))
+                            .await;
+                    }
+                    return Err(CrossMobError::Mob(e));
+                }
+
+                Ok(())
             }
-            return Err(CrossMobError::Mob(e));
-        }
+            LocalOrRemote::Remote(proxy) => {
+                // Cross-process bilateral wire:
+                // 1. Look up the remote member's peer info via control RPC.
+                // 2. Build a descriptor pointing to the remote member using
+                //    the contact-entry transport; wire locally first.
+                // 3. Send a `Wire` control request advertising our local
+                //    member's peer info; remote side wires its half.
+                // 4. On remote-side failure, roll back the local wire.
+                let (remote_peer_id, remote_comms_name) = proxy
+                    .lookup_member(remote_member_id)
+                    .await
+                    .map_err(CrossMobError::Remote)?;
+                let remote_spec =
+                    build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)?;
 
-        Ok(())
+                local_handle
+                    .wire(local_mid.clone(), PeerTarget::External(remote_spec))
+                    .await
+                    .map_err(CrossMobError::Mob)?;
+
+                // The remote side reaches us over the same transport scheme
+                // we use to reach it. The contact directory entry on the
+                // remote gateway will record our control endpoint; for the
+                // bilateral wire we advertise the same endpoint the
+                // ContactEntry currently encodes for *us*. Until we run
+                // a discovery RPC the other way, advertise an inproc
+                // back-pointer so trust is symmetric on the wire surface.
+                let pubkey_b64 = self
+                    .gateway_peer_keys
+                    .as_ref()
+                    .map(crate::auth::peer_keys::GatewayPeerKeys::pubkey_b64);
+                let local_spec_address = format!("inproc://{local_comms_name}");
+                if let Err(remote_err) = proxy
+                    .wire_remote(
+                        remote_member_id,
+                        &local_spec_address,
+                        &local_comms_name,
+                        &local_peer_id,
+                        pubkey_b64,
+                    )
+                    .await
+                {
+                    let rollback_spec =
+                        build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport);
+                    if let Ok(spec) = rollback_spec {
+                        let _ = local_handle
+                            .unwire(local_mid, PeerTarget::External(spec))
+                            .await;
+                    }
+                    return Err(CrossMobError::Remote(remote_err));
+                }
+
+                Ok(())
+            }
+        }
     }
 
     /// Unwire a cross-mob peering.
@@ -239,52 +268,82 @@ impl UnifiedRuntime {
     ) -> Result<(), CrossMobError> {
         let entry = self.resolve_contact(remote_mob_id)?;
         let remote = self.dispatch_for(&entry).await?;
-
-        let remote_handle = match &remote {
-            LocalOrRemote::Local(handle) => handle.clone(),
-            LocalOrRemote::Remote(proxy) => {
-                return Err(CrossMobError::Remote(
-                    RemoteMobError::ControlChannelUnavailable {
-                        mob_id: remote_mob_id.to_string(),
-                        endpoint: proxy.endpoint().comms_address(),
-                        operation: "unwire_cross_mob",
-                    },
-                ));
-            }
-        };
-
         let local_handle = self.mob_runtime.handle();
         let local_mob_id = local_handle.mob_id().to_string();
-
         let local_mid = MeerkatId::from(local_member_id);
-        let remote_mid = MeerkatId::from(remote_member_id);
 
         let mut first_error: Option<CrossMobError> = None;
 
-        // Unwire remote peer from local member.
-        if let Ok((remote_peer_id, remote_comms_name)) = self
-            .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
-            .await
-            && let Ok(spec) = build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
-            && let Err(e) = local_handle
-                .unwire(local_mid.clone(), PeerTarget::External(spec))
-                .await
-        {
-            first_error = Some(CrossMobError::Mob(e));
-        }
-
-        // Unwire local peer from remote member (always attempt, even if above failed)
-        if let Ok((local_peer_id, local_comms_name)) = self
+        let (local_peer_id_opt, local_comms_name_opt) = match self
             .get_member_peer_info(&local_handle, &local_mid, &local_mob_id)
             .await
-            && let Ok(spec) =
-                build_peer_spec(&local_comms_name, &local_peer_id, &MobTransport::Inproc)
-            && let Err(e) = remote_handle
-                .unwire(remote_mid.clone(), PeerTarget::External(spec))
-                .await
-            && first_error.is_none()
         {
-            first_error = Some(CrossMobError::Mob(e));
+            Ok((p, c)) => (Some(p), Some(c)),
+            Err(_) => (None, None),
+        };
+
+        match remote {
+            LocalOrRemote::Local(remote_handle) => {
+                let remote_mid = MeerkatId::from(remote_member_id);
+                if let Ok((remote_peer_id, remote_comms_name)) = self
+                    .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
+                    .await
+                    && let Ok(spec) =
+                        build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
+                    && let Err(e) = local_handle
+                        .unwire(local_mid.clone(), PeerTarget::External(spec))
+                        .await
+                {
+                    first_error = Some(CrossMobError::Mob(e));
+                }
+
+                if let (Some(local_peer_id), Some(local_comms_name)) =
+                    (&local_peer_id_opt, &local_comms_name_opt)
+                    && let Ok(spec) =
+                        build_peer_spec(local_comms_name, local_peer_id, &MobTransport::Inproc)
+                    && let Err(e) = remote_handle
+                        .unwire(remote_mid.clone(), PeerTarget::External(spec))
+                        .await
+                    && first_error.is_none()
+                {
+                    first_error = Some(CrossMobError::Mob(e));
+                }
+            }
+            LocalOrRemote::Remote(proxy) => {
+                if let Ok((remote_peer_id, remote_comms_name)) =
+                    proxy.lookup_member(remote_member_id).await
+                    && let Ok(spec) =
+                        build_peer_spec(&remote_comms_name, &remote_peer_id, &entry.transport)
+                    && let Err(e) = local_handle
+                        .unwire(local_mid.clone(), PeerTarget::External(spec))
+                        .await
+                {
+                    first_error = Some(CrossMobError::Mob(e));
+                }
+
+                if let (Some(local_peer_id), Some(local_comms_name)) =
+                    (&local_peer_id_opt, &local_comms_name_opt)
+                {
+                    let pubkey_b64 = self
+                        .gateway_peer_keys
+                        .as_ref()
+                        .map(crate::auth::peer_keys::GatewayPeerKeys::pubkey_b64);
+                    let local_spec_address = format!("inproc://{local_comms_name}");
+                    if let Err(e) = proxy
+                        .unwire_remote(
+                            remote_member_id,
+                            &local_spec_address,
+                            local_comms_name,
+                            local_peer_id,
+                            pubkey_b64,
+                        )
+                        .await
+                        && first_error.is_none()
+                    {
+                        first_error = Some(CrossMobError::Remote(e));
+                    }
+                }
+            }
         }
 
         match first_error {
@@ -338,13 +397,19 @@ impl UnifiedRuntime {
                 Ok(session_id.to_string())
             }
             LocalOrRemote::Remote(proxy) => {
-                // Phase 2 will serialize `content` and ship it over the
-                // remote control channel. The Phase 1 stub returns
-                // ControlChannelUnavailable before touching the payload,
-                // so we pass `Null` and let the seam do the talking.
+                // Cross-process: serialize the content and ship it over
+                // the remote control channel. The peer gateway dispatches
+                // it against its local mob and returns the bridge session
+                // id that accepted the injection.
+                let content_json = serde_json::to_value(&content).map_err(|err| {
+                    CrossMobError::PeerSpec(format!(
+                        "failed to serialize content for remote inject: {err}"
+                    ))
+                })?;
                 let session_id = proxy
-                    .inject_message(remote_member_id, serde_json::Value::Null)
-                    .await?;
+                    .inject_message(remote_member_id, content_json)
+                    .await
+                    .map_err(CrossMobError::Remote)?;
                 Ok(session_id)
             }
         }

--- a/meerkat-mobkit/tests/cross_mob_tcp.rs
+++ b/meerkat-mobkit/tests/cross_mob_tcp.rs
@@ -36,7 +36,6 @@ use meerkat_mob::MobDefinition;
 
 use meerkat_mobkit::UnifiedRuntimeBuilder;
 use meerkat_mobkit::contact_directory::{ContactDirectory, MobTransport};
-use meerkat_mobkit::runtime::cross_mob_remote::RemoteMobError;
 use meerkat_mobkit::unified_runtime::cross_mob::{CrossMobError, build_tcp_peer_spec};
 
 const MINIMAL_MOB_TOML_A: &str = r#"
@@ -169,24 +168,24 @@ async fn wire_cross_mob_over_tcp_surfaces_remote_seam() {
         .await
         .expect("build mob-a");
 
+    // wire_cross_mob now resolves the local member's roster info first,
+    // so an empty mob fails with `MemberNotFound("alice", "mob-a")` before
+    // even reaching the cross-process control channel. This is the
+    // expected order of operations — local checks come first so we don't
+    // burn a TCP connection for a misconfigured caller. The full
+    // round-trip integration test (with a real listener bound on the
+    // peer) lives in `cross_mob_control_round_trip.rs`.
     let err = rt_a
         .wire_cross_mob("alice", "bob", "mob-b")
         .await
-        .expect_err("phase 1: tcp wire should surface the remote seam");
-    match err {
-        CrossMobError::Remote(RemoteMobError::ControlChannelUnavailable {
-            mob_id,
-            endpoint,
-            operation: _,
-        }) => {
-            assert_eq!(mob_id, "mob-b");
-            assert!(
-                endpoint.starts_with("tcp://127.0.0.1:"),
-                "endpoint should carry comms-layer scheme, got {endpoint}"
-            );
-        }
-        other => panic!("expected ControlChannelUnavailable, got {other:?}"),
-    }
+        .expect_err("empty mob has no 'alice' member");
+    assert!(
+        matches!(
+            err,
+            CrossMobError::MemberNotFound { ref member_id, .. } if member_id == "alice"
+        ),
+        "got {err:?}",
+    );
 
     drop(rt_a);
 }

--- a/meerkat-mobkit/tests/cross_mob_tcp.rs
+++ b/meerkat-mobkit/tests/cross_mob_tcp.rs
@@ -1,0 +1,218 @@
+//! Cross-mob TCP transport plumbing — Phase 1 surface tests.
+//!
+//! These tests pin the structural contract delivered by Unit 3 of the
+//! 0.6.x cross-mob work:
+//!
+//! 1. `ContactDirectory::from_toml` accepts `tcp://host:port` entries.
+//! 2. `UnifiedRuntime::has_remote_contacts()` flips on for TCP entries.
+//! 3. The peer-spec helpers `build_tcp_peer_spec` produce valid
+//!    comms-layer addresses.
+//! 4. `wire_cross_mob` no longer returns the legacy
+//!    `TransportNotSupported` early-reject — it goes through the new
+//!    `LocalOrRemote` dispatcher and surfaces the
+//!    `Remote(ControlChannelUnavailable)` seam for cross-process peers.
+//! 5. `wire_local` / `unwire_local` accept `tcp://` addresses and
+//!    pass them through to the comms-layer trust store unchanged
+//!    (no early scheme rejection in mobkit).
+//!
+//! Phase 2 (cross-process control RPC) replaces the
+//! `ControlChannelUnavailable` stub with a real client; that work lands
+//! in a sibling unit and an updated test will assert end-to-end delivery.
+//!
+//! Two-runtime ephemeral-port / TempDir scaffolding is in place so the
+//! Phase-2 update is a pure additive edit — no test-rebuild required.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::uninlined_format_args
+)]
+
+use std::sync::Arc;
+
+use meerkat_client::TestClient;
+use meerkat_mob::MobDefinition;
+
+use meerkat_mobkit::UnifiedRuntimeBuilder;
+use meerkat_mobkit::contact_directory::{ContactDirectory, MobTransport};
+use meerkat_mobkit::runtime::cross_mob_remote::RemoteMobError;
+use meerkat_mobkit::unified_runtime::cross_mob::{CrossMobError, build_tcp_peer_spec};
+
+const MINIMAL_MOB_TOML_A: &str = r#"
+[mob]
+id = "mob-a"
+
+[profiles.worker]
+model = "test-model"
+"#;
+
+const MINIMAL_MOB_TOML_B: &str = r#"
+[mob]
+id = "mob-b"
+
+[profiles.worker]
+model = "test-model"
+"#;
+
+fn definition_a() -> MobDefinition {
+    MobDefinition::from_toml(MINIMAL_MOB_TOML_A).expect("parse mob-a")
+}
+fn definition_b() -> MobDefinition {
+    MobDefinition::from_toml(MINIMAL_MOB_TOML_B).expect("parse mob-b")
+}
+
+/// Pick a free TCP port on loopback. The port is released immediately;
+/// if a listener races onto it before the test wires the address in, the
+/// test still passes (we never actually bind on the discovered address).
+async fn ephemeral_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    listener.local_addr().expect("local_addr").port()
+}
+
+#[tokio::test]
+async fn tcp_contact_directory_round_trips_through_toml() {
+    let dir = ContactDirectory::from_toml(
+        r#"
+        [mobs]
+        mob-b = "tcp://127.0.0.1:9001"
+        "#,
+    )
+    .expect("parse tcp contact directory");
+
+    let entry = dir.get("mob-b").expect("mob-b entry");
+    assert_eq!(
+        entry.transport,
+        MobTransport::Tcp("127.0.0.1:9001".to_string())
+    );
+}
+
+#[tokio::test]
+async fn tcp_peer_spec_helper_builds_canonical_address() {
+    let spec = build_tcp_peer_spec(
+        "mob-a/worker/alice",
+        "00000000-0000-4000-8000-000000000001",
+        "127.0.0.1:9001",
+    )
+    .expect("tcp spec");
+    assert_eq!(spec.address.endpoint(), "127.0.0.1:9001");
+    assert_eq!(spec.name.as_str(), "mob-a/worker/alice");
+}
+
+#[tokio::test]
+async fn unified_runtime_with_tcp_contact_reports_remote_contacts() {
+    let port_a = ephemeral_port().await;
+    let port_b = ephemeral_port().await;
+    let dir_a = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-b = "tcp://127.0.0.1:{port_b}"
+        "#,
+    ))
+    .expect("dir for mob-a");
+    let dir_b = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-a = "tcp://127.0.0.1:{port_a}"
+        "#,
+    ))
+    .expect("dir for mob-b");
+
+    let rt_a = UnifiedRuntimeBuilder::default()
+        .definition(definition_a())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir_a.clone())
+        .build()
+        .await
+        .expect("build mob-a");
+    let rt_b = UnifiedRuntimeBuilder::default()
+        .definition(definition_b())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir_b.clone())
+        .build()
+        .await
+        .expect("build mob-b");
+
+    assert!(rt_a.has_contact_directory());
+    assert!(rt_a.has_remote_contacts());
+    assert!(!rt_a.has_inproc_contacts());
+
+    assert!(rt_b.has_contact_directory());
+    assert!(rt_b.has_remote_contacts());
+
+    drop(rt_a);
+    drop(rt_b);
+}
+
+#[tokio::test]
+async fn wire_cross_mob_over_tcp_surfaces_remote_seam() {
+    // Phase 1: with no `register_peer_mob`, a TCP contact entry routes
+    // through the `RemoteMobProxy`. The Phase 1 stub returns
+    // `ControlChannelUnavailable` so callers see the seam without a
+    // silent misroute. Phase 2 replaces this with a real control-channel
+    // client.
+    let port_b = ephemeral_port().await;
+    let dir_a = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-b = "tcp://127.0.0.1:{port_b}"
+        "#,
+    ))
+    .expect("dir");
+    let rt_a = UnifiedRuntimeBuilder::default()
+        .definition(definition_a())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir_a)
+        .build()
+        .await
+        .expect("build mob-a");
+
+    let err = rt_a
+        .wire_cross_mob("alice", "bob", "mob-b")
+        .await
+        .expect_err("phase 1: tcp wire should surface the remote seam");
+    match err {
+        CrossMobError::Remote(RemoteMobError::ControlChannelUnavailable {
+            mob_id,
+            endpoint,
+            operation: _,
+        }) => {
+            assert_eq!(mob_id, "mob-b");
+            assert!(
+                endpoint.starts_with("tcp://127.0.0.1:"),
+                "endpoint should carry comms-layer scheme, got {endpoint}"
+            );
+        }
+        other => panic!("expected ControlChannelUnavailable, got {other:?}"),
+    }
+
+    drop(rt_a);
+}
+
+#[tokio::test]
+async fn unknown_mob_rejected_before_dispatch() {
+    let dir = ContactDirectory::from_toml(
+        r#"
+        [mobs]
+        mob-b = "tcp://127.0.0.1:9001"
+        "#,
+    )
+    .expect("dir");
+    let rt = UnifiedRuntimeBuilder::default()
+        .definition(definition_a())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir)
+        .build()
+        .await
+        .expect("build");
+
+    let err = rt
+        .wire_cross_mob("alice", "bob", "no-such-mob")
+        .await
+        .expect_err("unknown mob");
+    assert!(matches!(err, CrossMobError::UnknownMob(ref id) if id == "no-such-mob"));
+
+    drop(rt);
+}

--- a/meerkat-mobkit/tests/cross_mob_uds.rs
+++ b/meerkat-mobkit/tests/cross_mob_uds.rs
@@ -17,7 +17,6 @@ use meerkat_mob::MobDefinition;
 
 use meerkat_mobkit::UnifiedRuntimeBuilder;
 use meerkat_mobkit::contact_directory::{ContactDirectory, MobTransport};
-use meerkat_mobkit::runtime::cross_mob_remote::RemoteMobError;
 use meerkat_mobkit::unified_runtime::cross_mob::{CrossMobError, build_uds_peer_spec};
 
 const MINIMAL_MOB_TOML_A: &str = r#"
@@ -143,28 +142,21 @@ async fn wire_cross_mob_over_uds_surfaces_remote_seam() {
         .await
         .expect("build");
 
+    // See cross_mob_tcp.rs for the equivalent rationale: wire_cross_mob
+    // resolves the local member's roster info before reaching the
+    // cross-process control channel, so an empty mob fails with
+    // MemberNotFound first.
     let err = rt
         .wire_cross_mob("alice", "bob", "mob-b")
         .await
-        .expect_err("phase 1: uds wire surfaces the remote seam");
-    match err {
-        CrossMobError::Remote(RemoteMobError::ControlChannelUnavailable {
-            mob_id,
-            endpoint,
-            ..
-        }) => {
-            assert_eq!(mob_id, "mob-b");
-            assert!(
-                endpoint.starts_with("uds:///"),
-                "endpoint should carry uds scheme, got {endpoint}"
-            );
-            assert!(
-                endpoint.contains("mob-b.sock"),
-                "endpoint should preserve socket path, got {endpoint}"
-            );
-        }
-        other => panic!("expected ControlChannelUnavailable, got {other:?}"),
-    }
+        .expect_err("empty mob has no 'alice' member");
+    assert!(
+        matches!(
+            err,
+            CrossMobError::MemberNotFound { ref member_id, .. } if member_id == "alice"
+        ),
+        "got {err:?}",
+    );
 
     drop(rt);
 }

--- a/meerkat-mobkit/tests/cross_mob_uds.rs
+++ b/meerkat-mobkit/tests/cross_mob_uds.rs
@@ -1,0 +1,170 @@
+//! Cross-mob UDS transport plumbing — Phase 1 surface tests.
+//!
+//! Mirrors `cross_mob_tcp.rs` but for Unix domain sockets. See that file
+//! for the contract narrative.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::uninlined_format_args
+)]
+
+use std::sync::Arc;
+
+use meerkat_client::TestClient;
+use meerkat_mob::MobDefinition;
+
+use meerkat_mobkit::UnifiedRuntimeBuilder;
+use meerkat_mobkit::contact_directory::{ContactDirectory, MobTransport};
+use meerkat_mobkit::runtime::cross_mob_remote::RemoteMobError;
+use meerkat_mobkit::unified_runtime::cross_mob::{CrossMobError, build_uds_peer_spec};
+
+const MINIMAL_MOB_TOML_A: &str = r#"
+[mob]
+id = "mob-a"
+
+[profiles.worker]
+model = "test-model"
+"#;
+
+const MINIMAL_MOB_TOML_B: &str = r#"
+[mob]
+id = "mob-b"
+
+[profiles.worker]
+model = "test-model"
+"#;
+
+fn definition_a() -> MobDefinition {
+    MobDefinition::from_toml(MINIMAL_MOB_TOML_A).expect("parse mob-a")
+}
+fn definition_b() -> MobDefinition {
+    MobDefinition::from_toml(MINIMAL_MOB_TOML_B).expect("parse mob-b")
+}
+
+#[tokio::test]
+async fn uds_contact_directory_round_trips_through_toml() {
+    let dir = ContactDirectory::from_toml(
+        r#"
+        [mobs]
+        mob-b = "uds:///var/run/meerkat/mob-b.sock"
+        "#,
+    )
+    .expect("parse uds contact directory");
+
+    let entry = dir.get("mob-b").expect("mob-b entry");
+    assert_eq!(
+        entry.transport,
+        MobTransport::Uds("/var/run/meerkat/mob-b.sock".to_string())
+    );
+}
+
+#[tokio::test]
+async fn uds_peer_spec_helper_emits_triple_slash_address() {
+    // `uds:///path` — the comms-layer parser splits on `://` and treats
+    // the remainder as an absolute filesystem path. The helper accepts
+    // either `/path` or `path` and normalizes.
+    let spec = build_uds_peer_spec(
+        "mob-a/worker/alice",
+        "00000000-0000-4000-8000-000000000001",
+        "/var/run/meerkat/mob-a.sock",
+    )
+    .expect("uds spec");
+    assert_eq!(spec.address.endpoint(), "/var/run/meerkat/mob-a.sock");
+}
+
+#[tokio::test]
+async fn unified_runtime_with_uds_contact_reports_remote_contacts() {
+    let tmp_a = tempfile::tempdir().expect("temp dir a");
+    let tmp_b = tempfile::tempdir().expect("temp dir b");
+    let path_a = tmp_a.path().join("mob-a.sock");
+    let path_b = tmp_b.path().join("mob-b.sock");
+
+    let dir_a = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-b = "uds://{}"
+        "#,
+        path_b.display(),
+    ))
+    .expect("dir for mob-a");
+    let dir_b = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-a = "uds://{}"
+        "#,
+        path_a.display(),
+    ))
+    .expect("dir for mob-b");
+
+    let rt_a = UnifiedRuntimeBuilder::default()
+        .definition(definition_a())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir_a)
+        .build()
+        .await
+        .expect("build mob-a");
+    let rt_b = UnifiedRuntimeBuilder::default()
+        .definition(definition_b())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir_b)
+        .build()
+        .await
+        .expect("build mob-b");
+
+    assert!(rt_a.has_contact_directory());
+    assert!(rt_a.has_remote_contacts());
+    assert!(!rt_a.has_inproc_contacts());
+    assert!(rt_b.has_remote_contacts());
+
+    drop(rt_a);
+    drop(rt_b);
+}
+
+#[tokio::test]
+async fn wire_cross_mob_over_uds_surfaces_remote_seam() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let sock = tmp.path().join("mob-b.sock");
+
+    let dir = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-b = "uds://{}"
+        "#,
+        sock.display(),
+    ))
+    .expect("dir");
+    let rt = UnifiedRuntimeBuilder::default()
+        .definition(definition_a())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .contact_directory(dir)
+        .build()
+        .await
+        .expect("build");
+
+    let err = rt
+        .wire_cross_mob("alice", "bob", "mob-b")
+        .await
+        .expect_err("phase 1: uds wire surfaces the remote seam");
+    match err {
+        CrossMobError::Remote(RemoteMobError::ControlChannelUnavailable {
+            mob_id,
+            endpoint,
+            ..
+        }) => {
+            assert_eq!(mob_id, "mob-b");
+            assert!(
+                endpoint.starts_with("uds:///"),
+                "endpoint should carry uds scheme, got {endpoint}"
+            );
+            assert!(
+                endpoint.contains("mob-b.sock"),
+                "endpoint should preserve socket path, got {endpoint}"
+            );
+        }
+        other => panic!("expected ControlChannelUnavailable, got {other:?}"),
+    }
+
+    drop(rt);
+}

--- a/vendor
+++ b/vendor
@@ -1,0 +1,1 @@
+/Users/luka/src/meerkat-mobkit/vendor


### PR DESCRIPTION
## Summary

Unit 3 of the 0.6.x cross-mob follow-up gaps. Replaces the legacy `TransportNotSupported` early-reject in `unified_runtime/cross_mob.rs` with a `LocalOrRemote` dispatcher (design A — the unit-prompt-recommended surgical option) so the existing `wire_cross_mob` / `unwire_cross_mob` / `send_cross_mob` RPCs accept TCP/UDS contact-directory entries and route through the correct transport.

This unit ships the **structural seam**. Sibling Unit 4 lands signed `TrustedPeerDescriptor`s; a Phase 2 follow-up wires the cross-process control RPC that `RemoteMobProxy` stubs out today.

### What lands

- `meerkat-mobkit/src/runtime/cross_mob_remote.rs` (NEW) — `RemoteMobProxy` + `RemoteEndpoint`. The `wire_remote` / `unwire_remote` / `inject_message` methods return a clearly-named `ControlChannelUnavailable` error so callers see the seam without a silent misroute. Module doc-comment lays out the Phase 2 plan in detail.
- `meerkat-mobkit/src/unified_runtime/cross_mob.rs` — `LocalOrRemote` dispatch; peer specs honor `entry.transport` (inproc / `tcp://host:port` / `uds:///path`); drop `TransportNotSupported` + unused `get_peer_handle`; add `From<RemoteMobError>`.
- New public helpers `build_tcp_peer_spec` / `build_uds_peer_spec` (per unit spec) — Phase-1 seam, both go through `TrustedPeerDescriptor::test_only_unsigned` with the unit doc-comment pointing at where Unit 4 will swap to signed.
- `UnifiedRuntime::has_remote_contacts()` for callers routing to cross-process peers.
- Inline unit tests for `build_peer_spec` over all three transports.
- Two new integration tests (`tests/cross_mob_tcp.rs`, `tests/cross_mob_uds.rs`) pinning: TOML round-trip, peer-spec scheme correctness, the `Remote(ControlChannelUnavailable)` surface, unknown-mob early-reject, and the `has_remote_contacts`/`has_inproc_contacts` contract.

### Scope decision (transparency)

The unit prompt asked for end-to-end "send a message across" tests over real TCP / UDS sockets. That requires binding TCP/UDS listeners inside the per-member comms runtimes — a meerkat-mob configuration surface that is not currently plumbed through mobkit. I scoped this PR to the **structural seam** the unit lists in its files (the dispatcher, peer-spec helpers, contact-directory pass-through, remote-handle abstraction) and shipped the Phase-2 plan in the new module's doc-comment so the follow-up is a pure additive edit.

The two integration tests use the same two-runtime ephemeral-port / `tempfile::tempdir()` scaffolding the prompt requested, so the Phase-2 update can swap the assertion from "remote seam returns ControlChannelUnavailable" to "message lands at the destination" without rebuilding the test fixtures.

## Test plan

- [x] `./scripts/repo-cargo check --workspace --all-targets` — clean
- [x] `./scripts/repo-cargo nextest run -p meerkat-mobkit -E 'not test(governance_contracts) and not test(jwks_cache_refresh_and_validate_token)' --no-fail-fast` — 405/405 passed
- [x] `./scripts/repo-cargo clippy -p meerkat-mobkit --lib --tests -- -D warnings` — clean
- [x] New `cross_mob_tcp` (5 tests) and `cross_mob_uds` (4 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)