### PR TITLE
chore: resync meerkat to 72cecf92e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tokio_with_wasm",
 ]
 


### PR DESCRIPTION
28 new meerkat commits since 9226407e5. Notables for awareness:

- LUC-404 connection refs renamed to auth bindings
- LUC-395 AuthMachine OAuth freshness gate
- LUC-394 realtime tool timeouts via runtime dispatch
- Quarantine skill builtin raw ingress paths / hook semantic rewrites
- Harden mobpack validation
- Scoped session recovery config
- Boundary-atomic runtime terminalization

No mobkit-side call-site changes. Only \`Cargo.lock\` churn (\`tokio\` dep added to meerkat-skills).

Verified: \`cargo check --workspace --all-targets\` clean; \`cargo nextest run -p meerkat-mobkit\` (less governance + JWKS) 471/471 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)