### PR TITLE
docs: structural events + list_runs + bug-hunt SDK contract

### DIFF
--- a/docs/api/rpc.mdx
+++ b/docs/api/rpc.mdx
@@ -49,9 +49,75 @@ Clients must validate the contract version before sending requests.
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "error": { "code": -32602, "message": "Invalid params" }
+  "error": {
+    "code": -32602,
+    "message": "Invalid params",
+    "data": { ... }
+  }
 }
 ```
+
+The optional `data` field carries structured context for typed
+errors. SDKs surface it on `RpcError.data`.
+
+### Mobkit-specific error codes
+
+| Code | Meaning | `data` shape |
+|------|---------|--------------|
+| `-32010` | `mob_events/{query,subscribe}` `after_seq` past `latest_cursor` (stale cursor) | `{after_cursor, latest_cursor, error: "event_query_stale"}` |
+| `-32012` | `memory/{index,query}` backend unavailable | none |
+
+The `-32010` constant is exported from both SDKs as
+`MOB_EVENTS_STALE_CURSOR_CODE`. The Python and TypeScript SDKs auto-
+reify `-32010` errors into `MobEventsStaleError` (a typed subclass of
+`RpcError`) carrying `after_cursor` and `latest_cursor`.
+
+---
+
+## Mob events
+
+### `mob_events/query`
+
+Scan the meerkat structural-event ledger and return matches.
+
+<Accordion title="Parameters">
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `after_seq` | `u64` | no | Resume after this cursor (exclusive). Without it, returns the **latest N** matching events. |
+| `limit` | `usize` | no | Cap on returned events (default 256). |
+| `mob_id` / `run_id` / `step_id` | `string` | no | Filter by id |
+| `identity` / `member_id` | `string` | no | Filter by agent identity |
+| `event_types` | `string[]` | no | E.g. `["flow_started", "step_completed"]` |
+| `since_ms` / `until_ms` | `u64` | no | Inclusive / exclusive timestamp filters |
+</Accordion>
+
+The response always carries a numeric `next_after_seq` — even when
+the filter matches nothing — so polling SDKs keep a valid resume
+anchor (caller's `after_seq` or the current `latest_cursor`).
+
+### `mob_events/subscribe`
+
+JSON-RPC handshake that returns a snapshot plus a `subscribe_url`
+pointing to the [`/mobkit/mob_events/stream`](/api/sse) SSE route.
+The URL carries `after_seq` (`next_after_seq` ∨ caller's `after_seq` ∨
+`latest_cursor`) and the original filters so the SSE handler picks
+up gaplessly with the same predicate.
+
+### `list_runs`
+
+List flow runs for this mob.
+
+<Accordion title="Parameters">
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `flow_id` | `string` | no | When given, only return runs for this flow. |
+</Accordion>
+
+Returns `{runs: MobRun[]}` carrying the full meerkat ledger projection:
+`step_ledger`, `failure_ledger`, `frames` (map keyed by frame id),
+`loops` (map keyed by loop id), `loop_iteration_ledger`,
+`flow_state`, `activation_params`, `schema_version`,
+`root_step_outputs`, `loop_iteration_outputs`.
 
 ---
 

--- a/docs/api/sse.mdx
+++ b/docs/api/sse.mdx
@@ -4,10 +4,25 @@ description: "Server-Sent Events for real-time MobKit interaction and event subs
 icon: "bolt"
 ---
 
-MobKit uses Server-Sent Events (SSE) for two related real-time flows:
+MobKit uses Server-Sent Events (SSE) for several real-time flows:
 
 - interaction-scoped streaming through `POST /interactions/stream`
+- agent-scoped streaming through `GET /agents/{agent_id}/events`
+- mob-merged streaming through `GET /mob/events`
+- structural mob events through `GET /mobkit/mob_events/stream`
 - event subscription and replay through `mobkit/events/subscribe`
+
+## Authentication
+
+Every SSE route honors `RuntimeDecisionState.console.require_app_auth`.
+When `require_app_auth` is on, the request must carry one of:
+
+- `Authorization: Bearer <token>` header, or
+- `?auth_token=<token>` query parameter
+
+Missing or invalid credentials return HTTP **401**. Tokens are
+percent-decoded; a token containing characters that need URL-encoding
+(`=`, `&`, `+`, `%`) is handled correctly.
 
 ## Interaction stream
 
@@ -77,6 +92,73 @@ Supported scopes:
 | `agent` | Requires `agent_id` |
 | `interaction` | Interaction-scoped replay |
 
+## Structural mob events stream
+
+```
+GET /mobkit/mob_events/stream?after_seq=<cursor>&mob_id=<id>&run_id=<id>&event_types=<list>
+```
+
+Per-client SSE stream of structural `MobEvent`s (typed envelopes
+preserving `mob_id`, `run_id`, `step_id`, `agent_identity`, and the
+full `MobEventKind` payload).
+
+Each connection opens its own `MobEventsView::subscribe_after` so
+catch-up and live tail share the same ordered stream — there is no
+race window between snapshot and live subscription.
+
+### Query parameters
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `after_seq` | u64 | Resume from this cursor (exclusive). When omitted, starts at the current `latest_cursor` (live tail only). |
+| `mob_id` | string | Filter by mob id |
+| `run_id` | string | Filter by flow run id |
+| `step_id` | string | Filter by flow step id |
+| `event_types` | comma-separated | e.g. `flow_started,step_completed` |
+| `since_ms` / `until_ms` | u64 | Inclusive / exclusive timestamp filters |
+| `identity` / `member_id` | string | Filter by agent identity |
+
+### Frame format
+
+```
+event: flow_started
+id: mob-evt-1234
+data: {"event_id":"mob-evt-1234","cursor":1234,"mob_id":"home","run_id":"...","kind":"flow_started",...}
+```
+
+### Stale cursor
+
+If `after_seq > latest_cursor`, the route returns HTTP **410 Gone**
+with `{"error":"event_query_stale","after_cursor":N,"latest_cursor":M}`.
+SDK clients should rewind to `latest_cursor` and reconnect.
+
+### Continuation from `mobkit/mob_events/subscribe`
+
+The JSON-RPC handshake returns a snapshot frame plus a
+`subscribe_url` field that already encodes the resume cursor and
+filters:
+
+```json
+{
+  "stream": "mob_events",
+  "events": [...],
+  "next_after_seq": 1234,
+  "subscribe_url": "/mobkit/mob_events/stream?after_seq=1234&mob_id=home",
+  "keep_alive": {"interval_ms": 15000, "event": "keep_alive"}
+}
+```
+
+`after_seq` falls back to `latest_cursor` captured at handshake
+when the snapshot is empty, so the SSE handler picks up gaplessly
+even when no events match yet.
+
+### Cursor durability
+
+`MobStructuralEvent.cursor` is the meerkat ledger cursor — durable
+across mobkit gateway restarts when the runtime is built with
+`.persistent_state(path)`. SDK consumers can checkpoint a cursor
+and resume by reconnecting with `after_seq=<checkpointed cursor>`.
+
 ## Keep-alive
 
 The server sends keep-alive frames at a configurable interval (default: 15 seconds) to prevent connection timeouts:
@@ -84,6 +166,12 @@ The server sends keep-alive frames at a configurable interval (default: 15 secon
 ```
 : keep-alive
 ```
+
+When the broadcast lags (slow consumer, channel saturated), the
+console SSE routes emit a synthetic `stream_lagged` envelope with
+the count of skipped events instead of silently breaking the
+connection. Clients should refetch via the catch-up endpoint or
+reconnect with a fresh `last-event-id`.
 
 ## Sending messages
 

--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -89,6 +89,56 @@ Raw event lines from modules are normalized before entering the merged stream. N
 - Source tags are consistent
 - Malformed events produce `NormalizationError` rather than silent corruption
 
+## Structural mob events (durable)
+
+In addition to the lossy `UnifiedEvent::Agent` projection, mobkit
+exposes the **structural** event surface — typed envelopes
+preserving every meerkat `MobEventKind` (25 variants —
+`flow_started`, `step_dispatched`, `members_wired`,
+`supervisor_escalation`, ...) with their `mob_id`, `run_id`,
+`step_id`, and `agent_identity` context intact.
+
+```
+{
+  "event_id": "mob-evt-1234",
+  "cursor": 1234,
+  "mob_id": "home",
+  "timestamp_ms": 1729700000000,
+  "kind": "step_dispatched",
+  "run_id": "run-9c1...",
+  "step_id": "draft",
+  "agent_identity": "lead",
+  "mob_labels": {...},
+  "run_labels": {...},
+  "data": { /* full MobEventKind payload */ }
+}
+```
+
+### Durable cursors
+
+`cursor` is the **meerkat ledger cursor** — the same monotonic id
+the upstream store uses. Mobkit's subscription task streams events
+from `MobEventsView::subscribe_after(cursor)` and writes the
+last-projected cursor to a `PersistentMetadataStore` after each
+projection. On restart, the runtime resumes from that cursor —
+events written while mobkit was down are replayed, not skipped.
+
+- `.persistent_state(path)` builds auto-install a SQLite metadata
+  store at `<path>/mobkit_metadata.sqlite`. No caller action required.
+- Ephemeral builds use the in-memory store (no durable resume —
+  the ledger isn't persistent either).
+
+### Access surfaces
+
+| Surface | Use for |
+|---------|---------|
+| `mobkit/mob_events/query` JSON-RPC | Snapshot / batched scan |
+| `mobkit/mob_events/subscribe` JSON-RPC | Snapshot + handshake; returns a `subscribe_url` for the SSE route |
+| `GET /mobkit/mob_events/stream` SSE | Per-client live tail with cursor + filter resume |
+
+See [SSE API](/api/sse) for the SSE shape and
+[JSON-RPC API](/api/rpc) for the snapshot RPCs and error codes.
+
 ## Lifecycle events
 
 The runtime emits lifecycle events at key milestones:

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -115,6 +115,59 @@ async for event in handle.subscribe_mob():
 
 Observation is independent of delivery. Subscribe before or after sending — the stream is continuous.
 
+### Structural mob events — durable observability
+
+`MobHandle.query_mob_events()` and `subscribe_mob_events()` project
+every meerkat `MobEventKind` (25 variants) into a typed envelope
+preserving `mob_id`, `run_id`, `step_id`, `agent_identity`, and the
+full payload.
+
+```python
+from meerkat_mobkit import EventQuery, MobEventsStaleError
+
+# Latest 256 matching events
+events = await handle.query_mob_events(EventQuery(
+    event_types=["flow_started", "flow_completed"],
+    mob_id="home",
+))
+for e in events:
+    print(e.cursor, e.kind, e.run_id, e.data)
+
+# Resume from a checkpointed cursor
+try:
+    new_events = await handle.query_mob_events(EventQuery(
+        after_seq=last_seen_cursor,
+    ))
+except MobEventsStaleError as exc:
+    # Cursor is past the current frontier — rewind.
+    new_events = await handle.query_mob_events(EventQuery(
+        after_seq=exc.latest_cursor,
+    ))
+```
+
+`MobStructuralEvent.cursor` is the **meerkat ledger cursor** —
+durable across mobkit gateway restarts when the runtime is built
+with `.persistent_state(path)`. Checkpoint a cursor and resume by
+passing it as `after_seq` on the next call.
+
+### Flow runs
+
+```python
+# All runs across all flows
+runs = await handle.list_runs()
+
+# Filter to one flow
+runs = await handle.list_runs(flow_id="onboarding")
+
+for run in runs:
+    print(run.run_id, run.status, len(run.step_ledger))
+```
+
+Returns `MobRun` carrying the full meerkat ledger projection
+(`step_ledger`, `failure_ledger`, `frames` keyed by frame id, `loops`
+keyed by loop id, `loop_iteration_ledger`, `flow_state`,
+`activation_params`, `schema_version`, etc.).
+
 ### Control plane — manage the runtime
 
 ```python
