### PR TITLE
chore: resync meerkat to 9226407e5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,6 @@ version = "0.6.0"
 dependencies = [
  "indexmap",
  "meerkat-core",
- "meerkat-machine-dsl",
  "meerkat-machine-schema",
  "serde",
  "thiserror 2.0.18",
@@ -1720,7 +1719,6 @@ name = "meerkat-runtime"
 version = "0.6.0"
 dependencies = [
  "async-trait",
- "base64",
  "chrono",
  "indexmap",
  "meerkat-auth-core",
@@ -1751,7 +1749,6 @@ dependencies = [
  "futures",
  "indexmap",
  "meerkat-core",
- "meerkat-machine-dsl",
  "meerkat-machine-schema",
  "schemars",
  "serde",


### PR DESCRIPTION
Three new meerkat commits since the last resync (a39cf0864):
- LUC-365 budget exhaustion cause machine-owned
- profile.tools scoping (canonical resolver + provenance filter)
- 0.6 release gate stabilisation

No mobkit-side call-site changes — only \`Cargo.lock\` churn from upstream dep-graph cleanup.

Verified: \`cargo check --workspace --all-targets\` clean; \`cargo nextest run -p meerkat-mobkit\` (less governance + JWKS) 471/471 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)