### PR TITLE
[codex] Add first-class module boundary support

### DIFF
--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -17,7 +17,7 @@
 )]
 //! Phase 0b binary — JSON-RPC gateway bridging SDK clients to the unified runtime.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -30,10 +30,11 @@ use meerkat_mobkit::{
     ConsolePolicy, DiscoverySpec, ElephantMemoryBackendConfig, EventLogConfig, EventLogStore,
     EventQuery, InMemoryMetadataStore, MOBKIT_CONTRACT_VERSION, MemoryBackendConfig,
     MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, ModuleConfig, ObjectStoreBlobStore,
-    PersistedEvent, PersistentMetadataStore, ReleaseMetadata, RestartPolicy, RuntimeDecisionState,
-    RuntimeOpsPolicy, RuntimeOptions, RuntimeRoute, ScheduleDefinition, SqliteMetadataStore,
-    TrustedOidcRuntimeConfig, UnifiedRuntime, handle_mobkit_rpc_json, handle_unified_rpc_json,
-    mob_handle_runtime::mob_definition_may_use_image_generation, start_mobkit_runtime,
+    PersistedEvent, PersistentMetadataStore, PreSpawnData, ReleaseMetadata, RestartPolicy,
+    RuntimeDecisionState, RuntimeOpsPolicy, RuntimeOptions, RuntimeRoute, ScheduleDefinition,
+    SqliteMetadataStore, TrustedOidcRuntimeConfig, UnifiedRuntime, handle_mobkit_rpc_json,
+    handle_unified_rpc_json, mob_handle_runtime::mob_definition_may_use_image_generation,
+    start_mobkit_runtime,
 };
 use sha2::{Digest, Sha256};
 
@@ -48,6 +49,7 @@ use meerkat_core::error::{AgentError, ToolError};
 use meerkat_core::ops::ToolDispatchOutcome;
 use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
 use meerkat_mob::{MobDefinition, MobStorage};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, mpsc, oneshot};
 