@@ -301,6 +354,7 @@ from meerkat_mobkit import (
     SessionAgentBuilder,
     # Errors
     MobKitError, TransportError, RpcError,
+    MobEventsStaleError, MOB_EVENTS_STALE_CURSOR_CODE,
     NotConnectedError, CapabilityUnavailableError, ContractMismatchError,
     # Typed results
     StatusResult, CapabilitiesResult, ReconcileResult,
@@ -319,6 +373,9 @@ from meerkat_mobkit import (
     MemoryQueryResult, MemoryStoreInfo, MemoryIndexResult,
     # Events
     MobEvent, AgentEvent, EventStream,
+    # Structural mob events + flow runs
+    MobStructuralEvent, MobRun, MobRunStatus,
+    StepRecord, FailureRecord, FrameRecord, LoopRecord, LoopIterationRecord,
     # Config modules
     auth, memory, session_store,
 )

--- a/docs/sdks/typescript.mdx
+++ b/docs/sdks/typescript.mdx
@@ -88,10 +88,83 @@ The SDK supports both ESM and CommonJS:
 
 ```typescript
 // ESM
-import { MobKitClient } from "@meerkat/mobkit-sdk";
+import { MobKit } from "@rkat/mobkit-sdk";
 
 // CommonJS
-const { MobKitClient } = require("@meerkat/mobkit-sdk");
+const { MobKit } = require("@rkat/mobkit-sdk");
+```
+
+### Cross-module identity check
+
+Because dual CJS+ESM packaging, vitest module isolation, and
+hoisted-vs-nested monorepos can ship two distinct `RpcError`
+constructors in the same process, **prefer the structural type guards
+over `instanceof`**:
+
+```typescript
+import { isRpcError, isMobEventsStaleError } from "@rkat/mobkit-sdk";
+
+try {
+  await handle.queryMobEvents({ afterSeq: cursor });
+} catch (err) {
+  if (isMobEventsStaleError(err)) {
+    // err.afterCursor, err.latestCursor available
+  } else if (isRpcError(err)) {
+    console.error(`RPC ${err.method} failed: ${err.code}`);
+  } else {
+    throw err;
+  }
+}
+```
+
+## Structural mob events + flow runs
+
+Both APIs return the full meerkat ledger projection:
+
+```typescript
+import {
+  MobEventsStaleError,
+  MOB_EVENTS_STALE_CURSOR_CODE,
+} from "@rkat/mobkit-sdk";
+
+const events = await handle.queryMobEvents({
+  eventTypes: ["flow_started", "flow_completed"],
+  mobId: "home",
+});
+for (const e of events) {
+  console.log(e.cursor, e.kind, e.runId, e.data);
+}
+
+// MobStructuralEvent.cursor is the meerkat ledger cursor — durable
+// across mobkit restarts on persistent_state builds. Resume by
+// passing the highest-seen cursor as afterSeq.
+try {
+  const more = await handle.queryMobEvents({ afterSeq: lastCursor });
+} catch (err) {
+  if (err instanceof MobEventsStaleError) {
+    // Rewind to err.latestCursor and reconnect.
+  }
+}
+
+// Flow runs with the full ledger projection
+const runs = await handle.listRuns(); // or handle.listRuns("flow-id")
+for (const run of runs) {
+  console.log(run.runId, run.status, run.stepLedger.length);
+}
+```
+
+## HTTP transport timeout
+
+`createJsonRpcHttpTransport` defaults to a 60-second timeout (via
+`AbortController`) so a server that accepts but never replies cannot
+hang the caller's `await` forever. Override per-call:
+
+```typescript
+import { createJsonRpcHttpTransport } from "@rkat/mobkit-sdk";
+
+const transport = createJsonRpcHttpTransport(endpoint, {
+  timeoutMs: 5_000,
+});
 ```
 
 ## Contract parity

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to the Python SDK are documented here.
 
 ## Unreleased
 
+### Streaming structural events + durable cursors
+
+Mobkit's structural-events surface is now durable end-to-end. Consumers
+can checkpoint a `cursor` from any `MobStructuralEvent` and resume
+across mobkit gateway restarts on SQLite-backed deployments.
+
+- `MobStructuralEvent.cursor` is now the **meerkat ledger cursor** —
+  not a per-process `AtomicU64`. The 500ms poller is gone; mobkit's
+  subscription task streams from `MobEventsView::subscribe_after`
+  directly. Restart-resume is automatic when the runtime is built
+  with `.persistent_state(path)` (a `SqliteMetadataStore` is
+  auto-installed at `<path>/mobkit_metadata.sqlite`).
+- New `MobEventsStaleError(RpcError)` raised by `query_mob_events()`
+  / `subscribe_mob_events()` when `after_seq` is past the current
+  ledger frontier. Carries `after_cursor` and `latest_cursor` so
+  callers can rewind. JSON-RPC code is `-32010`
+  (`MOB_EVENTS_STALE_CURSOR_CODE`).
+- `mobkit/mob_events/subscribe` now returns a `subscribe_url`
+  pointing to `/mobkit/mob_events/stream?after_seq=...&...` — a
+  per-client SSE route that opens its own
+  `MobEventsView::subscribe_after`, eliminating the gap between
+  snapshot and live tail. Original filters are echoed back.
+- `mobkit/mob_events/query` always returns a numeric
+  `next_after_seq` even when the filter matches nothing (was
+  `null`); a polling SDK keeps a valid resume anchor.
+
+### `MobHandle.list_runs(flow_id?)`
+
+New SDK method wrapping `mobkit/list_runs` over `MobHandle::list_runs`.
+Returns `list[MobRun]` carrying the **full meerkat ledger projection**
+— `step_ledger`, `failure_ledger`, `frames` (map keyed by frame id),
+`loops` (map keyed by loop id), `loop_iteration_ledger`, `flow_state`,
+`activation_params`, `schema_version`, `root_step_outputs`,
+`loop_iteration_outputs`. Meerkat-internal sub-shapes (kernel state,
+output blobs) pass through opaquely as `Any`.
+
+New types in `meerkat_mobkit.types`:
+`MobRun`, `MobRunStatus`, `StepRecord`, `FailureRecord`,
+`FrameRecord`, `LoopRecord`, `LoopIterationRecord`. All exported
+from `meerkat_mobkit`.
+
+### Bug-hunt fixes (PR #69)
+
+- `RpcError.data` propagates the JSON-RPC `error.data` payload —
+  used by `MobEventsStaleError` to surface typed cursor info.
+- `AsgiApp.__call__("/rpc", ...)` no longer masks `RpcError` as
+  `-32603 / AttributeError`: the handler used a non-existent
+  `exc.message` attribute and fell through to the generic
+  `except Exception`. Real RPC code/message/data are now returned.
+- `_transport.send_sync` rejects empty / duplicate request ids
+  (`ValueError`) instead of deadlocking concurrent callers on the
+  shared `_pending[""]` slot for the full 60s timeout.
+- `EventEnvelope.from_dict` / `KeepAliveConfig.from_dict` coerce
+  numeric fields (`timestamp_ms`, `interval_ms`) via `_coerce_int`.
+  Pre-fix `None`, `"15"`, or floats survived into `int`-annotated
+  fields and broke arithmetic far from the parse site.
+- `MobEvent.from_sse` / `AgentEvent.from_sse` preserve non-dict
+  payloads as `UnknownEvent(type="non_dict_payload", data={"raw":
+  ...})`. Pre-fix the raw value was silently dropped.
+- `subscribe_mob_events` accepts bare-list responses (not just dict
+  envelopes), matching `query_mob_events`.
+- Memory backend failures (`mobkit/memory/index`,
+  `mobkit/memory/query`) now use distinct JSON-RPC code `-32012`
+  (`MEMORY_BACKEND_UNAVAILABLE_CODE`). Pre-fix they shared `-32010`
+  with the mob_events stale-cursor contract; SDKs branching on the
+  code misclassified.
+
 ### Cross-mob signed-peer surface
 
 - New `MobHandle.peer_pubkey()` → returns the local gateway's Ed25519

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 ## Unreleased
 
+### Streaming structural events + durable cursors
+
+Parity with the Python SDK: structural events are now durable
+end-to-end. Cursors come from the meerkat ledger and survive mobkit
+restarts on SQLite-backed deployments.
+
+- `MobStructuralEvent.cursor` is the meerkat ledger cursor (not a
+  per-process counter). The runtime auto-installs a SQLite metadata
+  store next to `.persistent_state(path)` builds.
+- New `MobEventsStaleError extends RpcError` raised by
+  `queryMobEvents()` / `subscribeMobEvents()` on JSON-RPC code
+  `-32010`. Carries `afterCursor` and `latestCursor`. The shared
+  `MOB_EVENTS_STALE_CURSOR_CODE` constant is exported.
+- `mobkit/mob_events/subscribe` returns a `subscribe_url` pointing
+  to the new `/mobkit/mob_events/stream?after_seq=...&...` SSE
+  route; original filters echo back so the SSE handler picks up
+  gaplessly with the same predicate.
+- `mobkit/mob_events/query` always returns a numeric
+  `next_after_seq` even on empty match (was `null`).
+
+### `MobHandle.listRuns(flowId?)`
+
+New SDK method wrapping `mobkit/list_runs`. Returns `MobRun[]` with
+the full meerkat ledger projection: `stepLedger`, `failureLedger`,
+`frames` (map keyed by frame id), `loops` (map keyed by loop id),
+`loopIterationLedger`, `flowState`, `activationParams`,
+`schemaVersion`, `rootStepOutputs`, `loopIterationOutputs`.
+Meerkat-internal sub-shapes pass through opaquely as `unknown`.
+
+New interfaces and parsers exported from `@rkat/mobkit-sdk`:
+`MobRun`, `MobRunStatus`, `StepRecord`, `FailureRecord`,
+`FrameRecord`, `LoopRecord`, `LoopIterationRecord` plus
+`parseMobRun` / `parseStepRecord` / etc.
+
+### Bug-hunt fixes (PR #69)
+
+- `RpcError.data` propagates the JSON-RPC `error.data` payload.
+- New `isRpcError(err)` / `isMobEventsStaleError(err)` structural
+  type guards. **Use these instead of `instanceof RpcError`** —
+  dual CJS+ESM packaging, vitest module isolation, and
+  hoisted-vs-nested monorepos all produce two `RpcError`
+  constructors that fail `instanceof` for each other's instances.
+  The structural checks survive the split.
+- `MobKitRuntime.start()` no longer rewrites `mobkit/init`
+  `RpcError` as a generic `TransportError`. Original code/message/
+  data flow through; only synthesizes `TransportError` when the
+  subprocess actually died.
+- `SseBridge` ties the underlying HTTP request to the generator
+  lifetime. Breaking out of `for await (const e of
+  handle.subscribeAgent(...))` now destroys the request — pre-fix
+  it leaked an `http.ClientRequest` per iteration.
+- `createJsonRpcHttpTransport` accepts a `timeoutMs` option
+  (default 60s) and aborts via `AbortController`. Pre-fix a server
+  that accepted but never replied hung the caller's `await`
+  forever.
+- SSE parser handles `id:N` / `event:foo` lines without the
+  optional space (SSE-spec-legal). Pre-fix only the
+  `"id: "` / `"event: "` prefixes matched and resume cursors were
+  lost.
+- `parseSubscribeResult` filters non-object entries from `events[]`
+  before mapping. Pre-fix null/string/number entries were coerced
+  into silently-empty envelopes — data loss.
+- `parseDispatchInput` validates `origin` against the closed
+  `DispatchOrigin` union and falls back to `"system"` for unknown
+  values. Pre-fix it was an unchecked cast.
+
 ### Cross-mob signed-peer surface
 
 - New `mobkit/peer_pubkey` RPC returns the local gateway's Ed25519


### PR DESCRIPTION
## Summary

Brings the documentation up to date with PR #68 (streaming structural events + durable cursors + `list_runs`) and the SDK / wire impacts of PR #69 (25 bug-hunt fixes).

### Repo docs

- **`docs/concepts/events.mdx`** — new "Structural mob events (durable)" section: cursor-durability semantics, the per-process counter → meerkat ledger cursor migration, three access surfaces.
- **`docs/api/sse.mdx`** — lists all four SSE routes; documents `/mobkit/mob_events/stream` (query params, 410-on-stale, continuation URL); auth-gating note; `stream_lagged` synthetic envelope.
- **`docs/api/rpc.mdx`** — error envelope gains `data`; new mobkit error-code table (`-32010` stale cursor, `-32012` memory backend); `mob_events/{query,subscribe}` and `list_runs` method docs.
- **`docs/sdks/python.mdx`** — structural-events + `list_runs` examples with `MobEventsStaleError` rewind; expanded public-surface export list.
- **`docs/sdks/typescript.mdx`** — corrected package name (`@rkat/mobkit-sdk`); `isRpcError`/`isMobEventsStaleError` cross-module guard; HTTP transport timeout.

### SDK CHANGELOGs

`sdk/python/CHANGELOG.md` and `sdk/typescript/CHANGELOG.md` Unreleased section gains:
- Streaming structural events + durable cursors (subscription cursor persistence, `MobEventsStaleError` typed code, `subscribe_url` continuation, `next_after_seq` always-numeric).
- `MobHandle.list_runs()` / `MobHandle.listRuns()` returning the full `MobRun` ledger projection.
- Bug-hunt fixes (PR #69) impacting wire/SDK behavior.

### Skill file

The `~/.claude/skills/mobkit-platform/SKILL.md` was updated separately (lives outside the repo) — added "Structural events surface (durable cursors, SSE)", "JSON-RPC error codes", and "SSE auth gating" sections, plus 8 new "Common mistakes" entries reflecting the trust + auth + parser-defense lessons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)