### PR TITLE
[codex] Align builder durability state wiring

### DIFF
--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1597,14 +1597,7 @@ external_addressable = true
                     format!("failed to open SQLite session store: {e}"),
                 ),
             };
-        let mob_storage = match MobStorage::persistent(state_path.join("mob.redb")) {
-            Ok(s) => s,
-            Err(e) => fail_init(
-                &request_id,
-                -32603,
-                format!("failed to open redb mob storage: {e}"),
-            ),
-        };
+        let mob_storage = MobStorage::in_memory();
         let binary_blob_store: Arc<dyn BinaryBlobStore> =
             match ObjectStoreBlobStore::local(state_path.join("blobs")) {
                 Ok(store) => Arc::new(store),

--- a/meerkat-mobkit/src/blob_store.rs
+++ b/meerkat-mobkit/src/blob_store.rs
@@ -284,6 +284,47 @@ impl BlobStore for Base64BlobStoreAdapter {
     }
 }
 
+pub struct BinaryBlobStoreAdapter {
+    inner: Arc<dyn BlobStore>,
+}
+
+impl BinaryBlobStoreAdapter {
+    pub fn new(inner: Arc<dyn BlobStore>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl BinaryBlobStore for BinaryBlobStoreAdapter {
+    async fn put_bytes(&self, media_type: &str, data: Bytes) -> Result<BlobRef, BlobStoreError> {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data.as_ref());
+        self.inner.put_image(media_type, &encoded).await
+    }
+
+    async fn get_bytes(&self, blob_id: &BlobId) -> Result<BinaryBlobPayload, BlobStoreError> {
+        let payload = self.inner.get(blob_id).await?;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(payload.data.as_bytes())
+            .map_err(|err| {
+                BlobStoreError::ReadFailed(format!("invalid blob base64 payload: {err}"))
+            })?;
+        Ok(BinaryBlobPayload {
+            blob_id: payload.blob_id,
+            media_type: payload.media_type,
+            size: decoded.len() as u64,
+            data: Bytes::from(decoded),
+        })
+    }
+
+    async fn delete(&self, blob_id: &BlobId) -> Result<(), BlobStoreError> {
+        self.inner.delete(blob_id).await
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.inner.is_persistent()
+    }
+}
+
 fn compute_blob_id(media_type: &str, bytes: &[u8]) -> BlobId {
     let mut hasher = Sha256::new();
     hasher.update(media_type.as_bytes());

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -419,11 +419,11 @@ impl SessionBridge for MobSessionBridge {
 
     async fn retire_member(&self, runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
         let mid = MeerkatId::from(runtime_id.as_str());
-        self.handle
-            .retire(mid)
-            .await
-            .map_err(|e| BridgeError::Mob(e.to_string()))?;
-        Ok(())
+        match self.handle.retire(mid).await {
+            Ok(()) => Ok(()),
+            Err(err) if is_archive_not_found_cleanup_error(&err.to_string()) => Ok(()),
+            Err(err) => Err(BridgeError::Mob(err.to_string())),
+        }
     }
 
     async fn wire_peer(&self, a: &AgentRuntimeId, b: &AgentRuntimeId) -> Result<(), BridgeError> {

--- a/meerkat-mobkit/src/identity_first/local_lease.rs
+++ b/meerkat-mobkit/src/identity_first/local_lease.rs
@@ -20,7 +20,11 @@ use super::types::{
 };
 
 /// Default TTL returned by the local lease provider.
-const LOCAL_LEASE_TTL: Duration = Duration::from_mins(5);
+///
+/// The provider is single-process and does not expire records internally, so
+/// this is a generous local ownership window rather than a distributed lease
+/// deadline. External lease providers should return their real coordination TTL.
+const LOCAL_LEASE_TTL: Duration = Duration::from_hours(24);
 
 struct LeaseRecord {
     fencing_token: FencingToken,

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -36,7 +36,8 @@ pub use baseline::{
     REQUIRED_MEERKAT_SYMBOLS, verify_meerkat_baseline_symbols,
 };
 pub use blob_store::{
-    Base64BlobStoreAdapter, BinaryBlobPayload, BinaryBlobStore, ObjectStoreBlobStore,
+    Base64BlobStoreAdapter, BinaryBlobPayload, BinaryBlobStore, BinaryBlobStoreAdapter,
+    ObjectStoreBlobStore,
 };
 pub use config_convention::ConventionalPaths;
 pub use console_aggregator::{

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -22,7 +22,9 @@ use meerkat_mob::{
 use meerkat_store::StoreAdapter;
 use serde_json::Value;
 
-use crate::blob_store::{Base64BlobStoreAdapter, BinaryBlobStore, ObjectStoreBlobStore};
+use crate::blob_store::{
+    Base64BlobStoreAdapter, BinaryBlobStore, BinaryBlobStoreAdapter, ObjectStoreBlobStore,
+};
 
 pub(crate) const DELEGATE_IDLE_RETIRE_SECS_LABEL: &str = "implicit_delegate_idle_retire_secs";
 pub(crate) const DELEGATE_IDLE_RETIRE_DISABLED_LABEL: &str = "disabled";
@@ -1680,6 +1682,7 @@ impl MobBootstrapSpec {
             max_sessions,
             session_store,
             None,
+            None,
             CapabilityFlags::default(),
             None,
         )
@@ -1708,6 +1711,7 @@ impl MobBootstrapSpec {
             store_path,
             max_sessions,
             session_store,
+            None,
             Some(Arc::new(hook)),
             CapabilityFlags::default(),
             None,
@@ -1721,25 +1725,37 @@ impl MobBootstrapSpec {
         store_path: PathBuf,
         max_sessions: usize,
         session_store: Arc<dyn SessionStore>,
+        custom_blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
         hook: Option<PreBuildHook>,
         mut caps: CapabilityFlags,
         after_create_hook: Option<AfterCreateHook>,
     ) -> Self {
         caps.image_generation |= mob_definition_may_use_image_generation(&definition);
-        let binary_blob_store: Arc<dyn BinaryBlobStore> = match ObjectStoreBlobStore::local(
-            store_path.join("blobs"),
-        ) {
-            Ok(store) => Arc::new(store),
-            Err(err) => {
-                tracing::warn!(
-                    error = %err,
-                    "failed to initialize persistent binary blob store; falling back to in-memory blobs"
-                );
-                Arc::new(ObjectStoreBlobStore::memory())
-            }
+        let (binary_blob_store, blob_store): (
+            Arc<dyn BinaryBlobStore>,
+            Arc<dyn meerkat_core::BlobStore>,
+        ) = if let Some(blob_store) = custom_blob_store {
+            (
+                Arc::new(BinaryBlobStoreAdapter::new(blob_store.clone())),
+                blob_store,
+            )
+        } else {
+            let binary_blob_store: Arc<dyn BinaryBlobStore> = match ObjectStoreBlobStore::local(
+                store_path.join("blobs"),
+            ) {
+                Ok(store) => Arc::new(store),
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "failed to initialize persistent binary blob store; falling back to in-memory blobs"
+                    );
+                    Arc::new(ObjectStoreBlobStore::memory())
+                }
+            };
+            let blob_store: Arc<dyn meerkat_core::BlobStore> =
+                Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
+            (binary_blob_store, blob_store)
         };
-        let blob_store: Arc<dyn meerkat_core::BlobStore> =
-            Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
         // Use a SQLite-backed runtime store so we get BOTH durability across
         // process restart AND control-op authority (archive/retire). The
         // earlier 0.6.1 wiring used `Some(InMemoryRuntimeStore)`, which was
@@ -1801,6 +1817,7 @@ impl MobBootstrapSpec {
         store_path: PathBuf,
         max_sessions: usize,
         custom_session_store: Option<Arc<dyn SessionStore>>,
+        custom_blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
         hook: Option<PreBuildHook>,
         mut caps: CapabilityFlags,
         after_create_hook: Option<AfterCreateHook>,
@@ -1810,9 +1827,21 @@ impl MobBootstrapSpec {
         let session_store: Arc<dyn SessionStore> = custom_session_store
             .clone()
             .unwrap_or_else(|| Arc::new(meerkat_store::MemoryStore::new()));
-        let binary_blob_store: Arc<dyn BinaryBlobStore> = Arc::new(ObjectStoreBlobStore::memory());
-        let blob_store: Arc<dyn meerkat_core::BlobStore> =
-            Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
+        let (binary_blob_store, blob_store): (
+            Arc<dyn BinaryBlobStore>,
+            Arc<dyn meerkat_core::BlobStore>,
+        ) = if let Some(blob_store) = custom_blob_store {
+            (
+                Arc::new(BinaryBlobStoreAdapter::new(blob_store.clone())),
+                blob_store,
+            )
+        } else {
+            let binary_blob_store: Arc<dyn BinaryBlobStore> =
+                Arc::new(ObjectStoreBlobStore::memory());
+            let blob_store: Arc<dyn meerkat_core::BlobStore> =
+                Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
+            (binary_blob_store, blob_store)
+        };
         // Runtime-backed ephemeral mode keeps the live EphemeralSessionService
         // as the comms authority, but registers each created session with the
         // same in-memory machine used by image generation. Meerkat 0.6.4's
@@ -3320,6 +3349,7 @@ realm_profile = "worker-v2"
             4,
             None,
             None,
+            None,
             CapabilityFlags::default(),
             None,
         );
@@ -3347,6 +3377,7 @@ realm_profile = "worker-v2"
             store_path,
             4,
             Some(custom_store.clone()),
+            None,
             None,
             CapabilityFlags::default(),
             None,

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -3367,11 +3367,13 @@ realm_profile = "worker-v2"
     async fn ephemeral_runtime_backed_custom_session_store_persists_created_session() {
         let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
         let store_path = dir.path().to_path_buf();
-        let Ok(definition) = meerkat_mob::MobDefinition::from_toml("[mob]\nid = \"test\"\n") else {
+        let Ok(definition) = meerkat_mob::MobDefinition::from_toml(
+            "[mob]\nid = \"test\"\n\n[profiles.worker]\nmodel = \"gpt-5.5\"\n[profiles.worker.tools]\ncomms = true\n",
+        ) else {
             panic!("failed to parse minimal mob definition");
         };
         let custom_store: Arc<dyn SessionStore> = Arc::new(meerkat_store::MemoryStore::new());
-        let spec = MobBootstrapSpec::ephemeral_runtime_backed_inner(
+        let mut spec = MobBootstrapSpec::ephemeral_runtime_backed_inner(
             definition,
             meerkat_mob::MobStorage::in_memory(),
             store_path,
@@ -3382,29 +3384,28 @@ realm_profile = "worker-v2"
             CapabilityFlags::default(),
             None,
         );
+        spec.options.default_llm_client = Some(Arc::new(meerkat_client::TestClient::default()));
 
-        let req = CreateSessionRequest {
-            model: "gpt-5.5".to_string(),
-            prompt: meerkat_core::ContentInput::Text("test".to_string()),
-            render_metadata: None,
-            system_prompt: None,
-            max_tokens: None,
-            event_tx: None,
-            skill_references: None,
-            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
-            build: None,
-            labels: None,
-            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
-        };
-        let result = meerkat_core::service::SessionService::create_session(
-            spec.session_service.as_ref(),
-            req,
-        )
-        .await
-        .unwrap_or_else(|e| panic!("{e}"));
+        let runtime = MobRuntime::bootstrap(spec)
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        let mid = meerkat_mob::ids::MeerkatId::from("worker:one");
+        runtime
+            .handle
+            .spawn_spec(SpawnMemberSpec::new(
+                ProfileName::from("worker"),
+                mid.clone(),
+            ))
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        let session_id = runtime
+            .handle
+            .resolve_bridge_session_id(&mid)
+            .await
+            .unwrap_or_else(|| panic!("spawned worker has no bridge session id"));
 
         let stored = custom_store
-            .load(&result.session_id)
+            .load(&session_id)
             .await
             .unwrap_or_else(|e| panic!("{e}"));
         assert!(

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -1800,13 +1800,16 @@ impl MobBootstrapSpec {
         storage: MobStorage,
         store_path: PathBuf,
         max_sessions: usize,
+        custom_session_store: Option<Arc<dyn SessionStore>>,
         hook: Option<PreBuildHook>,
         mut caps: CapabilityFlags,
         after_create_hook: Option<AfterCreateHook>,
     ) -> Self {
         caps.image_generation |= mob_definition_may_use_image_generation(&definition);
         let config = Config::default();
-        let session_store: Arc<dyn SessionStore> = Arc::new(meerkat_store::MemoryStore::new());
+        let session_store: Arc<dyn SessionStore> = custom_session_store
+            .clone()
+            .unwrap_or_else(|| Arc::new(meerkat_store::MemoryStore::new()));
         let binary_blob_store: Arc<dyn BinaryBlobStore> = Arc::new(ObjectStoreBlobStore::memory());
         let blob_store: Arc<dyn meerkat_core::BlobStore> =
             Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
@@ -1836,9 +1839,21 @@ impl MobBootstrapSpec {
         builder.default_session_store = Some(Arc::new(StoreAdapter::new(session_store.clone())));
         builder.default_blob_store = Some(blob_store.clone());
         let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
-        let session_service: Arc<dyn MobSessionService> = Arc::new(
-            meerkat_session::EphemeralSessionService::new(builder, max_sessions),
-        );
+        let session_service: Arc<dyn MobSessionService> =
+            if let Some(custom_session_store) = custom_session_store {
+                Arc::new(meerkat_session::PersistentSessionService::new(
+                    builder,
+                    max_sessions,
+                    custom_session_store,
+                    Some(runtime_store.clone()),
+                    blob_store,
+                ))
+            } else {
+                Arc::new(meerkat_session::EphemeralSessionService::new(
+                    builder,
+                    max_sessions,
+                ))
+            };
         let hook = hook.unwrap_or_else(no_op_pre_build_hook);
         let runtime_adapter_for_after_create = runtime_adapter.clone();
         let combined_after_create_hook: AfterCreateHook = Arc::new(move |session_id, ctx| {
@@ -3304,6 +3319,7 @@ realm_profile = "worker-v2"
             store_path,
             4,
             None,
+            None,
             CapabilityFlags::default(),
             None,
         );
@@ -3314,6 +3330,55 @@ realm_profile = "worker-v2"
         assert!(
             spec.session_service.runtime_adapter().is_some(),
             "session service must still expose a runtime adapter so autonomous-host comms can wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn ephemeral_runtime_backed_custom_session_store_persists_created_session() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store_path = dir.path().to_path_buf();
+        let Ok(definition) = meerkat_mob::MobDefinition::from_toml("[mob]\nid = \"test\"\n") else {
+            panic!("failed to parse minimal mob definition");
+        };
+        let custom_store: Arc<dyn SessionStore> = Arc::new(meerkat_store::MemoryStore::new());
+        let spec = MobBootstrapSpec::ephemeral_runtime_backed_inner(
+            definition,
+            meerkat_mob::MobStorage::in_memory(),
+            store_path,
+            4,
+            Some(custom_store.clone()),
+            None,
+            CapabilityFlags::default(),
+            None,
+        );
+
+        let req = CreateSessionRequest {
+            model: "gpt-5.5".to_string(),
+            prompt: meerkat_core::ContentInput::Text("test".to_string()),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: None,
+            event_tx: None,
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            build: None,
+            labels: None,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+        };
+        let result = meerkat_core::service::SessionService::create_session(
+            spec.session_service.as_ref(),
+            req,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let stored = custom_store
+            .load(&result.session_id)
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            stored.is_some(),
+            "ephemeral runtime-backed builds with a custom store must persist through that store"
         );
     }
 

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -56,7 +56,6 @@ pub struct UnifiedRuntimeBuilder {
     continuity_store: Option<Arc<dyn crate::identity_first::contracts::ContinuityStore>>,
     lease_provider: Option<Arc<dyn crate::identity_first::contracts::LeaseProvider>>,
     scratch_dir: Option<PathBuf>,
-    runtime_store: Option<Arc<dyn meerkat::SessionStore>>,
     blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
     console_log_store: Option<Arc<dyn ConsoleLogStore>>,
 
@@ -74,7 +73,6 @@ pub struct UnifiedRuntimeBuilder {
     pre_spawn_hook: Option<PreSpawnHook>,
     edge_discovery: Option<Box<dyn EdgeDiscovery>>,
     contact_directory: Option<ContactDirectory>,
-    mob_storage_in_memory: bool,
     persistent_metadata: Option<Arc<dyn PersistentMetadataStore>>,
 }
 
@@ -96,9 +94,10 @@ impl UnifiedRuntimeBuilder {
     }
 
     /// Enable persistent state at the given path. When set, the builder
-    /// creates a `SqliteSessionStore`, binary blob store, and
-    /// `MobStorage::redb()` under this directory. When not set, the builder
-    /// uses an ephemeral session service with an auto-created temp directory.
+    /// creates a `SqliteSessionStore`, runtime store, metadata store, console
+    /// log store, and binary blob store under this directory. Mob storage stays
+    /// in-memory. When not set, the builder uses an ephemeral session service
+    /// with an auto-created temp directory.
     pub fn persistent_state(mut self, path: impl Into<PathBuf>) -> Self {
         self.persistent_state_path = Some(path.into());
         self
@@ -113,18 +112,9 @@ impl UnifiedRuntimeBuilder {
     /// Set a custom session store. When set, the builder uses this store
     /// instead of creating a default one. Works with both `.persistent_state()`
     /// (overrides the auto-created SQLite store) and ephemeral builds
-    /// (provides durable sessions without redb mob storage).
+    /// (provides durable sessions without local mob storage).
     pub fn session_store(mut self, store: Arc<dyn meerkat::SessionStore>) -> Self {
         self.custom_session_store = Some(store);
-        self
-    }
-
-    /// Use in-memory mob storage instead of redb. When set with
-    /// `.persistent_state()`, sessions are still persisted (via the session
-    /// store) but mob-level metadata (events, flow runs, specs) is ephemeral.
-    /// Avoids the redb exclusive file lock.
-    pub fn mob_storage_in_memory(mut self) -> Self {
-        self.mob_storage_in_memory = true;
         self
     }
 
@@ -174,18 +164,10 @@ impl UnifiedRuntimeBuilder {
         self
     }
 
-    /// Set an optional runtime store for durable dispatch.
-    ///
-    /// Without this, dispatch acknowledgment means in-memory only.
-    /// Can be used with both `persistent_state()` and the external path.
-    pub fn runtime_store(mut self, store: Arc<dyn meerkat::SessionStore>) -> Self {
-        self.runtime_store = Some(store);
-        self
-    }
-
     /// Set an optional blob store for custom blob persistence.
     ///
-    /// Can be used with both `persistent_state()` and the external path.
+    /// The same store is used for runtime image blobs and for MobKit's
+    /// `/blobs/{id}` and `mobkit/blob/*` serving/upload paths.
     pub fn blob_store(mut self, store: Arc<dyn meerkat_core::BlobStore>) -> Self {
         self.blob_store = Some(store);
         self
@@ -593,7 +575,7 @@ impl UnifiedRuntimeBuilder {
                 })
             });
 
-        // Note: blocking I/O (fs, SQLite, redb) — acceptable at startup.
+        // Note: blocking I/O (fs, SQLite) — acceptable at startup.
         let mut spec = if let Some(ref state_path) = self.persistent_state_path {
             std::fs::create_dir_all(state_path).map_err(|e| {
                 UnifiedRuntimeBuilderError::Io(format!(
@@ -615,13 +597,7 @@ impl UnifiedRuntimeBuilder {
                         })?,
                     )
                 };
-            let mob_storage = if self.mob_storage_in_memory {
-                MobStorage::in_memory()
-            } else {
-                MobStorage::persistent(state_path.join("mob.redb")).map_err(|e| {
-                    UnifiedRuntimeBuilderError::Io(format!("failed to open redb mob storage: {e}"))
-                })?
-            };
+            let mob_storage = MobStorage::in_memory();
 
             MobBootstrapSpec::persistent_inner(
                 definition,
@@ -629,6 +605,7 @@ impl UnifiedRuntimeBuilder {
                 state_path.clone(),
                 max_sessions,
                 session_store,
+                self.blob_store.clone(),
                 hook,
                 caps,
                 after_hook.clone(),
@@ -646,6 +623,7 @@ impl UnifiedRuntimeBuilder {
                 store_path,
                 max_sessions,
                 self.custom_session_store.clone(),
+                self.blob_store.clone(),
                 hook,
                 caps,
                 after_hook,
@@ -778,7 +756,6 @@ runtime_mode = "autonomous_host"
         let builder = UnifiedRuntimeBuilder::default()
             .definition(definition)
             .persistent_state(tmp.path().join("state"))
-            .mob_storage_in_memory()
             .max_sessions(2);
         let spec = builder.resolve_mob_spec().await.expect("spec resolves");
 

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -645,6 +645,7 @@ impl UnifiedRuntimeBuilder {
                 MobStorage::in_memory(),
                 store_path,
                 max_sessions,
+                self.custom_session_store.clone(),
                 hook,
                 caps,
                 after_hook,

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -24,6 +24,12 @@ enum LocalOrRemote {
     Remote(RemoteMobProxy),
 }
 
+struct MemberPeerInfo {
+    peer_id: String,
+    comms_name: String,
+    pubkey: [u8; 32],
+}
+
 /// Errors from cross-mob operations.
 #[derive(Debug)]
 pub enum CrossMobError {
@@ -161,28 +167,28 @@ impl UnifiedRuntime {
         let local_mob_id = local_handle.mob_id().to_string();
         let local_mid = MeerkatId::from(local_member_id);
 
-        let (local_peer_id, local_comms_name) = self
+        let local_info = self
             .get_member_peer_info(&local_handle, &local_mid, &local_mob_id)
             .await?;
 
         match remote {
             LocalOrRemote::Local(remote_handle) => {
                 let remote_mid = MeerkatId::from(remote_member_id);
-                let (remote_peer_id, remote_comms_name) = self
+                let remote_info = self
                     .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
                     .await?;
 
                 let remote_spec = build_peer_spec(
-                    &remote_comms_name,
-                    &remote_peer_id,
+                    &remote_info.comms_name,
+                    &remote_info.peer_id,
                     &entry.transport,
-                    entry.pubkey,
+                    Some(remote_info.pubkey),
                 )?;
                 let local_spec = build_peer_spec(
-                    &local_comms_name,
-                    &local_peer_id,
+                    &local_info.comms_name,
+                    &local_info.peer_id,
                     &MobTransport::Inproc,
-                    None,
+                    Some(local_info.pubkey),
                 )?;
 
                 local_handle
@@ -195,10 +201,10 @@ impl UnifiedRuntime {
                     .await
                 {
                     if let Ok(rollback_spec) = build_peer_spec(
-                        &remote_comms_name,
-                        &remote_peer_id,
+                        &remote_info.comms_name,
+                        &remote_info.peer_id,
                         &entry.transport,
-                        entry.pubkey,
+                        Some(remote_info.pubkey),
                     ) {
                         let _ = local_handle
                             .unwire(local_mid, PeerTarget::External(rollback_spec))
@@ -244,13 +250,13 @@ impl UnifiedRuntime {
                     .gateway_peer_keys
                     .as_ref()
                     .map(crate::auth::peer_keys::GatewayPeerKeys::pubkey_b64);
-                let local_spec_address = format!("inproc://{local_comms_name}");
+                let local_spec_address = format!("inproc://{}", local_info.comms_name);
                 if let Err(remote_err) = proxy
                     .wire_remote(
                         remote_member_id,
                         &local_spec_address,
-                        &local_comms_name,
-                        &local_peer_id,
+                        &local_info.comms_name,
+                        &local_info.peer_id,
                         pubkey_b64,
                     )
                     .await
@@ -293,25 +299,22 @@ impl UnifiedRuntime {
 
         let mut first_error: Option<CrossMobError> = None;
 
-        let (local_peer_id_opt, local_comms_name_opt) = match self
+        let local_info_opt = self
             .get_member_peer_info(&local_handle, &local_mid, &local_mob_id)
             .await
-        {
-            Ok((p, c)) => (Some(p), Some(c)),
-            Err(_) => (None, None),
-        };
+            .ok();
 
         match remote {
             LocalOrRemote::Local(remote_handle) => {
                 let remote_mid = MeerkatId::from(remote_member_id);
-                if let Ok((remote_peer_id, remote_comms_name)) = self
+                if let Ok(remote_info) = self
                     .get_member_peer_info(&remote_handle, &remote_mid, remote_mob_id)
                     .await
                     && let Ok(spec) = build_peer_spec(
-                        &remote_comms_name,
-                        &remote_peer_id,
+                        &remote_info.comms_name,
+                        &remote_info.peer_id,
                         &entry.transport,
-                        entry.pubkey,
+                        Some(remote_info.pubkey),
                     )
                     && let Err(e) = local_handle
                         .unwire(local_mid.clone(), PeerTarget::External(spec))
@@ -320,13 +323,12 @@ impl UnifiedRuntime {
                     first_error = Some(CrossMobError::Mob(e));
                 }
 
-                if let (Some(local_peer_id), Some(local_comms_name)) =
-                    (&local_peer_id_opt, &local_comms_name_opt)
+                if let Some(local_info) = &local_info_opt
                     && let Ok(spec) = build_peer_spec(
-                        local_comms_name,
-                        local_peer_id,
+                        &local_info.comms_name,
+                        &local_info.peer_id,
                         &MobTransport::Inproc,
-                        None,
+                        Some(local_info.pubkey),
                     )
                     && let Err(e) = remote_handle
                         .unwire(remote_mid.clone(), PeerTarget::External(spec))
@@ -352,20 +354,18 @@ impl UnifiedRuntime {
                     first_error = Some(CrossMobError::Mob(e));
                 }
 
-                if let (Some(local_peer_id), Some(local_comms_name)) =
-                    (&local_peer_id_opt, &local_comms_name_opt)
-                {
+                if let Some(local_info) = &local_info_opt {
                     let pubkey_b64 = self
                         .gateway_peer_keys
                         .as_ref()
                         .map(crate::auth::peer_keys::GatewayPeerKeys::pubkey_b64);
-                    let local_spec_address = format!("inproc://{local_comms_name}");
+                    let local_spec_address = format!("inproc://{}", local_info.comms_name);
                     if let Err(e) = proxy
                         .unwire_remote(
                             remote_member_id,
                             &local_spec_address,
-                            local_comms_name,
-                            local_peer_id,
+                            &local_info.comms_name,
+                            &local_info.peer_id,
                             pubkey_b64,
                         )
                         .await
@@ -501,9 +501,9 @@ impl UnifiedRuntime {
         let handle = self.mob_runtime.handle();
         let mob_id = handle.mob_id().to_string();
         let mid = MeerkatId::from(member_id);
-        let (peer_id, comms_name) = self.get_member_peer_info(&handle, &mid, &mob_id).await?;
-        let address = format!("inproc://{comms_name}");
-        Ok((peer_id, comms_name, address))
+        let info = self.get_member_peer_info(&handle, &mid, &mob_id).await?;
+        let address = format!("inproc://{}", info.comms_name);
+        Ok((info.peer_id, info.comms_name, address))
     }
 
     /// Wire a local member to an external peer using provided comms info.
@@ -602,19 +602,19 @@ impl UnifiedRuntime {
         }
     }
 
-    /// Resolve a member's peer_id and comms name from the roster entry.
+    /// Resolve a member's peer_id, comms name, and transport key from the roster entry.
     ///
-    /// Returns `(peer_id, comms_name)` where comms_name is derived as
-    /// `"{mob_id}/{profile}/{meerkat_id}"` — this matches the canonical
+    /// Returns peer id, comms name, and the member transport key. The comms
+    /// name is derived as `"{mob_id}/{profile}/{meerkat_id}"`, matching the
     /// format used by meerkat-mob's `derived_comms_name()` and
-    /// `build_agent_config()`. If meerkat-mob changes this format,
-    /// this must be updated to match.
+    /// `build_agent_config()`. If meerkat-mob changes this format, this must
+    /// be updated to match.
     async fn get_member_peer_info(
         &self,
         handle: &MobHandle,
         meerkat_id: &MeerkatId,
         mob_id: &str,
-    ) -> Result<(String, String), CrossMobError> {
+    ) -> Result<MemberPeerInfo, CrossMobError> {
         let entry =
             handle
                 .get_member(meerkat_id)
@@ -630,8 +630,22 @@ impl UnifiedRuntime {
                 mob_id: mob_id.to_string(),
             })?
             .to_string();
+        let pubkey_b64 = entry.transport_public_key().ok_or_else(|| {
+            CrossMobError::PeerSpec(format!(
+                "member '{meerkat_id}' in mob '{mob_id}' has no transport public key"
+            ))
+        })?;
+        let pubkey = crate::auth::peer_keys::decode_pubkey_b64(pubkey_b64).map_err(|err| {
+            CrossMobError::PeerSpec(format!(
+                "member '{meerkat_id}' in mob '{mob_id}' has invalid transport public key: {err}"
+            ))
+        })?;
         let comms_name = format!("{}/{}/{}", mob_id, entry.role, meerkat_id);
-        Ok((peer_id, comms_name))
+        Ok(MemberPeerInfo {
+            peer_id,
+            comms_name,
+            pubkey,
+        })
     }
 }
 

--- a/meerkat-mobkit/tests/builder_api.rs
+++ b/meerkat-mobkit/tests/builder_api.rs
@@ -284,3 +284,49 @@ async fn test_builder_persistent_custom_store() {
 
     runtime.mob_handle().stop().await.expect("stop");
 }
+
+#[tokio::test]
+async fn test_builder_ephemeral_custom_store_persists_sessions() {
+    let custom_store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+    let runtime = UnifiedRuntime::builder()
+        .definition(test_definition())
+        .session_store(custom_store.clone())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .build()
+        .await
+        .expect("ephemeral build with custom store");
+
+    let session_service = runtime
+        .mob_runtime()
+        .session_service()
+        .expect("builder-created runtime must expose its session service");
+    let result = meerkat_core::service::SessionService::create_session(
+        session_service.as_ref(),
+        CreateSessionRequest {
+            model: "gpt-5.5".to_string(),
+            prompt: meerkat_core::ContentInput::Text("test".to_string()),
+            render_metadata: None,
+            system_prompt: None,
+            max_tokens: None,
+            event_tx: None,
+            skill_references: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            build: None,
+            labels: None,
+        },
+    )
+    .await
+    .expect("deferred session create");
+
+    assert!(
+        custom_store
+            .load(&result.session_id)
+            .await
+            .expect("custom store load")
+            .is_some(),
+        "ephemeral builder session_store() must wire the custom store into the real session service"
+    );
+
+    runtime.mob_handle().stop().await.expect("stop");
+}

--- a/meerkat-mobkit/tests/builder_api.rs
+++ b/meerkat-mobkit/tests/builder_api.rs
@@ -20,7 +20,9 @@ use async_trait::async_trait;
 use base64::Engine as _;
 use meerkat_client::TestClient;
 use meerkat_core::service::{CreateSessionRequest, SessionError};
-use meerkat_mob::{MobDefinition, MobState, MobStorage};
+use meerkat_mob::{
+    MobDefinition, MobState, MobStorage, ProfileName, SpawnMemberSpec, ids::MeerkatId,
+};
 use meerkat_mobkit::{
     DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, SessionHook, UnifiedRuntime,
 };
@@ -289,40 +291,45 @@ async fn test_builder_persistent_custom_store() {
 #[tokio::test]
 async fn test_builder_ephemeral_custom_store_persists_sessions() {
     let custom_store: Arc<dyn meerkat::SessionStore> = Arc::new(meerkat::MemoryStore::new());
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "builder-test-mob"
+
+[profiles.worker]
+model = "test-model"
+
+[profiles.worker.tools]
+comms = true
+"#,
+    )
+    .expect("parse test mob definition");
     let runtime = UnifiedRuntime::builder()
-        .definition(test_definition())
+        .definition(definition)
         .session_store(custom_store.clone())
         .default_llm_client(Arc::new(TestClient::default()))
         .build()
         .await
         .expect("ephemeral build with custom store");
 
-    let session_service = runtime
-        .mob_runtime()
-        .session_service()
-        .expect("builder-created runtime must expose its session service");
-    let result = meerkat_core::service::SessionService::create_session(
-        session_service.as_ref(),
-        CreateSessionRequest {
-            model: "gpt-5.5".to_string(),
-            prompt: meerkat_core::ContentInput::Text("test".to_string()),
-            render_metadata: None,
-            system_prompt: None,
-            max_tokens: None,
-            event_tx: None,
-            skill_references: None,
-            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
-            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
-            build: None,
-            labels: None,
-        },
-    )
-    .await
-    .expect("deferred session create");
+    let mid = MeerkatId::from("worker:one");
+    runtime
+        .mob_handle()
+        .spawn_spec(SpawnMemberSpec::new(
+            ProfileName::from("worker"),
+            mid.clone(),
+        ))
+        .await
+        .expect("spawn worker");
+    let session_id = runtime
+        .mob_handle()
+        .resolve_bridge_session_id(&mid)
+        .await
+        .expect("spawned worker has a bridge session id");
 
     assert!(
         custom_store
-            .load(&result.session_id)
+            .load(&session_id)
             .await
             .expect("custom store load")
             .is_some(),

--- a/meerkat-mobkit/tests/builder_api.rs
+++ b/meerkat-mobkit/tests/builder_api.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::Engine as _;
 use meerkat_client::TestClient;
 use meerkat_core::service::{CreateSessionRequest, SessionError};
 use meerkat_mob::{MobDefinition, MobState, MobStorage};
@@ -60,7 +61,7 @@ async fn test_builder_ephemeral() {
 }
 
 // ---------------------------------------------------------------------------
-// 2. Builder persistent (SQLite session store + redb mob storage)
+// 2. Builder persistent (SQLite session/runtime state + in-memory mob storage)
 // ---------------------------------------------------------------------------
 #[tokio::test]
 #[ignore]
@@ -326,6 +327,44 @@ async fn test_builder_ephemeral_custom_store_persists_sessions() {
             .expect("custom store load")
             .is_some(),
         "ephemeral builder session_store() must wire the custom store into the real session service"
+    );
+
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn test_builder_custom_blob_store_serves_binary_blobs() {
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let runtime = UnifiedRuntime::builder()
+        .definition(test_definition())
+        .blob_store(blob_store.clone())
+        .default_llm_client(Arc::new(TestClient::default()))
+        .build()
+        .await
+        .expect("ephemeral build with custom blob store");
+
+    let binary_store = runtime
+        .binary_blob_store()
+        .expect("builder-created runtime must expose binary blob serving store");
+    let blob_ref = binary_store
+        .put_bytes("image/png", bytes::Bytes::from_static(b"tiny-png"))
+        .await
+        .expect("binary put");
+    let served = binary_store
+        .get_bytes(&blob_ref.blob_id)
+        .await
+        .expect("binary get");
+    assert_eq!(served.data.as_ref(), b"tiny-png");
+
+    let stored = blob_store.get(&blob_ref.blob_id).await.expect("blob get");
+    assert_eq!(stored.media_type, "image/png");
+    assert_eq!(
+        base64::engine::general_purpose::STANDARD
+            .decode(stored.data.as_bytes())
+            .expect("stored blob base64")
+            .as_slice(),
+        b"tiny-png"
     );
 
     runtime.mob_handle().stop().await.expect("stop");

--- a/meerkat-mobkit/tests/event_log_recovery.rs
+++ b/meerkat-mobkit/tests/event_log_recovery.rs
@@ -91,7 +91,6 @@ async fn batch_size_zero_does_not_panic() {
 
     // The bug pre-fix: this call panics inside `start_event_log`.
     let runtime = meerkat_mobkit::UnifiedRuntimeBuilder::default()
-        .mob_storage_in_memory()
         .definition(
             meerkat_mob::MobDefinition::from_toml(
                 "[mob]\nid = \"event-log-zero-batch\"\n\n\

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -191,21 +191,13 @@ async fn identity_first_builder_external_path_missing_scratch_dir() {
     assert_build_err_contains(builder, "scratch_dir").await;
 }
 
-// ===========================================================================
-// Task 1.14: Builder advanced durability knobs (REQ-25, REQ-26)
-// ===========================================================================
-
 #[tokio::test]
-async fn identity_first_builder_runtime_store_accepted_with_persistent_state() {
-    // runtime_store and blob_store should be accepted alongside persistent_state
-    // without triggering a conflict error. The build will fail later (missing definition).
+async fn identity_first_builder_blob_store_accepted_with_persistent_state() {
+    // blob_store should be accepted alongside persistent_state without
+    // triggering a conflict error. The build will fail later (missing definition).
     let tmp = tempfile::tempdir().unwrap();
-    let store_path = tmp.path().join("sessions.db");
     let builder = UnifiedRuntimeBuilder::default()
         .persistent_state(tmp.path())
-        .runtime_store(Arc::new(
-            meerkat_store::SqliteSessionStore::open(&store_path).unwrap(),
-        ))
         .blob_store(Arc::new(meerkat_store::FsBlobStore::new(
             tmp.path().join("blobs"),
         )));
@@ -213,16 +205,15 @@ async fn identity_first_builder_runtime_store_accepted_with_persistent_state() {
 }
 
 #[tokio::test]
-async fn identity_first_builder_runtime_store_accepted_with_external_path() {
+async fn identity_first_builder_blob_store_accepted_with_external_path() {
     let tmp = tempfile::tempdir().unwrap();
-    let store_path = tmp.path().join("sessions.db");
     let builder = UnifiedRuntimeBuilder::default()
         .continuity_store(Arc::new(StubContinuityStore))
         .lease_provider(Arc::new(StubLeaseProvider))
         .scratch_dir(tmp.path())
-        .runtime_store(Arc::new(
-            meerkat_store::SqliteSessionStore::open(&store_path).unwrap(),
-        ));
+        .blob_store(Arc::new(meerkat_store::FsBlobStore::new(
+            tmp.path().join("blobs"),
+        )));
     assert_build_err_not_contains(builder, "mutually exclusive", "conflicting").await;
 }
 

--- a/meerkat-mobkit/tests/identity_first_kitchen_sink.rs
+++ b/meerkat-mobkit/tests/identity_first_kitchen_sink.rs
@@ -24,7 +24,9 @@ use async_trait::async_trait;
 use tokio::sync::RwLock;
 
 use meerkat_mob::definition::WiringRules;
-use meerkat_mob::{MobDefinition, MobId, MobRuntimeMode, Profile, ProfileName, ToolConfig};
+use meerkat_mob::{
+    MobDefinition, MobId, MobRuntimeMode, Profile, ProfileBinding, ProfileName, ToolConfig,
+};
 
 use meerkat_mobkit::UnifiedRuntimeBuilder;
 use meerkat_mobkit::contact_directory::ContactDirectory;
@@ -101,7 +103,7 @@ fn author_definition(model: &str) -> MobDefinition {
     ] {
         profiles.insert(
             ProfileName::from(name),
-            Profile {
+            ProfileBinding::Inline(Profile {
                 model: model.to_string(),
                 skills: vec![],
                 tools: ToolConfig {
@@ -115,28 +117,17 @@ fn author_definition(model: &str) -> MobDefinition {
                 max_inline_peer_notifications: None,
                 output_schema: None,
                 provider_params: None,
-            },
+            }),
         );
     }
 
-    MobDefinition {
-        id: MobId::from("authors"),
-        orchestrator: None,
-        profiles,
-        mcp_servers: BTreeMap::new(),
-        wiring: WiringRules {
-            auto_wire_orchestrator: false,
-            role_wiring: vec![],
-        },
-        skills: BTreeMap::new(),
-        backend: Default::default(),
-        flows: Default::default(),
-        topology: None,
-        supervisor: None,
-        limits: None,
-        spawn_policy: None,
-        event_router: None,
-    }
+    let mut definition = MobDefinition::explicit(MobId::from("authors"));
+    definition.profiles = profiles;
+    definition.wiring = WiringRules {
+        auto_wire_orchestrator: false,
+        role_wiring: vec![],
+    };
+    definition
 }
 
 /// Critic mob: lead, judge profiles — all TurnDriven + comms.
@@ -149,7 +140,7 @@ fn critic_definition(model: &str) -> MobDefinition {
     ] {
         profiles.insert(
             ProfileName::from(name),
-            Profile {
+            ProfileBinding::Inline(Profile {
                 model: model.to_string(),
                 skills: vec![],
                 tools: ToolConfig {
@@ -163,28 +154,17 @@ fn critic_definition(model: &str) -> MobDefinition {
                 max_inline_peer_notifications: None,
                 output_schema: None,
                 provider_params: None,
-            },
+            }),
         );
     }
 
-    MobDefinition {
-        id: MobId::from("critics"),
-        orchestrator: None,
-        profiles,
-        mcp_servers: BTreeMap::new(),
-        wiring: WiringRules {
-            auto_wire_orchestrator: false,
-            role_wiring: vec![],
-        },
-        skills: BTreeMap::new(),
-        backend: Default::default(),
-        flows: Default::default(),
-        topology: None,
-        supervisor: None,
-        limits: None,
-        spawn_policy: None,
-        event_router: None,
-    }
+    let mut definition = MobDefinition::explicit(MobId::from("critics"));
+    definition.profiles = profiles;
+    definition.wiring = WiringRules {
+        auto_wire_orchestrator: false,
+        role_wiring: vec![],
+    };
+    definition
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-mobkit/tests/identity_first_kitchen_sink.rs
+++ b/meerkat-mobkit/tests/identity_first_kitchen_sink.rs
@@ -325,8 +325,7 @@ async fn e2e_kitchen_sink_two_mob_chaos() {
     let critic_continuity_path = temp.path().join("critic_continuity.db");
 
     // Shared session stores — survive across v1→v2 rebuild (like a persistent volume).
-    // Using mob_storage_in_memory() avoids the redb exclusive file lock while still
-    // getting persistent sessions via the shared SQLite store.
+    // Mob storage is in-memory; persistent_state covers sessions/runtime/blob/metadata surfaces.
     let author_session_store: Arc<dyn meerkat::SessionStore> = Arc::new(
         meerkat_store::SqliteSessionStore::open(temp.path().join("author_sessions.db"))
             .expect("author session store"),
@@ -356,7 +355,6 @@ async fn e2e_kitchen_sink_two_mob_chaos() {
         .definition(author_definition(&model))
         .persistent_state(&author_state)
         .session_store(author_session_store.clone())
-        .mob_storage_in_memory()
         .comms(true)
         .contact_directory(dir.clone())
         .build()
@@ -367,7 +365,6 @@ async fn e2e_kitchen_sink_two_mob_chaos() {
         .definition(critic_definition(&model))
         .persistent_state(&critic_state)
         .session_store(critic_session_store.clone())
-        .mob_storage_in_memory()
         .comms(true)
         .contact_directory(dir.clone())
         .build()
@@ -853,7 +850,6 @@ async fn e2e_kitchen_sink_two_mob_chaos() {
         .definition(author_definition(&model))
         .persistent_state(&author_state)
         .session_store(author_session_store.clone())
-        .mob_storage_in_memory()
         .comms(true)
         .contact_directory(dir2.clone())
         .build()
@@ -864,7 +860,6 @@ async fn e2e_kitchen_sink_two_mob_chaos() {
         .definition(critic_definition(&model))
         .persistent_state(&critic_state)
         .session_store(critic_session_store.clone())
-        .mob_storage_in_memory()
         .comms(true)
         .contact_directory(dir2)
         .build()

--- a/meerkat-mobkit/tests/identity_first_ob3_smoke.rs
+++ b/meerkat-mobkit/tests/identity_first_ob3_smoke.rs
@@ -22,7 +22,10 @@ use async_trait::async_trait;
 use tokio::time::sleep;
 
 use meerkat_mob::definition::WiringRules;
-use meerkat_mob::{MobDefinition, MobId, MobRuntimeMode, Profile, ProfileName, ToolConfig};
+use meerkat_mob::ids::MeerkatId;
+use meerkat_mob::{
+    MobDefinition, MobId, MobRuntimeMode, Profile, ProfileBinding, ProfileName, ToolConfig,
+};
 
 use meerkat_mobkit::UnifiedRuntimeBuilder;
 use meerkat_mobkit::identity_first::contracts::{AgentCustomizer, LeaseProvider, TopologyProvider};
@@ -86,7 +89,7 @@ fn ob3_definition(model: &str) -> MobDefinition {
 
     profiles.insert(
         ProfileName::from("personal"),
-        Profile {
+        ProfileBinding::Inline(Profile {
             model: model.to_string(),
             skills: vec![],
             tools: ToolConfig {
@@ -100,12 +103,12 @@ fn ob3_definition(model: &str) -> MobDefinition {
             max_inline_peer_notifications: None,
             output_schema: None,
             provider_params: None,
-        },
+        }),
     );
 
     profiles.insert(
         ProfileName::from("review"),
-        Profile {
+        ProfileBinding::Inline(Profile {
             model: model.to_string(),
             skills: vec![],
             tools: ToolConfig {
@@ -119,27 +122,16 @@ fn ob3_definition(model: &str) -> MobDefinition {
             max_inline_peer_notifications: None,
             output_schema: None,
             provider_params: None,
-        },
+        }),
     );
 
-    MobDefinition {
-        id: MobId::from("ob3-smoke"),
-        orchestrator: None,
-        profiles,
-        mcp_servers: BTreeMap::new(),
-        wiring: WiringRules {
-            auto_wire_orchestrator: false,
-            role_wiring: vec![],
-        },
-        skills: BTreeMap::new(),
-        backend: Default::default(),
-        flows: Default::default(),
-        topology: None,
-        supervisor: None,
-        limits: None,
-        spawn_policy: None,
-        event_router: None,
-    }
+    let mut definition = MobDefinition::explicit(MobId::from("ob3-smoke"));
+    definition.profiles = profiles;
+    definition.wiring = WiringRules {
+        auto_wire_orchestrator: false,
+        role_wiring: vec![],
+    };
+    definition
 }
 
 // History reading functions removed — we verify LLM response via
@@ -282,7 +274,7 @@ async fn e2e_ob3_01_identity_first_send_real_llm() {
     // --- Wait for ASSISTANT response by polling member status ---
     // MobMemberSnapshot.output_preview is Some when the LLM has produced output.
     let mob_handle = unified.mob_handle();
-    let alice_mid = meerkat_mob::MeerkatId::from(alice_record.agent_runtime_id.as_str());
+    let alice_mid = MeerkatId::from(alice_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     let output;
     loop {
@@ -432,7 +424,7 @@ async fn e2e_ob3_02_dynamic_roster_add_subscriber() {
 
     // Wait for alice's response
     let mob_handle = unified.mob_handle();
-    let alice_mid = meerkat_mob::MeerkatId::from(alice_record.agent_runtime_id.as_str());
+    let alice_mid = MeerkatId::from(alice_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&alice_mid).await.expect("member");
@@ -512,7 +504,7 @@ async fn e2e_ob3_02_dynamic_roster_add_subscriber() {
         .await
         .expect("send to carol");
 
-    let carol_mid = meerkat_mob::MeerkatId::from(carol_record.agent_runtime_id.as_str());
+    let carol_mid = MeerkatId::from(carol_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&carol_mid).await.expect("member");
@@ -624,7 +616,7 @@ async fn e2e_ob3_03_respawn_preserves_history() {
 
     // Wait for response
     let mob_handle = unified.mob_handle();
-    let alice_mid = meerkat_mob::MeerkatId::from(alice_record.agent_runtime_id.as_str());
+    let alice_mid = MeerkatId::from(alice_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&alice_mid).await.expect("member");
@@ -802,7 +794,7 @@ async fn e2e_ob3_04_reset_clean_slate() {
 
     // Wait for response
     let mob_handle = unified.mob_handle();
-    let alice_mid = meerkat_mob::MeerkatId::from(alice_record.agent_runtime_id.as_str());
+    let alice_mid = MeerkatId::from(alice_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&alice_mid).await.expect("member");
@@ -967,7 +959,7 @@ async fn e2e_ob3_05_async_checkpoint_durability() {
 
     // Wait for review to process
     let mob_handle = unified.mob_handle();
-    let review_mid = meerkat_mob::MeerkatId::from(review_record.agent_runtime_id.as_str());
+    let review_mid = MeerkatId::from(review_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&review_mid).await.expect("member");
@@ -1005,7 +997,7 @@ async fn e2e_ob3_05_async_checkpoint_durability() {
         .await
         .expect("send to alice");
 
-    let alice_mid = meerkat_mob::MeerkatId::from(alice_record.agent_runtime_id.as_str());
+    let alice_mid = MeerkatId::from(alice_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&alice_mid).await.expect("member");
@@ -1349,7 +1341,7 @@ async fn e2e_ob3_07_delete_and_recreate() {
 
     // Wait for alice to respond
     let mob_handle = unified.mob_handle();
-    let alice_mid = meerkat_mob::MeerkatId::from(alice_record.agent_runtime_id.as_str());
+    let alice_mid = MeerkatId::from(alice_record.agent_runtime_id.as_str());
     let deadline = Instant::now() + Duration::from_secs(90);
     loop {
         let member = mob_handle.member(&alice_mid).await.expect("member");

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Python SDK are documented here.
 
 ## Unreleased
 
+### Runtime state builders
+
+- `.persistent_state(path)` no longer creates a local redb mob store.
+  Gateway-backed SDK runtimes keep mob storage in-memory while sessions,
+  runtime state, metadata, console logs, and binary blobs remain under
+  the configured state directory.
+
 ### Multimodal attachments
 
 - Added `MobHandle.upload_blob(...)` for efficient binary image upload

--- a/sdk/python/meerkat_mobkit/builder.py
+++ b/sdk/python/meerkat_mobkit/builder.py
@@ -157,9 +157,10 @@ class MobKitBuilder:
     def persistent_state(self, path: str) -> MobKitBuilder:
         """Enable persistent state at the given path.
 
-        When set, the gateway creates SQLite session store, binary blob store,
-        and redb mob storage under this directory. When not set, the
-        gateway uses an ephemeral session service.
+        When set, the gateway creates SQLite-backed session/runtime state,
+        MobKit metadata, console logs, and binary blob storage under this
+        directory. Mob storage remains in-memory. When not set, the gateway
+        uses an ephemeral session service.
         """
         self._config.persistent_state = path
         return self

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Runtime state builders
+
+- `.persistentState(path)` no longer creates a local redb mob store.
+  Gateway-backed SDK runtimes keep mob storage in-memory while sessions,
+  runtime state, metadata, console logs, and binary blobs remain under
+  the configured state directory.
+
 ### Multimodal attachments
 
 - Added `MobHandle.uploadBlob(...)` / `upload_blob(...)` for efficient

--- a/sdk/typescript/src/builder.ts
+++ b/sdk/typescript/src/builder.ts
@@ -229,8 +229,9 @@ export class MobKitBuilder {
   /**
    * Enable persistent state at the given path.
    *
-   * When set, the gateway creates SQLite session store, binary blob store,
-   * and redb mob storage under this directory.
+   * When set, the gateway creates SQLite-backed session/runtime state,
+   * MobKit metadata, console logs, and binary blob storage under this
+   * directory. Mob storage remains in-memory.
    */
   persistentState(path: string): this {
     this._config.persistentState = path;


### PR DESCRIPTION
## Summary
- Wire `UnifiedRuntime::builder().session_store(...)` into the runtime-backed ephemeral path so custom stores use `PersistentSessionService` while default ephemeral builds keep `EphemeralSessionService`.
- Stop persistent builder/gateway paths from creating `mob.redb`; mob storage is now in-memory while sessions, runtime state, metadata, console logs, and binary blobs stay under `persistent_state`.
- Remove the misleading Rust builder `runtime_store(...)` API and remove `mob_storage_in_memory()` instead of preserving it as a silent no-op.
- Wire `blob_store(...)` through the binary blob serving/upload path via a `BinaryBlobStoreAdapter`, and update Python/TypeScript SDK docs/changelogs for the new persistent-state story.
- Revive the feature-gated identity-first kitchen sink/OB3 smoke targets against current `meerkat-mob`, and fix the runtime issues they exposed: signed in-process cross-mob descriptors, identity bridge retire cleanup parity, and local lease TTL behavior for long single-process runs.

## Root Cause
The builder kept custom session/blob stores separately from the actual runtime bootstrap choices. The runtime-backed ephemeral path always constructed its own memory-backed session/blob services, and persistent paths still defaulted to redb mob storage even though the useful persistent surfaces are sessions/runtime/blob/metadata/logs.

The hidden kitchen-sink target looked empty because it is both `integration-real-tests` gated and ignored. Once run with `--features integration-real-tests -- --ignored`, it exposed stale `meerkat-mob` struct construction plus real runtime drift in cross-mob peer validation, post-restore retire cleanup, and local lease duration.

## Validation
- `./scripts/repo-cargo test -p meerkat-mobkit test_builder_custom_blob_store_serves_binary_blobs -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mobkit test_builder_ephemeral_custom_store_persists_sessions -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_builder_blob_store_accepted --test identity_first_builder -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mobkit --lib`
- `./scripts/repo-cargo test -p meerkat-mobkit --test builder_api`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_builder`
- `./scripts/repo-cargo test -p meerkat-mobkit --test event_log_recovery`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_contracts_local_lease --test identity_first_contracts`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_kitchen_sink --features integration-real-tests -- --list` (1 test listed)
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_ob3_smoke --features integration-real-tests -- --list` (8 tests listed)
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_kitchen_sink --features integration-real-tests -- --ignored --test-threads=1 --nocapture` (1 passed, 352.36s)
- `./scripts/repo-cargo clippy -p meerkat-mobkit --all-targets -- -D warnings`
- `python -m pytest sdk/python/tests/test_builder.py sdk/python/tests/test_builder_api.py`
- `npm ci && npm run validate` in `sdk/typescript`
- `git diff --check`
