### PR TITLE
Cache console identity list reads

### DIFF
--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -3,6 +3,7 @@ mod store;
 mod types;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -73,7 +74,78 @@ struct AggregatorInner {
     active_session_backfills: tokio::sync::Mutex<BTreeSet<String>>,
     opportunistic_session_backfills: tokio::sync::Mutex<BTreeSet<String>>,
     session_backfill_permits: Arc<Semaphore>,
+    identity_read_model: ConsoleIdentityReadModel,
     options: ConsoleAggregatorOptions,
+}
+
+#[derive(Clone)]
+struct ConsoleIdentityReadModel {
+    inner: Arc<tokio::sync::RwLock<Vec<ConsoleIdentityRecord>>>,
+    refresh_lock: Arc<tokio::sync::Mutex<()>>,
+    primed: Arc<AtomicBool>,
+}
+
+impl Default for ConsoleIdentityReadModel {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            primed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl ConsoleIdentityReadModel {
+    async fn snapshot(
+        &self,
+        inner: Arc<AggregatorInner>,
+    ) -> ConsoleLogResult<Vec<ConsoleIdentityRecord>> {
+        if !self.primed.load(Ordering::Acquire) {
+            self.prime_now(inner).await?;
+        }
+        Ok(self.inner.read().await.clone())
+    }
+
+    async fn prime_now(&self, inner: Arc<AggregatorInner>) -> ConsoleLogResult<()> {
+        if self.primed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let _guard = self.refresh_lock.clone().lock_owned().await;
+        if self.primed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let identities = collect_identity_records(&inner).await?;
+        *self.inner.write().await = identities;
+        self.primed.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn refresh_soon(&self, inner: Arc<AggregatorInner>) {
+        let Ok(runtime_handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let Ok(guard) = self.refresh_lock.clone().try_lock_owned() else {
+            return;
+        };
+        let read_model = self.clone();
+        runtime_handle.spawn(async move {
+            let _guard = guard;
+            match collect_identity_records(&inner).await {
+                Ok(identities) => {
+                    *read_model.inner.write().await = identities;
+                    read_model.primed.store(true, Ordering::Release);
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, "console identity read-model refresh failed");
+                }
+            }
+        });
+    }
+
+    async fn replace(&self, identities: Vec<ConsoleIdentityRecord>) {
+        *self.inner.write().await = identities;
+        self.primed.store(true, Ordering::Release);
+    }
 }
 
 #[derive(Clone)]
@@ -173,6 +245,7 @@ impl MobKitConsoleAggregator {
                 session_backfill_permits: Arc::new(Semaphore::new(
                     options.max_concurrent_session_backfills,
                 )),
+                identity_read_model: ConsoleIdentityReadModel::default(),
                 options,
             }),
         }
