### PR TITLE
chore: resync meerkat to 765f681af

### DIFF
--- a/meerkat-mobkit/src/unified_runtime/mob_events.rs
+++ b/meerkat-mobkit/src/unified_runtime/mob_events.rs
@@ -424,6 +424,8 @@ fn event_kind_label(kind: &MobEventKind) -> &'static str {
     match kind {
         MobEventKind::MobCreated { .. } => "mob_created",
         MobEventKind::MobCompleted => "mob_completed",
+        MobEventKind::MobDestroying => "mob_destroying",
+        MobEventKind::MobDestroyStorageFinalizing => "mob_destroy_storage_finalizing",
         MobEventKind::MobReset => "mob_reset",
         MobEventKind::MemberSpawned(_) => "member_spawned",
         MobEventKind::MemberRetired { .. } => "member_retired",
@@ -524,6 +526,8 @@ pub(crate) fn extract_structural_fields(
         }
         MobEventKind::MobCreated { .. }
         | MobEventKind::MobCompleted
+        | MobEventKind::MobDestroying
+        | MobEventKind::MobDestroyStorageFinalizing
         | MobEventKind::MobReset
         | MobEventKind::MembersWired { .. }
         | MobEventKind::MembersUnwired { .. }


### PR DESCRIPTION
8 new meerkat commits. Notables:
- LUC-438 supervisor rotation fail-closed
- Partial mob destroy fail-closed — adds two new \`MobEventKind\` variants (\`MobDestroying\`, \`MobDestroyStorageFinalizing\`)
- Structured output on completion events
- Help skill surfaces
- Session cap hotfix

Mobkit-side adaptation: two match arms added in \`unified_runtime/mob_events.rs\` to cover the new destroy-fence variants.

Verified: \`cargo check --workspace --all-targets\` clean; \`cargo nextest run -p meerkat-mobkit\` (less governance + JWKS) 472/472 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)