@@ -159,6 +161,145 @@ fn shell_module(id: &str, script: &str) -> ModuleConfig {
         command: "sh".to_string(),
         args: vec!["-c".to_string(), script.to_string()],
         restart_policy: RestartPolicy::Never,
+    }
+}
+
+const MODULE_BOUNDARY_ENV_KEY: &str = "MOBKIT_MODULE_BOUNDARY";
+const MODULE_BOUNDARY_MCP: &str = "mcp";
+
+#[derive(Debug, Deserialize)]
+struct GatewayModuleConfig {
+    id: String,
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default = "gateway_restart_policy_never")]
+    restart_policy: RestartPolicy,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    boundary: Option<String>,
+}
+
+fn gateway_restart_policy_never() -> RestartPolicy {
+    RestartPolicy::Never
+}
+
+impl GatewayModuleConfig {
+    fn into_module_and_pre_spawn(self) -> (ModuleConfig, Option<PreSpawnData>) {
+        let GatewayModuleConfig {
+            id,
+            command,
+            args,
+            restart_policy,
+            mut env,
+            boundary,
+        } = self;
+        if boundary
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case(MODULE_BOUNDARY_MCP))
+        {
+            env.insert(
+                MODULE_BOUNDARY_ENV_KEY.to_string(),
+                MODULE_BOUNDARY_MCP.to_string(),
+            );
+        }
+        let pre_spawn = if env.is_empty() {
+            None
+        } else {
+            Some(PreSpawnData {
+                module_id: id.clone(),
+                env: env.into_iter().collect(),
+            })
+        };
+        (
+            ModuleConfig {
+                id,
+                command,
+                args,
+                restart_policy,
+            },
+            pre_spawn,
+        )
+    }
+}
+
+fn parse_gateway_modules(params: &Value) -> (Vec<ModuleConfig>, Vec<PreSpawnData>) {
+    let gateway_modules: Vec<GatewayModuleConfig> = params
+        .get("modules")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+
+    let mut modules = Vec::with_capacity(gateway_modules.len());
+    let mut pre_spawn = Vec::new();
+    for gateway_module in gateway_modules {
+        let (module, maybe_pre_spawn) = gateway_module.into_module_and_pre_spawn();
+        modules.push(module);
+        if let Some(pre_spawn_data) = maybe_pre_spawn {
+            pre_spawn.push(pre_spawn_data);
+        }
+    }
+    (modules, pre_spawn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_module_boundary_becomes_pre_spawn_data() {
+        let params = json!({
+            "modules": [{
+                "id": "router",
+                "command": "python3",
+                "args": ["router.py"],
+                "restart_policy": "on_failure",
+                "boundary": "mcp",
+                "env": {
+                    "ROUTER_FIXTURE": "homecore"
+                }
+            }]
+        });
+
+        let (modules, pre_spawn) = parse_gateway_modules(&params);
+
+        assert_eq!(
+            modules,
+            vec![ModuleConfig {
+                id: "router".to_string(),
+                command: "python3".to_string(),
+                args: vec!["router.py".to_string()],
+                restart_policy: RestartPolicy::OnFailure,
+            }]
+        );
+        assert_eq!(
+            pre_spawn,
+            vec![PreSpawnData {
+                module_id: "router".to_string(),
+                env: vec![
+                    ("MOBKIT_MODULE_BOUNDARY".to_string(), "mcp".to_string()),
+                    ("ROUTER_FIXTURE".to_string(), "homecore".to_string()),
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn gateway_module_without_env_does_not_create_pre_spawn_data() {
+        let params = json!({
+            "modules": [{
+                "id": "delivery",
+                "command": "python3"
+            }]
+        });
+
+        let (modules, pre_spawn) = parse_gateway_modules(&params);
+
+        assert_eq!(modules.len(), 1);
+        assert_eq!(modules[0].id, "delivery");
+        assert_eq!(modules[0].args, Vec::<String>::new());
+        assert_eq!(modules[0].restart_policy, RestartPolicy::Never);
+        assert!(pre_spawn.is_empty());
     }
 }
 
@@ -1055,10 +1196,7 @@ external_addressable = true
         }
     }
 
-    let modules: Vec<ModuleConfig> = params
-        .get("modules")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .unwrap_or_default();
+    let (modules, pre_spawn) = parse_gateway_modules(&params);
 
     let discovery_modules: Vec<String> = modules.iter().map(|m| m.id.clone()).collect();
     let module_config = MobKitConfig {
@@ -1067,7 +1205,7 @@ external_addressable = true
             namespace: "persistent-gateway".to_string(),
             modules: discovery_modules,
         },
-        pre_spawn: vec![],
+        pre_spawn,
     };
 
     let has_session_builder = params

--- a/sdk/python/meerkat_mobkit/helpers.py
+++ b/sdk/python/meerkat_mobkit/helpers.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Literal, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Literal, Mapping, Sequence
 from urllib.parse import quote
 
 RestartPolicy = Literal["never", "always", "on_failure"]
+ModuleBoundary = Literal["mcp"]
 
 
 def build_console_route(
@@ -38,14 +39,21 @@ class ModuleSpec:
     command: str
     args: tuple[str, ...]
     restart_policy: RestartPolicy = "never"
+    boundary: ModuleBoundary | None = None
+    env: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "id": self.id,
             "command": self.command,
             "args": list(self.args),
             "restart_policy": self.restart_policy,
         }
+        if self.boundary is not None:
+            payload["boundary"] = self.boundary
+        if self.env:
+            payload["env"] = dict(self.env)
+        return payload
 
 
 ModuleSpecDecorator = Callable[[ModuleSpec], ModuleSpec]
@@ -73,12 +81,16 @@ def build_module_spec(
     command: str,
     args: Sequence[str] | None = None,
     restart_policy: RestartPolicy = "never",
+    boundary: ModuleBoundary | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> ModuleSpec:
     return ModuleSpec(
         id=module_id,
         command=command,
         args=tuple(args or ()),
         restart_policy=restart_policy,
+        boundary=boundary,
+        env=dict(env or {}),
     )
 
 
@@ -88,12 +100,16 @@ def define_module_spec(
     command: str,
     args: list[str] | None = None,
     restart_policy: RestartPolicy = "never",
+    boundary: ModuleBoundary | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     return build_module_spec(
         module_id=module_id,
         command=command,
         args=args,
         restart_policy=restart_policy,
+        boundary=boundary,
+        env=env,
     ).to_dict()
 
 
@@ -103,6 +119,8 @@ def decorate_module_spec(spec: ModuleSpec, *decorators: ModuleSpecDecorator) -> 
         command=spec.command,
         args=tuple(spec.args),
         restart_policy=spec.restart_policy,
+        boundary=spec.boundary,
+        env=dict(spec.env),
     )
     for decorate in decorators:
         current = decorate(current)
@@ -141,6 +159,8 @@ def define_module(
             command=spec.command,
             args=tuple(spec.args),
             restart_policy=spec.restart_policy,
+            boundary=spec.boundary,
+            env=dict(spec.env),
         ),
         tools=tuple(tools or ()),
         description=description,

--- a/sdk/python/scripts/parity.py
+++ b/sdk/python/scripts/parity.py
@@ -95,12 +95,14 @@ def main() -> int:
             command="python3",
             args=["router.py"],
             restart_policy="on_failure",
+            boundary="mcp",
         ),
         {
             "id": "router",
             "command": "python3",
             "args": ["router.py"],
             "restart_policy": "on_failure",
+            "boundary": "mcp",
         },
         "unexpected module spec",
     ))

--- a/sdk/python/scripts/productization.py
+++ b/sdk/python/scripts/productization.py
@@ -441,6 +441,17 @@ async def main() -> int:
             },
             "compat module spec mismatch",
         )
