### PR TITLE
[codex] fix console image paste and working state

### DIFF
--- a/console/src/ConsoleApp.tsx
+++ b/console/src/ConsoleApp.tsx
@@ -263,13 +263,14 @@ function cursorSeq(cursor: string | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function isEndTurnFrame(frame: ConsoleFrame): boolean {
+function isTerminalTurnCompletedFrame(frame: ConsoleFrame): boolean {
   if (frame.event !== "turn_completed") return false;
   const data =
     frame.data && typeof frame.data === "object"
       ? (frame.data as Record<string, unknown>)
       : {};
-  return data.stop_reason === "end_turn";
+  const stopReason = data.stop_reason ?? data.stopReason;
+  return typeof stopReason === "string" ? stopReason !== "tool_use" : true;
 }
 
 // --- Event sets for the SSE handler ---
@@ -642,7 +643,7 @@ export function ConsoleApp({ baseUrl }: ConsoleAppProps): React.JSX.Element {
       frame.event === "run_completed" ||
       frame.event === "run_failed" ||
       frame.event === "message_delivery_failed" ||
-      isEndTurnFrame(frame)
+      isTerminalTurnCompletedFrame(frame)
     ) {
       return false;
     }
@@ -1090,7 +1091,7 @@ export function ConsoleApp({ baseUrl }: ConsoleAppProps): React.JSX.Element {
       case "run_failed":
         return commitPanelPhase(panelKey, null);
       case "turn_completed":
-        if (isEndTurnFrame(frame)) return commitPanelPhase(panelKey, null);
+        if (isTerminalTurnCompletedFrame(frame)) return commitPanelPhase(panelKey, null);
         return false;
       case "message_delivery_failed":
         return commitPanelPhase(panelKey, null);
@@ -1557,7 +1558,7 @@ export function ConsoleApp({ baseUrl }: ConsoleAppProps): React.JSX.Element {
       // already seen via SSE are skipped). If hasServerLog is false,
       // scheduleHistoryRefresh short-circuits.
       if (
-        (HISTORY_REFRESH_EVENTS.has(frame.event) || isEndTurnFrame(frame)) &&
+        (HISTORY_REFRESH_EVENTS.has(frame.event) || isTerminalTurnCompletedFrame(frame)) &&
         identity &&
         identity !== "_system"
       ) {

--- a/console/src/ConsoleApp.tsx
+++ b/console/src/ConsoleApp.tsx
@@ -642,9 +642,10 @@ export function ConsoleApp({ baseUrl }: ConsoleAppProps): React.JSX.Element {
       frame.event === "interaction_failed" ||
       frame.event === "run_completed" ||
       frame.event === "run_failed" ||
-      frame.event === "message_delivery_failed" ||
-      isTerminalTurnCompletedFrame(frame)
+      frame.event === "message_delivery_failed"
     ) {
+      // Queue draining follows run-level terminals so server-side
+      // interaction correlation advances before the next send leaves.
       return false;
     }
     return null;

--- a/console/src/lib/adapters.test.ts
+++ b/console/src/lib/adapters.test.ts
@@ -366,7 +366,7 @@ test("mapFramesToTimelineEntries ignores hidden turn markers before terminal com
   );
 });
 
-test("inferResponsePhaseFromFrames clears working state on terminal text and end-turn frames", () => {
+test("inferResponsePhaseFromFrames clears working state on terminal text and terminal turn-completed frames", () => {
   assert.equal(
     inferResponsePhaseFromFrames([
       { id: "evt-1", event: "user_input", data: { content: "Hello" } },
@@ -396,6 +396,22 @@ test("inferResponsePhaseFromFrames clears working state on terminal text and end
       { id: "evt-2", event: "turn_completed", data: { stop_reason: "tool_use" } },
     ]),
     "tool-executing",
+  );
+
+  assert.equal(
+    inferResponsePhaseFromFrames([
+      { id: "evt-1", event: "text_delta", data: { delta: "Partial." } },
+      { id: "evt-2", event: "turn_completed", data: { stop_reason: "max_tokens" } },
+    ]),
+    null,
+  );
+
+  assert.equal(
+    inferResponsePhaseFromFrames([
+      { id: "evt-1", event: "text_delta", data: { delta: "Stopped." } },
+      { id: "evt-2", event: "turn_completed", data: { stop_reason: "stop_sequence" } },
+    ]),
+    null,
   );
 });
 

--- a/console/src/lib/adapters.ts
+++ b/console/src/lib/adapters.ts
@@ -2190,7 +2190,8 @@ export function inferResponsePhaseFromFrames(
         break;
       case "turn_completed": {
         const data = frame.data && typeof frame.data === "object" ? frame.data as Record<string, unknown> : {};
-        if (data.stop_reason === "end_turn") phase = null;
+        const stopReason = data.stop_reason ?? data.stopReason;
+        if (typeof stopReason === "string" ? stopReason !== "tool_use" : true) phase = null;
         break;
       }
       default:

--- a/console/src/lib/composer-attachment-text.test.ts
+++ b/console/src/lib/composer-attachment-text.test.ts
@@ -4,6 +4,7 @@ import {
   dedupeComposerImageFiles,
   consoleBlobReferencesFromText,
   normalizeConsoleBlobUrl,
+  selectImageTransferFiles,
   stripConsoleBlobReferencesFromText,
 } from "./composer-attachment-text";
 
@@ -62,5 +63,19 @@ test("dedupeComposerImageFiles collapses duplicate drag/drop file surfaces", () 
   assert.deepEqual(
     dedupeComposerImageFiles([file, duplicate, other]),
     [file, other],
+  );
+});
+
+test("selectImageTransferFiles prefers direct clipboard files over item duplicates", () => {
+  const direct = { name: "image.png", type: "image/png", size: 42, lastModified: 1 };
+  const sameClipboardItem = { name: "pasted-image.png", type: "image/png", size: 42, lastModified: 2 };
+
+  assert.deepEqual(
+    selectImageTransferFiles([direct], [sameClipboardItem]),
+    [direct],
+  );
+  assert.deepEqual(
+    selectImageTransferFiles([], [sameClipboardItem]),
+    [sameClipboardItem],
   );
 });

--- a/console/src/lib/composer-attachment-text.ts
+++ b/console/src/lib/composer-attachment-text.ts
@@ -31,6 +31,16 @@ export function dedupeComposerImageFiles<T extends ComposerImageFileLike>(files:
   return deduped;
 }
 
+export function selectImageTransferFiles<T extends ComposerImageFileLike>(
+  directFiles: readonly T[],
+  itemFiles: readonly T[],
+): T[] {
+  // Browsers can expose the same pasted image through both
+  // DataTransfer.files and DataTransfer.items. Prefer the direct file list
+  // when present; it is the canonical browser surface for file transfers.
+  return dedupeComposerImageFiles(directFiles.length > 0 ? directFiles : itemFiles);
+}
+
 function defaultBaseHref(): string {
   if (typeof window !== "undefined") return window.location.href;
   return "http://localhost/";

--- a/console/src/lib/network.ts
+++ b/console/src/lib/network.ts
@@ -296,6 +296,7 @@ const TERMINAL_SSE_EVENTS = new Set([
   "run_completed",
   "interaction_failed",
   "run_failed",
+  "turn_completed",
 ]);
 
 interface TerminalCorrelation {
@@ -336,6 +337,18 @@ function matchesCorrelation(
   return false;
 }
 
+function isTerminalTurnCompletedData(data: unknown): boolean {
+  const record = data && typeof data === "object" ? data as Record<string, unknown> : {};
+  const stopReason = record.stop_reason ?? record.stopReason;
+  return typeof stopReason === "string" ? stopReason !== "tool_use" : true;
+}
+
+function isTerminalSseFrame(frame: ConsoleFrame): boolean {
+  if (!TERMINAL_SSE_EVENTS.has(frame.event || "")) return false;
+  if (frame.event !== "turn_completed") return true;
+  return isTerminalTurnCompletedData(frame.data);
+}
+
 /**
  * Scan complete SSE blocks (delimited by double-newline) for a terminal
  * event: line.  The last block is skipped because it may be incomplete.
@@ -356,13 +369,15 @@ function hasMatchingTerminalEvent(rawText: string, correlation?: TerminalCorrela
       else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
     }
     if (!TERMINAL_SSE_EVENTS.has(eventName)) continue;
-    if (!correlation?.sessionId && !correlation?.interactionId) return true;
+    let data: Record<string, unknown> | null = null;
     try {
-      const data = JSON.parse(dataLines.join("\n")) as Record<string, unknown>;
-      if (matchesCorrelation(data, correlation, false)) return true;
+      data = JSON.parse(dataLines.join("\n")) as Record<string, unknown>;
     } catch {
-      // unparseable data — treat as unmatched
+      data = null;
     }
+    if (eventName === "turn_completed" && !isTerminalTurnCompletedData(data)) continue;
+    if (!correlation?.sessionId && !correlation?.interactionId) return true;
+    if (data && matchesCorrelation(data, correlation, false)) return true;
   }
   return false;
 }
@@ -428,7 +443,7 @@ async function streamFramesFromResponse(
         if (matchesCorrelation(frame, options.correlation, true)) {
           frames.push(frame);
           options.onFrame?.(frame);
-          if (stopOnTerminal && TERMINAL_SSE_EVENTS.has(frame.event || "")) {
+          if (stopOnTerminal && isTerminalSseFrame(frame)) {
             sawTerminal = true;
           }
         }

--- a/console/src/panels/ChatPane.tsx
+++ b/console/src/panels/ChatPane.tsx
@@ -13,6 +13,7 @@ import {
   consoleBlobReferencesFromText,
   consoleBlobUrlsFromText,
   dedupeComposerImageFiles,
+  selectImageTransferFiles,
   stripConsoleBlobReferencesFromText,
 } from "../lib/composer-attachment-text";
 
@@ -265,7 +266,7 @@ function collectImageTransferPayload(data: DataTransfer): ImageTransferPayload {
     data.getData("text/uri-list"),
     data.getData("text/plain"),
   ].filter(Boolean);
-  return { files: dedupeComposerImageFiles([...directFiles, ...itemFiles]), textPayloads };
+  return { files: selectImageTransferFiles(directFiles, itemFiles), textPayloads };
 }
 
 function imageTransferPayloadHasImage(payload: ImageTransferPayload): boolean {

--- a/meerkat-mobkit/src/unified_runtime/console_events.rs
+++ b/meerkat-mobkit/src/unified_runtime/console_events.rs
@@ -331,6 +331,7 @@ impl ConsoleEventStore {
             }
         }
 
+        let terminal_turn_completed = is_terminal_turn_completed_event(event_type, &projected_data);
         {
             let mut state = self.state.write().await;
             match event_type.as_str() {
@@ -345,6 +346,11 @@ impl ConsoleEventStore {
                         .insert(identity.clone(), Some("generating".to_string()));
                 }
                 "run_completed" | "run_failed" => {
+                    state
+                        .response_phase_by_identity
+                        .insert(identity.clone(), None);
+                }
+                "turn_completed" if terminal_turn_completed => {
                     state
                         .response_phase_by_identity
                         .insert(identity.clone(), None);
@@ -378,6 +384,17 @@ impl ConsoleEventStore {
             .cloned()
             .flatten()
     }
+}
+
+fn is_terminal_turn_completed_event(event_type: &str, payload: &Value) -> bool {
+    if event_type != "turn_completed" {
+        return false;
+    }
+    let stop_reason = payload
+        .get("stop_reason")
+        .or_else(|| payload.get("stopReason"))
+        .and_then(Value::as_str);
+    !matches!(stop_reason, Some("tool_use"))
 }
 
 fn parse_generate_image_tool_result(
@@ -510,6 +527,145 @@ mod tests {
             replay.first().and_then(|event| event.data["idx"].as_u64()),
             Some(8)
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_turn_completed_clears_phase_without_stealing_run_correlation() {
+        let store = ConsoleEventStore::new();
+        store
+            .register_runtime_identity("rt:worker:1", "worker")
+            .await;
+        store
+            .reserve_interaction_value(
+                "worker",
+                Some("rt:worker:1"),
+                "turn-1",
+                "console",
+                json!({}),
+            )
+            .await
+            .expect("reserve first interaction");
+        store
+            .project_unified_event(&EventEnvelope {
+                event_id: "evt-1".to_string(),
+                source: "test".to_string(),
+                timestamp_ms: 1,
+                event: UnifiedEvent::Agent {
+                    agent_id: "rt:worker:1".to_string(),
+                    event_type: "text_delta".to_string(),
+                    payload: Some(json!({ "delta": "working" })),
+                },
+            })
+            .await;
+        assert_eq!(
+            store.response_phase_for_identity("worker").await.as_deref(),
+            Some("generating")
+        );
+
+        store
+            .project_unified_event(&EventEnvelope {
+                event_id: "evt-2".to_string(),
+                source: "test".to_string(),
+                timestamp_ms: 2,
+                event: UnifiedEvent::Agent {
+                    agent_id: "rt:worker:1".to_string(),
+                    event_type: "turn_completed".to_string(),
+                    payload: Some(json!({ "stop_reason": "max_tokens" })),
+                },
+            })
+            .await;
+        assert_eq!(store.response_phase_for_identity("worker").await, None);
+
+        store
+            .project_unified_event(&EventEnvelope {
+                event_id: "evt-3".to_string(),
+                source: "test".to_string(),
+                timestamp_ms: 3,
+                event: UnifiedEvent::Agent {
+                    agent_id: "rt:worker:1".to_string(),
+                    event_type: "run_completed".to_string(),
+                    payload: Some(json!({ "result": "done" })),
+                },
+            })
+            .await;
+
+        let replay = store
+            .replay_all(None)
+            .await
+            .expect("all-events replay should succeed");
+        let run_completed = replay
+            .iter()
+            .find(|event| event.event_id == "evt-3")
+            .expect("run completion should be replayed");
+        assert_eq!(run_completed.interaction_id.as_deref(), Some("turn-1"));
+    }
+
+    #[tokio::test]
+    async fn tool_use_turn_completed_keeps_phase_and_pending_interaction() {
+        let store = ConsoleEventStore::new();
+        store
+            .register_runtime_identity("rt:worker:1", "worker")
+            .await;
+        store
+            .reserve_interaction_value(
+                "worker",
+                Some("rt:worker:1"),
+                "turn-1",
+                "console",
+                json!({}),
+            )
+            .await
+            .expect("reserve interaction");
+        store
+            .project_unified_event(&EventEnvelope {
+                event_id: "evt-1".to_string(),
+                source: "test".to_string(),
+                timestamp_ms: 1,
+                event: UnifiedEvent::Agent {
+                    agent_id: "rt:worker:1".to_string(),
+                    event_type: "tool_call".to_string(),
+                    payload: Some(json!({ "name": "inspect" })),
+                },
+            })
+            .await;
+        store
+            .project_unified_event(&EventEnvelope {
+                event_id: "evt-2".to_string(),
+                source: "test".to_string(),
+                timestamp_ms: 2,
+                event: UnifiedEvent::Agent {
+                    agent_id: "rt:worker:1".to_string(),
+                    event_type: "turn_completed".to_string(),
+                    payload: Some(json!({ "stop_reason": "tool_use" })),
+                },
+            })
+            .await;
+        assert_eq!(
+            store.response_phase_for_identity("worker").await.as_deref(),
+            Some("tool-executing")
+        );
+
+        store
+            .project_unified_event(&EventEnvelope {
+                event_id: "evt-3".to_string(),
+                source: "test".to_string(),
+                timestamp_ms: 3,
+                event: UnifiedEvent::Agent {
+                    agent_id: "rt:worker:1".to_string(),
+                    event_type: "text_delta".to_string(),
+                    payload: Some(json!({ "delta": "after tool" })),
+                },
+            })
+            .await;
+        let replay = store
+            .replay_all(None)
+            .await
+            .expect("all-events replay should succeed");
+        let after_tool_delta = replay
+            .iter()
+            .find(|event| event.event_id == "evt-3")
+            .expect("after-tool delta should be replayed");
+        assert_eq!(after_tool_delta.interaction_id.as_deref(), Some("turn-1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Prevent pasted images from being attached twice when the browser exposes the same clipboard image through both `DataTransfer.files` and `DataTransfer.items`.
- Treat `turn_completed` as terminal for all stop reasons except `tool_use`, so autonomous-agent panes clear the `working...` indicator when generation stops via `max_tokens`, stop sequence, cancellation, or similar terminal outcomes.
- Keep `tool_use` turns non-terminal so tool-running phases still stay active until the actual run terminal event.

## Root Cause

The console merged two clipboard file surfaces that can represent the same pasted image with different metadata, defeating the existing file-key dedupe. Separately, the working-state logic only cleared on `turn_completed` with `stop_reason: end_turn`, even though Meerkat has other terminal stop reasons.

## Validation

- `cargo fmt`
- `npm --prefix console run phase0:types --silent` (101 tests)
- `./scripts/repo-cargo test -p meerkat-mobkit unified_runtime::console_events --quiet`
- `git diff --check`
- push hooks: hardcoded secrets, whitespace, EOF, merge conflict check, large files, `cargo fmt --check`, changed-crate clippy, workspace unit gate
