### PR TITLE
[codex] Bound bootstrap spawn concurrency

### DIFF
--- a/meerkat-mobkit/src/unified_runtime/mob_ops.rs
+++ b/meerkat-mobkit/src/unified_runtime/mob_ops.rs
@@ -7,10 +7,15 @@
 //! on `MobHandle` directly; callers reach through `runtime.mob_handle()`.
 
 use meerkat_mob::{MobHandle, SpawnMemberSpec, SpawnResult};
+use std::future::Future;
 
 use crate::mob_handle_runtime::MobRuntimeError;
 
 use super::UnifiedRuntime;
+
+// Upstream routed runtime-ready signals use a bounded actor queue (64 in
+// meerkat-mob 0.6.x), so bulk discovery bootstrap needs headroom.
+const MAX_CONCURRENT_SPAWN_MANY: usize = 32;
 
 impl UnifiedRuntime {
     pub fn mob_handle(&self) -> MobHandle {
@@ -52,18 +57,96 @@ impl UnifiedRuntime {
     ) -> Result<Vec<SpawnResult>, MobRuntimeError> {
         let member_ids: Vec<String> = specs.iter().map(|s| s.identity.to_string()).collect();
         let handle = self.mob_handle();
-        let futs = specs.into_iter().map(|spec| {
+        let refs = try_join_in_batches(specs, MAX_CONCURRENT_SPAWN_MANY, |spec| {
             let handle = handle.clone();
             async move { handle.spawn_spec(spec).await }
-        });
-        let refs = futures::future::try_join_all(futs)
-            .await
-            .map_err(MobRuntimeError::from)?;
+        })
+        .await
+        .map_err(MobRuntimeError::from)?;
         if !member_ids.is_empty()
             && let Some(hook) = &self.post_spawn_hook
         {
             hook(member_ids).await;
         }
         Ok(refs)
+    }
+}
+
+async fn try_join_in_batches<I, F, T, E, Build>(
+    items: Vec<I>,
+    batch_size: usize,
+    mut build: Build,
+) -> Result<Vec<T>, E>
+where
+    F: Future<Output = Result<T, E>>,
+    Build: FnMut(I) -> F,
+{
+    let batch_size = batch_size.max(1);
+    let mut results = Vec::with_capacity(items.len());
+    let mut iter = items.into_iter();
+
+    loop {
+        let batch: Vec<I> = iter.by_ref().take(batch_size).collect();
+        if batch.is_empty() {
+            break;
+        }
+
+        let futures = batch.into_iter().map(&mut build);
+        let mut batch_results = futures::future::try_join_all(futures).await?;
+        results.append(&mut batch_results);
+    }
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::try_join_in_batches;
+
+    #[tokio::test]
+    async fn try_join_in_batches_limits_concurrent_work_and_preserves_order() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let items: Vec<usize> = (0..75).collect();
+
+        let results = try_join_in_batches(items.clone(), 16, |item| {
+            let active = active.clone();
+            let max_active = max_active.clone();
+            async move {
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active.fetch_max(current, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok::<_, ()>(item)
+            }
+        })
+        .await;
+
+        assert_eq!(results, Ok(items));
+        assert!(max_active.load(Ordering::SeqCst) <= 16);
+    }
+
+    #[tokio::test]
+    async fn try_join_in_batches_stops_before_starting_later_batches_after_error() {
+        let started = Arc::new(AtomicUsize::new(0));
+        let items: Vec<usize> = (0..40).collect();
+
+        let result = try_join_in_batches(items, 16, |item| {
+            let started = started.clone();
+            async move {
+                started.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                if item == 20 { Err(item) } else { Ok(item) }
+            }
+        })
+        .await;
+
+        assert_eq!(result, Err(20));
+        assert_eq!(started.load(Ordering::SeqCst), 32);
     }
 }


### PR DESCRIPTION
## Summary

Bound `UnifiedRuntime::spawn_many` so discovery bootstrap spawns members in batches of 32 instead of firing the entire discovered roster concurrently.

## Why

Bulk discovery can return 100+ member specs during boot. `spawn_many` previously used one `try_join_all` over the full set, which could overrun upstream `meerkat-mob` routed runtime-ready signaling: the mob signal consumer projects `ObserveRuntimeReady` / `ObserveRuntimeRetired` onto a bounded actor queue using `try_send`. When that queue filled, bootstrap failed and rollback could fail on the same capacity path.

## Impact

Bootstrap now applies backpressure at the MobKit boundary while preserving the existing behavior that the post-spawn hook fires once after all members spawn successfully. Errors still stop the operation, and later batches are not started after a batch failure.

## Validation

- `./scripts/repo-cargo fmt --check`
- `./scripts/repo-cargo test -p meerkat-mobkit unified_runtime::mob_ops::tests --lib`
- `./scripts/repo-cargo test -p meerkat-mobkit --test discovery_bootstrap`
- pre-push hook: hardcoded secrets, whitespace, merge checks, `cargo fmt --check`, `cargo clippy (changed crates)`, workspace unit gate