@@ -224,6 +297,9 @@ impl MobKitConsoleAggregator {
         if let Ok(mut runtimes) = self.inner.runtimes.write() {
             runtimes.insert(runtime_key.clone(), entry);
         }
+        self.inner
+            .identity_read_model
+            .refresh_soon(self.inner.clone());
         let inner = self.inner.clone();
         let events_for_live = console_events.clone();
         let events_for_live_recovery = console_events.clone();
@@ -278,35 +354,35 @@ impl MobKitConsoleAggregator {
     }
 
     pub async fn list_identities(&self) -> ConsoleLogResult<Vec<ConsoleIdentityRecord>> {
-        let entries = self
+        self.inner
+            .identity_read_model
+            .refresh_soon(self.inner.clone());
+        let identities = self
             .inner
-            .runtimes
-            .read()
-            .map_err(|_| runtime_registry_lock_error())?
-            .clone();
-        let mut identities = Vec::new();
-        let mut backfill_targets = Vec::new();
-        for entry in entries.values() {
-            for resolved in member_sources_for_entry(entry).await {
-                if let Some(record) =
-                    identity_record_for_member(entry, &resolved.handle, &resolved.member).await
-                    && entry.visibility_policy.identity_visible(&record)
-                {
-                    if let Some(session_id) = record.session_id.clone() {
-                        backfill_targets.push(SessionBackfillTarget {
-                            entry: entry.clone(),
-                            record: record.clone(),
-                            session_id,
-                        });
-                    }
-                    identities.push(record);
-                }
-            }
-        }
-        for target in backfill_targets {
-            spawn_session_history_backfill_target(self.inner.clone(), target, false);
-        }
-        Ok(dedupe_identity_records(identities))
+            .identity_read_model
+            .snapshot(self.inner.clone())
+            .await?;
+        spawn_identity_backfills_for_records(self.inner.clone(), &identities);
+        Ok(identities)
+    }
+
+    pub(crate) async fn list_identities_fresh(
+        &self,
+    ) -> ConsoleLogResult<Vec<ConsoleIdentityRecord>> {
+        let _guard = self
+            .inner
+            .identity_read_model
+            .refresh_lock
+            .clone()
+            .lock_owned()
+            .await;
+        let identities = collect_identity_records(&self.inner).await?;
+        self.inner
+            .identity_read_model
+            .replace(identities.clone())
+            .await;
+        spawn_identity_backfills_for_records(self.inner.clone(), &identities);
+        Ok(identities)
     }
 
     pub async fn inspect_identity(
@@ -729,6 +805,58 @@ fn identity_record_prefer(
         return candidate_live;
     }
     candidate.session_id.as_deref().unwrap_or("") > current.session_id.as_deref().unwrap_or("")
+}
+
+async fn collect_identity_records(
+    inner: &Arc<AggregatorInner>,
+) -> ConsoleLogResult<Vec<ConsoleIdentityRecord>> {
+    let entries = inner
+        .runtimes
+        .read()
+        .map_err(|_| runtime_registry_lock_error())?
+        .clone();
+    let mut identities = Vec::new();
+    for entry in entries.values() {
+        for resolved in member_sources_for_entry(entry).await {
+            if let Some(record) =
+                identity_record_for_member(entry, &resolved.handle, &resolved.member).await
+                && entry.visibility_policy.identity_visible(&record)
+            {
+                identities.push(record);
+            }
+        }
+    }
+    Ok(dedupe_identity_records(identities))
+}
+
+fn spawn_identity_backfills_for_records(
+    inner: Arc<AggregatorInner>,
+    records: &[ConsoleIdentityRecord],
+) {
+    if !inner.options.session_history_backfill_enabled {
+        return;
+    }
+    let entries = match inner.runtimes.read() {
+        Ok(entries) => entries.clone(),
+        Err(_) => return,
+    };
+    for record in records {
+        let Some(entry) = entries.get(&record.runtime_key).cloned() else {
+            continue;
+        };
+        let Some(session_id) = record.session_id.clone() else {
+            continue;
+        };
+        spawn_session_history_backfill_target(
+            inner.clone(),
+            SessionBackfillTarget {
+                entry,
+                record: record.clone(),
+                session_id,
+            },
+            false,
+        );
+    }
 }
 
 async fn member_sources_for_entry(entry: &RuntimeEntry) -> Vec<ResolvedConsoleMember> {
@@ -2609,6 +2737,85 @@ comms = true
         }
     }
 
