### PR TITLE
console: fix stuck "working" indicator after tool completion

### DIFF
--- a/console/src/ConsoleApp.tsx
+++ b/console/src/ConsoleApp.tsx
@@ -1064,13 +1064,19 @@ export function ConsoleApp({ baseUrl }: ConsoleAppProps): React.JSX.Element {
       case "tool_call_requested":
       case "tool_call":
       case "tool_execution_started":
-      case "tool_result_received":
-      case "tool_execution_completed":
         if (currentPhase === "waiting" && elapsedMs < 300) {
           schedulePanelPhase(panelKey, "tool-executing", 300 - elapsedMs);
           return true;
         }
         return commitPanelPhase(panelKey, "tool-executing");
+      case "tool_result_received":
+      case "tool_execution_completed":
+        // Tool has just finished — no tool is currently executing. Clear
+        // the phase; the next event (text_delta or another tool_call_*)
+        // will set the right one. Without this, a run that ends on a tool
+        // call leaves the indicator stuck at "tool-executing" indefinitely
+        // when no run_completed frame follows.
+        return commitPanelPhase(panelKey, null);
       case "text_delta": {
         if (currentPhase === "tool-executing") {
           const r = Math.max(0, 300 - elapsedMs);

--- a/console/src/lib/adapters.test.ts
+++ b/console/src/lib/adapters.test.ts
@@ -413,6 +413,39 @@ test("inferResponsePhaseFromFrames clears working state on terminal text and ter
     ]),
     null,
   );
+
+  // Tool-completion events should not claim "tool-executing" — at that
+  // instant no tool is running. Without this, a stream that ends on
+  // tool_execution_completed (e.g., agent finishes by saving a result and
+  // no subsequent run_completed event fires) leaves the indicator stuck
+  // at "...working" indefinitely.
+  assert.equal(
+    inferResponsePhaseFromFrames([
+      { id: "evt-1", event: "text_delta", data: { delta: "Done." } },
+      { id: "evt-2", event: "text_complete", data: { content: "Done." } },
+      { id: "evt-3", event: "tool_call_requested", data: { name: "save_investigation_result" } },
+      { id: "evt-4", event: "tool_execution_started", data: {} },
+      { id: "evt-5", event: "tool_execution_completed", data: {} },
+    ]),
+    null,
+  );
+
+  assert.equal(
+    inferResponsePhaseFromFrames([
+      { id: "evt-1", event: "tool_call_requested", data: { name: "save_investigation_result" } },
+      { id: "evt-2", event: "tool_result_received", data: {} },
+    ]),
+    null,
+  );
+
+  // A new tool call after a completed one should re-arm the indicator.
+  assert.equal(
+    inferResponsePhaseFromFrames([
+      { id: "evt-1", event: "tool_execution_completed", data: {} },
+      { id: "evt-2", event: "tool_call_requested", data: { name: "next_tool" } },
+    ]),
+    "tool-executing",
+  );
 });
 
 test("mapFramesToTimelineEntries renders terminal completion without streamed deltas", () => {

--- a/console/src/lib/adapters.ts
+++ b/console/src/lib/adapters.ts
@@ -2174,9 +2174,15 @@ export function inferResponsePhaseFromFrames(
       case "tool_call_requested":
       case "tool_call":
       case "tool_execution_started":
+        phase = "tool-executing";
+        break;
       case "tool_result_received":
       case "tool_execution_completed":
-        phase = "tool-executing";
+        // Tool has just finished — no tool is currently executing.
+        // The next event (text_delta or another tool_call_requested) will
+        // set the appropriate phase. If nothing follows, the indicator
+        // correctly resolves to idle even when no run_completed arrives.
+        phase = null;
         break;
       case "text_delta":
         phase = "generating";


### PR DESCRIPTION
## Summary

The console's typing indicator stays at \"...working\" after the agent has finished, when the interaction ends on a tool call.

`inferResponsePhaseFromFrames` was treating `tool_execution_completed` / `tool_result_received` the same as `tool_execution_started` — all of them set `phase = \"tool-executing\"`. That conflates a tool **finishing** with a tool **still running**.

Repro path (observed in OB3's deep-investigator):

```
text_delta × N        → phase = \"generating\"
text_complete         → phase = null
tool_call_requested   → phase = \"tool-executing\"
tool_execution_started → phase = \"tool-executing\"
tool_execution_completed → phase = \"tool-executing\"   ← stuck here
```

If `run_completed` / `interaction_complete` doesn't arrive promptly (or the host loop has gone genuinely idle after a final tool call), the indicator stays at \"working\" forever even though no tool is actually executing.

## Fix

`tool_execution_completed` and `tool_result_received` clear `phase` to `null`. The next event (`text_delta` or another `tool_call_requested`) sets the appropriate phase. If nothing follows, the indicator correctly resolves to idle without needing `run_completed` to arrive.

## Test plan

Added three cases to the existing `inferResponsePhaseFromFrames` test:

- [x] Run-ending-on-tool sequence (the OB3 repro shape) → `null`
- [x] Bare `tool_result_received` → `null`
- [x] `tool_execution_completed` followed by a new `tool_call_requested` → `\"tool-executing\"` (regression guard for adjacent tool calls)

\`npm run phase0:types\` passes (55/55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)