### PR TITLE
chore: upgrade Meerkat to v0.6.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,9 +1299,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fac1e2e2e547d4b4600a56db46a08ed9f4a5925fed64eb7b04012b33416800"
+checksum = "36cd9d30bf25752bfad17d42064d909973456f16e39f26ec6fe58d50f452c74e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439806ca07dc201a50669b69b916ff15cdb3ce6658dc6d17bcc1e733596e65a5"
+checksum = "98f91b34056763774a800ec9c625ee5f1ed2835afa360d5117c43792aec7254e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf7509fcd5c09e840d68a8172a85d8a6ac71b0006c3ddb7b098eadd0e441f9b"
+checksum = "c30e7ffd4e13e7503577288b52a7f779de37018774439f33354a7dbc7b9f11fb"
 dependencies = [
  "async-trait",
  "axum",
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f978e035fcccd24859fe64d7e7daa9dd263235c123bb771fd664287d58a1349"
+checksum = "6720343a3bf92f26df8ef8a5cc70a6e9d42ebebbdcabee5d564f25ae5ab0b5cb"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b784a26aeaeeeac2f977512644c8e99a3bf9c8ebb518a69ae7c5537a3c86d1e7"
+checksum = "a6ac4a92b964e7dfa73fc67fd3c981ae04f6ccbc9b04d648eb0c1227f56d1dee"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399a7fd06d544f52b6f6e9241fd792def3971b3475f2ae6ab5e3047ccfcc15f1"
+checksum = "456f948bb6f9e440b0e6c5515523dbaccb31cc352b19fa31d750f8e07747ee68"
 dependencies = [
  "async-trait",
  "base64",
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95d1d9b17f8aee95d1bb8070108ffbae7b21be06796714bec1adf2b51a6e182"
+checksum = "5cf070ddd582a8dd853e07bac2341077c29a9d9dc50eb41f4de78aa5b53d0d7c"
 dependencies = [
  "base64",
  "chrono",
@@ -1472,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9977a819f8864c5a24b14ba36977467e64a1666fb5a00b115fb55cde253d79"
+checksum = "c8e0e39e03d17af8fabf78084ef929a26bbddfc4cc6e439d929e657bf931700f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1c2f8cbe8d713870c7935d0b80f669f497e377c74c0144960147e7b6a8c363"
+checksum = "e3a8d33ca351c0a745d0918db4ad136d36097237ec0ff8bed6770c8ae7ba58fa"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e70199089498c28661b93cd91d210c0bc6df92199e5115b1899cb03ca7c6fdb"
+checksum = "c1f117f267c7f353c421f4d6a01d6fc7f086977da3cf24de8b22de4fd5d15adb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d85752c782e2d0b4e80cfb81fbbf7526f1fd700ff1c575673daa6f168ee04a0"
+checksum = "14e1018a1cfbe1422238fa4e8159f70646bd7457a36d3be803375a114e039a6a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2637766f4b76b7e0071e7994e6c710eb7146e1bc69a9ca709405b9ee179ac21"
+checksum = "af0a865af358bfd510587825938608ce9dbbaa577acf89630a3839b9b635aac8"
 dependencies = [
  "quote",
  "syn",
@@ -1584,18 +1584,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc8b8ca1669d57f745af5c2bb643c60962f757df46d792bd6d0503f70bff557"
+checksum = "78fbacabadbb06ccc74aceb79ebc82909a6e01343518b9c8d1adda764cec910f"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6e0acd1d02c226f6834ba0203d4420278377c76b9e80bf24fdd3def4370273"
+checksum = "6909f689948dce7bf26f620cc3a4da3797d7c9c8bfdb0f623da98f31339bb442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1604,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61173a49e220dd01140e090216c65e2e344efa3390efa87e5da8562165bc0b9b"
+checksum = "00a341708fd91175a123c93bd2dd6d0aa3d5ecb9abdf1514b3f8564696a587ef"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f1fd7fab9ea691eb5874cbb747e087d5af32b773a562584ce4c8132c18c6f6"
+checksum = "079af5dab15d3f5fc82b01ed78eb7f34326c617b5151303180a2323f59239fb2"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -1630,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0165c4ca4f4b34e2c3c1d4f8744af5765ccc9a487c273f069e94ea37047d9eba"
+checksum = "dfea1419ee3e5a53961c4b63a2f13b96048481b52c83e18e41b80b272b1108fb"
 dependencies = [
  "async-trait",
  "futures",
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e21bec541df0ba3787413149d7112220b9bca269eacc577949f33721ca3d97d"
+checksum = "2bddd266b963b67732a932045a406a511815bedabd1d9de40c7d788efc1e7233"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797845ef7783bee268118aca85a1efa0086c9bd803eafa49c03a7dc5eb109cdf"
+checksum = "fcbf56953f8567b4a71e183fb5eb231b75d1b29106aee217576c6216693702e1"
 dependencies = [
  "async-trait",
  "futures",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f9151761823e2abce7607e2375c8ffc28729cd6581a79703ef8ce2eecaa62"
+checksum = "e5baa843e1b2bb34f8694db78b8f756153e10128a2cb05fb4e86290b111205bd"
 dependencies = [
  "meerkat-core",
  "schemars",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-openai"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46e700eb2de91b1c15dbf14343f262d5a1056bbc35251f43d72b4f4313671ea"
+checksum = "4cc338b27f12f5f022cebfad519d24c5c589ed111f8755cd147c8fabc249053d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a43566005a10cb48bd7260eb85ab1b3cc3dc411605709042a764a9d0ddd0507"
+checksum = "4e92dff5e060f61d7cc4efec4e7d9822a14e033a55319b6bcbccd9ae776a76db"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -1810,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99cfaf9b3dcf27a8d32c3dd42ddb119d6c44f8a77714d5e38677177f80cad07"
+checksum = "a349a2d82cc08a7d54c4e330c3f8a0359ab3234097d3822fc1c35581dd14978f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1836,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d934597d913b87870c78a64be9f786697aeaac041348a3a1f819e0fac4b8d59"
+checksum = "63af871aa9d48532b38e60b1cd8349a52d4b86d89a7d4abe71dca754fb8bd34d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2660970b0a0646b78586e19251acda7a37f34c566cdb9debf8e056ce70f052de"
+checksum = "189c45d55ac043f5420150814b10c0e19a2b9f9ea109cc12da30cc1aade3472d"
 dependencies = [
  "async-trait",
  "futures",
@@ -1886,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed714f6218c6fbcf97308ccc5b44a3614af4a54246742b180f4372ef0122339c"
+checksum = "dcd6cf7e650178719f5a93cbb997f1e2aac1493ae476be2b7e713b6cb542e578"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308ad8a7d95d810e761f7333b0103760c1a6317ee2f8fd3c7210c2241ef1a3ce"
+checksum = "9bf3762c9026622762e975a1b645c2cfcaf1932b25307eb6992a3b9865175ea4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af56d32d2847511eda4cb41ecaaa3810067d5a039c082e7a20a09842777b2cdc"
+checksum = "e42c9c1f3bd42b65d009440c256dffb98ec8ed2106b38f9a4863b818412c8340"
 dependencies = [
  "async-trait",
  "base64",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e93688f725cf90ade839d96a5e2a557f8c54f597fa61662fdbfbe21e9eb6b5"
+checksum = "d92575340edfb93b231824317ca28cd347bb5733b5a6ba87d0f944ed2871bddf"
 dependencies = [
  "async-trait",
  "chrono",

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -43,18 +43,18 @@ form_urlencoded = "1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 futures = "0.3"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "0.6.14"
-meerkat-client = "0.6.14"
-meerkat-contracts = "0.6.14"
-meerkat-mob = "0.6.14"
-meerkat-mob-mcp = "0.6.14"
-meerkat-mcp = "0.6.14"
-meerkat-models = "0.6.14"
-meerkat = { version = "0.6.14", features = ["comms", "skills", "mcp", "memory-store", "jsonl-store", "session-store", "sqlite-store"] }
-meerkat-runtime = { version = "0.6.14", features = ["sqlite-store"] }
-meerkat-session = { version = "0.6.14", features = ["session-store"] }
-meerkat-store = { version = "0.6.14", features = ["sqlite"] }
-meerkat-tools = "0.6.14"
+meerkat-core = "0.6.15"
+meerkat-client = "0.6.15"
+meerkat-contracts = "0.6.15"
+meerkat-mob = "0.6.15"
+meerkat-mob-mcp = "0.6.15"
+meerkat-mcp = "0.6.15"
+meerkat-models = "0.6.15"
+meerkat = { version = "0.6.15", features = ["comms", "skills", "mcp", "memory-store", "jsonl-store", "session-store", "sqlite-store"] }
+meerkat-runtime = { version = "0.6.15", features = ["sqlite-store"] }
+meerkat-session = { version = "0.6.15", features = ["session-store"] }
+meerkat-store = { version = "0.6.15", features = ["sqlite"] }
+meerkat-tools = "0.6.15"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -75,4 +75,4 @@ futures = "0.3"
 tower = "0.5"
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "0.6.14"
+meerkat-comms = "0.6.15"


### PR DESCRIPTION
## Summary
- Upgrade the Meerkat dependency family from 0.6.14 to 0.6.15
- Refresh Cargo.lock for the published 0.6.15 crates

## Validation
- ./scripts/verify-version-parity.sh
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo check -p meerkat-mobkit
- ./scripts/repo-cargo test -p meerkat-mobkit --test gateway_memory_config
- ./scripts/repo-cargo test -p meerkat-mobkit --test incident_command_center_pack
- console: npm run phase0:types --silent (98 passed)
- sdk/typescript: npm run build && npm test (454 passed)
- sdk/python: pytest tests -q (433 passed, 28 skipped)