+        env_dict = define_module_spec(
+            module_id="routing",
+            command="python3",
+            args=["routing.py"],
+            boundary="mcp",
+        )
+        _assert_eq(
+            env_dict["boundary"],
+            "mcp",
+            "module boundary should be preserved for gateway init",
+        )
 
         decorated_spec = decorate_module_spec(
             base_spec,
@@ -449,6 +460,8 @@ async def main() -> int:
                 command=spec.command,
                 args=spec.args + ("--prod",),
                 restart_policy="on_failure",
+                boundary=spec.boundary,
+                env=spec.env,
             ),
         )
 

--- a/sdk/python/tests/test_helpers.py
+++ b/sdk/python/tests/test_helpers.py
@@ -1,0 +1,42 @@
+from meerkat_mobkit.helpers import build_module_spec, define_module, define_module_spec
+
+
+def test_module_spec_boundary_serializes_for_gateway_init():
+    spec = build_module_spec(
+        module_id="router",
+        command="python3",
+        args=["router.py"],
+        boundary="mcp",
+    )
+
+    assert spec.to_dict() == {
+        "id": "router",
+        "command": "python3",
+        "args": ["router.py"],
+        "restart_policy": "never",
+        "boundary": "mcp",
+    }
+
+
+def test_define_module_spec_keeps_boundary_and_env_out_when_empty():
+    assert define_module_spec(module_id="delivery", command="python3") == {
+        "id": "delivery",
+        "command": "python3",
+        "args": [],
+        "restart_policy": "never",
+    }
+
+
+def test_define_module_preserves_module_boundary_and_env_copy():
+    spec = build_module_spec(
+        module_id="router",
+        command="python3",
+        boundary="mcp",
+        env={"ROUTER_FIXTURE": "homecore"},
+    )
+
+    definition = define_module(spec=spec)
+    definition.spec.env["ROUTER_FIXTURE"] = "other"
+
+    assert definition.spec.boundary == "mcp"
+    assert spec.env == {"ROUTER_FIXTURE": "homecore"}

