### PR TITLE
[codex] Materialize identity-first topology wires

### DIFF
--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -90,6 +90,20 @@ pub trait SessionBridge: Send + Sync {
     /// Retire a mob member.
     async fn retire_member(&self, runtime_id: &AgentRuntimeId) -> Result<(), BridgeError>;
 
+    /// Wire two active same-mob members by their concrete runtime IDs.
+    async fn wire_peer(&self, _a: &AgentRuntimeId, _b: &AgentRuntimeId) -> Result<(), BridgeError> {
+        Err(BridgeError::Mob("peer wiring not supported".to_string()))
+    }
+
+    /// Unwire two active same-mob members by their concrete runtime IDs.
+    async fn unwire_peer(
+        &self,
+        _a: &AgentRuntimeId,
+        _b: &AgentRuntimeId,
+    ) -> Result<(), BridgeError> {
+        Err(BridgeError::Mob("peer unwiring not supported".to_string()))
+    }
+
     /// Inspect the current execution state of a mob member.
     async fn inspect_member(
         &self,
@@ -344,6 +358,26 @@ impl SessionBridge for MobSessionBridge {
             .await
             .map_err(|e| BridgeError::Mob(e.to_string()))?;
         Ok(())
+    }
+
+    async fn wire_peer(&self, a: &AgentRuntimeId, b: &AgentRuntimeId) -> Result<(), BridgeError> {
+        self.handle
+            .wire(
+                meerkat_mob::AgentIdentity::from(a.as_str()),
+                MeerkatId::from(b.as_str()),
+            )
+            .await
+            .map_err(|e| BridgeError::Mob(e.to_string()))
+    }
+
+    async fn unwire_peer(&self, a: &AgentRuntimeId, b: &AgentRuntimeId) -> Result<(), BridgeError> {
+        self.handle
+            .unwire(
+                meerkat_mob::AgentIdentity::from(a.as_str()),
+                MeerkatId::from(b.as_str()),
+            )
+            .await
+            .map_err(|e| BridgeError::Mob(e.to_string()))
     }
 
     async fn inspect_member(

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -367,6 +367,8 @@ pub async fn restore_flow(
         }
     }
 
+    runtime.reconcile_managed_peer_edges(&managed_edges).await?;
+
     Ok(RestoreFlowResult {
         outcomes,
         managed_edges,

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -6,7 +6,7 @@
 //! - Lifecycle: `retire()`, `respawn()`, `reset()`, `delete_identity()`
 //! - Ownership: lease tracking, fencing, and invariant enforcement
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -18,7 +18,7 @@ use super::types::{
     AgentAddressability, AgentIdentity, AgentRuntimeId, CheckpointVersion, ContinuityGeneration,
     ContinuityHealth, ContinuityRecord, ContinuityStoreError, DispatchInput, DurabilityPolicy,
     DurableAgentSpec, FencingToken, IdentityLifecycleState, IdentityStatus, LeaseGrant, LeaseInfo,
-    NotAddressable, SessionSnapshot,
+    ManagedPeerEdge, NotAddressable, SessionSnapshot,
 };
 
 // ---------------------------------------------------------------------------
@@ -231,6 +231,7 @@ pub struct IdentityRuntime {
     has_runtime_store: bool,
     durability_policy: DurabilityPolicy,
     bridge: Option<Arc<dyn SessionBridge>>,
+    managed_peer_edges: RwLock<BTreeSet<(AgentIdentity, AgentIdentity)>>,
     default_timeout: Duration,
 }
 
@@ -246,6 +247,7 @@ impl IdentityRuntime {
             has_runtime_store: config.has_runtime_store,
             durability_policy: config.durability_policy,
             bridge: config.bridge,
+            managed_peer_edges: RwLock::new(BTreeSet::new()),
             default_timeout: config.default_timeout.unwrap_or(Duration::from_secs(90)),
         }
     }
@@ -253,6 +255,81 @@ impl IdentityRuntime {
     #[must_use]
     pub fn has_session_bridge(&self) -> bool {
         self.bridge.is_some()
+    }
+
+    /// Apply identity-first managed topology to the concrete mob graph.
+    ///
+    /// Topology providers return stable logical identities. The mob comms graph
+    /// is keyed by active runtime member IDs, so this resolves each endpoint
+    /// through continuity records before calling the same-mob bridge wire APIs.
+    pub async fn reconcile_managed_peer_edges(
+        &self,
+        desired_edges: &[ManagedPeerEdge],
+    ) -> Result<(), IdentityRuntimeError> {
+        let Some(bridge) = self.bridge.clone() else {
+            return Ok(());
+        };
+
+        let active_runtimes: BTreeMap<AgentIdentity, AgentRuntimeId> = {
+            let entries = self.entries.read().await;
+            entries
+                .iter()
+                .filter_map(|(identity, entry)| {
+                    if entry.state != IdentityLifecycleState::Active {
+                        return None;
+                    }
+                    entry
+                        .continuity
+                        .as_ref()
+                        .map(|record| (identity.clone(), record.agent_runtime_id.clone()))
+                })
+                .collect()
+        };
+
+        let desired: BTreeSet<(AgentIdentity, AgentIdentity)> = desired_edges
+            .iter()
+            .map(|edge| (edge.a().clone(), edge.b().clone()))
+            .collect();
+
+        let mut managed = self.managed_peer_edges.write().await;
+
+        for (a, b) in &desired {
+            let (Some(runtime_a), Some(runtime_b)) =
+                (active_runtimes.get(a), active_runtimes.get(b))
+            else {
+                continue;
+            };
+
+            bridge
+                .wire_peer(runtime_a, runtime_b)
+                .await
+                .map_err(|e| IdentityRuntimeError::Internal(format!("bridge wire_peer: {e}")))?;
+            managed.insert((a.clone(), b.clone()));
+        }
+
+        let stale: Vec<(AgentIdentity, AgentIdentity)> = managed
+            .iter()
+            .filter(|edge| !desired.contains(*edge))
+            .cloned()
+            .collect();
+
+        for (a, b) in stale {
+            let key = (a.clone(), b.clone());
+            let (Some(runtime_a), Some(runtime_b)) =
+                (active_runtimes.get(&a), active_runtimes.get(&b))
+            else {
+                managed.remove(&key);
+                continue;
+            };
+
+            bridge
+                .unwire_peer(runtime_a, runtime_b)
+                .await
+                .map_err(|e| IdentityRuntimeError::Internal(format!("bridge unwire_peer: {e}")))?;
+            managed.remove(&key);
+        }
+
+        Ok(())
     }
 
     /// Emit an event for the given identity. Best-effort — no error if no subscribers.

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -26,12 +26,12 @@ use meerkat_mobkit::identity_first::orchestrator::{
 use meerkat_mobkit::identity_first::runtime::IdentityEvent;
 use meerkat_mobkit::identity_first::{
     AgentAddressability, AgentBuildContext, AgentBuildDraft, AgentIdentity, AgentRuntimeId,
-    CheckpointVersion, ContinuityFailure, ContinuityFailureKind, ContinuityGeneration,
+    BridgeError, CheckpointVersion, ContinuityFailure, ContinuityFailureKind, ContinuityGeneration,
     ContinuityRecord, ContinuityResolveState, ContinuityStoreError, CustomizerError,
     DispatchIdempotencyKey, DispatchInput, DispatchOrigin, DurabilityPolicy, DurableAgentSpec,
     FencingToken, IdentityLifecycleState, IdentityRuntime, IdentityRuntimeConfig,
-    IdentityRuntimeError, LeaseAcquireResult, LeaseGrant, ManagedPeerEdge, SessionSnapshot,
-    TopologyContext, TopologyError,
+    IdentityRuntimeError, LeaseAcquireResult, LeaseGrant, ManagedPeerEdge, SessionBridge,
+    SessionSnapshot, TopologyContext, TopologyError,
 };
 use meerkat_mobkit::identity_first::{LocalContinuityStore, LocalLeaseProvider};
 
@@ -1401,6 +1401,156 @@ async fn identity_first_runtime_topology_compute_edges() {
     let edge = &result.managed_edges[0];
     assert_eq!(edge.a(), &make_identity("a:main"));
     assert_eq!(edge.b(), &make_identity("b:main"));
+}
+
+#[tokio::test]
+async fn identity_first_runtime_topology_materializes_runtime_peer_wires() {
+    #[derive(Default)]
+    struct RecordingBridge {
+        wires: tokio::sync::Mutex<Vec<(String, String)>>,
+        unwires: tokio::sync::Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl SessionBridge for RecordingBridge {
+        async fn create_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(meerkat_core::types::SessionId::new())
+        }
+
+        async fn resume_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            session_id: &meerkat_core::types::SessionId,
+            _snapshot: &SessionSnapshot,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(session_id.clone())
+        }
+
+        async fn deliver(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _content: &meerkat_core::ContentInput,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(meerkat_core::types::SessionId::new())
+        }
+
+        async fn checkpoint_session(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _session_id: &meerkat_core::types::SessionId,
+        ) -> Result<SessionSnapshot, BridgeError> {
+            Ok(SessionSnapshot { data: Vec::new() })
+        }
+
+        async fn retire_member(&self, _runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn wire_peer(
+            &self,
+            a: &AgentRuntimeId,
+            b: &AgentRuntimeId,
+        ) -> Result<(), BridgeError> {
+            self.wires
+                .lock()
+                .await
+                .push((a.as_str().to_string(), b.as_str().to_string()));
+            Ok(())
+        }
+
+        async fn unwire_peer(
+            &self,
+            a: &AgentRuntimeId,
+            b: &AgentRuntimeId,
+        ) -> Result<(), BridgeError> {
+            self.unwires
+                .lock()
+                .await
+                .push((a.as_str().to_string(), b.as_str().to_string()));
+            Ok(())
+        }
+    }
+
+    struct StaticTopology(Vec<(&'static str, &'static str)>);
+
+    #[async_trait]
+    impl TopologyProvider for StaticTopology {
+        async fn compute_edges(
+            &self,
+            _target_identities: &[AgentIdentity],
+            _context: &TopologyContext,
+        ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+            self.0
+                .iter()
+                .map(|(a, b)| {
+                    ManagedPeerEdge::new(make_identity(a), make_identity(b))
+                        .map_err(|e| TopologyError::InvalidEdge(format!("{e}")))
+                })
+                .collect()
+        }
+    }
+
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_provider = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(RecordingBridge::default());
+    let runtime = IdentityRuntime::new(IdentityRuntimeConfig {
+        continuity_store: store,
+        lease_provider,
+        runtime_instance_id: "test-runtime".to_string(),
+        has_runtime_store: false,
+        durability_policy: DurabilityPolicy::SyncWriteThrough,
+        bridge: Some(bridge.clone()),
+        default_timeout: None,
+    });
+    let roster = vec![
+        make_spec("a:main"),
+        make_spec("b:main"),
+        make_spec("c:main"),
+    ];
+
+    restore_flow(
+        &runtime,
+        &roster,
+        Some(&StaticTopology(vec![("a:main", "b:main")])),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        bridge.wires.lock().await.as_slice(),
+        &[("rt:a:main:0".to_string(), "rt:b:main:0".to_string())]
+    );
+
+    restore_flow(
+        &runtime,
+        &roster,
+        Some(&StaticTopology(vec![("b:main", "c:main")])),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        bridge.wires.lock().await.as_slice(),
+        &[
+            ("rt:a:main:0".to_string(), "rt:b:main:0".to_string()),
+            ("rt:b:main:0".to_string(), "rt:c:main:0".to_string()),
+        ]
+    );
+    assert_eq!(
+        bridge.unwires.lock().await.as_slice(),
+        &[("rt:a:main:0".to_string(), "rt:b:main:0".to_string())]
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Resolve identity-first `ManagedPeerEdge` endpoints to active runtime member IDs after `restore_flow`.
- Apply desired topology through the same-mob `SessionBridge` wire/unwire path so `/console/experience` and comms observe real peer wiring.
- Track managed identity edges across restore/reconcile calls so stale provider edges are unwired.
- Add a regression covering logical identity edges materializing as `rt:<identity>:<generation>` runtime peer wires.

## Root Cause

The Python SDK + `rpc_gateway` identity-first path collected topology provider edges and returned their count, but `restore_flow` never bridged those logical identity edges into the mob graph. As a result, HomeCore could report `managed_edges: 57` while every live console node still had `wired_to: []`.

## Validation

- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime identity_first_runtime_topology_materializes_runtime_peer_wires`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime`
- `./scripts/repo-cargo check -p meerkat-mobkit --bins`
- Pre-push hook: `cargo fmt --check`, `cargo clippy (changed crates)`, `workspace unit gate`
