### PR TITLE
Honor SDK Elephant memory config in rpc_gateway

### DIFF
--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -20,9 +20,11 @@ ElephantMemoryBackendConfig {
 | Field | Type | Description |
 |-------|------|-------------|
 | `endpoint` | `String` | Elephant HTTP API base URL |
-| `state_path` | `String` | Local directory for memory state files |
+| `state_path` | `String` | Local JSON state file used by the Elephant-backed adapter |
 
 The `ElephantMemoryStoreAdapter` handles connection health checks, request serialization, and error mapping.
+
+When using the Python or TypeScript SDK through the stock `rpc_gateway`, configure Elephant with `memory.elephant(endpoint)` and enable `.persistent_state(path)`. The gateway derives the adapter state file as `<persistent_state>/elephant-memory-state.json`. Gateway `memory_config` currently supports only `backend: "elephant"` and `endpoint`; fields such as `stores`, `space_id`, and `collection` are rejected at init so unsupported configuration does not become a silent no-op.
 
 ## Indexing
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -88,6 +88,21 @@ PreSpawnData {
 
 ---
 
+## SDK/Gateway runtime options
+
+The stock SDK gateway consumes the `runtime_options` object sent by Python and TypeScript builders during `mobkit/init`.
+
+| Field | Type | Gateway behavior |
+|-------|------|------------------|
+| `memory_config` | Object | Supports `{ "backend": "elephant", "endpoint": "..." }` and derives `state_path` as `<persistent_state>/elephant-memory-state.json`. |
+| `routing_config_path` | String | Loads JSON or TOML route config (`routes = [...]` / `[[routes]]`) and installs the routes into the unified runtime before serving RPCs. |
+| `scheduling_files` | String array | Loads JSON or TOML schedule definitions and uses them as the default schedules for `mobkit/scheduling/evaluate` and `mobkit/scheduling/dispatch` when the RPC request omits `schedules`. |
+| `gating_config_path` | String | Loads JSON or TOML action policies from an `actions` object and supplies a configured `risk_tier` for `mobkit/gating/evaluate` requests that omit `risk_tier`. |
+| `auth_config` | Object | Supports JWT shared-secret auth (`provider = "jwt"` / `shared_secret`) and wires the reference HTTP console/SSE routes to the configured trusted issuer, audience, and email allowlist. |
+| `event_log` | Object | Supports the built-in memory event log with `storage = "memory"`, `batch_size`, and `flush_interval_ms`; `mobkit/query_events` returns the configured store instead of `no_event_log_configured`. |
+
+Unsupported nested fields fail initialization with `-32602` instead of being silently ignored.
+
 ## AuthPolicy
 
 ```rust
@@ -162,7 +177,9 @@ ElephantMemoryBackendConfig {
 | Field | Type | Description |
 |-------|------|-------------|
 | `endpoint` | `String` | Elephant HTTP API base URL (e.g. `"http://localhost:3000"`) |
-| `state_path` | `String` | Local directory for memory state files |
+| `state_path` | `String` | Local JSON state file used by the Elephant-backed adapter |
+
+For SDK builds that boot through `rpc_gateway`, `state_path` is derived from `.persistent_state(path)` as `<path>/elephant-memory-state.json`; callers provide only `backend: "elephant"` and `endpoint`.
 
 ---
 

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -19,16 +19,21 @@
 
 use std::collections::HashMap;
 use std::io::Write;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use base64::Engine;
+use meerkat_mobkit::unified_runtime::EventLogError;
 use meerkat_mobkit::{
-    AuthPolicy, Base64BlobStoreAdapter, BigQueryNaming, BinaryBlobStore, ConsolePolicy,
-    DiscoverySpec, MOBKIT_CONTRACT_VERSION, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig,
-    ModuleConfig, ObjectStoreBlobStore, ReleaseMetadata, RestartPolicy, RuntimeDecisionState,
-    RuntimeOpsPolicy, TrustedOidcRuntimeConfig, UnifiedRuntime, handle_mobkit_rpc_json,
-    handle_unified_rpc_json, mob_handle_runtime::mob_definition_may_use_image_generation,
-    start_mobkit_runtime,
+    AuthPolicy, AuthProvider, Base64BlobStoreAdapter, BigQueryNaming, BinaryBlobStore,
+    ConsolePolicy, DiscoverySpec, ElephantMemoryBackendConfig, EventLogConfig, EventLogStore,
+    EventQuery, InMemoryMetadataStore, MOBKIT_CONTRACT_VERSION, MemoryBackendConfig,
+    MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, ModuleConfig, ObjectStoreBlobStore,
+    PersistedEvent, PersistentMetadataStore, ReleaseMetadata, RestartPolicy, RuntimeDecisionState,
+    RuntimeOpsPolicy, RuntimeOptions, RuntimeRoute, ScheduleDefinition, SqliteMetadataStore,
+    TrustedOidcRuntimeConfig, UnifiedRuntime, handle_mobkit_rpc_json, handle_unified_rpc_json,
+    mob_handle_runtime::mob_definition_may_use_image_generation, start_mobkit_runtime,
 };
 use sha2::{Digest, Sha256};
 
@@ -45,6 +50,81 @@ use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
 use meerkat_mob::{MobDefinition, MobStorage};
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, mpsc, oneshot};
+
+#[derive(Clone, Default)]
+struct GatewayGatingConfig {
+    action_risk_tiers: HashMap<String, String>,
+}
+
+#[derive(Default)]
+struct GatewayRuntimeOptions {
+    runtime_options: RuntimeOptions,
+    routing_routes: Vec<RuntimeRoute>,
+    schedules: Vec<ScheduleDefinition>,
+    gating: GatewayGatingConfig,
+    event_log: Option<EventLogConfig>,
+    decisions: Option<RuntimeDecisionState>,
+}
+
+#[derive(Default)]
+struct InMemoryEventLogStore {
+    events: std::sync::Mutex<Vec<PersistedEvent>>,
+}
+
+impl EventLogStore for InMemoryEventLogStore {
+    fn append_batch(
+        &self,
+        events: Vec<PersistedEvent>,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), EventLogError>> + Send + '_>> {
+        Box::pin(async move {
+            self.events.lock().unwrap().extend(events);
+            Ok(())
+        })
+    }
+
+    fn query(
+        &self,
+        query: EventQuery,
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<Output = Result<Vec<PersistedEvent>, EventLogError>>
+                + Send
+                + '_,
+        >,
+    > {
+        Box::pin(async move {
+            let mut events = self.events.lock().unwrap().clone();
+            events.retain(|event| {
+                query
+                    .since_ms
+                    .is_none_or(|since| event.timestamp_ms >= since)
+                    && query
+                        .until_ms
+                        .is_none_or(|until| event.timestamp_ms < until)
+                    && query
+                        .after_seq
+                        .is_none_or(|after_seq| event.seq > after_seq)
+                    && query
+                        .member_id
+                        .as_ref()
+                        .is_none_or(|member_id| event.member_id.as_ref() == Some(member_id))
+                    && (query.event_types.is_empty()
+                        || query.event_types.iter().any(|event_type| {
+                            matches!(
+                                &event.event,
+                                meerkat_mobkit::UnifiedEvent::Module(module)
+                                    if &module.event_type == event_type
+                            )
+                        }))
+            });
+            events.sort_by_key(|event| event.seq);
+            if let Some(limit) = query.limit {
+                events.truncate(limit);
+            }
+            Ok(events)
+        })
+    }
+}
 
 fn minimal_decision_state() -> RuntimeDecisionState {
     RuntimeDecisionState {
@@ -80,6 +160,351 @@ fn shell_module(id: &str, script: &str) -> ModuleConfig {
         args: vec!["-c".to_string(), script.to_string()],
         restart_policy: RestartPolicy::Never,
     }
+}
+
+fn parse_gateway_runtime_options(
+    params: &Value,
+    persistent_state: Option<&std::path::Path>,
+) -> Result<GatewayRuntimeOptions, String> {
+    let Some(runtime_options) = params.get("runtime_options") else {
+        return Ok(GatewayRuntimeOptions::default());
+    };
+    let runtime_options = runtime_options
+        .as_object()
+        .ok_or_else(|| "runtime_options must be a JSON object".to_string())?;
+    let supported = [
+        "memory_config",
+        "routing_config_path",
+        "scheduling_files",
+        "gating_config_path",
+        "auth_config",
+        "event_log",
+    ];
+    let unsupported = runtime_options
+        .keys()
+        .filter(|key| !supported.contains(&key.as_str()))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if !unsupported.is_empty() {
+        return Err(format!(
+            "unsupported runtime_options fields: {}",
+            unsupported.join(", ")
+        ));
+    }
+
+    let mut parsed = GatewayRuntimeOptions::default();
+    if let Some(memory_config) = runtime_options.get("memory_config") {
+        parsed.runtime_options.memory_backend = Some(parse_gateway_memory_config(
+            memory_config,
+            persistent_state,
+        )?);
+    }
+    if let Some(path) = runtime_options
+        .get("routing_config_path")
+        .and_then(Value::as_str)
+    {
+        parsed.routing_routes = parse_gateway_routing_config_path(path)?;
+    }
+    if let Some(files) = runtime_options.get("scheduling_files") {
+        parsed.schedules = parse_gateway_scheduling_files(files)?;
+    }
+    if let Some(path) = runtime_options
+        .get("gating_config_path")
+        .and_then(Value::as_str)
+    {
+        parsed.gating = parse_gateway_gating_config_path(path)?;
+    }
+    if let Some(auth_config) = runtime_options.get("auth_config") {
+        parsed.decisions = Some(parse_gateway_auth_config(auth_config)?);
+    }
+    if let Some(event_log) = runtime_options.get("event_log") {
+        parsed.event_log = Some(parse_gateway_event_log_config(event_log)?);
+    }
+    Ok(parsed)
+}
+
+fn read_gateway_config_file(path: &str, option_name: &str) -> Result<Value, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|err| format!("failed to read runtime_options.{option_name} '{path}': {err}"))?;
+    if path.ends_with(".json") {
+        return serde_json::from_str(&text)
+            .map_err(|err| format!("invalid JSON in runtime_options.{option_name}: {err}"));
+    }
+    let toml_value: toml::Value = toml::from_str(&text)
+        .map_err(|err| format!("invalid TOML in runtime_options.{option_name}: {err}"))?;
+    serde_json::to_value(toml_value)
+        .map_err(|err| format!("failed to normalize runtime_options.{option_name}: {err}"))
+}
+
+fn parse_gateway_routing_config_path(path: &str) -> Result<Vec<RuntimeRoute>, String> {
+    let value = read_gateway_config_file(path, "routing_config_path")?;
+    let routes_value = value
+        .get("routes")
+        .cloned()
+        .unwrap_or_else(|| value.clone());
+    serde_json::from_value(routes_value)
+        .map_err(|err| format!("runtime_options.routing_config_path routes are invalid: {err}"))
+}
+
+fn parse_gateway_scheduling_files(files: &Value) -> Result<Vec<ScheduleDefinition>, String> {
+    let files = files
+        .as_array()
+        .ok_or_else(|| "runtime_options.scheduling_files must be an array".to_string())?;
+    let mut schedules = Vec::new();
+    for file in files {
+        let path = file.as_str().ok_or_else(|| {
+            "runtime_options.scheduling_files entries must be strings".to_string()
+        })?;
+        let value = read_gateway_config_file(path, "scheduling_files")?;
+        let schedules_value = value
+            .get("schedules")
+            .cloned()
+            .unwrap_or_else(|| value.clone());
+        let mut parsed: Vec<ScheduleDefinition> =
+            serde_json::from_value(schedules_value).map_err(|err| {
+                format!("runtime_options.scheduling_files schedule definitions are invalid: {err}")
+            })?;
+        schedules.append(&mut parsed);
+    }
+    meerkat_mobkit::evaluate_schedules_at_tick(&schedules, 0)
+        .map_err(|err| format!("runtime_options.scheduling_files are invalid: {err:?}"))?;
+    Ok(schedules)
+}
+
+fn parse_gateway_gating_config_path(path: &str) -> Result<GatewayGatingConfig, String> {
+    let value = read_gateway_config_file(path, "gating_config_path")?;
+    let actions = value
+        .get("actions")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            "runtime_options.gating_config_path must define an actions object".to_string()
+        })?;
+    let mut action_risk_tiers = HashMap::new();
+    for (action, config) in actions {
+        let risk_tier = config.as_str().or_else(|| {
+            config
+                .as_object()
+                .and_then(|object| object.get("risk_tier"))
+                .and_then(Value::as_str)
+        });
+        let risk_tier = risk_tier.ok_or_else(|| {
+            format!("runtime_options.gating_config_path action '{action}' must define risk_tier")
+        })?;
+        let normalized = risk_tier.trim().to_ascii_lowercase();
+        if !matches!(normalized.as_str(), "r0" | "r1" | "r2" | "r3") {
+            return Err(format!(
+                "runtime_options.gating_config_path action '{action}' has unsupported risk_tier '{risk_tier}'"
+            ));
+        }
+        action_risk_tiers.insert(action.trim().to_string(), normalized);
+    }
+    Ok(GatewayGatingConfig { action_risk_tiers })
+}
+
+fn parse_gateway_event_log_config(value: &Value) -> Result<EventLogConfig, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "runtime_options.event_log must be a JSON object".to_string())?;
+    let storage = object
+        .get("storage")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "runtime_options.event_log.storage must be 'memory'".to_string())?;
+    if !matches!(storage, "memory" | "in_memory") {
+        return Err(format!(
+            "unsupported runtime_options.event_log.storage '{storage}'"
+        ));
+    }
+    let batch_size = object
+        .get("batch_size")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(64);
+    let flush_interval_ms = object
+        .get("flush_interval_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(1_000);
+    Ok(EventLogConfig {
+        store: Box::new(InMemoryEventLogStore::default()),
+        filter: None,
+        batch_size,
+        flush_interval: Duration::from_millis(flush_interval_ms),
+    })
+}
+
+fn parse_gateway_auth_config(value: &Value) -> Result<RuntimeDecisionState, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "runtime_options.auth_config must be a JSON object".to_string())?;
+    let provider = object
+        .get("provider")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            if object.contains_key("sharedSecret") || object.contains_key("shared_secret") {
+                Some("jwt")
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| "runtime_options.auth_config.provider is required".to_string())?;
+    if provider != "jwt" {
+        return Err(format!(
+            "unsupported runtime_options.auth_config.provider '{provider}'"
+        ));
+    }
+    let shared_secret = object
+        .get("shared_secret")
+        .or_else(|| object.get("sharedSecret"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "runtime_options.auth_config.shared_secret must be a non-empty string".to_string()
+        })?;
+    let issuer = object
+        .get("issuer")
+        .and_then(Value::as_str)
+        .unwrap_or("http://127.0.0.1/mobkit-gateway");
+    let audience = object
+        .get("audience")
+        .and_then(Value::as_str)
+        .unwrap_or("persistent-gateway");
+    let email_allowlist = object
+        .get("email_allowlist")
+        .or_else(|| object.get("emailAllowlist"))
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(shared_secret.as_bytes());
+    let discovery_json = serde_json::to_string(&json!({
+        "issuer": issuer,
+        "jwks_uri": "http://127.0.0.1/mobkit-gateway/jwks.json"
+    }))
+    .map_err(|err| format!("failed to build trusted OIDC discovery: {err}"))?;
+    let jwks_json = serde_json::to_string(&json!({
+        "keys": [{
+            "kty": "oct",
+            "alg": "HS256",
+            "k": key
+        }]
+    }))
+    .map_err(|err| format!("failed to build trusted JWKS: {err}"))?;
+    Ok(RuntimeDecisionState {
+        bigquery: BigQueryNaming {
+            dataset: "default_dataset".to_string(),
+            table: "default_table".to_string(),
+        },
+        modules: vec![],
+        auth: AuthPolicy {
+            default_provider: AuthProvider::GenericOidc,
+            email_allowlist,
+        },
+        trusted_oidc: TrustedOidcRuntimeConfig {
+            discovery_json,
+            jwks_json,
+            audience: audience.to_string(),
+        },
+        console: ConsolePolicy {
+            require_app_auth: true,
+        },
+        ops: RuntimeOpsPolicy::default(),
+        release_metadata: ReleaseMetadata {
+            targets: vec![
+                "crates.io".to_string(),
+                "npm".to_string(),
+                "pypi".to_string(),
+                "github-releases".to_string(),
+            ],
+            support_matrix: "lts".to_string(),
+        },
+    })
+}
+
+fn apply_gateway_runtime_config_to_request(
+    request_line: &str,
+    schedules: &[ScheduleDefinition],
+    gating: &GatewayGatingConfig,
+) -> String {
+    let Ok(mut request) = serde_json::from_str::<Value>(request_line) else {
+        return request_line.to_string();
+    };
+    let method = request.get("method").and_then(Value::as_str).unwrap_or("");
+    match method {
+        "mobkit/scheduling/evaluate" | "mobkit/scheduling/dispatch" if !schedules.is_empty() => {
+            let params = request.get_mut("params").and_then(Value::as_object_mut);
+            if let Some(params) = params
+                && !params.contains_key("schedules")
+            {
+                params.insert(
+                    "schedules".to_string(),
+                    serde_json::to_value(schedules).unwrap_or(Value::Null),
+                );
+            }
+        }
+        "mobkit/gating/evaluate" => {
+            let params = request.get_mut("params").and_then(Value::as_object_mut);
+            if let Some(params) = params
+                && !params.contains_key("risk_tier")
+                && let Some(action) = params.get("action").and_then(Value::as_str)
+                && let Some(risk_tier) = gating.action_risk_tiers.get(action.trim())
+            {
+                params.insert("risk_tier".to_string(), Value::String(risk_tier.clone()));
+            }
+        }
+        _ => {}
+    }
+    serde_json::to_string(&request).unwrap_or_else(|_| request_line.to_string())
+}
+
+fn parse_gateway_memory_config(
+    memory_config: &Value,
+    persistent_state: Option<&std::path::Path>,
+) -> Result<MemoryBackendConfig, String> {
+    let object = memory_config
+        .as_object()
+        .ok_or_else(|| "runtime_options.memory_config must be a JSON object".to_string())?;
+    let backend = object
+        .get("backend")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "runtime_options.memory_config.backend must be 'elephant'".to_string())?;
+    if backend != "elephant" {
+        return Err(format!(
+            "unsupported runtime_options.memory_config.backend '{backend}'"
+        ));
+    }
+    let endpoint = object
+        .get("endpoint")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "runtime_options.memory_config.endpoint must be a non-empty string".to_string()
+        })?;
+    let unsupported = object
+        .keys()
+        .filter(|key| key.as_str() != "backend" && key.as_str() != "endpoint")
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if !unsupported.is_empty() {
+        return Err(format!(
+            "unsupported runtime_options.memory_config fields: {}",
+            unsupported.join(", ")
+        ));
+    }
+    let state_path = persistent_state
+        .ok_or_else(|| {
+            "runtime_options.memory_config requires persistent_state so Elephant memory state has a stable path"
+                .to_string()
+        })?
+        .join("elephant-memory-state.json");
+    Ok(MemoryBackendConfig::Elephant(ElephantMemoryBackendConfig {
+        endpoint: endpoint.to_string(),
+        state_path: state_path.to_string_lossy().to_string(),
+    }))
 }
 
 /// Original single-shot mode: reads request from env, runs once, prints response.
@@ -670,23 +1095,6 @@ external_addressable = true
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Warn about SDK-forwarded runtime_options that the gateway does not yet
-    // consume.  This surfaces "accepted but ignored" config as visible noise
-    // so integrators notice early rather than debugging silent no-ops.
-    if let Some(runtime_options) = params.get("runtime_options").and_then(|v| v.as_object()) {
-        let unrecognized: Vec<&String> = runtime_options.keys().collect();
-        if !unrecognized.is_empty() {
-            eprintln!(
-                "[mobkit-gateway] warning: runtime_options keys [{}] were sent by the SDK but are not consumed by the gateway — this config has no effect",
-                unrecognized
-                    .iter()
-                    .map(|k| k.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        }
-    }
-
     // 3. Set up stdout writer channel for multiplexed output
     let (stdout_tx, mut stdout_rx) = mpsc::channel::<String>(64);
     let stdout_writer = tokio::spawn(async move {
@@ -758,6 +1166,11 @@ external_addressable = true
         let _ = stdout.flush();
         std::process::exit(1);
     }
+
+    let mut gateway_options = parse_gateway_runtime_options(&params, persistent_state.as_deref())
+        .unwrap_or_else(|e| {
+            fail_init(&request_id, -32602, e);
+        });
 
     // 5. Build session service with callback bridge.
     let (mob_spec, _temp_dir) = if let Some(ref state_path) = persistent_state {
@@ -923,24 +1336,60 @@ external_addressable = true
     };
 
     let timeout = Duration::from_secs(30);
-    let mut runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, timeout)
-        .await
-        .unwrap_or_else(|e| {
-            let error_response = json!({
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": { "code": -32603, "message": format!("Runtime bootstrap failed: {e}") }
-            });
-            let mut stdout = std::io::stdout().lock();
-            let _ = writeln!(
-                stdout,
-                "{}",
-                serde_json::to_string(&error_response)
-                    .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string())
-            );
-            let _ = stdout.flush();
-            std::process::exit(1);
+    let persistent_metadata: Arc<dyn PersistentMetadataStore> =
+        if let Some(state_path) = persistent_state.as_ref() {
+            let metadata_path = state_path.join("mobkit_metadata.sqlite");
+            Arc::new(
+                SqliteMetadataStore::open(&metadata_path).unwrap_or_else(|e| {
+                    fail_init(
+                        &request_id,
+                        -32603,
+                        format!("failed to open mobkit_metadata.sqlite: {e}"),
+                    );
+                }),
+            )
+        } else {
+            Arc::new(InMemoryMetadataStore::new())
+        };
+    let mut runtime = UnifiedRuntime::bootstrap_with_options(
+        mob_spec,
+        module_config,
+        Vec::new(),
+        timeout,
+        gateway_options.runtime_options.clone(),
+        persistent_metadata,
+    )
+    .await
+    .unwrap_or_else(|e| {
+        let error_response = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": { "code": -32603, "message": format!("Runtime bootstrap failed: {e}") }
         });
+        let mut stdout = std::io::stdout().lock();
+        let _ = writeln!(
+            stdout,
+            "{}",
+            serde_json::to_string(&error_response)
+                .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string())
+        );
+        let _ = stdout.flush();
+        std::process::exit(1);
+    });
+
+    for route in gateway_options.routing_routes.iter().cloned() {
+        if let Err(err) = runtime.add_runtime_route(route).await {
+            fail_init(
+                &request_id,
+                -32602,
+                format!("runtime_options.routing_config_path route failed validation: {err}"),
+            );
+        }
+    }
+
+    if let Some(event_log_config) = gateway_options.event_log.take() {
+        runtime.start_event_log(event_log_config);
+    }
 
     // 5b. Wire error hook — forwards ErrorEvents to Python as JSON-RPC notifications
     {
@@ -1088,7 +1537,11 @@ external_addressable = true
 
     // 7. Start HTTP with graceful shutdown
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    let app = runtime.build_reference_app_router(minimal_decision_state());
+    let decision_state = gateway_options
+        .decisions
+        .clone()
+        .unwrap_or_else(minimal_decision_state);
+    let app = runtime.build_reference_app_router(decision_state);
     let serve_task = tokio::spawn({
         let mut shutdown_rx = shutdown_rx.clone();
         async move {
@@ -1145,6 +1598,11 @@ external_addressable = true
                 },
                 _ = tokio::signal::ctrl_c() => break,
             };
+            let request_line = apply_gateway_runtime_config_to_request(
+                &request_line,
+                &gateway_options.schedules,
+                &gateway_options.gating,
+            );
             let response = handle_unified_rpc_json(
                 &runtime,
                 &request_line,

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -17,7 +17,7 @@ use crate::runtime::{
     SessionPersistenceRow, SubscribeError, SubscribeRequest, SubscribeScope,
     handle_console_rest_json_route, route_module_call, validate_schedules,
 };
-use crate::unified_runtime::UnifiedRuntime;
+use crate::unified_runtime::{EventQuery, UnifiedRuntime};
 
 mod console_ingress;
 mod gating_methods;
@@ -1036,6 +1036,7 @@ pub async fn handle_unified_rpc_json(
                 "mobkit/delivery/send",
                 "mobkit/delivery/history",
                 "mobkit/events/subscribe",
+                "mobkit/query_events",
                 "mobkit/memory/stores",
                 "mobkit/memory/index",
                 "mobkit/memory/query",
@@ -1508,6 +1509,57 @@ pub async fn handle_unified_rpc_json(
                 }),
             },
         },
+        "mobkit/query_events" => {
+            let query: EventQuery = if request.params.is_null() {
+                EventQuery::default()
+            } else {
+                match serde_json::from_value(request.params.clone()) {
+                    Ok(query) => query,
+                    Err(err) => {
+                        return serde_json::to_string(&JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id,
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32602,
+                                message: format!("Invalid params: invalid query params: {err}"),
+                                data: None,
+                            }),
+                        })
+                        .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string());
+                    }
+                }
+            };
+            match runtime.event_log_store() {
+                Some(store) => match store.query(query).await {
+                    Ok(events) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id,
+                        result: Some(serde_json::to_value(events).unwrap_or(Value::Null)),
+                        error: None,
+                    },
+                    Err(err) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32603,
+                            message: format!("query_events failed: {err}"),
+                            data: None,
+                        }),
+                    },
+                },
+                None => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id,
+                    result: Some(serde_json::json!({
+                        "status": "no_event_log_configured",
+                        "events": [],
+                    })),
+                    error: None,
+                },
+            }
+        }
         "mobkit/memory/stores" => match parse_memory_stores_params(&request.params) {
             Ok(()) => {
                 let stores = runtime.memory_stores().await;

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -300,7 +300,7 @@ impl UnifiedRuntime {
     /// Start the event log ingestion engine. Must be called after
     /// construction (the builder calls this automatically when event_log
     /// config is provided).
-    pub(crate) fn start_event_log(&mut self, config: EventLogConfig) {
+    pub fn start_event_log(&mut self, config: EventLogConfig) {
         let handle = event_log::start_event_log(config, self.error_hook.clone());
         self.event_log = Some(handle);
     }

--- a/meerkat-mobkit/tests/gateway_memory_config.rs
+++ b/meerkat-mobkit/tests/gateway_memory_config.rs
@@ -1,0 +1,493 @@
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::uninlined_format_args,
+    clippy::manual_assert
+)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use serde_json::{Value, json};
+use sha2::Sha256;
+use tempfile::TempDir;
+
+const MOB_CONFIG: &str = r#"
+[mob]
+id = "gateway-memory-config-test"
+
+[profiles.default]
+model = "gpt-5.5"
+external_addressable = true
+"#;
+
+struct HealthEndpointServer {
+    endpoint: String,
+    paths: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl HealthEndpointServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind health endpoint");
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let endpoint = format!(
+            "http://{}",
+            listener.local_addr().expect("listener address")
+        );
+        let paths = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_paths = Arc::clone(&paths);
+        let thread_stop = Arc::clone(&stop);
+        let thread = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _addr)) => {
+                        let mut reader =
+                            BufReader::new(stream.try_clone().expect("clone health stream"));
+                        let mut request_line = String::new();
+                        if reader.read_line(&mut request_line).is_ok()
+                            && let Some(path) = request_line.split_whitespace().nth(1)
+                        {
+                            thread_paths
+                                .lock()
+                                .expect("paths lock")
+                                .push(path.to_string());
+                        }
+                        let response =
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
+                        let _ = stream.write_all(response);
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Self {
+            endpoint,
+            paths,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    fn paths(&self) -> Vec<String> {
+        self.paths.lock().expect("paths lock").clone()
+    }
+}
+
+impl Drop for HealthEndpointServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = std::net::TcpStream::connect(self.endpoint.trim_start_matches("http://"));
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+struct GatewayProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl GatewayProcess {
+    fn start() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rpc_gateway"))
+            .arg("--persistent")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn rpc_gateway");
+        let stdin = child.stdin.take().expect("gateway stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("gateway stdout"));
+        Self {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    fn rpc(&mut self, request: Value) -> Value {
+        writeln!(
+            self.stdin,
+            "{}",
+            serde_json::to_string(&request).expect("request json")
+        )
+        .expect("write request");
+        self.stdin.flush().expect("flush request");
+
+        let mut line = String::new();
+        self.stdout.read_line(&mut line).expect("read response");
+        assert!(!line.is_empty(), "gateway closed stdout before response");
+        serde_json::from_str(line.trim()).expect("response json")
+    }
+
+    fn init_with_memory(&mut self, state_dir: &TempDir, endpoint: &str) -> Value {
+        self.rpc(json!({
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "mobkit/init",
+            "params": {
+                "persistent_state": state_dir.path(),
+                "mob_config": MOB_CONFIG,
+                "runtime_options": {
+                    "memory_config": {
+                        "backend": "elephant",
+                        "endpoint": endpoint
+                    }
+                }
+            }
+        }))
+    }
+
+    fn init_with_runtime_options(&mut self, state_dir: &TempDir, runtime_options: Value) -> Value {
+        self.rpc(json!({
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "mobkit/init",
+            "params": {
+                "persistent_state": state_dir.path(),
+                "mob_config": MOB_CONFIG,
+                "runtime_options": runtime_options
+            }
+        }))
+    }
+}
+
+impl Drop for GatewayProcess {
+    fn drop(&mut self) {
+        let _ = self.stdin.flush();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn gateway_runtime_options_memory_config_persists_memory_across_restart() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let endpoint = HealthEndpointServer::start();
+
+    {
+        let mut gateway = GatewayProcess::start();
+        let init = gateway.init_with_memory(&state_dir, endpoint.endpoint());
+        assert!(init["result"]["contract_version"].is_string());
+
+        let indexed = gateway.rpc(json!({
+            "jsonrpc": "2.0",
+            "id": "index",
+            "method": "mobkit/memory/index",
+            "params": {
+                "entity": "delivery",
+                "topic": "email_send",
+                "store": "todo",
+                "fact": "double-check recipient consent"
+            }
+        }));
+        assert_eq!(indexed["result"]["store"], json!("todo"));
+    }
+
+    assert!(
+        state_dir.path().join("elephant-memory-state.json").exists(),
+        "gateway should store Elephant memory state under persistent_state"
+    );
+
+    {
+        let mut gateway = GatewayProcess::start();
+        let init = gateway.init_with_memory(&state_dir, endpoint.endpoint());
+        assert!(init["result"]["contract_version"].is_string());
+
+        let queried = gateway.rpc(json!({
+            "jsonrpc": "2.0",
+            "id": "query",
+            "method": "mobkit/memory/query",
+            "params": {
+                "entity": "delivery",
+                "topic": "email_send",
+                "store": "todo"
+            }
+        }));
+        assert_eq!(
+            queried["result"]["assertions"][0]["fact"],
+            json!("double-check recipient consent")
+        );
+    }
+
+    assert!(
+        endpoint.paths().iter().any(|path| path == "/v1/health"),
+        "Elephant adapter should health-check the configured endpoint"
+    );
+}
+
+#[test]
+fn gateway_rejects_unsupported_memory_config_fields() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let endpoint = HealthEndpointServer::start();
+    let mut gateway = GatewayProcess::start();
+
+    let init = gateway.rpc(json!({
+        "jsonrpc": "2.0",
+        "id": "init",
+        "method": "mobkit/init",
+        "params": {
+            "persistent_state": state_dir.path(),
+            "mob_config": MOB_CONFIG,
+            "runtime_options": {
+                "memory_config": {
+                    "backend": "elephant",
+                    "endpoint": endpoint.endpoint(),
+                    "stores": ["todo"]
+                }
+            }
+        }
+    }));
+
+    assert_eq!(init["error"]["code"], json!(-32602));
+    assert!(
+        init["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("unsupported runtime_options.memory_config fields: stores")
+    );
+}
+
+fn write_config(dir: &Path, name: &str, contents: &str) -> String {
+    let path = dir.join(name);
+    std::fs::write(&path, contents).expect("write config");
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+fn gateway_runtime_options_routing_config_path_loads_routes() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let routing_path = write_config(
+        state_dir.path(),
+        "routing.toml",
+        r#"
+[[routes]]
+route_key = "ops.email"
+recipient = "ops@example.com"
+channel = "notification"
+sink = "email"
+target_module = "delivery"
+retry_max = 2
+backoff_ms = 500
+rate_limit_per_minute = 10
+"#,
+    );
+    let mut gateway = GatewayProcess::start();
+
+    let init = gateway.init_with_runtime_options(
+        &state_dir,
+        json!({
+            "routing_config_path": routing_path
+        }),
+    );
+    assert!(init["result"]["contract_version"].is_string());
+
+    let routes = gateway.rpc(json!({
+        "jsonrpc": "2.0",
+        "id": "routes",
+        "method": "mobkit/routing/routes/list",
+        "params": {}
+    }));
+    assert_eq!(
+        routes["result"]["routes"][0]["route_key"],
+        json!("ops.email")
+    );
+    assert_eq!(routes["result"]["routes"][0]["sink"], json!("email"));
+}
+
+#[test]
+fn gateway_runtime_options_scheduling_files_load_default_schedules() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let schedule_path = write_config(
+        state_dir.path(),
+        "schedules.toml",
+        r#"
+[[schedules]]
+schedule_id = "every-minute"
+interval = "* * * * *"
+timezone = "UTC"
+enabled = true
+"#,
+    );
+    let mut gateway = GatewayProcess::start();
+
+    let init = gateway.init_with_runtime_options(
+        &state_dir,
+        json!({
+            "scheduling_files": [schedule_path]
+        }),
+    );
+    assert!(init["result"]["contract_version"].is_string());
+
+    let evaluated = gateway.rpc(json!({
+        "jsonrpc": "2.0",
+        "id": "schedule",
+        "method": "mobkit/scheduling/evaluate",
+        "params": {
+            "tick_ms": 0
+        }
+    }));
+    assert_eq!(
+        evaluated["result"]["due_triggers"][0]["schedule_id"],
+        json!("every-minute")
+    );
+}
+
+#[test]
+fn gateway_runtime_options_gating_config_path_supplies_risk_tiers() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let gating_path = write_config(
+        state_dir.path(),
+        "gating.toml",
+        r#"
+[actions."delivery.send"]
+risk_tier = "r3"
+"#,
+    );
+    let mut gateway = GatewayProcess::start();
+
+    let init = gateway.init_with_runtime_options(
+        &state_dir,
+        json!({
+            "gating_config_path": gating_path
+        }),
+    );
+    assert!(init["result"]["contract_version"].is_string());
+
+    let evaluated = gateway.rpc(json!({
+        "jsonrpc": "2.0",
+        "id": "gate",
+        "method": "mobkit/gating/evaluate",
+        "params": {
+            "action": "delivery.send",
+            "actor_id": "agent-lead"
+        }
+    }));
+    assert_eq!(evaluated["result"]["risk_tier"], json!("r3"));
+    assert_eq!(evaluated["result"]["outcome"], json!("pending_approval"));
+}
+
+#[test]
+fn gateway_runtime_options_event_log_configures_queryable_store() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = GatewayProcess::start();
+
+    let init = gateway.init_with_runtime_options(
+        &state_dir,
+        json!({
+            "event_log": {
+                "storage": "memory",
+                "batch_size": 1,
+                "flush_interval_ms": 10
+            }
+        }),
+    );
+    assert!(init["result"]["contract_version"].is_string());
+
+    let queried = gateway.rpc(json!({
+        "jsonrpc": "2.0",
+        "id": "events",
+        "method": "mobkit/query_events",
+        "params": {}
+    }));
+    assert_eq!(queried["result"], json!([]));
+}
+
+#[test]
+fn gateway_runtime_options_auth_config_protects_reference_http_routes() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = GatewayProcess::start();
+
+    let init = gateway.init_with_runtime_options(
+        &state_dir,
+        json!({
+            "auth_config": {
+                "provider": "jwt",
+                "shared_secret": "top-secret",
+                "issuer": "http://127.0.0.1/mobkit-test",
+                "audience": "mobkit-test",
+                "email_allowlist": ["svc:gateway-test"]
+            }
+        }),
+    );
+    let base_url = init["result"]["http_base_url"]
+        .as_str()
+        .expect("http_base_url");
+
+    let unauthenticated = http_get_status(base_url, "/console/experience", None);
+    assert_eq!(unauthenticated, 401);
+
+    let token = hs256_jwt(
+        "top-secret",
+        json!({
+            "iss": "http://127.0.0.1/mobkit-test",
+            "aud": "mobkit-test",
+            "sub": "svc:gateway-test",
+            "actor_type": "service",
+            "exp": 4_102_444_800u64
+        }),
+    );
+    let authenticated = http_get_status(base_url, "/console/experience", Some(&token));
+    assert_eq!(authenticated, 200);
+}
+
+fn http_get_status(base_url: &str, path: &str, bearer: Option<&str>) -> u16 {
+    let addr = base_url.trim_start_matches("http://");
+    let mut stream = std::net::TcpStream::connect(addr).expect("connect http");
+    let auth = bearer
+        .map(|token| format!("Authorization: Bearer {token}\r\n"))
+        .unwrap_or_default();
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: {addr}\r\n{auth}Connection: close\r\n\r\n"
+    )
+    .expect("write http request");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read http response");
+    response
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .expect("status code")
+}
+
+fn hs256_jwt(secret: &str, claims: Value) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+    let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = engine.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
+    let claims = engine.encode(serde_json::to_vec(&claims).expect("claims json"));
+    let signing_input = format!("{header}.{claims}");
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(signing_input.as_bytes());
+    let signature = engine.encode(mac.finalize().into_bytes());
+    format!("{signing_input}.{signature}")
+}

--- a/sdk/typescript/src/agent-builder.ts
+++ b/sdk/typescript/src/agent-builder.ts
@@ -225,7 +225,7 @@ export class CallbackDispatcher {
 
     // -- Continuity callbacks -----------------------------------------------
 
-    if (method === "callback/continuity/resolve_many") {
+    if (method === "callback/continuity_store/resolve_many") {
       if (this._continuityStore === null) {
         throw new Error("no ContinuityStore registered");
       }
@@ -235,7 +235,7 @@ export class CallbackDispatcher {
       return this._continuityStore.resolveMany(identities);
     }
 
-    if (method === "callback/continuity/load_session_snapshot") {
+    if (method === "callback/continuity_store/load_session_snapshot") {
       if (this._continuityStore === null) {
         throw new Error("no ContinuityStore registered");
       }
@@ -245,23 +245,25 @@ export class CallbackDispatcher {
       return sessionSnapshotToDict(snap);
     }
 
-    if (method === "callback/continuity/save_session_snapshot") {
+    if (method === "callback/continuity_store/save_session_snapshot") {
       if (this._continuityStore === null) {
         throw new Error("no ContinuityStore registered");
       }
       const identity = String(params.identity ?? "");
       const sessionId = String(params.session_id ?? "");
       const generation = Number(params.generation ?? 0);
-      const version = Number(params.checkpoint_version ?? 0);
+      const version = Number(params.version ?? params.checkpoint_version ?? 0);
       const fencingToken = Number(params.fencing_token ?? 0);
-      const snapshot = parseSessionSnapshot({ data: params.snapshot ?? "" });
+      const snapshot = typeof params.snapshot === "string"
+        ? parseSessionSnapshot({ data: params.snapshot })
+        : parseSessionSnapshot(params.snapshot);
       await this._continuityStore.saveSessionSnapshot(
         identity, sessionId, generation, version, fencingToken, snapshot,
       );
       return null;
     }
 
-    if (method === "callback/continuity/upsert_continuity_record") {
+    if (method === "callback/continuity_store/upsert_continuity_record") {
       if (this._continuityStore === null) {
         throw new Error("no ContinuityStore registered");
       }
@@ -273,7 +275,7 @@ export class CallbackDispatcher {
 
     // -- Lease callbacks ----------------------------------------------------
 
-    if (method === "callback/lease/acquire_leases") {
+    if (method === "callback/lease_provider/acquire_leases") {
       if (this._leaseProvider === null) {
         throw new Error("no LeaseProvider registered");
       }
@@ -284,7 +286,7 @@ export class CallbackDispatcher {
       return this._leaseProvider.acquireLeases(identities, runtimeInstance);
     }
 
-    if (method === "callback/lease/renew_leases") {
+    if (method === "callback/lease_provider/renew_leases") {
       if (this._leaseProvider === null) {
         throw new Error("no LeaseProvider registered");
       }
@@ -293,7 +295,7 @@ export class CallbackDispatcher {
       return this._leaseProvider.renewLeases(grants);
     }
 
-    if (method === "callback/lease/release_leases") {
+    if (method === "callback/lease_provider/release_leases") {
       if (this._leaseProvider === null) {
         throw new Error("no LeaseProvider registered");
       }
@@ -305,7 +307,7 @@ export class CallbackDispatcher {
 
     // -- Roster callback ----------------------------------------------------
 
-    if (method === "callback/roster") {
+    if (method === "callback/roster_provider/roster") {
       if (this._rosterProvider === null) {
         throw new Error("no RosterProvider registered");
       }
@@ -316,7 +318,7 @@ export class CallbackDispatcher {
 
     // -- Topology callback --------------------------------------------------
 
-    if (method === "callback/topology/compute_edges") {
+    if (method === "callback/topology_provider/compute_edges") {
       if (this._topologyProvider === null) {
         throw new Error("no TopologyProvider registered");
       }
@@ -333,7 +335,7 @@ export class CallbackDispatcher {
 
     // -- Customizer callbacks -----------------------------------------------
 
-    if (method === "callback/customizer/customize_build") {
+    if (method === "callback/agent_customizer/customize_build") {
       if (this._agentCustomizer === null) {
         throw new Error("no AgentCustomizer registered");
       }
@@ -344,7 +346,7 @@ export class CallbackDispatcher {
       return agentBuildDraftToDict(draft);
     }
 
-    if (method === "callback/customizer/after_create") {
+    if (method === "callback/agent_customizer/after_create") {
       if (
         this._agentCustomizer !== null &&
         typeof this._agentCustomizer.afterCreate === "function"

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -236,6 +236,21 @@ export class MobKitRuntime {
       if (this._config.errorCallback !== null) {
         this._dispatcher.registerErrorCallback(this._config.errorCallback);
       }
+      if (this._config.continuityStore !== null) {
+        this._dispatcher.registerContinuityStore(this._config.continuityStore);
+      }
+      if (this._config.leaseProvider !== null) {
+        this._dispatcher.registerLeaseProvider(this._config.leaseProvider);
+      }
+      if (this._config.rosterProvider !== null) {
+        this._dispatcher.registerRosterProvider(this._config.rosterProvider);
+      }
+      if (this._config.topologyProvider !== null) {
+        this._dispatcher.registerTopologyProvider(this._config.topologyProvider);
+      }
+      if (this._config.agentCustomizer !== null) {
+        this._dispatcher.registerAgentCustomizer(this._config.agentCustomizer);
+      }
       this._transport.setCallbackHandler(
         this._dispatcher.handleCallback.bind(this._dispatcher),
       );
@@ -320,6 +335,15 @@ export class MobKitRuntime {
     params.runtime_options = runtimeOptions;
     if (this._config.persistentState) {
       params.persistent_state = this._config.persistentState;
+    }
+    if (this._config.rosterProvider !== null) {
+      params.has_roster_provider = true;
+    }
+    if (this._config.topologyProvider !== null) {
+      params.has_topology_provider = true;
+    }
+    if (this._config.agentCustomizer !== null) {
+      params.has_agent_customizer = true;
     }
     return params;
   }

--- a/sdk/typescript/tests/identity-first.test.ts
+++ b/sdk/typescript/tests/identity-first.test.ts
@@ -517,6 +517,12 @@ describe("Identity-first runtime APIs (REQ-47)", () => {
       gatewayBin: null,
       modules: [],
       persistentState: null,
+      continuityStore: null,
+      leaseProvider: null,
+      scratchDir: null,
+      rosterProvider: null,
+      agentCustomizer: null,
+      topologyProvider: null,
     });
     // Stub _rpc to capture calls and return plausible results
     (rt as unknown as Record<string, unknown>)._rpc = async (
@@ -830,6 +836,42 @@ describe("Builder identity-first extensions (REQ-50)", () => {
     assert.equal(builder._config.leaseProvider, lease);
     assert.equal(builder._config.scratchDir, "/tmp/scratch");
   });
+
+  it("runtime init params advertise identity-first provider callbacks", async () => {
+    const { MobKitRuntime } = await import("../src/runtime.js");
+    const rosterProvider = { async roster() { return []; } };
+    const topologyProvider = { async computeEdges() { return []; } };
+    const agentCustomizer = { async customizeBuild() {} };
+    const rt = new MobKitRuntime({
+      mobConfigPath: null,
+      sessionBuilder: null,
+      sessionStore: null,
+      discoveryCallback: null,
+      preSpawnCallback: null,
+      errorCallback: null,
+      eventLog: null,
+      gatingConfigPath: null,
+      routingConfigPath: null,
+      schedulingFiles: [],
+      memoryConfig: null,
+      authConfig: null,
+      gatewayBin: "/bin/rpc_gateway",
+      modules: [],
+      persistentState: "/tmp/state",
+      continuityStore: null,
+      leaseProvider: null,
+      scratchDir: null,
+      rosterProvider,
+      agentCustomizer,
+      topologyProvider,
+    });
+
+    const params = (rt as unknown as { _buildInitParams(): Record<string, unknown> })
+      ._buildInitParams();
+    assert.equal(params.has_roster_provider, true);
+    assert.equal(params.has_topology_provider, true);
+    assert.equal(params.has_agent_customizer, true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -837,7 +879,7 @@ describe("Builder identity-first extensions (REQ-50)", () => {
 // ---------------------------------------------------------------------------
 
 describe("CallbackDispatcher provider routing (REQ-51)", () => {
-  it("routes callback/continuity/resolve_many to ContinuityStore", async () => {
+  it("routes callback/continuity_store/resolve_many to ContinuityStore", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
     const resolveCalls: string[][] = [];
@@ -856,7 +898,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       async upsertContinuityRecord() {},
     });
 
-    const result = await dispatcher.handleCallback("callback/continuity/resolve_many", {
+    const result = await dispatcher.handleCallback("callback/continuity_store/resolve_many", {
       identities: ["lead:main", "worker:1"],
     });
     assert.equal(resolveCalls.length, 1);
@@ -864,7 +906,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
     assert.ok(result !== null);
   });
 
-  it("routes callback/continuity/load_session_snapshot", async () => {
+  it("routes callback/continuity_store/load_session_snapshot", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
     let loadedSessionId: string | null = null;
@@ -879,14 +921,14 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       async upsertContinuityRecord() {},
     });
 
-    const result = await dispatcher.handleCallback("callback/continuity/load_session_snapshot", {
+    const result = await dispatcher.handleCallback("callback/continuity_store/load_session_snapshot", {
       session_id: "sess-1",
     });
     assert.equal(loadedSessionId, "sess-1");
     assert.ok(result !== null);
   });
 
-  it("routes callback/continuity/save_session_snapshot", async () => {
+  it("routes callback/continuity_store/save_session_snapshot", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
     let savedArgs: Record<string, unknown> | null = null;
@@ -900,7 +942,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       async upsertContinuityRecord() {},
     });
 
-    await dispatcher.handleCallback("callback/continuity/save_session_snapshot", {
+    await dispatcher.handleCallback("callback/continuity_store/save_session_snapshot", {
       identity: "lead:main",
       session_id: "sess-1",
       generation: 0,
@@ -914,7 +956,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
     assert.equal(savedArgs!.hasData, true);
   });
 
-  it("routes callback/continuity/upsert_continuity_record", async () => {
+  it("routes callback/continuity_store/upsert_continuity_record", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
     let upsertedRecord: Record<string, unknown> | null = null;
@@ -928,7 +970,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       },
     });
 
-    await dispatcher.handleCallback("callback/continuity/upsert_continuity_record", {
+    await dispatcher.handleCallback("callback/continuity_store/upsert_continuity_record", {
       record: {
         identity: "lead:main",
         agent_runtime_id: "rt-1",
@@ -943,7 +985,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
     assert.equal(upsertedRecord!.fencingToken, 42);
   });
 
-  it("routes callback/lease/acquire_leases to LeaseProvider", async () => {
+  it("routes callback/lease_provider/acquire_leases to LeaseProvider", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
 
@@ -959,14 +1001,14 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       async releaseLeases() {},
     });
 
-    const result = await dispatcher.handleCallback("callback/lease/acquire_leases", {
+    const result = await dispatcher.handleCallback("callback/lease_provider/acquire_leases", {
       identities: ["x:1"],
       runtime_instance: "rt-1",
     });
     assert.ok(result !== null);
   });
 
-  it("routes callback/lease/renew_leases to LeaseProvider", async () => {
+  it("routes callback/lease_provider/renew_leases to LeaseProvider", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
 
@@ -982,13 +1024,13 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       async releaseLeases() {},
     });
 
-    const result = await dispatcher.handleCallback("callback/lease/renew_leases", {
+    const result = await dispatcher.handleCallback("callback/lease_provider/renew_leases", {
       grants: [{ identity: "x:1", fencing_token: 1, ttl_ms: 30000 }],
     });
     assert.ok(result !== null);
   });
 
-  it("routes callback/lease/release_leases to LeaseProvider", async () => {
+  it("routes callback/lease_provider/release_leases to LeaseProvider", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
     let releasedCount = 0;
@@ -999,13 +1041,13 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       async releaseLeases(grants) { releasedCount = grants.length; },
     });
 
-    await dispatcher.handleCallback("callback/lease/release_leases", {
+    await dispatcher.handleCallback("callback/lease_provider/release_leases", {
       grants: [{ identity: "x:1", fencing_token: 1, ttl_ms: 30000 }],
     });
     assert.equal(releasedCount, 1);
   });
 
-  it("routes callback/roster to RosterProvider", async () => {
+  it("routes callback/roster_provider/roster to RosterProvider", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
 
@@ -1025,7 +1067,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       },
     });
 
-    const result = await dispatcher.handleCallback("callback/roster", {
+    const result = await dispatcher.handleCallback("callback/roster_provider/roster", {
       context: {},
     });
     const specs = result as Array<Record<string, unknown>>;
@@ -1033,7 +1075,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
     assert.equal(specs[0].identity, "triage:main");
   });
 
-  it("routes callback/topology/compute_edges to TopologyProvider", async () => {
+  it("routes callback/topology_provider/compute_edges to TopologyProvider", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
 
@@ -1043,7 +1085,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       },
     });
 
-    const result = await dispatcher.handleCallback("callback/topology/compute_edges", {
+    const result = await dispatcher.handleCallback("callback/topology_provider/compute_edges", {
       target_identities: ["lead:main", "worker:1"],
       context: {},
     });
@@ -1052,7 +1094,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
     assert.equal(edges[0].a, "lead:main");
   });
 
-  it("routes callback/customizer/customize_build to AgentCustomizer", async () => {
+  it("routes callback/agent_customizer/customize_build to AgentCustomizer", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
 
@@ -1067,7 +1109,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       },
     });
 
-    const result = await dispatcher.handleCallback("callback/customizer/customize_build", {
+    const result = await dispatcher.handleCallback("callback/agent_customizer/customize_build", {
       context: { identity: "x:1", active_peers: [], managed_edges: [] },
       spec: { identity: "x:1", profile: "worker", addressability: "addressable" },
       draft: { model: null, system_prompt: null, additional_instructions: [], labels: {}, app_context: null, external_tools: [] },
@@ -1078,7 +1120,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
     assert.equal(tools[0].name, "search");
   });
 
-  it("routes callback/customizer/after_create to AgentCustomizer", async () => {
+  it("routes callback/agent_customizer/after_create to AgentCustomizer", async () => {
     const { CallbackDispatcher } = await import("../src/agent-builder.js");
     const dispatcher = new CallbackDispatcher();
     let afterCreateCalled = false;
@@ -1090,7 +1132,7 @@ describe("CallbackDispatcher provider routing (REQ-51)", () => {
       },
     });
 
-    await dispatcher.handleCallback("callback/customizer/after_create", {
+    await dispatcher.handleCallback("callback/agent_customizer/after_create", {
       identity: "x:1",
       agent_runtime_id: "rt-1",
       session_id: "sess-1",

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -37,6 +37,13 @@ function createMockRuntime(): {
     authConfig: null,
     gatewayBin: null,
     modules: [],
+    persistentState: null,
+    continuityStore: null,
+    leaseProvider: null,
+    scratchDir: null,
+    rosterProvider: null,
+    agentCustomizer: null,
+    topologyProvider: null,
   };
 
   const rt = new MobKitRuntime(config);


### PR DESCRIPTION
## Summary
- Parse SDK-forwarded `runtime_options.memory_config` in `rpc_gateway` and translate Elephant config into `RuntimeOptions.memory_backend`.
- Derive gateway Elephant state at `<persistent_state>/elephant-memory-state.json` and boot with `UnifiedRuntime::bootstrap_with_options`.
- Implement the other SDK-forwarded runtime option keys in the stock gateway path: `routing_config_path`, `scheduling_files`, `gating_config_path`, `auth_config`, and `event_log`.
- Keep unsupported nested memory config fields fail-fast instead of accepting no-op config.
- Align TypeScript identity-first provider callback flags/method names with the Rust gateway bridge.
- Document gateway runtime option behavior, including the derived Elephant memory state path.

## Verification
- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo check -p meerkat-mobkit --bin rpc_gateway`
- `./scripts/repo-cargo test -p meerkat-mobkit --test gateway_memory_config`
- `cd sdk/typescript && npm install && npm run build --silent && npm test -- --runInBand`
- `cd sdk/python && PYTHONPATH=. pytest tests/test_identity_first_builder_dispatcher.py tests/test_builder.py -q`

## Broader suite notes
- `./scripts/repo-cargo test -p meerkat-mobkit` reaches the new gateway regression and then fails in pre-existing governance-contract checks because this worktree lacks `.rct/spec.yaml`.
- Full `cd sdk/python && PYTHONPATH=. pytest -q` has 441 passing tests and 6 live HomeCore E2E failures in existing respawn/retire/autonomous dispatch paths, unrelated to the memory/runtime-options gateway change.