--- a/sdk/typescript/scripts/parity.cjs
+++ b/sdk/typescript/scripts/parity.cjs
@@ -92,6 +92,7 @@ check("module-authoring helper normalizes schema", () => {
     command: "node",
     args: ["router.js"],
     restartPolicy: "on_failure",
+    boundary: "mcp",
   });
 
   assertDeepEqual(moduleSpec, {
@@ -99,6 +100,7 @@ check("module-authoring helper normalizes schema", () => {
     command: "node",
     args: ["router.js"],
     restart_policy: "on_failure",
+    boundary: "mcp",
   }, "unexpected module spec");
 });
 

--- a/sdk/typescript/scripts/productization.cjs
+++ b/sdk/typescript/scripts/productization.cjs
@@ -362,6 +362,7 @@ async function run() {
       command: "node",
       args: ["routing.js"],
       restartPolicy: "never",
+      boundary: "mcp",
     });
 
     const decoratedSpec = decorateModuleSpec(
@@ -402,6 +403,7 @@ async function run() {
       command: "node",
       args: ["routing.js", "--prod"],
       restart_policy: "on_failure",
+      boundary: "mcp",
     }, "unexpected decorated spec");
 
     assertDeepEqual(toolResult, {

--- a/sdk/typescript/src/helpers.ts
+++ b/sdk/typescript/src/helpers.ts
@@ -8,12 +8,15 @@
 // -- Types ----------------------------------------------------------------
 
 export type RestartPolicy = "never" | "always" | "on_failure";
+export type ModuleBoundary = "mcp";
 
 export interface ModuleSpec {
   readonly id: string;
   readonly command: string;
   readonly args: readonly string[];
   readonly restart_policy: RestartPolicy;
+  readonly boundary?: ModuleBoundary;
+  readonly env?: Readonly<Record<string, string>>;
 }
 
 export type ModuleSpecDecorator = (spec: ModuleSpec) => ModuleSpec;
@@ -56,12 +59,20 @@ export function defineModuleSpec(input: {
   command: string;
   args?: string[];
   restartPolicy?: RestartPolicy;
+  boundary?: ModuleBoundary;
+  env?: Readonly<Record<string, string>>;
 }): ModuleSpec {
+  const env =
+    input.env && Object.keys(input.env).length > 0
+      ? { env: { ...input.env } }
+      : {};
   return {
     id: input.id,
     command: input.command,
     args: input.args ?? [],
     restart_policy: input.restartPolicy ?? "never",
+    ...(input.boundary ? { boundary: input.boundary } : {}),
+    ...env,
   };
 }
 
@@ -69,7 +80,11 @@ export function decorateModuleSpec(
   spec: ModuleSpec,
   ...decorators: ModuleSpecDecorator[]
 ): ModuleSpec {
-  const base: ModuleSpec = { ...spec, args: [...spec.args] };
+  const base: ModuleSpec = {
+    ...spec,
+    args: [...spec.args],
+    ...(spec.env ? { env: { ...spec.env } } : {}),
+  };
   return decorators.reduce((current, decorate) => decorate(current), base);
 }
 
@@ -103,7 +118,11 @@ export function defineModule(input: {
   tools?: ModuleToolDefinition[];
 }): ModuleDefinition {
   return {
-    spec: { ...input.spec, args: [...input.spec.args] },
+    spec: {
+      ...input.spec,
+      args: [...input.spec.args],
+      ...(input.spec.env ? { env: { ...input.spec.env } } : {}),
+    },
     description: input.description,
     tools: [...(input.tools ?? [])],
   };

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -260,6 +260,7 @@ export {
 
 export type {
   RestartPolicy,
+  ModuleBoundary,
   ModuleSpec,
   ModuleSpecDecorator,
   ModuleToolContext,

--- a/sdk/typescript/tests/helpers.test.ts
+++ b/sdk/typescript/tests/helpers.test.ts
@@ -51,6 +51,16 @@ describe("defineModuleSpec()", () => {
     });
     assert.equal(spec.restart_policy, "on_failure");
   });
+
+  it("preserves module boundary for gateway init payloads", () => {
+    const spec = defineModuleSpec({
+      id: "router",
+      command: "python3",
+      boundary: "mcp",
+    });
+
+    assert.equal(spec.boundary, "mcp");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -76,6 +86,20 @@ describe("decorateModuleSpec()", () => {
     // result should be a copy (different reference for args)
     assert.notEqual(result.args, base.args);
     assert.deepEqual(result.args, base.args);
+  });
+
+  it("copies boundary and env when decorating", () => {
+    const base = defineModuleSpec({
+      id: "mod",
+      command: "cmd",
+      boundary: "mcp",
+      env: { ROUTER_FIXTURE: "homecore" },
+    });
+    const result = decorateModuleSpec(base);
+
+    assert.equal(result.boundary, "mcp");
+    assert.notEqual(result.env, base.env);
+    assert.deepEqual(result.env, base.env);
   });
 
   it("works with no decorators", () => {
@@ -199,7 +223,13 @@ describe("defineModule()", () => {
   });
 
   it("creates copies of spec and tools arrays", () => {
-    const spec = defineModuleSpec({ id: "mod", command: "cmd", args: ["a"] });
+    const spec = defineModuleSpec({
+      id: "mod",
+      command: "cmd",
+      args: ["a"],
+      boundary: "mcp",
+      env: { ROUTER_FIXTURE: "homecore" },
+    });
     const tools = [defineModuleTool({ name: "t", handler: async () => {} })];
 
     const mod = defineModule({ spec, tools });
@@ -207,6 +237,9 @@ describe("defineModule()", () => {
     // Spec args should be a different array reference
     assert.notEqual(mod.spec.args, spec.args);
     assert.deepEqual(mod.spec.args, spec.args);
+    assert.equal(mod.spec.boundary, "mcp");
+    assert.notEqual(mod.spec.env, spec.env);
+    assert.deepEqual(mod.spec.env, spec.env);
 
     // Tools should be a different array reference
     assert.notEqual(mod.tools, tools);


### PR DESCRIPTION
## Summary
- add first-class module boundary fields to Python and TypeScript module helpers (`boundary="mcp"` / `boundary: "mcp"`)
- teach `rpc_gateway` init to lower `modules[].boundary == "mcp"` into existing `PreSpawnData` for the runtime
- keep `env` as an advanced escape hatch for additional module environment, not the primary MCP-backed-module API
- add Rust/Python/TypeScript regression coverage for MCP boundary preservation

## Verification
- `./scripts/repo-cargo test -p meerkat-mobkit --bin rpc_gateway gateway_module -- --nocapture`
- `pytest sdk/python/tests/test_helpers.py sdk/python/tests/test_models.py -q`
- `npm --prefix sdk/typescript run build --silent`
- `npm --prefix sdk/typescript run typecheck --silent`
- `npm --prefix sdk/typescript test --silent`
- `MOBKIT_RPC_GATEWAY_BIN=/Users/luka/Library/Caches/rust-workspaces/meerkat-mobkit-2783c42580/targets/meerkat-mobkit-08be7a9886/debug/rpc_gateway python sdk/python/scripts/parity.py`
- `MOBKIT_RPC_GATEWAY_BIN=/Users/luka/Library/Caches/rust-workspaces/meerkat-mobkit-2783c42580/targets/meerkat-mobkit-08be7a9886/debug/rpc_gateway python sdk/python/scripts/productization.py`
- `MOBKIT_RPC_GATEWAY_BIN=/Users/luka/Library/Caches/rust-workspaces/meerkat-mobkit-2783c42580/targets/meerkat-mobkit-08be7a9886/debug/rpc_gateway node sdk/typescript/scripts/parity.cjs`
- `MOBKIT_RPC_GATEWAY_BIN=/Users/luka/Library/Caches/rust-workspaces/meerkat-mobkit-2783c42580/targets/meerkat-mobkit-08be7a9886/debug/rpc_gateway node sdk/typescript/scripts/productization.cjs`
- pre-push hooks: cargo fmt, changed-crate clippy, workspace unit gate