+    fn identity_record_for_test(identity: &str) -> ConsoleIdentityRecord {
+        ConsoleIdentityRecord {
+            identity: identity.to_string(),
+            display_name: identity.to_string(),
+            runtime_key: "runtime-cache".to_string(),
+            runtime_member_id: identity.to_string(),
+            session_id: Some(format!("session-{identity}")),
+            visibility: ConsoleVisibility::Addressable,
+            addressable: true,
+            health: "ready".to_string(),
+            labels: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_identities_serves_hot_cache_while_identity_refresh_is_in_flight() {
+        let aggregator = MobKitConsoleAggregator::in_memory();
+        let record = identity_record_for_test("agent-cached");
+        *aggregator.inner.identity_read_model.inner.write().await = vec![record.clone()];
+        aggregator
+            .inner
+            .identity_read_model
+            .primed
+            .store(true, Ordering::Release);
+        let _guard = aggregator
+            .inner
+            .identity_read_model
+            .refresh_lock
+            .clone()
+            .lock_owned()
+            .await;
+
+        let identities =
+            tokio::time::timeout(Duration::from_millis(50), aggregator.list_identities())
+                .await
+                .expect("hot identity list should not wait for refresh lock")
+                .expect("identity list succeeds");
+
+        assert_eq!(identities, vec![record]);
+    }
+
+    #[tokio::test]
+    async fn list_identities_waits_for_inflight_identity_refresh_on_cold_cache() {
+        let aggregator = MobKitConsoleAggregator::in_memory();
+        let guard = aggregator
+            .inner
+            .identity_read_model
+            .refresh_lock
+            .clone()
+            .lock_owned()
+            .await;
+        let waiter = tokio::spawn({
+            let aggregator = aggregator.clone();
+            async move { aggregator.list_identities().await }
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !waiter.is_finished(),
+            "cold identity list should wait for the in-flight refresh to finish"
+        );
+
+        let record = identity_record_for_test("agent-primed");
+        *aggregator.inner.identity_read_model.inner.write().await = vec![record.clone()];
+        aggregator
+            .inner
+            .identity_read_model
+            .primed
+            .store(true, Ordering::Release);
+        drop(guard);
+
+        let identities = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("cold identity list waiter should resume")
+            .expect("waiter joins")
+            .expect("identity list succeeds");
+        assert_eq!(identities, vec![record]);
+    }
+
     #[tokio::test]
     async fn query_timeline_reads_from_aggregate_store() {
         let aggregator = MobKitConsoleAggregator::in_memory();
@@ -2792,17 +2999,13 @@ comms = true
         )
         .await
         .expect("direct member send succeeds");
-        let identities = aggregator
-            .list_identities()
-            .await
-            .expect("late identities list");
-        assert!(
-            identities
-                .iter()
-                .any(|record| record.identity == "late/agent-late"
-                    && record.session_id.as_deref() == Some(session_id.as_str())),
-            "late member should be visible with its bridge session"
-        );
+        wait_for_identity_record(
+            &aggregator,
+            "late/agent-late",
+            Some(session_id.as_str()),
+            Duration::from_secs(5),
+        )
+        .await?;
 
         wait_for_session_history_text(
             &aggregator,
@@ -2904,6 +3107,32 @@ comms = true
 
         Err(format!(
             "session history text {expected:?} was not backfilled; observed frames: {observed:#?}",
+        ))
+    }
+
+    async fn wait_for_identity_record(
+        aggregator: &MobKitConsoleAggregator,
+        identity: &str,
+        session_id: Option<&str>,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        let mut observed = Vec::new();
+        while Instant::now() < deadline {
+            observed = aggregator
+                .list_identities()
+                .await
+                .map_err(|err| err.to_string())?;
+            if observed.iter().any(|record| {
+                record.identity == identity && record.session_id.as_deref() == session_id
+            }) {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        Err(format!(
+            "identity {identity:?} with session {session_id:?} was not projected; observed identities: {observed:#?}",
         ))
     }
 

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -1924,7 +1924,7 @@ async fn handle_console_aggregator_rpc(
             let Some(aggregator) = &console_aggregator else {
                 return console_aggregator_unavailable(response_id);
             };
-            match aggregator.list_identities().await {
+            match aggregator.list_identities_fresh().await {
                 Ok(identities) => {
                     let mut retired = Vec::new();
                     let mut failed = Vec::new();
@@ -4009,24 +4009,71 @@ mod tests {
         MAX_MULTIPART_IMAGE_BYTES, MultipartImageUpload, apply_console_visibility_policy,
         collect_console_snapshot_read_model, cursor_is_after, dedupe_console_members_by_identity,
         externalize_image_upload_placeholders, externalize_single_image_upload,
-        project_console_members_from_handle, query_timeline_snapshot,
+        handle_console_aggregator_rpc, project_console_members_from_handle,
+        query_timeline_snapshot,
     };
     use crate::blob_store::{BinaryBlobStore, ObjectStoreBlobStore};
-    use crate::console_aggregator::HideImplicitDelegateMembersConsoleVisibilityPolicy;
+    use crate::console_aggregator::{
+        AllowAllConsoleVisibilityPolicy, HideImplicitDelegateMembersConsoleVisibilityPolicy,
+    };
     use crate::console_aggregator::{
         ConsoleCursor, ConsoleFrameSource, ConsoleFrameSourceKind, ConsoleFrameStatus,
         ConsoleTimelineQuery, MobKitConsoleAggregator, NewConsoleFrame,
     };
     use crate::mob_handle_runtime::{MobRuntime, model_capabilities_for_role};
+    use crate::rpc::{JSONRPC_VERSION, JsonRpcRequest};
     use crate::runtime::{ConsoleAgentLiveSnapshot, ConsoleLiveSnapshot, ConsoleMember};
+    use crate::unified_runtime::ConsoleEventStore;
     use crate::{MobBootstrapOptions, MobBootstrapSpec};
     use bytes::Bytes;
     use meerkat::{AgentFactory, Config, build_ephemeral_service};
     use meerkat_client::TestClient;
     use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
-    use serde_json::json;
+    use serde_json::{Value, json};
     use std::collections::BTreeMap;
     use std::sync::Arc;
+
+    async fn build_empty_console_test_runtime(
+        mob_id: &str,
+    ) -> Result<(tempfile::TempDir, MobRuntime), Box<dyn std::error::Error + Send + Sync>> {
+        let temp_dir = tempfile::tempdir()?;
+        let session_path = temp_dir.path().join("sessions");
+        std::fs::create_dir_all(&session_path)?;
+        let factory = AgentFactory::new(&session_path).comms(true);
+        let session_service = Arc::new(build_ephemeral_service(factory, Config::default(), 16));
+        let definition = MobDefinition::from_toml(&format!(
+            r#"
+[mob]
+id = "{mob_id}"
+
+[profiles.worker]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.worker.tools]
+comms = true
+"#
+        ))?;
+        let runtime = MobRuntime::bootstrap(
+            MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
+                .with_options(MobBootstrapOptions {
+                    allow_ephemeral_sessions: true,
+                    notify_orchestrator_on_resume: true,
+                    default_llm_client: Some(Arc::new(TestClient::default())),
+                }),
+        )
+        .await?;
+        Ok((temp_dir, runtime))
+    }
+
+    fn rpc_request(method: &str) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(json!(1)),
+            method: method.to_string(),
+            params: json!({}),
+        }
+    }
 
     #[test]
     fn multipart_body_limit_covers_configured_image_limit() {
@@ -4128,6 +4175,46 @@ mod tests {
         };
         let result = tokio::time::timeout(Duration::from_millis(100), snap_fast_path).await;
         assert!(result.is_ok(), "hot-cache snapshot path should not block");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn console_aggregator_reset_all_rpc_force_refreshes_identity_cache()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let (_temp_dir, runtime) =
+            build_empty_console_test_runtime("console-reset-fresh-identity-cache").await?;
+        let aggregator = MobKitConsoleAggregator::in_memory();
+        aggregator.register_runtime_handles_with_policy(
+            "runtime-reset",
+            "reset",
+            runtime.clone(),
+            ConsoleEventStore::new(),
+            Arc::new(AllowAllConsoleVisibilityPolicy),
+        );
+        let primed_empty = aggregator.list_identities().await?;
+        assert!(
+            primed_empty.is_empty(),
+            "test precondition: identity cache should be primed empty before late spawn"
+        );
+
+        runtime
+            .handle()
+            .spawn_spec(SpawnMemberSpec::from_wire(
+                "worker".to_string(),
+                "agent-reset".to_string(),
+                Some("You are agent-reset.".into()),
+                None,
+                None,
+            ))
+            .await?;
+
+        let response =
+            handle_console_aggregator_rpc(Some(aggregator), rpc_request("mobkit/reset_all"), true)
+                .await;
+
+        assert_eq!(response["error"], Value::Null);
+        assert_eq!(response["result"]["retired"], json!(["reset/agent-reset"]));
+        let _ = runtime.handle().stop().await;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add an aggregator-side ConsoleIdentityReadModel for /console/identities and mobkit/console/list_identities
- refresh identities in the background and serve hot-path reads from the cached projection
- keep reset_all on a fresh identity read so mutations do not act on stale cache

## Verification
- cargo test -p meerkat-mobkit list_identities --lib
- cargo test -p meerkat-mobkit discovered_late_member_session_backfills_without_manual_refresh --lib
- cargo test -p meerkat-mobkit --lib
- cargo clippy -p meerkat-mobkit --all-targets -- -D warnings
- ./scripts/verify-version-parity.sh
- cargo test --workspace --all-targets (passes until pre-existing governance_contracts failures because .rct/spec.yaml is absent in this worktree)