### PR TITLE
Implement identity-first MobKit bootstrap

### DIFF
--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1638,6 +1638,60 @@ external_addressable = true
             }
             false => None,
         };
+    let identity_continuity_store: Option<
+        Arc<dyn meerkat_mobkit::identity_first::ContinuityStore>,
+    > = if has_roster_provider {
+        Some(if has_continuity_store {
+            Arc::new(meerkat_mobkit::identity_first::GatewayContinuityStore::new(
+                bridge.clone(),
+            ))
+        } else if let Some(ref state_path) = persistent_state {
+            Arc::new(
+                meerkat_mobkit::identity_first::LocalContinuityStore::open(
+                    state_path.join("continuity.db"),
+                )
+                .unwrap_or_else(|e| {
+                    fail_init(
+                        &request_id,
+                        -32603,
+                        format!("failed to open continuity store: {e}"),
+                    );
+                }),
+            )
+        } else {
+            Arc::new(
+                meerkat_mobkit::identity_first::LocalContinuityStore::open(
+                    std::env::temp_dir()
+                        .join(format!("mobkit-continuity-{}.db", std::process::id())),
+                )
+                .unwrap_or_else(|e| {
+                    fail_init(
+                        &request_id,
+                        -32603,
+                        format!("failed to open continuity store: {e}"),
+                    );
+                }),
+            )
+        })
+    } else {
+        None
+    };
+    let identity_lease_provider: Option<
+        Arc<dyn meerkat_mobkit::identity_first::contracts::LeaseProvider>,
+    > = if has_roster_provider {
+        Some(if has_lease_provider {
+            Arc::new(meerkat_mobkit::identity_first::GatewayLeaseProvider::new(
+                bridge.clone(),
+            ))
+        } else {
+            Arc::new(meerkat_mobkit::identity_first::LocalLeaseProvider::new())
+        })
+    } else {
+        None
+    };
+    let identity_session_store_adapter = identity_continuity_store.as_ref().map(|store| {
+        Arc::new(meerkat_mobkit::identity_first::ContinuitySessionStoreAdapter::new(store.clone()))
+    });
 
     // 5. Build session service with callback bridge.
     let (mob_spec, _temp_dir) = if let Some(ref state_path) = persistent_state {
@@ -1650,13 +1704,17 @@ external_addressable = true
         }
         let sqlite_path = state_path.join("sessions.db");
         let session_store: Arc<dyn meerkat::SessionStore> =
-            match meerkat_store::SqliteSessionStore::open(sqlite_path) {
-                Ok(s) => Arc::new(s),
-                Err(e) => fail_init(
-                    &request_id,
-                    -32603,
-                    format!("failed to open SQLite session store: {e}"),
-                ),
+            if let Some(adapter) = identity_session_store_adapter.clone() {
+                adapter
+            } else {
+                match meerkat_store::SqliteSessionStore::open(sqlite_path) {
+                    Ok(s) => Arc::new(s),
+                    Err(e) => fail_init(
+                        &request_id,
+                        -32603,
+                        format!("failed to open SQLite session store: {e}"),
+                    ),
+                }
             };
         let mob_storage = MobStorage::in_memory();
         let binary_blob_store: Arc<dyn BinaryBlobStore> =
@@ -1766,17 +1824,47 @@ external_addressable = true
             factory = factory.with_image_generation_machine(adapter.clone());
         }
         let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
-        inner_builder.default_blob_store = Some(blob_store);
+        inner_builder.default_blob_store = Some(blob_store.clone());
         let callback_builder = StdioCallbackAgentBuilder {
             inner: inner_builder,
             bridge: bridge.clone(),
             has_session_builder,
             session_store: None,
         };
-        let session_service = Arc::new(EphemeralSessionService::new(
-            callback_builder,
-            gateway_options.max_sessions,
-        ));
+        let session_service: Arc<dyn meerkat_mob::MobSessionService> =
+            if let Some(session_adapter) = identity_session_store_adapter.clone() {
+                let session_store: Arc<dyn meerkat::SessionStore> = session_adapter.clone();
+                let mut factory = AgentFactory::new(agent_workspace)
+                    .builtins(false)
+                    .comms(true)
+                    .session_store(Arc::new(meerkat::MemoryStore::new()));
+                if image_generation {
+                    factory = factory.with_image_generation_machine(adapter.clone());
+                }
+                let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+                inner_builder.default_session_store = Some(Arc::new(
+                    meerkat_store::StoreAdapter::new(session_store.clone()),
+                ));
+                inner_builder.default_blob_store = Some(blob_store.clone());
+                let callback_builder = StdioCallbackAgentBuilder {
+                    inner: inner_builder,
+                    bridge: bridge.clone(),
+                    has_session_builder,
+                    session_store: Some(session_store.clone()),
+                };
+                Arc::new(meerkat_session::PersistentSessionService::new(
+                    callback_builder,
+                    gateway_options.max_sessions,
+                    session_store,
+                    Some(Arc::clone(&runtime_store)),
+                    blob_store.clone(),
+                ))
+            } else {
+                Arc::new(EphemeralSessionService::new(
+                    callback_builder,
+                    gateway_options.max_sessions,
+                ))
+            };
 
         let mut spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
             .with_session_runtime_adapter(adapter.clone())
@@ -1903,68 +1991,43 @@ external_addressable = true
     // 5c. Build identity-first runtime if providers are configured
     let identity_ctx: Option<meerkat_mobkit::rpc::IdentityFirstContext> = if has_roster_provider {
         use meerkat_mobkit::identity_first::{
-            DurabilityPolicy, IdentityRuntime, IdentityRuntimeConfig, LocalContinuityStore,
-            LocalLeaseProvider, RosterContext,
-            contracts::LeaseProvider as LeaseProviderTrait,
+            AgentRuntimeServices, DurabilityPolicy, IdentityFirstRuntimeContext, IdentityRuntime,
+            IdentityRuntimeConfig, RosterContext,
             gateway_bridges::{
-                GatewayAgentCustomizer, GatewayContinuityStore, GatewayLeaseProvider,
-                GatewayRosterProvider, GatewayTopologyProvider,
+                GatewayAgentCustomizer, GatewayRosterProvider, GatewayTopologyProvider,
             },
         };
 
-        // Build provider bridges
-        let continuity_store: Arc<dyn meerkat_mobkit::identity_first::ContinuityStore> =
-            if has_continuity_store {
-                Arc::new(GatewayContinuityStore::new(bridge.clone()))
-            } else if let Some(ref state_path) = persistent_state {
-                Arc::new(
-                    LocalContinuityStore::open(state_path.join("continuity.db")).unwrap_or_else(
-                        |e| {
-                            fail_init(
-                                &request_id,
-                                -32603,
-                                format!("failed to open continuity store: {e}"),
-                            );
-                        },
-                    ),
-                )
-            } else {
-                Arc::new(
-                    LocalContinuityStore::open(
-                        std::env::temp_dir()
-                            .join(format!("mobkit-continuity-{}.db", std::process::id())),
-                    )
-                    .unwrap_or_else(|e| {
-                        fail_init(
-                            &request_id,
-                            -32603,
-                            format!("failed to open continuity store: {e}"),
-                        );
-                    }),
-                )
-            };
-
-        let lease_provider: Arc<dyn LeaseProviderTrait> = if has_lease_provider {
-            Arc::new(GatewayLeaseProvider::new(bridge.clone()))
-        } else {
-            Arc::new(LocalLeaseProvider::new())
-        };
+        let continuity_store = identity_continuity_store
+            .clone()
+            .expect("identity continuity store initialized with roster provider");
+        let lease_provider = identity_lease_provider
+            .clone()
+            .expect("identity lease provider initialized with roster provider");
 
         // Construct the session bridge from the mob handle. The gateway
         // uses the raw bootstrap path (not UnifiedRuntimeBuilder), so
         // session_bridge() won't be set — build it directly.
         let mob_handle = runtime.mob_handle();
         let bridge_arc: Arc<dyn meerkat_mobkit::identity_first::SessionBridge> =
-            if let Some(session_service) = runtime.mob_runtime().session_service().cloned() {
+            if let Some(adapter) = identity_session_store_adapter.clone() {
+                Arc::new(
+                    meerkat_mobkit::identity_first::MobSessionBridge::with_continuity_session_store(
+                        mob_handle.clone(),
+                        adapter,
+                        runtime.mob_runtime().session_service().cloned(),
+                    ),
+                )
+            } else if let Some(session_service) = runtime.mob_runtime().session_service().cloned() {
                 Arc::new(
                     meerkat_mobkit::identity_first::MobSessionBridge::with_session_service(
-                        mob_handle,
+                        mob_handle.clone(),
                         session_service,
                     ),
                 )
             } else {
                 Arc::new(meerkat_mobkit::identity_first::MobSessionBridge::new(
-                    mob_handle,
+                    mob_handle.clone(),
                 ))
             };
 
@@ -1972,11 +2035,13 @@ external_addressable = true
             continuity_store,
             lease_provider,
             runtime_instance_id: format!("gateway-{}", std::process::id()),
-            has_runtime_store: persistent_state.is_some(),
+            has_runtime_store: identity_session_store_adapter.is_some()
+                || persistent_state.is_some(),
             durability_policy: DurabilityPolicy::SyncWriteThrough,
             bridge: Some(bridge_arc),
             default_timeout: None,
-        });
+        })
+        .with_runtime_services(AgentRuntimeServices::new(mob_handle));
 
         // Build provider bridges for callbacks to Python
         let roster: Arc<dyn meerkat_mobkit::identity_first::contracts::RosterProvider> =
@@ -2021,8 +2086,17 @@ external_addressable = true
             );
         }
 
+        let identity_runtime = Arc::new(irt);
+        runtime.attach_identity_first_context(Arc::new(IdentityFirstRuntimeContext::new(
+            identity_runtime.clone(),
+            roster.clone(),
+            topology.clone(),
+            customizer.clone(),
+            Some(runtime.mob_handle().definition().clone()),
+        )));
+
         Some(meerkat_mobkit::rpc::IdentityFirstContext {
-            runtime: Arc::new(irt),
+            runtime: identity_runtime,
             roster_provider: roster,
             topology_provider: topology,
             customizer,

--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -700,6 +700,109 @@ impl MobKitConsoleAggregator {
         Ok(accepted)
     }
 
+    pub async fn reserve_identity_first_interaction(
+        &self,
+        request: ConsoleSendRequest,
+        session_id: Option<&str>,
+    ) -> Result<ConsoleInteractionAccepted, ConsoleSendError> {
+        validate_send_request(&request)?;
+        let _content = content_input_from_value(&request.content)?;
+        let handling_mode_value = request
+            .handling_mode
+            .as_deref()
+            .unwrap_or("queue")
+            .to_string();
+        let dedupe_key = send_dedupe_key(
+            "identity-first",
+            &request.identity,
+            &request.origin,
+            &request.idempotency_key,
+        );
+        let request_fingerprint =
+            send_request_fingerprint(&request.origin, &request.content, &handling_mode_value);
+        if let Some(existing) = self
+            .inner
+            .store
+            .frame_by_dedupe_key(&dedupe_key)
+            .await
+            .map_err(ConsoleSendError::Log)?
+        {
+            let same_request = existing.source.source_cursor.as_deref()
+                == Some(request_fingerprint.as_str())
+                || existing.source.source_cursor.is_none()
+                    && existing.payload.get("origin").and_then(Value::as_str)
+                        == Some(request.origin.as_str())
+                    && existing.payload.get("content") == Some(&request.content)
+                    && existing
+                        .payload
+                        .get("handling_mode")
+                        .and_then(Value::as_str)
+                        == Some(handling_mode_value.as_str());
+            if !same_request {
+                return Err(ConsoleSendError::IdempotencyConflict(
+                    request.idempotency_key,
+                ));
+            }
+            return Ok(accepted_from_frame(&existing));
+        }
+
+        let interaction_id = format!("console-interaction-{}", hash_short(&dedupe_key));
+        let new_frame = NewConsoleFrame {
+            id: None,
+            dedupe_key,
+            timestamp_ms: current_time_ms(),
+            runtime_key: "identity-first".to_string(),
+            identity: request.identity.clone(),
+            conversation_id: Some(request.identity.clone()),
+            session_id: session_id.map(ToString::to_string),
+            kind: "user_input".to_string(),
+            status: ConsoleFrameStatus::Accepted,
+            payload: json!({
+                "content": request.content,
+                "origin": request.origin,
+                "idempotency_key": request.idempotency_key,
+                "handling_mode": handling_mode_value,
+            }),
+            source: ConsoleFrameSource {
+                kind: ConsoleFrameSourceKind::Send,
+                source_cursor: Some(request_fingerprint),
+            },
+            source_event_id: None,
+            interaction_id: Some(interaction_id),
+            turn_id: None,
+            run_id: None,
+            parent_frame_id: None,
+            caused_by_frame_id: None,
+        };
+        let outcome = self
+            .inner
+            .store
+            .append_if_absent(new_frame)
+            .await
+            .map_err(ConsoleSendError::Log)?;
+        let _ = self
+            .inner
+            .event_tx
+            .send(ConsoleTimelineEvent::ConsoleFrame {
+                frame: outcome.frame.clone(),
+            });
+        Ok(accepted_from_frame(&outcome.frame))
+    }
+
+    pub async fn mark_interaction_delivery_failed(
+        &self,
+        input_frame_id: &str,
+    ) -> Result<(), ConsoleSendError> {
+        update_frame_status_and_emit(
+            &self.inner,
+            input_frame_id,
+            ConsoleFrameStatus::DeliveryFailed,
+        )
+        .await
+        .map_err(ConsoleSendError::Log)?;
+        Ok(())
+    }
+
     pub async fn binary_blob_store_for_identity(
         &self,
         identity: &str,

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -9,6 +9,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::Engine;
 use futures::future::join_all;
+use meerkat_core::ContentInput;
 use meerkat_core::comms::TrustedPeerDescriptor;
 use meerkat_mob::MobState;
 use meerkat_mob::ids::{MeerkatId, MobId};
@@ -59,6 +60,7 @@ pub struct ConsoleJsonState {
     /// dispatch can answer `mobkit/peer_pubkey` and stamp non-inproc
     /// `cross_mob/wire_local` descriptors with a real pubkey.
     pub gateway_peer_keys: Option<crate::auth::peer_keys::GatewayPeerKeys>,
+    pub(crate) identity_runtime: Option<Arc<crate::identity_first::IdentityRuntime>>,
     pub(crate) console_events: Option<ConsoleEventStore>,
     pub(crate) console_aggregator: Option<MobKitConsoleAggregator>,
     pub(crate) mob_events: Option<MobEventsStore>,
@@ -192,6 +194,7 @@ pub fn console_json_router(decisions: RuntimeDecisionState) -> Router {
         contact_directory: None,
         event_log: None,
         gateway_peer_keys: None,
+        identity_runtime: None,
         console_events: None,
         console_aggregator: None,
         mob_events: None,
@@ -212,6 +215,7 @@ pub fn console_json_router_with_aggregator(
         contact_directory: None,
         event_log: None,
         gateway_peer_keys: None,
+        identity_runtime: None,
         console_events: None,
         console_aggregator: Some(console_aggregator),
         mob_events: None,
@@ -238,6 +242,7 @@ pub fn console_json_router_with_runtime(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -253,6 +258,7 @@ pub(crate) fn console_json_router_with_runtime_and_events(
     console_log_store: Option<std::sync::Arc<dyn ConsoleLogStore>>,
     mob_events: Option<MobEventsStore>,
     metadata_table: Option<std::sync::Arc<RuntimeMetadataTable>>,
+    identity_runtime: Option<Arc<crate::identity_first::IdentityRuntime>>,
 ) -> Router {
     console_json_router_with_runtime_events_and_policy(
         decisions,
@@ -265,6 +271,7 @@ pub(crate) fn console_json_router_with_runtime_and_events(
         console_log_store,
         mob_events,
         metadata_table,
+        identity_runtime,
         Arc::new(HideImplicitDelegateMembersConsoleVisibilityPolicy),
     )
 }
@@ -281,6 +288,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
     console_log_store: Option<std::sync::Arc<dyn ConsoleLogStore>>,
     mob_events: Option<MobEventsStore>,
     metadata_table: Option<std::sync::Arc<RuntimeMetadataTable>>,
+    identity_runtime: Option<Arc<crate::identity_first::IdentityRuntime>>,
     visibility_policy: Arc<dyn ConsoleVisibilityPolicy>,
 ) -> Router {
     let console_aggregator = console_events.clone().map(|events| {
@@ -315,6 +323,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
         contact_directory,
         event_log,
         gateway_peer_keys,
+        identity_runtime,
         console_events,
         console_aggregator,
         mob_events,
@@ -349,6 +358,10 @@ fn console_json_router_with_state(state: ConsoleJsonState) -> Router {
         .route(
             "/console/timeline/stream",
             get(console_timeline_stream_handler),
+        )
+        .route(
+            "/console/identity/{identity}/stream",
+            get(console_identity_timeline_stream_handler),
         )
         .route("/console/send", post(console_send_handler))
         .route("/console/rpc", post(console_rpc_handler))
@@ -506,6 +519,7 @@ pub async fn console_rpc_handler(
         state.gateway_peer_keys.as_ref(),
         state.console_events.clone(),
         state.console_aggregator.clone(),
+        state.identity_runtime.clone(),
         state.metadata_table.clone(),
         state.mob_events.clone(),
         parsed_request,
@@ -614,6 +628,25 @@ async fn console_send_handler(
             "console aggregator unavailable",
         );
     };
+    if let Some(identity_runtime) = &state.identity_runtime {
+        return match console_send_identity_first(
+            aggregator,
+            identity_runtime,
+            state.console_events.as_ref(),
+            request,
+        )
+        .await
+        {
+            Ok(accepted) => (
+                StatusCode::OK,
+                Json::<Value>(
+                    serde_json::to_value(accepted).unwrap_or_else(|_| json!({ "accepted": true })),
+                ),
+            )
+                .into_response(),
+            Err(err) => console_send_error_response(err),
+        };
+    }
     match aggregator.send(request).await {
         Ok(accepted) => (
             StatusCode::OK,
@@ -623,6 +656,105 @@ async fn console_send_handler(
         )
             .into_response(),
         Err(err) => console_send_error_response(err),
+    }
+}
+
+async fn console_send_identity_first(
+    aggregator: &MobKitConsoleAggregator,
+    identity_runtime: &crate::identity_first::IdentityRuntime,
+    console_events: Option<&ConsoleEventStore>,
+    request: ConsoleSendRequest,
+) -> Result<crate::console_aggregator::ConsoleInteractionAccepted, ConsoleSendError> {
+    let identity = crate::identity_first::AgentIdentity::parse(request.identity.as_str())
+        .map_err(|err| ConsoleSendError::InvalidRequest(format!("invalid identity: {err}")))?;
+    let content: ContentInput = serde_json::from_value(request.content.clone())
+        .map_err(|err| ConsoleSendError::InvalidContent(err.to_string()))?;
+    if let ContentInput::Text(text) = &content
+        && text.trim().is_empty()
+    {
+        return Err(ConsoleSendError::InvalidContent(
+            "content must be non-empty".to_string(),
+        ));
+    }
+    if let ContentInput::Blocks(blocks) = &content
+        && blocks.is_empty()
+    {
+        return Err(ConsoleSendError::InvalidContent(
+            "content blocks must be non-empty".to_string(),
+        ));
+    }
+
+    let status = identity_runtime
+        .status(&identity)
+        .await
+        .map_err(|err| identity_runtime_error_to_console_send_error(identity.as_str(), err))?;
+    let session_id = status
+        .session_id
+        .as_ref()
+        .map(std::string::ToString::to_string);
+    let runtime_member_id = status
+        .agent_runtime_id
+        .as_ref()
+        .map(|id| id.as_str().to_string());
+    let accepted = aggregator
+        .reserve_identity_first_interaction(request.clone(), session_id.as_deref())
+        .await?;
+
+    if let Some(events) = console_events {
+        events
+            .reserve_interaction_value(
+                identity.as_str(),
+                runtime_member_id.as_deref(),
+                &accepted.interaction_id,
+                &request.origin,
+                request.content.clone(),
+            )
+            .await
+            .map_err(ConsoleSendError::State)?;
+    }
+
+    match identity_runtime.send(&identity, &content).await {
+        Ok(_) => Ok(accepted),
+        Err(err) => {
+            let _ = aggregator
+                .mark_interaction_delivery_failed(&accepted.input_frame_id)
+                .await;
+            if let Some(events) = console_events {
+                events
+                    .record_lifecycle(
+                        identity.as_str(),
+                        "interaction_failed",
+                        json!({
+                            "interaction_id": accepted.interaction_id,
+                            "origin": request.origin,
+                            "error": err.to_string(),
+                        }),
+                    )
+                    .await;
+            }
+            Err(identity_runtime_error_to_console_send_error(
+                identity.as_str(),
+                err,
+            ))
+        }
+    }
+}
+
+fn identity_runtime_error_to_console_send_error(
+    identity: &str,
+    err: crate::identity_first::IdentityRuntimeError,
+) -> ConsoleSendError {
+    match err {
+        crate::identity_first::IdentityRuntimeError::UnknownIdentity(_) => {
+            ConsoleSendError::UnknownIdentity(identity.to_string())
+        }
+        crate::identity_first::IdentityRuntimeError::NotAddressable(_) => {
+            ConsoleSendError::NotAddressable(identity.to_string())
+        }
+        crate::identity_first::IdentityRuntimeError::InvalidState { .. } => {
+            ConsoleSendError::Retired(identity.to_string())
+        }
+        other => ConsoleSendError::Dispatch(other.to_string()),
     }
 }
 
@@ -736,6 +868,24 @@ async fn console_timeline_stream_handler(
                 .text(KEEP_ALIVE_TEXT),
         )
         .into_response()
+}
+
+async fn console_identity_timeline_stream_handler(
+    State(state): State<ConsoleJsonState>,
+    headers: HeaderMap,
+    uri: Uri,
+    AxumPath(identity): AxumPath<String>,
+    Query(mut query): Query<ConsoleTimelineHttpQuery>,
+) -> impl IntoResponse {
+    query.identity = Some(identity);
+    Box::pin(console_timeline_stream_handler(
+        State(state),
+        headers,
+        uri,
+        Query(query),
+    ))
+    .await
+    .into_response()
 }
 
 fn timeline_query_from_http(
@@ -1274,6 +1424,7 @@ pub async fn console_rpc_multipart_handler(
             state.gateway_peer_keys.as_ref(),
             state.console_events.clone(),
             state.console_aggregator.clone(),
+            state.identity_runtime.clone(),
             state.metadata_table.clone(),
             state.mob_events.clone(),
             parsed_request,
@@ -1991,6 +2142,7 @@ async fn handle_console_runtime_rpc(
     gateway_peer_keys: Option<&crate::auth::peer_keys::GatewayPeerKeys>,
     console_events: Option<ConsoleEventStore>,
     console_aggregator: Option<MobKitConsoleAggregator>,
+    identity_runtime: Option<Arc<crate::identity_first::IdentityRuntime>>,
     metadata_table: Option<std::sync::Arc<RuntimeMetadataTable>>,
     mob_events: Option<MobEventsStore>,
     request: JsonRpcRequest,
@@ -2203,6 +2355,31 @@ async fn handle_console_runtime_rpc(
                     }),
                 );
             };
+            if let Some(identity_runtime) = &identity_runtime {
+                return match console_send_identity_first(
+                    aggregator,
+                    identity_runtime,
+                    console_events.as_ref(),
+                    send_request,
+                )
+                .await
+                {
+                    Ok(accepted) => response_value(
+                        response_id,
+                        Some(serde_json::to_value(accepted).unwrap_or(Value::Null)),
+                        None,
+                    ),
+                    Err(err) => response_value(
+                        response_id,
+                        None,
+                        Some(JsonRpcError {
+                            code: console_send_rpc_code(&err),
+                            message: err.to_string(),
+                            data: None,
+                        }),
+                    ),
+                };
+            }
             match aggregator.send(send_request).await {
                 Ok(accepted) => response_value(
                     response_id,
@@ -4007,10 +4184,10 @@ mod tests {
     use super::{
         ConsoleSnapshotReadModel, ConsoleSnapshotReadModelState, MAX_MULTIPART_BODY_BYTES,
         MAX_MULTIPART_IMAGE_BYTES, MultipartImageUpload, apply_console_visibility_policy,
-        collect_console_snapshot_read_model, cursor_is_after, dedupe_console_members_by_identity,
-        externalize_image_upload_placeholders, externalize_single_image_upload,
-        handle_console_aggregator_rpc, project_console_members_from_handle,
-        query_timeline_snapshot,
+        collect_console_snapshot_read_model, console_send_identity_first, cursor_is_after,
+        dedupe_console_members_by_identity, externalize_image_upload_placeholders,
+        externalize_single_image_upload, handle_console_aggregator_rpc,
+        project_console_members_from_handle, query_timeline_snapshot,
     };
     use crate::blob_store::{BinaryBlobStore, ObjectStoreBlobStore};
     use crate::console_aggregator::{
@@ -4020,6 +4197,12 @@ mod tests {
         ConsoleCursor, ConsoleFrameSource, ConsoleFrameSourceKind, ConsoleFrameStatus,
         ConsoleTimelineQuery, MobKitConsoleAggregator, NewConsoleFrame,
     };
+    use crate::identity_first::{
+        AgentAddressability, AgentIdentity, AgentRuntimeId, CheckpointVersion,
+        ContinuityGeneration, ContinuityRecord, DurabilityPolicy, DurableAgentSpec, FencingToken,
+        IdentityLifecycleState, IdentityRuntime, IdentityRuntimeConfig, LeaseGrant,
+        LocalContinuityStore, LocalLeaseProvider,
+    };
     use crate::mob_handle_runtime::{MobRuntime, model_capabilities_for_role};
     use crate::rpc::{JSONRPC_VERSION, JsonRpcRequest};
     use crate::runtime::{ConsoleAgentLiveSnapshot, ConsoleLiveSnapshot, ConsoleMember};
@@ -4028,10 +4211,12 @@ mod tests {
     use bytes::Bytes;
     use meerkat::{AgentFactory, Config, build_ephemeral_service};
     use meerkat_client::TestClient;
+    use meerkat_mob::ProfileName;
     use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
     use serde_json::{Value, json};
     use std::collections::BTreeMap;
     use std::sync::Arc;
+    use std::time::Duration;
 
     async fn build_empty_console_test_runtime(
         mob_id: &str,
@@ -4073,6 +4258,87 @@ comms = true
             method: method.to_string(),
             params: json!({}),
         }
+    }
+
+    #[tokio::test]
+    async fn identity_first_console_send_reserves_timeline_and_uses_identity_runtime()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let identity = AgentIdentity::parse("agent:console")?;
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:agent:console:0")?,
+            session_id: meerkat_core::types::SessionId::new(),
+            generation: ContinuityGeneration::new(0),
+            checkpoint_version: CheckpointVersion::new(0),
+        };
+        let runtime = IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(LocalContinuityStore::in_memory()?),
+            lease_provider: Arc::new(LocalLeaseProvider::new()),
+            runtime_instance_id: "console-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: None,
+            default_timeout: None,
+        });
+        runtime
+            .register(
+                DurableAgentSpec {
+                    identity: identity.clone(),
+                    profile: ProfileName::from("default"),
+                    addressability: AgentAddressability::Addressable,
+                    display_name: None,
+                    labels: BTreeMap::new(),
+                    context: None,
+                    additional_instructions: Vec::new(),
+                    initial_message: None,
+                    runtime_mode_override: None,
+                },
+                IdentityLifecycleState::Active,
+                Some(record.clone()),
+                Some(LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: FencingToken::new(7),
+                    ttl: Duration::from_mins(1),
+                }),
+            )
+            .await;
+
+        let aggregator = MobKitConsoleAggregator::in_memory();
+        let events = ConsoleEventStore::new();
+        let accepted = console_send_identity_first(
+            &aggregator,
+            &runtime,
+            Some(&events),
+            crate::console_aggregator::ConsoleSendRequest {
+                identity: identity.as_str().to_string(),
+                content: serde_json::to_value(meerkat_core::ContentInput::Text(
+                    "hello".to_string(),
+                ))?,
+                origin: "test".to_string(),
+                idempotency_key: "idem-1".to_string(),
+                handling_mode: None,
+            },
+        )
+        .await?;
+
+        assert_eq!(accepted.identity, identity.as_str());
+        assert_eq!(accepted.status, ConsoleFrameStatus::Accepted);
+        assert_eq!(accepted.session_id, Some(record.session_id.to_string()));
+
+        let page = aggregator
+            .query_timeline(ConsoleTimelineQuery {
+                identity: Some(identity.as_str().to_string()),
+                ..ConsoleTimelineQuery::default()
+            })
+            .await?;
+        assert_eq!(page.frames.len(), 1);
+        assert_eq!(page.frames[0].runtime_key, "identity-first");
+        assert_eq!(page.frames[0].status, ConsoleFrameStatus::Accepted);
+        assert_eq!(
+            page.frames[0].session_id,
+            Some(record.session_id.to_string())
+        );
+        Ok(())
     }
 
     #[test]

--- a/meerkat-mobkit/src/identity_first/adapters.rs
+++ b/meerkat-mobkit/src/identity_first/adapters.rs
@@ -61,6 +61,8 @@ pub fn agent_discovery_to_durable(
         labels: spec.labels.clone().unwrap_or_default(),
         context: spec.context.clone(),
         additional_instructions: spec.additional_instructions.clone(),
+        initial_message: None,
+        runtime_mode_override: None,
     })
 }
 
@@ -138,6 +140,7 @@ pub(crate) struct SessionRuntimeState {
     pub identity: AgentIdentity,
     pub generation: super::types::ContinuityGeneration,
     pub fencing_token: super::types::FencingToken,
+    pub checkpoint_version: super::types::CheckpointVersion,
 }
 
 /// Adapts a `ContinuityStore` to the Meerkat `SessionStore` interface.
@@ -155,6 +158,9 @@ pub struct ContinuitySessionStoreAdapter {
     versions: Mutex<HashMap<String, AtomicU64>>,
     /// Session→identity mapping, populated by the runtime.
     session_registry: Mutex<HashMap<String, SessionRuntimeState>>,
+    /// Session saves that arrive before the bridge can publish the owning
+    /// identity. These are flushed immediately when the session is registered.
+    pending_unregistered: Mutex<HashMap<String, Vec<u8>>>,
 }
 
 impl ContinuitySessionStoreAdapter {
@@ -163,6 +169,7 @@ impl ContinuitySessionStoreAdapter {
             store,
             versions: Mutex::new(HashMap::new()),
             session_registry: Mutex::new(HashMap::new()),
+            pending_unregistered: Mutex::new(HashMap::new()),
         }
     }
 
@@ -171,16 +178,46 @@ impl ContinuitySessionStoreAdapter {
     /// Called by the runtime during restore/activate to wire real
     /// identity/generation/fencing data into the adapter.
     #[allow(dead_code)]
-    pub(crate) fn register_session(
+    pub(crate) async fn register_session(
         &self,
         session_id: &meerkat_core::types::SessionId,
         state: SessionRuntimeState,
-    ) {
-        let mut registry = self
-            .session_registry
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        registry.insert(session_id.to_string(), state);
+    ) -> Result<super::types::CheckpointVersion, meerkat_store::SessionStoreError> {
+        let session_key = session_id.to_string();
+        let checkpoint_version = state.checkpoint_version.get();
+        {
+            let mut registry = self
+                .session_registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            registry.insert(session_key.clone(), state.clone());
+        }
+
+        {
+            let mut versions = self
+                .versions
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let counter = versions
+                .entry(session_key)
+                .or_insert_with(|| AtomicU64::new(checkpoint_version));
+            counter.fetch_max(checkpoint_version, Ordering::Relaxed);
+        }
+
+        let pending = {
+            let mut pending = self
+                .pending_unregistered
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            pending.remove(&session_id.to_string())
+        };
+        let mut effective_checkpoint_version = self.current_version(session_id);
+        if let Some(data) = pending {
+            effective_checkpoint_version = self
+                .save_registered_snapshot(session_id, data, state)
+                .await?;
+        }
+        Ok(effective_checkpoint_version)
     }
 
     /// Update the fencing token for a session (e.g., after lease renewal).
@@ -211,6 +248,21 @@ impl ContinuitySessionStoreAdapter {
         counter.fetch_add(1, Ordering::Relaxed) + 1
     }
 
+    fn current_version(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> super::types::CheckpointVersion {
+        let map = self
+            .versions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let version = map
+            .get(&session_id.to_string())
+            .map(|counter| counter.load(Ordering::Relaxed))
+            .unwrap_or(0);
+        super::types::CheckpointVersion::new(version)
+    }
+
     /// Look up the runtime state for a session.
     fn lookup_session(&self, session_id: &str) -> Option<SessionRuntimeState> {
         let registry = self
@@ -218,6 +270,31 @@ impl ContinuitySessionStoreAdapter {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         registry.get(session_id).cloned()
+    }
+
+    async fn save_registered_snapshot(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+        data: Vec<u8>,
+        state: SessionRuntimeState,
+    ) -> Result<super::types::CheckpointVersion, meerkat_store::SessionStoreError> {
+        let version = self.next_version(&session_id.to_string());
+        let checkpoint_version = super::types::CheckpointVersion::new(version);
+        let snapshot = super::types::SessionSnapshot { data };
+        self.store
+            .save_session_snapshot(
+                &state.identity,
+                session_id,
+                state.generation,
+                checkpoint_version,
+                state.fencing_token,
+                &snapshot,
+            )
+            .await
+            .map_err(|e| {
+                meerkat_store::SessionStoreError::Internal(format!("continuity save: {e}"))
+            })?;
+        Ok(checkpoint_version)
     }
 }
 
@@ -229,52 +306,30 @@ impl meerkat::SessionStore for ContinuitySessionStoreAdapter {
     ) -> Result<(), meerkat_store::SessionStoreError> {
         let data = serde_json::to_vec(session)
             .map_err(|e| meerkat_store::SessionStoreError::Serialization(e.to_string()))?;
-        let snapshot = super::types::SessionSnapshot { data };
         let sid_str = session.id().to_string();
-        let version = self.next_version(&sid_str);
 
         // Use real identity/generation/fencing from the runtime registry.
-        let (identity, generation, fencing_token) = match self.lookup_session(&sid_str) {
-            Some(state) => (state.identity, state.generation, state.fencing_token),
+        match self.lookup_session(&sid_str) {
+            Some(state) => {
+                self.save_registered_snapshot(session.id(), data, state)
+                    .await?;
+            }
             None => {
-                // Fallback for sessions not yet registered (shouldn't happen
-                // in normal operation, but preserves backward compat).
+                // PersistentSessionService can save during member creation
+                // before the bridge call returns. Hold that first snapshot
+                // until the identity runtime registers the real owner; never
+                // checkpoint under a synthetic `_session:*` identity.
                 tracing::warn!(
                     session_id = %sid_str,
-                    "ContinuitySessionStoreAdapter: no runtime state registered for session"
+                    "ContinuitySessionStoreAdapter: delaying save until runtime state is registered"
                 );
-                let identity = match AgentIdentity::parse(&format!("_session:{sid_str}")) {
-                    Ok(id) => id,
-                    Err(_) => match AgentIdentity::parse("_adapter:fallback") {
-                        Ok(id) => id,
-                        Err(e) => {
-                            return Err(meerkat_store::SessionStoreError::Internal(format!(
-                                "failed to construct adapter identity: {e}"
-                            )));
-                        }
-                    },
-                };
-                (
-                    identity,
-                    super::types::ContinuityGeneration::new(0),
-                    super::types::FencingToken::new(0),
-                )
+                let mut pending = self
+                    .pending_unregistered
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                pending.insert(sid_str, data);
             }
-        };
-
-        self.store
-            .save_session_snapshot(
-                &identity,
-                session.id(),
-                generation,
-                super::types::CheckpointVersion::new(version),
-                fencing_token,
-                &snapshot,
-            )
-            .await
-            .map_err(|e| {
-                meerkat_store::SessionStoreError::Internal(format!("continuity save: {e}"))
-            })?;
+        }
         Ok(())
     }
 
@@ -290,6 +345,9 @@ impl meerkat::SessionStore for ContinuitySessionStoreAdapter {
                 let session: meerkat_core::Session = serde_json::from_slice(&snap.data)
                     .map_err(|e| meerkat_store::SessionStoreError::Serialization(e.to_string()))?;
                 Ok(Some(session))
+            }
+            None if self.lookup_session(&id.to_string()).is_some() => {
+                Ok(Some(meerkat_core::Session::with_id(id.clone())))
             }
             None => Ok(None),
         }
@@ -445,5 +503,141 @@ impl AgentCustomizer for SessionHookCustomizerAdapter {
     ) -> Result<(), CustomizerError> {
         self.hook.after_create(session_id, context).await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::super::contracts::ContinuityStore;
+    use super::super::local_store::LocalContinuityStore;
+    use super::super::types::{
+        AgentIdentity, AgentRuntimeId, CheckpointVersion, ContinuityGeneration, ContinuityRecord,
+        ContinuityResolveState, FencingToken,
+    };
+    use super::*;
+
+    #[tokio::test]
+    async fn continuity_session_store_adapter_seeds_registered_checkpoint_version() {
+        let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
+        let adapter = ContinuitySessionStoreAdapter::new(store.clone());
+        let session = meerkat_core::Session::new();
+        let identity = AgentIdentity::parse("agent:restored").expect("identity");
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:agent:restored:0").expect("runtime id"),
+            session_id: session.id().clone(),
+            generation: ContinuityGeneration::new(2),
+            checkpoint_version: CheckpointVersion::new(5),
+        };
+        let fencing_token = FencingToken::new(9);
+        store
+            .upsert_continuity_record(&record, fencing_token)
+            .await
+            .expect("seed record");
+
+        adapter
+            .register_session(
+                session.id(),
+                SessionRuntimeState {
+                    identity: identity.clone(),
+                    generation: record.generation,
+                    fencing_token,
+                    checkpoint_version: record.checkpoint_version,
+                },
+            )
+            .await
+            .expect("register");
+
+        meerkat::SessionStore::save(&adapter, &session)
+            .await
+            .expect("save should advance from restored checkpoint");
+        let effective_version = adapter
+            .register_session(
+                session.id(),
+                SessionRuntimeState {
+                    identity: identity.clone(),
+                    generation: record.generation,
+                    fencing_token,
+                    checkpoint_version: record.checkpoint_version,
+                },
+            )
+            .await
+            .expect("post-save register should report advanced version");
+        assert_eq!(effective_version, CheckpointVersion::new(6));
+        let resolved = store
+            .resolve_many(std::slice::from_ref(&identity))
+            .await
+            .expect("resolve");
+        let ContinuityResolveState::Ready { record } = resolved.get(&identity).expect("record")
+        else {
+            panic!("expected ready record");
+        };
+        assert_eq!(record.checkpoint_version, CheckpointVersion::new(6));
+    }
+
+    #[tokio::test]
+    async fn continuity_session_store_adapter_flushes_pending_save_under_registered_identity() {
+        let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
+        let adapter = ContinuitySessionStoreAdapter::new(store.clone());
+        let session = meerkat_core::Session::new();
+        let identity = AgentIdentity::parse("agent:fresh").expect("identity");
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:agent:fresh:0").expect("runtime id"),
+            session_id: session.id().clone(),
+            generation: ContinuityGeneration::new(0),
+            checkpoint_version: CheckpointVersion::new(0),
+        };
+        let fencing_token = FencingToken::new(3);
+        store
+            .upsert_continuity_record(&record, fencing_token)
+            .await
+            .expect("seed record");
+
+        meerkat::SessionStore::save(&adapter, &session)
+            .await
+            .expect("unregistered save should be delayed, not written under fallback identity");
+        assert!(
+            store
+                .load_session_snapshot(session.id())
+                .await
+                .expect("load before register")
+                .is_none(),
+            "unregistered save must not be visible in continuity store"
+        );
+
+        adapter
+            .register_session(
+                session.id(),
+                SessionRuntimeState {
+                    identity: identity.clone(),
+                    generation: record.generation,
+                    fencing_token,
+                    checkpoint_version: record.checkpoint_version,
+                },
+            )
+            .await
+            .expect("register flushes pending");
+
+        assert!(
+            store
+                .load_session_snapshot(session.id())
+                .await
+                .expect("load after register")
+                .is_some(),
+            "pending save should flush under the registered identity"
+        );
+        let resolved = store
+            .resolve_many(std::slice::from_ref(&identity))
+            .await
+            .expect("resolve");
+        let ContinuityResolveState::Ready { record } = resolved.get(&identity).expect("record")
+        else {
+            panic!("expected ready record");
+        };
+        assert_eq!(record.checkpoint_version, CheckpointVersion::new(1));
     }
 }

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -6,12 +6,14 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use meerkat_mob::ids::MeerkatId;
 use meerkat_mob::launch::MemberLaunchMode;
-use meerkat_mob::{MobHandle, MobSessionService, SpawnMemberSpec};
+use meerkat_mob::{MobHandle, MobSessionService, SpawnMemberSpec, SpawnSystemPromptOverride};
 
 use crate::mob_handle_runtime::{content_input_has_images, model_capabilities_for_member};
 
+use super::adapters::{ContinuitySessionStoreAdapter, SessionRuntimeState};
 use super::types::{
-    AgentBuildDraft, AgentIdentity, AgentRuntimeId, DurableAgentSpec, SessionSnapshot,
+    AgentBuildDraft, AgentIdentity, AgentRuntimeId, CheckpointVersion, ContinuityGeneration,
+    DurableAgentSpec, FencingToken, SessionSnapshot,
 };
 
 fn is_missing_event_injector_error(error: &str) -> bool {
@@ -67,6 +69,7 @@ pub trait SessionBridge: Send + Sync {
         runtime_id: &AgentRuntimeId,
         spec: &DurableAgentSpec,
         draft: &AgentBuildDraft,
+        session_id: &meerkat_core::types::SessionId,
     ) -> Result<meerkat_core::types::SessionId, BridgeError>;
 
     /// Resume a mob member from a previously checkpointed snapshot.
@@ -142,6 +145,22 @@ pub trait SessionBridge: Send + Sync {
     ) -> Result<MemberInspection, BridgeError> {
         Err(BridgeError::Mob("inspect not supported".to_string()))
     }
+
+    /// Register identity ownership for a concrete bridge session.
+    ///
+    /// Bridges that install a continuity-backed session store use this to
+    /// ensure subsequent Meerkat session saves checkpoint under the durable
+    /// identity/generation/fencing tuple.
+    async fn register_session_runtime_state(
+        &self,
+        _session_id: &meerkat_core::types::SessionId,
+        _identity: &AgentIdentity,
+        _generation: ContinuityGeneration,
+        checkpoint_version: CheckpointVersion,
+        _fencing_token: FencingToken,
+    ) -> Result<CheckpointVersion, BridgeError> {
+        Ok(checkpoint_version)
+    }
 }
 
 /// Lightweight inspection of a mob member's current execution state.
@@ -166,6 +185,8 @@ pub struct MobSessionBridge {
     session_store: Option<Arc<dyn meerkat::SessionStore>>,
     /// Session service used to project the live effective model for capability checks.
     session_service: Option<Arc<dyn MobSessionService>>,
+    /// Continuity-backed session store, when installed by the identity-first builder.
+    continuity_session_store: Option<Arc<ContinuitySessionStoreAdapter>>,
 }
 
 impl MobSessionBridge {
@@ -175,6 +196,7 @@ impl MobSessionBridge {
             handle,
             session_store: None,
             session_service: None,
+            continuity_session_store: None,
         }
     }
 
@@ -187,6 +209,7 @@ impl MobSessionBridge {
             handle,
             session_store: None,
             session_service: Some(session_service),
+            continuity_session_store: None,
         }
     }
 
@@ -199,6 +222,7 @@ impl MobSessionBridge {
             handle,
             session_store: Some(session_store),
             session_service: None,
+            continuity_session_store: None,
         }
     }
 
@@ -212,12 +236,27 @@ impl MobSessionBridge {
             handle,
             session_store: Some(session_store),
             session_service: Some(session_service),
+            continuity_session_store: None,
+        }
+    }
+
+    /// Create a bridge with an identity-owned continuity session store.
+    pub fn with_continuity_session_store(
+        handle: MobHandle,
+        session_store: Arc<ContinuitySessionStoreAdapter>,
+        session_service: Option<Arc<dyn MobSessionService>>,
+    ) -> Self {
+        Self {
+            handle,
+            session_store: Some(session_store.clone()),
+            session_service,
+            continuity_session_store: Some(session_store),
         }
     }
 }
 
 /// Build a `SpawnMemberSpec` from identity-first types, wiring draft fields.
-fn build_spawn_spec(
+pub(crate) fn build_spawn_spec(
     runtime_id: &AgentRuntimeId,
     spec: &DurableAgentSpec,
     draft: &AgentBuildDraft,
@@ -225,6 +264,12 @@ fn build_spawn_spec(
     let mid = MeerkatId::from(runtime_id.as_str());
     let mut spawn_spec = SpawnMemberSpec::new(spec.profile.clone(), mid);
 
+    if let Some(message) = spec.initial_message.as_ref() {
+        spawn_spec = spawn_spec.with_initial_message(message.clone());
+    }
+    if let Some(runtime_mode) = spec.runtime_mode_override {
+        spawn_spec = spawn_spec.with_runtime_mode(runtime_mode);
+    }
     if let Some(ref ctx) = draft.app_context {
         spawn_spec = spawn_spec.with_context(ctx.clone());
     }
@@ -233,6 +278,16 @@ fn build_spawn_spec(
     }
     if !draft.additional_instructions.is_empty() {
         spawn_spec = spawn_spec.with_additional_instructions(draft.additional_instructions.clone());
+    }
+    if let Some(model) = draft.model.as_ref() {
+        spawn_spec.model_override = Some(model.clone());
+    }
+    if let Some(system_prompt) = draft.system_prompt.as_ref() {
+        spawn_spec.system_prompt_override =
+            Some(SpawnSystemPromptOverride::Replace(system_prompt.clone()));
+    }
+    if let Some(dispatcher) = draft.local_external_tools.dispatcher() {
+        spawn_spec.external_tools = Some(dispatcher);
     }
 
     spawn_spec
@@ -246,6 +301,7 @@ impl SessionBridge for MobSessionBridge {
         runtime_id: &AgentRuntimeId,
         spec: &DurableAgentSpec,
         draft: &AgentBuildDraft,
+        session_id: &meerkat_core::types::SessionId,
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         let mid = MeerkatId::from(runtime_id.as_str());
         let spawn_spec = build_spawn_spec(runtime_id, spec, draft);
@@ -255,10 +311,13 @@ impl SessionBridge for MobSessionBridge {
             .await
             .map_err(|e| BridgeError::Mob(e.to_string()))?;
 
-        self.handle
+        let actual_session_id = self
+            .handle
             .resolve_bridge_session_id(&mid)
             .await
-            .ok_or_else(|| BridgeError::Mob("member spawned but has no session ID".to_string()))
+            .ok_or_else(|| BridgeError::Mob("member spawned but has no session ID".to_string()))?;
+        let _ = session_id;
+        Ok(actual_session_id)
     }
 
     async fn resume_session(
@@ -488,13 +547,24 @@ impl SessionBridge for MobSessionBridge {
     }
 
     async fn unwire_peer(&self, a: &AgentRuntimeId, b: &AgentRuntimeId) -> Result<(), BridgeError> {
-        self.handle
+        match self
+            .handle
             .unwire(
                 meerkat_mob::AgentIdentity::from(a.as_str()),
                 MeerkatId::from(b.as_str()),
             )
             .await
-            .map_err(|e| BridgeError::Mob(e.to_string()))
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let message = err.to_string();
+                if message.contains("peer not found") || message.contains("not wired") {
+                    Ok(())
+                } else {
+                    Err(BridgeError::Mob(message))
+                }
+            }
+        }
     }
 
     async fn inspect_member(
@@ -516,5 +586,117 @@ impl SessionBridge for MobSessionBridge {
                 .map(|pc| pc.reachable_peer_count)
                 .unwrap_or(0),
         })
+    }
+
+    async fn register_session_runtime_state(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+        identity: &AgentIdentity,
+        generation: ContinuityGeneration,
+        checkpoint_version: CheckpointVersion,
+        fencing_token: FencingToken,
+    ) -> Result<CheckpointVersion, BridgeError> {
+        if let Some(adapter) = self.continuity_session_store.as_ref() {
+            return adapter
+                .register_session(
+                    session_id,
+                    SessionRuntimeState {
+                        identity: identity.clone(),
+                        generation,
+                        checkpoint_version,
+                        fencing_token,
+                    },
+                )
+                .await
+                .map_err(|err| BridgeError::Mob(format!("continuity register_session: {err}")));
+        }
+        Ok(checkpoint_version)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use meerkat_core::agent::AgentToolDispatcher;
+    use meerkat_core::types::ToolCallView;
+    use meerkat_core::{ToolDef, error::ToolError, ops::ToolDispatchOutcome};
+    use meerkat_mob::MobRuntimeMode;
+
+    use super::*;
+    use crate::identity_first::{AgentAddressability, LocalExternalToolOverlay};
+
+    struct EmptyDispatcher;
+
+    #[async_trait]
+    impl AgentToolDispatcher for EmptyDispatcher {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            Arc::from([])
+        }
+
+        async fn dispatch(
+            &self,
+            _call: ToolCallView<'_>,
+        ) -> Result<ToolDispatchOutcome, ToolError> {
+            Err(ToolError::ExecutionFailed {
+                message: "not implemented".to_string(),
+            })
+        }
+    }
+
+    fn durable_spec() -> DurableAgentSpec {
+        DurableAgentSpec {
+            identity: AgentIdentity::parse("agent:alpha").expect("identity"),
+            profile: meerkat_mob::ProfileName::from("worker"),
+            addressability: AgentAddressability::Addressable,
+            display_name: None,
+            labels: Default::default(),
+            context: None,
+            additional_instructions: Vec::new(),
+            initial_message: Some(meerkat_core::ContentInput::Text("hello".to_string())),
+            runtime_mode_override: Some(MobRuntimeMode::TurnDriven),
+        }
+    }
+
+    #[test]
+    fn build_spawn_spec_maps_identity_first_overrides() {
+        let runtime_id = AgentRuntimeId::parse("rt:agent:alpha:0").expect("runtime id");
+        let mut labels = std::collections::BTreeMap::new();
+        labels.insert("team".to_string(), "ops".to_string());
+        let draft = AgentBuildDraft {
+            model: Some("gpt-test".to_string()),
+            system_prompt: Some("system override".to_string()),
+            additional_instructions: vec!["stay focused".to_string()],
+            labels,
+            app_context: Some(serde_json::json!({"ticket": 7})),
+            external_tools: Vec::new(),
+            local_external_tools: LocalExternalToolOverlay::new(Arc::new(EmptyDispatcher)),
+        };
+
+        let spawn = build_spawn_spec(&runtime_id, &durable_spec(), &draft);
+
+        assert_eq!(spawn.model_override.as_deref(), Some("gpt-test"));
+        assert_eq!(
+            spawn.system_prompt_override,
+            Some(SpawnSystemPromptOverride::Replace(
+                "system override".to_string()
+            ))
+        );
+        assert!(spawn.external_tools.is_some());
+        assert_eq!(spawn.runtime_mode, Some(MobRuntimeMode::TurnDriven));
+        assert_eq!(
+            spawn.initial_message,
+            Some(meerkat_core::ContentInput::Text("hello".to_string()))
+        );
+        assert_eq!(
+            spawn
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get("team"))
+                .map(String::as_str),
+            Some("ops")
+        );
     }
 }

--- a/meerkat-mobkit/src/identity_first/gateway_bridges.rs
+++ b/meerkat-mobkit/src/identity_first/gateway_bridges.rs
@@ -14,8 +14,12 @@
 //! - Errors propagate as JSON-RPC errors → typed Rust errors
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use meerkat_core::agent::AgentToolDispatcher;
+use meerkat_core::types::ToolCallView;
+use meerkat_core::{ContentBlock, ToolDef, ToolResult, error::ToolError, ops::ToolDispatchOutcome};
 use serde_json::{Value, json};
 
 use super::contracts::{
@@ -24,8 +28,8 @@ use super::contracts::{
 use super::types::{
     AgentBuildContext, AgentBuildDraft, AgentIdentity, CheckpointVersion, ContinuityGeneration,
     ContinuityResolveState, ContinuityStoreError, CustomizerError, DurableAgentSpec, FencingToken,
-    LeaseAcquireResult, LeaseError, LeaseGrant, LeaseRenewResult, ManagedPeerEdge, RosterContext,
-    RosterError, SessionSnapshot, TopologyContext, TopologyError,
+    LeaseAcquireResult, LeaseError, LeaseGrant, LeaseRenewResult, LocalExternalToolOverlay,
+    ManagedPeerEdge, RosterContext, RosterError, SessionSnapshot, TopologyContext, TopologyError,
 };
 use crate::mob_handle_runtime::SessionCreatedContext;
 
@@ -298,13 +302,92 @@ impl RosterProvider for GatewayRosterProvider {
 
 /// Gateway-side `AgentCustomizer` that delegates to Python/TypeScript via JSON-RPC.
 pub struct GatewayAgentCustomizer {
-    bridge: Box<dyn CallbackBridge>,
+    bridge: Arc<dyn CallbackBridge>,
 }
 
 impl GatewayAgentCustomizer {
     pub fn new(bridge: impl CallbackBridge + 'static) -> Self {
         Self {
-            bridge: Box::new(bridge),
+            bridge: Arc::new(bridge),
+        }
+    }
+}
+
+struct GatewayCallbackToolDispatcher {
+    bridge: Arc<dyn CallbackBridge>,
+    scope_id: String,
+    tool_defs: Arc<[Arc<ToolDef>]>,
+}
+
+impl GatewayCallbackToolDispatcher {
+    fn new(
+        bridge: Arc<dyn CallbackBridge>,
+        scope_id: String,
+        external_tools: Vec<super::types::ExternalToolDef>,
+    ) -> Self {
+        let tool_defs = external_tools
+            .into_iter()
+            .map(|tool| {
+                Arc::new(ToolDef {
+                    name: tool.name.into(),
+                    description: tool.description,
+                    input_schema: tool.input_schema,
+                    provenance: None,
+                })
+            })
+            .collect::<Vec<_>>()
+            .into();
+        Self {
+            bridge,
+            scope_id,
+            tool_defs,
+        }
+    }
+}
+
+#[async_trait]
+impl AgentToolDispatcher for GatewayCallbackToolDispatcher {
+    fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        self.tool_defs.clone()
+    }
+
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+        let args: Value =
+            serde_json::from_str(call.args.get()).map_err(|err| ToolError::InvalidArguments {
+                name: call.name.to_string(),
+                reason: err.to_string(),
+            })?;
+        let params = json!({
+            "scope_id": self.scope_id,
+            "tool": call.name,
+            "arguments": args,
+        });
+        match self.bridge.call("callback/call_tool", params).await {
+            Ok(result) => {
+                let text = result
+                    .get("content")
+                    .map(|value| {
+                        value
+                            .as_str()
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| serde_json::to_string(value).unwrap_or_default())
+                    })
+                    .unwrap_or_else(|| serde_json::to_string(&result).unwrap_or_default());
+                Ok(ToolResult {
+                    tool_use_id: call.id.to_string(),
+                    content: vec![ContentBlock::Text { text }],
+                    is_error: false,
+                }
+                .into())
+            }
+            Err(err) => Ok(ToolResult {
+                tool_use_id: call.id.to_string(),
+                content: vec![ContentBlock::Text {
+                    text: format!("Tool execution failed: {err}"),
+                }],
+                is_error: true,
+            }
+            .into()),
         }
     }
 }
@@ -332,8 +415,16 @@ impl AgentCustomizer for GatewayAgentCustomizer {
             .map_err(CustomizerError::Io)?;
 
         // The SDK returns the mutated draft. Deserialize and apply.
-        let returned_draft: AgentBuildDraft = serde_json::from_value(result)
+        let mut returned_draft: AgentBuildDraft = serde_json::from_value(result)
             .map_err(|e| CustomizerError::Io(format!("deserialize draft: {e}")))?;
+        if !returned_draft.external_tools.is_empty() {
+            returned_draft.local_external_tools =
+                LocalExternalToolOverlay::new(Arc::new(GatewayCallbackToolDispatcher::new(
+                    self.bridge.clone(),
+                    context.identity.as_str().to_string(),
+                    returned_draft.external_tools.clone(),
+                )));
+        }
         *draft = returned_draft;
         Ok(())
     }
@@ -559,6 +650,7 @@ mod tests {
             identity: id.clone(),
             active_peers: vec![],
             managed_edges: vec![],
+            runtime_services: Default::default(),
         };
         let spec = DurableAgentSpec {
             identity: id,
@@ -568,6 +660,8 @@ mod tests {
             labels: BTreeMap::new(),
             context: None,
             additional_instructions: vec![],
+            initial_message: None,
+            runtime_mode_override: None,
         };
         let mut draft = AgentBuildDraft {
             model: None,
@@ -576,6 +670,7 @@ mod tests {
             labels: BTreeMap::new(),
             app_context: None,
             external_tools: vec![],
+            local_external_tools: Default::default(),
         };
         let result = customizer
             .customize_build(&context, &spec, &mut draft)
@@ -939,6 +1034,8 @@ mod tests {
             },
             context: Some(json!({"key": "value"})),
             additional_instructions: vec!["Be helpful.".to_string()],
+            initial_message: None,
+            runtime_mode_override: None,
         }];
         mock.set_response(
             "callback/roster_provider/roster",
@@ -988,6 +1085,7 @@ mod tests {
                 description: "A custom tool".to_string(),
                 input_schema: json!({"type": "object", "properties": {"x": {"type": "string"}}}),
             }],
+            local_external_tools: Default::default(),
         };
         mock.set_response(
             "callback/agent_customizer/customize_build",
@@ -1007,6 +1105,7 @@ mod tests {
                 )
                 .unwrap(),
             ],
+            runtime_services: Default::default(),
         };
         let spec = DurableAgentSpec {
             identity: id,
@@ -1016,6 +1115,8 @@ mod tests {
             labels: BTreeMap::new(),
             context: None,
             additional_instructions: vec![],
+            initial_message: None,
+            runtime_mode_override: None,
         };
         let mut draft = AgentBuildDraft {
             model: None,
@@ -1024,6 +1125,7 @@ mod tests {
             labels: BTreeMap::new(),
             app_context: None,
             external_tools: vec![],
+            local_external_tools: Default::default(),
         };
 
         customizer
@@ -1041,6 +1143,12 @@ mod tests {
         assert_eq!(draft.labels["custom"], "label");
         assert_eq!(draft.external_tools.len(), 1);
         assert_eq!(draft.external_tools[0].name, "my_tool");
+        let dispatcher = draft
+            .local_external_tools
+            .dispatcher()
+            .expect("SDK external_tools should install a local callback dispatcher");
+        assert_eq!(dispatcher.tools().len(), 1);
+        assert_eq!(dispatcher.tools()[0].name.as_ref(), "my_tool");
 
         // Verify wire format sent to SDK
         let (method, params) = mock.last_call().await;
@@ -1118,6 +1226,8 @@ mod tests {
             labels: BTreeMap::new(),
             context: None,
             additional_instructions: vec![],
+            initial_message: None,
+            runtime_mode_override: None,
         };
         let ctx = TopologyContext {
             roster: vec![roster_spec],

--- a/meerkat-mobkit/src/identity_first/mod.rs
+++ b/meerkat-mobkit/src/identity_first/mod.rs
@@ -26,6 +26,7 @@ pub use orchestrator::{
     ReconcileAction, RestoreFlowResult, RestoreOutcome, compute_reconcile_actions, restore_flow,
 };
 pub use runtime::{
-    IdentityRuntime, IdentityRuntimeConfig, IdentityRuntimeError, wire_cross_mob_by_identity,
+    IdentityFirstRuntimeContext, IdentityRuntime, IdentityRuntimeConfig, IdentityRuntimeError,
+    wire_cross_mob_by_identity,
 };
 pub use types::*;

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -203,6 +203,7 @@ pub async fn restore_flow(
             identity: identity.clone(),
             active_peers: identities.clone(),
             managed_edges: managed_edges.clone(),
+            runtime_services: runtime.runtime_services(),
         };
 
         // Step 6: customize
@@ -213,6 +214,7 @@ pub async fn restore_flow(
             labels: spec.labels.clone(),
             app_context: spec.context.clone(),
             external_tools: Vec::new(),
+            local_external_tools: Default::default(),
         };
 
         if let Some(cust) = customizer {
@@ -236,12 +238,48 @@ pub async fn restore_flow(
                     generation: ContinuityGeneration::new(0),
                     checkpoint_version: CheckpointVersion::new(0),
                 };
+                let initial_session_id = record.session_id.clone();
+                let mut initial_record_persisted = false;
+
+                // Persist the initial record before spawning through a
+                // continuity-backed session store. PersistentSessionService
+                // saves during member creation, and the store enforces CAS
+                // against the continuity record.
+                if let Some(grant) = grants.get(identity) {
+                    runtime
+                        .continuity_store()
+                        .upsert_continuity_record(&record, grant.fencing_token)
+                        .await?;
+                    initial_record_persisted = true;
+                }
 
                 // Bridge: create the real mob member when available.
                 // Skip if the identity is already active (mob member exists).
                 if !already_active && let Some(bridge) = runtime.bridge() {
+                    if let Some(grant) = grants.get(identity) {
+                        bridge
+                            .register_session_runtime_state(
+                                &record.session_id,
+                                identity,
+                                record.generation,
+                                record.checkpoint_version,
+                                grant.fencing_token,
+                            )
+                            .await
+                            .map_err(|e| {
+                                IdentityRuntimeError::Internal(format!(
+                                    "bridge register_session_runtime_state: {e}"
+                                ))
+                            })?;
+                    }
                     let session_id = bridge
-                        .create_session(identity, &record.agent_runtime_id, spec, &draft)
+                        .create_session(
+                            identity,
+                            &record.agent_runtime_id,
+                            spec,
+                            &draft,
+                            &record.session_id,
+                        )
                         .await
                         .map_err(|e| {
                             IdentityRuntimeError::Internal(format!("bridge create_session: {e}"))
@@ -249,13 +287,32 @@ pub async fn restore_flow(
                     // Update the record with the actual session ID from the mob
                     record.session_id = session_id;
                 }
-
-                // Persist initial continuity record
-                if let Some(grant) = grants.get(identity) {
+                if let Some(grant) = grants.get(identity)
+                    && (!initial_record_persisted || record.session_id != initial_session_id)
+                {
                     runtime
                         .continuity_store()
                         .upsert_continuity_record(&record, grant.fencing_token)
                         .await?;
+                }
+                if let Some(grant) = grants.get(identity)
+                    && let Some(bridge) = runtime.bridge()
+                {
+                    let effective_checkpoint_version = bridge
+                        .register_session_runtime_state(
+                            &record.session_id,
+                            identity,
+                            record.generation,
+                            record.checkpoint_version,
+                            grant.fencing_token,
+                        )
+                        .await
+                        .map_err(|e| {
+                            IdentityRuntimeError::Internal(format!(
+                                "bridge register actual session runtime state: {e}"
+                            ))
+                        })?;
+                    record.checkpoint_version = effective_checkpoint_version;
                 }
 
                 // Register in runtime
@@ -273,6 +330,7 @@ pub async fn restore_flow(
 
             // Step 9: Ready → resume from snapshot
             ContinuityResolveState::Ready { record } => {
+                let mut record = record.clone();
                 // Step 7: load snapshot for resume injection
                 let snapshot = runtime
                     .continuity_store()
@@ -283,24 +341,38 @@ pub async fn restore_flow(
                 // Bridge: resume or create the real mob member when available.
                 // Skip if the identity is already active (mob member exists).
                 if !already_active && let Some(bridge) = runtime.bridge() {
-                    match &snapshot {
-                        Some(snap) => {
-                            bridge
-                                .resume_session(
-                                    identity,
-                                    &record.agent_runtime_id,
-                                    spec,
-                                    &draft,
-                                    &record.session_id,
-                                    snap,
-                                )
-                                .await
-                                .map_err(|e| {
-                                    IdentityRuntimeError::Internal(format!(
-                                        "bridge resume_session: {e}"
-                                    ))
-                                })?;
-                        }
+                    if let Some(grant) = grants.get(identity) {
+                        bridge
+                            .register_session_runtime_state(
+                                &record.session_id,
+                                identity,
+                                record.generation,
+                                record.checkpoint_version,
+                                grant.fencing_token,
+                            )
+                            .await
+                            .map_err(|e| {
+                                IdentityRuntimeError::Internal(format!(
+                                    "bridge register_session_runtime_state: {e}"
+                                ))
+                            })?;
+                    }
+                    let resumed_session_id = match &snapshot {
+                        Some(snap) => bridge
+                            .resume_session(
+                                identity,
+                                &record.agent_runtime_id,
+                                spec,
+                                &draft,
+                                &record.session_id,
+                                snap,
+                            )
+                            .await
+                            .map_err(|e| {
+                                IdentityRuntimeError::Internal(format!(
+                                    "bridge resume_session: {e}"
+                                ))
+                            })?,
                         None => {
                             // No snapshot but record exists — resume from session
                             // store using the session_id from the continuity record.
@@ -320,9 +392,35 @@ pub async fn restore_flow(
                                     IdentityRuntimeError::Internal(format!(
                                         "bridge resume_session (no snapshot): {e}"
                                     ))
-                                })?;
+                                })?
                         }
-                    }
+                    };
+                    record.session_id = resumed_session_id;
+                }
+                if let Some(grant) = grants.get(identity) {
+                    runtime
+                        .continuity_store()
+                        .upsert_continuity_record(&record, grant.fencing_token)
+                        .await?;
+                }
+                if let Some(bridge) = runtime.bridge()
+                    && let Some(grant) = grants.get(identity)
+                {
+                    let effective_checkpoint_version = bridge
+                        .register_session_runtime_state(
+                            &record.session_id,
+                            identity,
+                            record.generation,
+                            record.checkpoint_version,
+                            grant.fencing_token,
+                        )
+                        .await
+                        .map_err(|e| {
+                            IdentityRuntimeError::Internal(format!(
+                                "bridge register_session_runtime_state: {e}"
+                            ))
+                        })?;
+                    record.checkpoint_version = effective_checkpoint_version;
                 }
 
                 // Register in runtime

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -14,12 +14,14 @@ use futures::stream::{self, StreamExt};
 use tokio::sync::{RwLock, broadcast};
 
 use super::bridge::SessionBridge;
-use super::contracts::{ContinuityStore, LeaseProvider};
+use super::contracts::{
+    AgentCustomizer, ContinuityStore, LeaseProvider, RosterProvider, TopologyProvider,
+};
 use super::types::{
-    AgentAddressability, AgentIdentity, AgentRuntimeId, CheckpointVersion, ContinuityGeneration,
-    ContinuityHealth, ContinuityRecord, ContinuityStoreError, DispatchInput, DurabilityPolicy,
-    DurableAgentSpec, FencingToken, IdentityLifecycleState, IdentityStatus, LeaseGrant, LeaseInfo,
-    ManagedPeerEdge, NotAddressable, SessionSnapshot,
+    AgentAddressability, AgentIdentity, AgentRuntimeId, AgentRuntimeServices, CheckpointVersion,
+    ContinuityGeneration, ContinuityHealth, ContinuityRecord, ContinuityStoreError, DispatchInput,
+    DurabilityPolicy, DurableAgentSpec, FencingToken, IdentityLifecycleState, IdentityStatus,
+    LeaseGrant, LeaseInfo, ManagedPeerEdge, NotAddressable, RosterContext, SessionSnapshot,
 };
 
 const MANAGED_PEER_RECONCILE_CONCURRENCY: usize = 64;
@@ -223,6 +225,54 @@ pub struct IdentityRuntimeConfig {
     pub default_timeout: Option<Duration>,
 }
 
+#[derive(Clone)]
+pub struct IdentityFirstRuntimeContext {
+    pub runtime: Arc<IdentityRuntime>,
+    pub roster_provider: Arc<dyn RosterProvider>,
+    pub topology_provider: Option<Arc<dyn TopologyProvider>>,
+    pub customizer: Option<Arc<dyn AgentCustomizer>>,
+    mob_definition: Option<meerkat_mob::MobDefinition>,
+}
+
+impl IdentityFirstRuntimeContext {
+    pub fn new(
+        runtime: Arc<IdentityRuntime>,
+        roster_provider: Arc<dyn RosterProvider>,
+        topology_provider: Option<Arc<dyn TopologyProvider>>,
+        customizer: Option<Arc<dyn AgentCustomizer>>,
+        mob_definition: Option<meerkat_mob::MobDefinition>,
+    ) -> Self {
+        Self {
+            runtime,
+            roster_provider,
+            topology_provider,
+            customizer,
+            mob_definition,
+        }
+    }
+
+    pub async fn refresh_desired_topology(
+        &self,
+    ) -> Result<super::orchestrator::RestoreFlowResult, IdentityRuntimeError> {
+        let roster = self
+            .roster_provider
+            .roster(&RosterContext {
+                mob_definition: self.mob_definition.clone(),
+                previous_identities: Vec::new(),
+            })
+            .await
+            .map_err(|err| IdentityRuntimeError::Internal(format!("roster provider: {err}")))?;
+
+        super::orchestrator::restore_flow(
+            &self.runtime,
+            &roster,
+            self.topology_provider.as_deref(),
+            self.customizer.as_deref(),
+        )
+        .await
+    }
+}
+
 /// The identity-first runtime tracks active identities and enforces delivery,
 /// ownership, and lifecycle invariants.
 pub struct IdentityRuntime {
@@ -234,6 +284,7 @@ pub struct IdentityRuntime {
     has_runtime_store: bool,
     durability_policy: DurabilityPolicy,
     bridge: Option<Arc<dyn SessionBridge>>,
+    runtime_services: AgentRuntimeServices,
     managed_peer_edges: RwLock<BTreeSet<(AgentIdentity, AgentIdentity)>>,
     default_timeout: Duration,
 }
@@ -250,9 +301,19 @@ impl IdentityRuntime {
             has_runtime_store: config.has_runtime_store,
             durability_policy: config.durability_policy,
             bridge: config.bridge,
+            runtime_services: AgentRuntimeServices::empty(),
             managed_peer_edges: RwLock::new(BTreeSet::new()),
             default_timeout: config.default_timeout.unwrap_or(Duration::from_secs(90)),
         }
+    }
+
+    pub fn with_runtime_services(mut self, runtime_services: AgentRuntimeServices) -> Self {
+        self.runtime_services = runtime_services;
+        self
+    }
+
+    pub(crate) fn runtime_services(&self) -> AgentRuntimeServices {
+        self.runtime_services.clone()
     }
 
     #[must_use]
@@ -292,25 +353,30 @@ impl IdentityRuntime {
             .iter()
             .map(|(identity, runtime_id)| (runtime_id.clone(), identity.clone()))
             .collect();
-        let current_runtime_edges = bridge.current_member_wires().await.unwrap_or_else(|err| {
-            tracing::debug!(
-                error = %err,
-                "identity-first topology reconcile could not inspect current member wires"
-            );
-            Vec::new()
-        });
-        let current_logical_edges: BTreeSet<(AgentIdentity, AgentIdentity)> = current_runtime_edges
-            .iter()
-            .filter_map(|(runtime_a, runtime_b)| {
-                let a = runtime_identities.get(runtime_a)?;
-                let b = runtime_identities.get(runtime_b)?;
-                if a <= b {
-                    Some((a.clone(), b.clone()))
-                } else {
-                    Some((b.clone(), a.clone()))
+        let current_logical_edges: Option<BTreeSet<(AgentIdentity, AgentIdentity)>> =
+            match bridge.current_member_wires().await {
+                Ok(current_runtime_edges) => Some(
+                    current_runtime_edges
+                        .iter()
+                        .filter_map(|(runtime_a, runtime_b)| {
+                            let a = runtime_identities.get(runtime_a)?;
+                            let b = runtime_identities.get(runtime_b)?;
+                            if a <= b {
+                                Some((a.clone(), b.clone()))
+                            } else {
+                                Some((b.clone(), a.clone()))
+                            }
+                        })
+                        .collect(),
+                ),
+                Err(err) => {
+                    tracing::debug!(
+                        error = %err,
+                        "identity-first topology reconcile could not inspect current member wires"
+                    );
+                    None
                 }
-            })
-            .collect();
+            };
 
         let desired: BTreeSet<(AgentIdentity, AgentIdentity)> = desired_edges
             .iter()
@@ -321,14 +387,22 @@ impl IdentityRuntime {
         let retained_logical_edges: Vec<(AgentIdentity, AgentIdentity)> = desired
             .iter()
             .filter(|edge| !managed_snapshot.contains(*edge))
-            .filter(|edge| current_logical_edges.contains(*edge))
+            .filter(|edge| {
+                current_logical_edges
+                    .as_ref()
+                    .is_some_and(|edges| edges.contains(*edge))
+            })
             .filter(|(a, b)| active_runtimes.contains_key(a) && active_runtimes.contains_key(b))
             .cloned()
             .collect();
         let to_wire: Vec<(AgentIdentity, AgentIdentity, AgentRuntimeId, AgentRuntimeId)> = desired
             .iter()
             .filter(|edge| !managed_snapshot.contains(*edge))
-            .filter(|edge| !current_logical_edges.contains(*edge))
+            .filter(|edge| {
+                current_logical_edges
+                    .as_ref()
+                    .is_none_or(|edges| !edges.contains(*edge))
+            })
             .filter_map(|(a, b)| {
                 let runtime_a = active_runtimes.get(a)?;
                 let runtime_b = active_runtimes.get(b)?;
@@ -346,8 +420,9 @@ impl IdentityRuntime {
             .filter_map(|(a, b)| {
                 let runtime_a = active_runtimes.get(a)?;
                 let runtime_b = active_runtimes.get(b)?;
-                if !current_logical_edges.is_empty()
-                    && !current_logical_edges.contains(&(a.clone(), b.clone()))
+                if current_logical_edges
+                    .as_ref()
+                    .is_some_and(|edges| !edges.contains(&(a.clone(), b.clone())))
                 {
                     return None;
                 }
@@ -721,6 +796,7 @@ impl IdentityRuntime {
                 .map(|c| c.agent_runtime_id.clone()),
             session_id: entry.continuity.as_ref().map(|c| c.session_id.clone()),
             profile: Some(entry.spec.profile.clone()),
+            runtime_mode: entry.spec.runtime_mode_override,
             addressability: entry.spec.addressability,
             display_name: entry.spec.display_name.clone(),
             labels: entry.spec.labels.clone(),
@@ -935,9 +1011,30 @@ impl IdentityRuntime {
                     labels: spec.labels.clone(),
                     app_context: spec.context.clone(),
                     external_tools: Vec::new(),
+                    local_external_tools: Default::default(),
                 };
+                bridge
+                    .register_session_runtime_state(
+                        &new_record.session_id,
+                        identity,
+                        new_record.generation,
+                        new_record.checkpoint_version,
+                        grant.fencing_token,
+                    )
+                    .await
+                    .map_err(|e| {
+                        IdentityRuntimeError::Internal(format!(
+                            "bridge register_session_runtime_state after reset: {e}"
+                        ))
+                    })?;
                 let session_id = bridge
-                    .create_session(identity, &new_record.agent_runtime_id, &spec, &draft)
+                    .create_session(
+                        identity,
+                        &new_record.agent_runtime_id,
+                        &spec,
+                        &draft,
+                        &new_record.session_id,
+                    )
                     .await
                     .map_err(|e| {
                         IdentityRuntimeError::Internal(format!(
@@ -945,13 +1042,31 @@ impl IdentityRuntime {
                         ))
                     })?;
                 // Update the record with the actual session ID
+                let initial_session_id = new_record.session_id.clone();
                 let mut new_record = new_record;
                 new_record.session_id = session_id;
 
                 // Persist the updated record
-                self.continuity_store
-                    .upsert_continuity_record(&new_record, grant.fencing_token)
-                    .await?;
+                if new_record.session_id != initial_session_id {
+                    self.continuity_store
+                        .upsert_continuity_record(&new_record, grant.fencing_token)
+                        .await?;
+                }
+                let effective_checkpoint_version = bridge
+                    .register_session_runtime_state(
+                        &new_record.session_id,
+                        identity,
+                        new_record.generation,
+                        new_record.checkpoint_version,
+                        grant.fencing_token,
+                    )
+                    .await
+                    .map_err(|e| {
+                        IdentityRuntimeError::Internal(format!(
+                            "bridge register actual session runtime state after reset: {e}"
+                        ))
+                    })?;
+                new_record.checkpoint_version = effective_checkpoint_version;
 
                 // Update runtime state
                 let mut entries = self.entries.write().await;
@@ -963,7 +1078,7 @@ impl IdentityRuntime {
                         acquired_at: Instant::now(),
                     });
                     entry.state = IdentityLifecycleState::Active;
-                    entry.checkpoint_version = CheckpointVersion::new(0);
+                    entry.checkpoint_version = new_record.checkpoint_version;
                 }
                 return Ok(new_record);
             }
@@ -1134,6 +1249,7 @@ impl IdentityRuntime {
                     .map(|c| c.agent_runtime_id.clone()),
                 session_id: entry.continuity.as_ref().map(|c| c.session_id.clone()),
                 profile: Some(entry.spec.profile.clone()),
+                runtime_mode: entry.spec.runtime_mode_override,
                 addressability: entry.spec.addressability,
                 display_name: entry.spec.display_name.clone(),
                 labels: entry.spec.labels.clone(),

--- a/meerkat-mobkit/src/identity_first/types.rs
+++ b/meerkat-mobkit/src/identity_first/types.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -563,6 +565,10 @@ pub struct DurableAgentSpec {
     pub context: Option<serde_json::Value>,
     #[serde(default)]
     pub additional_instructions: Vec<String>,
+    #[serde(default)]
+    pub initial_message: Option<meerkat_core::ContentInput>,
+    #[serde(default)]
+    pub runtime_mode_override: Option<meerkat_mob::MobRuntimeMode>,
 }
 
 // ---------------------------------------------------------------------------
@@ -616,6 +622,7 @@ pub struct IdentityStatus {
     pub agent_runtime_id: Option<AgentRuntimeId>,
     pub session_id: Option<meerkat_core::types::SessionId>,
     pub profile: Option<meerkat_mob::ProfileName>,
+    pub runtime_mode: Option<meerkat_mob::MobRuntimeMode>,
     pub addressability: AgentAddressability,
     pub display_name: Option<DisplayName>,
     #[serde(default)]
@@ -630,12 +637,55 @@ pub struct IdentityStatus {
 // AgentBuildContext + AgentBuildDraft + ExternalToolDef
 // ---------------------------------------------------------------------------
 
+#[derive(Clone, Default)]
+pub struct AgentRuntimeServices {
+    mob_handle: Option<meerkat_mob::MobHandle>,
+}
+
+impl AgentRuntimeServices {
+    pub fn new(mob_handle: meerkat_mob::MobHandle) -> Self {
+        Self {
+            mob_handle: Some(mob_handle),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self { mob_handle: None }
+    }
+
+    pub fn mob_handle(&self) -> Option<meerkat_mob::MobHandle> {
+        self.mob_handle.clone()
+    }
+
+    pub fn has_mob_handle(&self) -> bool {
+        self.mob_handle.is_some()
+    }
+}
+
+impl std::fmt::Debug for AgentRuntimeServices {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentRuntimeServices")
+            .field("mob_handle", &self.mob_handle.is_some())
+            .finish()
+    }
+}
+
+impl PartialEq for AgentRuntimeServices {
+    fn eq(&self, other: &Self) -> bool {
+        self.mob_handle.is_some() == other.mob_handle.is_some()
+    }
+}
+
+impl Eq for AgentRuntimeServices {}
+
 /// Read-only context provided to `AgentCustomizer` at build time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentBuildContext {
     pub identity: AgentIdentity,
     pub active_peers: Vec<AgentIdentity>,
     pub managed_edges: Vec<ManagedPeerEdge>,
+    #[serde(default, skip)]
+    pub runtime_services: AgentRuntimeServices,
 }
 
 /// Tool definition for the customizer boundary.
@@ -647,6 +697,52 @@ pub struct ExternalToolDef {
 }
 
 /// Mutable draft that `AgentCustomizer` modifies.
+#[derive(Clone, Default)]
+pub struct LocalExternalToolOverlay {
+    dispatcher: Option<Arc<dyn meerkat_core::agent::AgentToolDispatcher>>,
+}
+
+impl LocalExternalToolOverlay {
+    pub fn new(dispatcher: Arc<dyn meerkat_core::agent::AgentToolDispatcher>) -> Self {
+        Self {
+            dispatcher: Some(dispatcher),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self { dispatcher: None }
+    }
+
+    pub fn dispatcher(&self) -> Option<Arc<dyn meerkat_core::agent::AgentToolDispatcher>> {
+        self.dispatcher.clone()
+    }
+
+    pub fn is_some(&self) -> bool {
+        self.dispatcher.is_some()
+    }
+}
+
+impl std::fmt::Debug for LocalExternalToolOverlay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalExternalToolOverlay")
+            .field("dispatcher", &self.dispatcher.is_some())
+            .finish()
+    }
+}
+
+impl PartialEq for LocalExternalToolOverlay {
+    fn eq(&self, other: &Self) -> bool {
+        self.dispatcher.is_some() == other.dispatcher.is_some()
+    }
+}
+
+impl Eq for LocalExternalToolOverlay {}
+
+/// Mutable draft that `AgentCustomizer` modifies.
+///
+/// `external_tools` remains the serializable SDK/gateway declaration surface.
+/// `local_external_tools` is intentionally skipped by serde and is the
+/// in-process Rust overlay for apps that can supply a real dispatcher.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentBuildDraft {
     pub model: Option<String>,
@@ -658,6 +754,8 @@ pub struct AgentBuildDraft {
     pub app_context: Option<serde_json::Value>,
     #[serde(default)]
     pub external_tools: Vec<ExternalToolDef>,
+    #[serde(default, skip)]
+    pub local_external_tools: LocalExternalToolOverlay,
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -1086,6 +1086,7 @@ pub async fn handle_unified_rpc_json(
             if identity_ctx.is_some() {
                 methods.extend_from_slice(&[
                     "mobkit/send",
+                    "mobkit/interact",
                     "mobkit/dispatch",
                     "mobkit/subscribe",
                     "mobkit/status_identity",
@@ -1989,6 +1990,102 @@ pub async fn handle_unified_rpc_json(
                     error: None,
                 },
                 Err(e) => identity_error_response(response_id, &e),
+            }
+        }
+        "mobkit/interact" => {
+            let identity_rt = match identity_ctx {
+                Some(ctx) => &*ctx.runtime,
+                None => return identity_not_configured(response_id),
+            };
+            let identity_str = request
+                .params
+                .get("identity")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let identity = match crate::identity_first::AgentIdentity::parse(identity_str) {
+                Ok(id) => id,
+                Err(e) => {
+                    return error_response(response_id, -32602, format!("invalid identity: {e}"));
+                }
+            };
+            let content_val = request
+                .params
+                .get("content")
+                .cloned()
+                .unwrap_or(Value::Null);
+            let content =
+                match serde_json::from_value::<meerkat_core::ContentInput>(content_val.clone()) {
+                    Ok(content) => content,
+                    Err(err) => {
+                        return error_response(
+                            response_id,
+                            -32602,
+                            format!("invalid content: {err}"),
+                        );
+                    }
+                };
+            let origin = request
+                .params
+                .get("origin")
+                .and_then(|v| v.as_str())
+                .unwrap_or("console");
+            let interaction_id = request
+                .params
+                .get("interaction_id")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string)
+                .unwrap_or_else(|| meerkat_core::types::SessionId::new().to_string());
+            let runtime_member_id = identity_rt
+                .status(&identity)
+                .await
+                .ok()
+                .and_then(|status| status.agent_runtime_id.map(|id| id.as_str().to_string()));
+
+            if let Err(err) = runtime
+                .reserve_identity_interaction(
+                    identity.as_str(),
+                    runtime_member_id.as_deref(),
+                    &interaction_id,
+                    origin,
+                    content_val,
+                )
+                .await
+            {
+                return error_response(
+                    response_id,
+                    -32003,
+                    format!("failed to reserve interaction: {err}"),
+                );
+            }
+
+            match identity_rt.send(&identity, &content).await {
+                Ok(token) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id,
+                    result: Some(serde_json::json!({
+                        "interaction_id": interaction_id,
+                        "fencing_token": token.get(),
+                        "stream": {
+                            "route": format!("/console/identity/{}/stream", identity.as_str()),
+                            "identity": identity.as_str(),
+                        }
+                    })),
+                    error: None,
+                },
+                Err(e) => {
+                    runtime
+                        .record_console_lifecycle(
+                            identity.as_str(),
+                            "interaction_failed",
+                            serde_json::json!({
+                                "interaction_id": interaction_id,
+                                "origin": origin,
+                                "error": e.to_string(),
+                            }),
+                        )
+                        .await;
+                    identity_error_response(response_id, &e)
+                }
             }
         }
         "mobkit/dispatch" => {

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -9,6 +9,11 @@ use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
 
 use crate::console_aggregator::{ConsoleLogStore, InMemoryConsoleLogStore, SqliteConsoleLogStore};
 use crate::contact_directory::ContactDirectory;
+use crate::identity_first::{
+    AgentCustomizer, AgentRuntimeServices, ContinuitySessionStoreAdapter, DurabilityPolicy,
+    IdentityFirstRuntimeContext, IdentityRuntime, IdentityRuntimeConfig, RosterContext,
+    RosterProvider, TopologyProvider, restore_flow,
+};
 use crate::mob_handle_runtime::{
     CapabilityFlags, MobBootstrapOptions, MobBootstrapSpec, SessionHook,
 };
@@ -55,6 +60,10 @@ pub struct UnifiedRuntimeBuilder {
     // --- Identity-first external path ---
     continuity_store: Option<Arc<dyn crate::identity_first::contracts::ContinuityStore>>,
     lease_provider: Option<Arc<dyn crate::identity_first::contracts::LeaseProvider>>,
+    roster_provider: Option<Arc<dyn RosterProvider>>,
+    topology_provider: Option<Arc<dyn TopologyProvider>>,
+    agent_customizer: Option<Arc<dyn AgentCustomizer>>,
+    identity_runtime_instance_id: Option<String>,
     scratch_dir: Option<PathBuf>,
     blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
     console_log_store: Option<Arc<dyn ConsoleLogStore>>,
@@ -153,6 +162,30 @@ impl UnifiedRuntimeBuilder {
         provider: Arc<dyn crate::identity_first::contracts::LeaseProvider>,
     ) -> Self {
         self.lease_provider = Some(provider);
+        self
+    }
+
+    /// Set the desired identity roster provider for identity-first bootstrap.
+    pub fn roster_provider(mut self, provider: Arc<dyn RosterProvider>) -> Self {
+        self.roster_provider = Some(provider);
+        self
+    }
+
+    /// Set the managed topology provider for identity-first bootstrap and refresh.
+    pub fn topology_provider(mut self, provider: Arc<dyn TopologyProvider>) -> Self {
+        self.topology_provider = Some(provider);
+        self
+    }
+
+    /// Set the identity-first build customizer.
+    pub fn agent_customizer(mut self, customizer: Arc<dyn AgentCustomizer>) -> Self {
+        self.agent_customizer = Some(customizer);
+        self
+    }
+
+    /// Set the identity runtime instance id used when acquiring leases.
+    pub fn identity_runtime_instance_id(mut self, id: impl Into<String>) -> Self {
+        self.identity_runtime_instance_id = Some(id.into());
         self
     }
 
@@ -321,20 +354,35 @@ impl UnifiedRuntimeBuilder {
         let has_persistent_state = self.persistent_state_path.is_some();
         let has_continuity_store = self.continuity_store.is_some();
         let has_lease_provider = self.lease_provider.is_some();
+        let has_roster_provider = self.roster_provider.is_some();
+        let has_topology_provider = self.topology_provider.is_some();
+        let has_agent_customizer = self.agent_customizer.is_some();
+        let has_identity_runtime_instance_id = self.identity_runtime_instance_id.is_some();
         let has_scratch_dir = self.scratch_dir.is_some();
-        let has_any_external = has_continuity_store || has_lease_provider || has_scratch_dir;
+        let has_any_external = has_continuity_store
+            || has_lease_provider
+            || has_roster_provider
+            || has_topology_provider
+            || has_agent_customizer
+            || has_identity_runtime_instance_id
+            || has_scratch_dir;
 
         // REQ-23: persistent_state and explicit providers are mutually exclusive
         if has_persistent_state && has_any_external {
             return Err(UnifiedRuntimeBuilderError::ConflictingConfiguration(
-                "persistent_state() and continuity_store()/lease_provider()/scratch_dir() \
+                "persistent_state() and identity-first provider/customizer/scratch_dir setters \
                  are mutually exclusive — use one path or the other"
                     .to_string(),
             ));
         }
 
         // REQ-24: external path requires all three
-        if has_any_external && !(has_continuity_store && has_lease_provider && has_scratch_dir) {
+        if has_any_external
+            && !(has_continuity_store
+                && has_lease_provider
+                && has_roster_provider
+                && has_scratch_dir)
+        {
             let mut missing = Vec::new();
             if !has_continuity_store {
                 missing.push("continuity_store");
@@ -342,16 +390,27 @@ impl UnifiedRuntimeBuilder {
             if !has_lease_provider {
                 missing.push("lease_provider");
             }
+            if !has_roster_provider {
+                missing.push("roster_provider");
+            }
             if !has_scratch_dir {
                 missing.push("scratch_dir");
             }
             return Err(UnifiedRuntimeBuilderError::ConflictingConfiguration(
                 format!(
-                    "external-authoritative path requires continuity_store() + lease_provider() + \
-                     scratch_dir(); missing: {}",
+                    "identity-first path requires continuity_store() + lease_provider() + \
+                     roster_provider() + scratch_dir(); missing: {}",
                     missing.join(", ")
                 ),
             ));
+        }
+
+        let continuity_session_store = self
+            .continuity_store
+            .as_ref()
+            .map(|store| Arc::new(ContinuitySessionStoreAdapter::new(store.clone())));
+        if let Some(store) = continuity_session_store.as_ref() {
+            self.custom_session_store = Some(store.clone());
         }
 
         // Legacy mob_spec path takes precedence — must be consumed before
@@ -447,22 +506,116 @@ impl UnifiedRuntimeBuilder {
             let handle = runtime.mob_runtime.handle();
             let session_service = runtime.mob_runtime.session_service().cloned();
             let session_store = self.custom_session_store.clone();
-            let bridge = if let (Some(store), Some(service)) =
-                (session_store.clone(), session_service.clone())
-            {
-                crate::identity_first::bridge::MobSessionBridge::with_session_store_and_service(
-                    handle, store, service,
+            let bridge: Arc<dyn crate::identity_first::bridge::SessionBridge> =
+                if let Some(store) = continuity_session_store.clone() {
+                    Arc::new(
+                    crate::identity_first::bridge::MobSessionBridge::with_continuity_session_store(
+                        handle,
+                        store,
+                        session_service,
+                    ),
                 )
-            } else if let Some(store) = session_store {
-                crate::identity_first::bridge::MobSessionBridge::with_session_store(handle, store)
-            } else if let Some(service) = session_service {
-                crate::identity_first::bridge::MobSessionBridge::with_session_service(
-                    handle, service,
+                } else if let (Some(store), Some(service)) =
+                    (session_store.clone(), session_service.clone())
+                {
+                    Arc::new(
+                    crate::identity_first::bridge::MobSessionBridge::with_session_store_and_service(
+                        handle, store, service,
+                    ),
                 )
-            } else {
-                crate::identity_first::bridge::MobSessionBridge::new(handle)
+                } else if let Some(store) = session_store {
+                    Arc::new(
+                        crate::identity_first::bridge::MobSessionBridge::with_session_store(
+                            handle, store,
+                        ),
+                    )
+                } else if let Some(service) = session_service {
+                    Arc::new(
+                        crate::identity_first::bridge::MobSessionBridge::with_session_service(
+                            handle, service,
+                        ),
+                    )
+                } else {
+                    Arc::new(crate::identity_first::bridge::MobSessionBridge::new(handle))
+                };
+            Some(bridge)
+        };
+
+        let identity_first_context = if has_any_external {
+            let Some(continuity_store) = self.continuity_store.clone() else {
+                return Err(UnifiedRuntimeBuilderError::Bootstrap(
+                    UnifiedRuntimeBootstrapError::IdentityFirst(
+                        "identity-first validation requires continuity_store".to_string(),
+                    ),
+                ));
             };
-            Some(Arc::new(bridge))
+            let Some(lease_provider) = self.lease_provider.clone() else {
+                return Err(UnifiedRuntimeBuilderError::Bootstrap(
+                    UnifiedRuntimeBootstrapError::IdentityFirst(
+                        "identity-first validation requires lease_provider".to_string(),
+                    ),
+                ));
+            };
+            let Some(roster_provider) = self.roster_provider.clone() else {
+                return Err(UnifiedRuntimeBuilderError::Bootstrap(
+                    UnifiedRuntimeBootstrapError::IdentityFirst(
+                        "identity-first validation requires roster_provider".to_string(),
+                    ),
+                ));
+            };
+            let bridge = session_bridge.clone();
+            let identity_runtime = Arc::new(
+                IdentityRuntime::new(IdentityRuntimeConfig {
+                    continuity_store,
+                    lease_provider,
+                    runtime_instance_id: self
+                        .identity_runtime_instance_id
+                        .clone()
+                        .unwrap_or_else(|| format!("mobkit-{}", std::process::id())),
+                    has_runtime_store: true,
+                    durability_policy: DurabilityPolicy::SyncWriteThrough,
+                    bridge,
+                    default_timeout: None,
+                })
+                .with_runtime_services(AgentRuntimeServices::new(runtime.mob_runtime.handle())),
+            );
+
+            let roster_specs = roster_provider
+                .roster(&RosterContext {
+                    mob_definition: Some(runtime.mob_runtime.handle().definition().clone()),
+                    previous_identities: Vec::new(),
+                })
+                .await
+                .map_err(|err| {
+                    UnifiedRuntimeBuilderError::Bootstrap(
+                        UnifiedRuntimeBootstrapError::IdentityFirst(format!(
+                            "roster provider failed: {err}"
+                        )),
+                    )
+                })?;
+
+            restore_flow(
+                &identity_runtime,
+                &roster_specs,
+                self.topology_provider.as_deref(),
+                self.agent_customizer.as_deref(),
+            )
+            .await
+            .map_err(|err| {
+                UnifiedRuntimeBuilderError::Bootstrap(UnifiedRuntimeBootstrapError::IdentityFirst(
+                    format!("restore_flow failed: {err}"),
+                ))
+            })?;
+
+            Some(Arc::new(IdentityFirstRuntimeContext::new(
+                identity_runtime,
+                roster_provider,
+                self.topology_provider.clone(),
+                self.agent_customizer.clone(),
+                Some(runtime.mob_runtime.handle().definition().clone()),
+            )))
+        } else {
+            None
         };
 
         // Set immutable outer fields by rebuilding the struct
@@ -475,6 +628,7 @@ impl UnifiedRuntimeBuilder {
             edge_discovery: self.edge_discovery,
             contact_directory: self.contact_directory,
             session_bridge,
+            identity_first_context,
             console_log_store,
             ..runtime
         };
@@ -488,7 +642,9 @@ impl UnifiedRuntimeBuilder {
         } else {
             serde_json::Value::Null
         };
-        if let Some(ref discovery) = runtime.discovery {
+        if runtime.identity_first_context.is_none()
+            && let Some(ref discovery) = runtime.discovery
+        {
             let specs = discovery.discover(pre_spawn_context).await;
             let spawn_specs: Vec<SpawnMemberSpec> =
                 specs.iter().map(discovery_spec_to_spawn_spec).collect();
@@ -609,6 +765,25 @@ impl UnifiedRuntimeBuilder {
                 hook,
                 caps,
                 after_hook.clone(),
+            )
+        } else if let Some(ref scratch_dir) = self.scratch_dir {
+            std::fs::create_dir_all(scratch_dir).map_err(|e| {
+                UnifiedRuntimeBuilderError::Io(format!(
+                    "failed to create scratch directory at {}: {e}",
+                    scratch_dir.display()
+                ))
+            })?;
+
+            MobBootstrapSpec::ephemeral_runtime_backed_inner(
+                definition,
+                MobStorage::in_memory(),
+                scratch_dir.clone(),
+                max_sessions,
+                self.custom_session_store.clone(),
+                self.blob_store.clone(),
+                hook,
+                caps,
+                after_hook,
             )
         } else {
             // Ephemeral: create a temp dir that lives as long as the runtime.

--- a/meerkat-mobkit/src/unified_runtime/http.rs
+++ b/meerkat-mobkit/src/unified_runtime/http.rs
@@ -53,6 +53,7 @@ impl UnifiedRuntime {
             Some(self.console_log_store()),
             Some(self.mob_events_store()),
             Some(Arc::clone(self.metadata_table())),
+            self.identity_runtime().cloned(),
             visibility_policy,
         )
     }

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -144,6 +144,7 @@ pub struct UnifiedRuntime {
 
     // Identity-first session bridge
     session_bridge: Option<Arc<dyn crate::identity_first::bridge::SessionBridge>>,
+    identity_first_context: Option<Arc<crate::identity_first::IdentityFirstRuntimeContext>>,
 
     // Mobkit-side label sidecar for mob- and run-scoped metadata
     metadata_table: Arc<RuntimeMetadataTable>,
@@ -212,6 +213,7 @@ impl UnifiedRuntime {
             peer_mob_handles: tokio::sync::RwLock::new(BTreeMap::new()),
             gateway_peer_keys: None,
             session_bridge: None,
+            identity_first_context: None,
             metadata_table,
             persistent_metadata,
         }
@@ -337,6 +339,35 @@ impl UnifiedRuntime {
     /// Return the session bridge for identity-first operations, if configured.
     pub fn session_bridge(&self) -> Option<&Arc<dyn crate::identity_first::bridge::SessionBridge>> {
         self.session_bridge.as_ref()
+    }
+
+    pub fn identity_first_context(
+        &self,
+    ) -> Option<&Arc<crate::identity_first::IdentityFirstRuntimeContext>> {
+        self.identity_first_context.as_ref()
+    }
+
+    pub fn identity_runtime(&self) -> Option<&Arc<crate::identity_first::IdentityRuntime>> {
+        self.identity_first_context.as_ref().map(|ctx| &ctx.runtime)
+    }
+
+    pub fn attach_identity_first_context(
+        &mut self,
+        context: Arc<crate::identity_first::IdentityFirstRuntimeContext>,
+    ) {
+        self.identity_first_context = Some(context);
+    }
+
+    pub async fn refresh_desired_topology(
+        &self,
+    ) -> Result<
+        Option<crate::identity_first::RestoreFlowResult>,
+        crate::identity_first::IdentityRuntimeError,
+    > {
+        match self.identity_first_context.as_ref() {
+            Some(ctx) => ctx.refresh_desired_topology().await.map(Some),
+            None => Ok(None),
+        }
     }
 
     /// Return the mob/run label sidecar table.
@@ -471,6 +502,19 @@ impl UnifiedRuntime {
         self.console_events
             .record_lifecycle(identity, event_type, data)
             .await;
+    }
+
+    pub async fn reserve_identity_interaction(
+        &self,
+        identity: &str,
+        runtime_member_id: Option<&str>,
+        interaction_id: &str,
+        origin: &str,
+        content: serde_json::Value,
+    ) -> Result<(), &'static str> {
+        self.console_events
+            .reserve_interaction_value(identity, runtime_member_id, interaction_id, origin, content)
+            .await
     }
 
     pub(crate) async fn project_console_event_from_unified(

--- a/meerkat-mobkit/src/unified_runtime/types.rs
+++ b/meerkat-mobkit/src/unified_runtime/types.rs
@@ -46,6 +46,7 @@ pub enum UnifiedRuntimeBootstrapError {
         rollback_error: MobRuntimeError,
     },
     PreSpawnHook(String),
+    IdentityFirst(String),
 }
 
 impl Display for UnifiedRuntimeBootstrapError {
@@ -61,6 +62,9 @@ impl Display for UnifiedRuntimeBootstrapError {
             }
             Self::PreSpawnHook(err) => {
                 write!(f, "pre-spawn hook failed: {err}")
+            }
+            Self::IdentityFirst(err) => {
+                write!(f, "identity-first bootstrap failed: {err}")
             }
             Self::ModuleStartupRollbackFailed {
                 startup_error,

--- a/meerkat-mobkit/tests/identity_first_boundary.rs
+++ b/meerkat-mobkit/tests/identity_first_boundary.rs
@@ -142,6 +142,8 @@ system_prompt = "You are a worker agent."
         labels: std::collections::BTreeMap::new(),
         context: None,
         additional_instructions: vec![],
+        initial_message: None,
+        runtime_mode_override: None,
     };
 
     // The fact that this compiles proves ProfileName type compatibility

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -14,11 +14,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use meerkat_mobkit::identity_first::contracts::{ContinuityStore, LeaseProvider};
+use meerkat_mobkit::identity_first::contracts::{
+    ContinuityStore, LeaseProvider, RosterProvider, TopologyProvider,
+};
 use meerkat_mobkit::identity_first::{
-    AgentIdentity, CheckpointVersion, ContinuityGeneration, ContinuityRecord,
-    ContinuityResolveState, ContinuityStoreError, FencingToken, LeaseAcquireResult, LeaseError,
-    LeaseGrant, LeaseRenewResult, SessionSnapshot,
+    AgentAddressability, AgentIdentity, CheckpointVersion, ContinuityGeneration, ContinuityRecord,
+    ContinuityResolveState, ContinuityStoreError, DurableAgentSpec, FencingToken,
+    LeaseAcquireResult, LeaseError, LeaseGrant, LeaseRenewResult, LocalContinuityStore,
+    ManagedPeerEdge, RosterContext, RosterError, SessionSnapshot, TopologyContext, TopologyError,
 };
 use meerkat_mobkit::unified_runtime::UnifiedRuntimeBuilder;
 
@@ -103,6 +106,72 @@ impl LeaseProvider for StubLeaseProvider {
     }
     async fn release_leases(&self, _grants: &[LeaseGrant]) -> Result<(), LeaseError> {
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct StubRosterProvider {
+    specs: Arc<tokio::sync::Mutex<Vec<DurableAgentSpec>>>,
+}
+
+impl StubRosterProvider {
+    fn new(specs: Vec<DurableAgentSpec>) -> Self {
+        Self {
+            specs: Arc::new(tokio::sync::Mutex::new(specs)),
+        }
+    }
+}
+
+#[async_trait]
+impl RosterProvider for StubRosterProvider {
+    async fn roster(&self, _context: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        Ok(self.specs.lock().await.clone())
+    }
+}
+
+struct StubTopologyProvider {
+    edges: Arc<tokio::sync::Mutex<Vec<ManagedPeerEdge>>>,
+}
+
+#[async_trait]
+impl TopologyProvider for StubTopologyProvider {
+    async fn compute_edges(
+        &self,
+        _target_identities: &[AgentIdentity],
+        _context: &TopologyContext,
+    ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+        Ok(self.edges.lock().await.clone())
+    }
+}
+
+fn test_definition() -> meerkat_mob::MobDefinition {
+    meerkat_mob::MobDefinition::from_toml(
+        r#"
+[mob]
+id = "identity-builder-test"
+
+[profiles.default]
+model = "gpt-5.5"
+runtime_mode = "turn_driven"
+
+[profiles.default.tools]
+comms = true
+"#,
+    )
+    .unwrap()
+}
+
+fn durable_spec(identity: &str) -> DurableAgentSpec {
+    DurableAgentSpec {
+        identity: AgentIdentity::parse(identity).unwrap(),
+        profile: meerkat_mob::ProfileName::from("default"),
+        addressability: AgentAddressability::Addressable,
+        display_name: None,
+        labels: BTreeMap::new(),
+        context: None,
+        additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: Some(meerkat_mob::MobRuntimeMode::TurnDriven),
     }
 }
 
@@ -192,6 +261,16 @@ async fn identity_first_builder_external_path_missing_scratch_dir() {
 }
 
 #[tokio::test]
+async fn identity_first_builder_identity_first_optional_setters_require_core_providers() {
+    let builder = UnifiedRuntimeBuilder::default()
+        .topology_provider(Arc::new(StubTopologyProvider {
+            edges: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        }))
+        .identity_runtime_instance_id("builder-test");
+    assert_build_err_contains(builder, "roster_provider").await;
+}
+
+#[tokio::test]
 async fn identity_first_builder_blob_store_accepted_with_persistent_state() {
     // blob_store should be accepted alongside persistent_state without
     // triggering a conflict error. The build will fail later (missing definition).
@@ -210,11 +289,189 @@ async fn identity_first_builder_blob_store_accepted_with_external_path() {
     let builder = UnifiedRuntimeBuilder::default()
         .continuity_store(Arc::new(StubContinuityStore))
         .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(Arc::new(StubRosterProvider::new(vec![])))
         .scratch_dir(tmp.path())
         .blob_store(Arc::new(meerkat_store::FsBlobStore::new(
             tmp.path().join("blobs"),
         )));
     assert_build_err_not_contains(builder, "mutually exclusive", "conflicting").await;
+}
+
+#[tokio::test]
+async fn identity_first_builder_bootstraps_and_exposes_identity_runtime() {
+    let tmp = tempfile::tempdir().unwrap();
+    let roster = Arc::new(StubRosterProvider::new(vec![durable_spec("agent:alpha")]));
+
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(Arc::new(StubContinuityStore))
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(roster)
+        .scratch_dir(tmp.path())
+        .identity_runtime_instance_id("builder-test")
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("builder should bootstrap identity-first runtime");
+
+    let identity_runtime = runtime
+        .identity_runtime()
+        .expect("identity runtime should be exposed");
+    let status = identity_runtime
+        .status(&AgentIdentity::parse("agent:alpha").unwrap())
+        .await
+        .expect("identity should be active");
+    assert_eq!(status.profile.unwrap().as_str(), "default");
+    assert_eq!(
+        status.runtime_mode,
+        Some(meerkat_mob::MobRuntimeMode::TurnDriven)
+    );
+}
+
+#[tokio::test]
+async fn identity_first_builder_runtime_checkpoint_follows_initial_session_save_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let roster = Arc::new(StubRosterProvider::new(vec![durable_spec("agent:alpha")]));
+    let continuity_store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(continuity_store)
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(roster)
+        .scratch_dir(tmp.path())
+        .identity_runtime_instance_id("builder-checkpoint-test")
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("builder should bootstrap identity-first runtime");
+
+    let identity = AgentIdentity::parse("agent:alpha").unwrap();
+    let identity_runtime = runtime
+        .identity_runtime()
+        .expect("identity runtime should be exposed");
+    let status = identity_runtime
+        .status(&identity)
+        .await
+        .expect("identity should be active");
+    assert!(
+        status
+            .checkpoint_version
+            .is_some_and(|version| version.get() >= 1),
+        "initial session save should advance the live checkpoint version"
+    );
+
+    let next_version = identity_runtime
+        .checkpoint(
+            &identity,
+            &SessionSnapshot {
+                data: b"builder checkpoint".to_vec(),
+            },
+        )
+        .await
+        .expect("checkpoint after bootstrap should not be stale");
+    assert!(next_version.get() >= 2);
+}
+
+#[tokio::test]
+async fn identity_first_builder_resume_checkpoint_follows_registered_session_save_version() {
+    let continuity_store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let identity = AgentIdentity::parse("agent:alpha").unwrap();
+
+    {
+        let tmp = tempfile::tempdir().unwrap();
+        let roster = Arc::new(StubRosterProvider::new(vec![durable_spec("agent:alpha")]));
+        UnifiedRuntimeBuilder::default()
+            .definition(test_definition())
+            .continuity_store(continuity_store.clone())
+            .lease_provider(Arc::new(StubLeaseProvider))
+            .roster_provider(roster)
+            .scratch_dir(tmp.path())
+            .identity_runtime_instance_id("builder-resume-seed")
+            .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+            .build()
+            .await
+            .expect("seed runtime should create continuity");
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let roster = Arc::new(StubRosterProvider::new(vec![durable_spec("agent:alpha")]));
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(continuity_store)
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(roster)
+        .scratch_dir(tmp.path())
+        .identity_runtime_instance_id("builder-resume-test")
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("builder should resume identity-first runtime");
+
+    let identity_runtime = runtime
+        .identity_runtime()
+        .expect("identity runtime should be exposed");
+    let status = identity_runtime
+        .status(&identity)
+        .await
+        .expect("identity should be active after resume");
+    let restored_version = status
+        .checkpoint_version
+        .expect("resume should expose a checkpoint version")
+        .get();
+    assert!(
+        restored_version >= 1,
+        "resume should inherit any registered session save version"
+    );
+
+    let next_version = identity_runtime
+        .checkpoint(
+            &identity,
+            &SessionSnapshot {
+                data: b"resume checkpoint".to_vec(),
+            },
+        )
+        .await
+        .expect("checkpoint after resume should not be stale");
+    assert!(next_version.get() > restored_version);
+}
+
+#[tokio::test]
+async fn identity_first_builder_refreshes_desired_topology_from_providers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let roster = Arc::new(StubRosterProvider::new(vec![
+        durable_spec("agent:alpha"),
+        durable_spec("agent:beta"),
+    ]));
+    let edges = Arc::new(tokio::sync::Mutex::new(vec![
+        ManagedPeerEdge::new(
+            AgentIdentity::parse("agent:alpha").unwrap(),
+            AgentIdentity::parse("agent:beta").unwrap(),
+        )
+        .unwrap(),
+    ]));
+
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(Arc::new(StubContinuityStore))
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(roster)
+        .topology_provider(Arc::new(StubTopologyProvider {
+            edges: edges.clone(),
+        }))
+        .scratch_dir(tmp.path())
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("builder should bootstrap identity-first runtime");
+
+    edges.lock().await.clear();
+    let result = runtime
+        .refresh_desired_topology()
+        .await
+        .expect("refresh should succeed")
+        .expect("identity-first context should be present");
+    assert!(result.managed_edges.is_empty());
 }
 
 // ===========================================================================

--- a/meerkat-mobkit/tests/identity_first_choke.rs
+++ b/meerkat-mobkit/tests/identity_first_choke.rs
@@ -63,6 +63,8 @@ fn make_spec(name: &str) -> DurableAgentSpec {
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
     }
 }
 
@@ -640,6 +642,8 @@ async fn identity_first_choke_09_durable_agent_spec_gateway_round_trip() {
         },
         context: Some(serde_json::json!({"app_key": "value123"})),
         additional_instructions: vec!["be thorough".to_string()],
+        initial_message: None,
+        runtime_mode_override: None,
     };
 
     // Serialize to JSON (simulates gateway wire)
@@ -1244,6 +1248,7 @@ async fn identity_first_choke_20_session_hook_adapter_unsupported_mutation() {
         identity: make_identity("triage:main"),
         active_peers: vec![],
         managed_edges: vec![],
+        runtime_services: Default::default(),
     };
     let spec = make_spec("triage:main");
     let mut draft = AgentBuildDraft {
@@ -1253,6 +1258,7 @@ async fn identity_first_choke_20_session_hook_adapter_unsupported_mutation() {
         labels: BTreeMap::new(),
         app_context: None,
         external_tools: vec![],
+        local_external_tools: Default::default(),
     };
 
     // Should succeed (unsupported mutations are warned, not errored)

--- a/meerkat-mobkit/tests/identity_first_contracts.rs
+++ b/meerkat-mobkit/tests/identity_first_contracts.rs
@@ -291,6 +291,8 @@ async fn identity_first_contracts_roster_provider_mock() {
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: vec![],
+        initial_message: None,
+        runtime_mode_override: None,
     };
     let provider: Arc<dyn RosterProvider> = Arc::new(MockRosterProvider {
         specs: vec![spec.clone()],
@@ -315,6 +317,7 @@ async fn identity_first_contracts_customizer_mock_modifies_draft() {
         identity: AgentIdentity::parse("triage:main").unwrap(),
         active_peers: vec![],
         managed_edges: vec![],
+        runtime_services: Default::default(),
     };
     let spec = DurableAgentSpec {
         identity: AgentIdentity::parse("triage:main").unwrap(),
@@ -324,6 +327,8 @@ async fn identity_first_contracts_customizer_mock_modifies_draft() {
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: vec![],
+        initial_message: None,
+        runtime_mode_override: None,
     };
     let mut draft = AgentBuildDraft {
         model: None,
@@ -332,6 +337,7 @@ async fn identity_first_contracts_customizer_mock_modifies_draft() {
         labels: BTreeMap::new(),
         app_context: None,
         external_tools: vec![],
+        local_external_tools: Default::default(),
     };
     customizer
         .customize_build(&ctx, &spec, &mut draft)
@@ -794,6 +800,7 @@ async fn identity_first_contracts_session_hook_customizer_adapter_model_mutation
         identity: AgentIdentity::parse("triage:main").unwrap(),
         active_peers: vec![],
         managed_edges: vec![],
+        runtime_services: Default::default(),
     };
     let spec = DurableAgentSpec {
         identity: AgentIdentity::parse("triage:main").unwrap(),
@@ -803,6 +810,8 @@ async fn identity_first_contracts_session_hook_customizer_adapter_model_mutation
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: vec![],
+        initial_message: None,
+        runtime_mode_override: None,
     };
     let mut draft = AgentBuildDraft {
         model: None,
@@ -811,6 +820,7 @@ async fn identity_first_contracts_session_hook_customizer_adapter_model_mutation
         labels: BTreeMap::new(),
         app_context: None,
         external_tools: vec![],
+        local_external_tools: Default::default(),
     };
 
     adapter
@@ -848,6 +858,7 @@ async fn identity_first_contracts_session_hook_customizer_resume_warning() {
         identity: AgentIdentity::parse("triage:main").unwrap(),
         active_peers: vec![],
         managed_edges: vec![],
+        runtime_services: Default::default(),
     };
     let spec = DurableAgentSpec {
         identity: AgentIdentity::parse("triage:main").unwrap(),
@@ -857,6 +868,8 @@ async fn identity_first_contracts_session_hook_customizer_resume_warning() {
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: vec![],
+        initial_message: None,
+        runtime_mode_override: None,
     };
     let mut draft = AgentBuildDraft {
         model: None,
@@ -865,6 +878,7 @@ async fn identity_first_contracts_session_hook_customizer_resume_warning() {
         labels: BTreeMap::new(),
         app_context: None,
         external_tools: vec![],
+        local_external_tools: Default::default(),
     };
 
     // Should succeed but log a warning — we verify it doesn't error
@@ -900,6 +914,7 @@ async fn identity_first_contracts_session_hook_customizer_unsupported_field_warn
         identity: AgentIdentity::parse("review:agent").unwrap(),
         active_peers: vec![],
         managed_edges: vec![],
+        runtime_services: Default::default(),
     };
     let spec = DurableAgentSpec {
         identity: AgentIdentity::parse("review:agent").unwrap(),
@@ -909,6 +924,8 @@ async fn identity_first_contracts_session_hook_customizer_unsupported_field_warn
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: vec![],
+        initial_message: None,
+        runtime_mode_override: None,
     };
     let mut draft = AgentBuildDraft {
         model: Some("claude-sonnet-4-6".to_string()),
@@ -917,6 +934,7 @@ async fn identity_first_contracts_session_hook_customizer_unsupported_field_warn
         labels: BTreeMap::new(),
         app_context: None,
         external_tools: vec![],
+        local_external_tools: Default::default(),
     };
 
     // Should succeed — unsupported mutations are warned, not errored

--- a/meerkat-mobkit/tests/identity_first_e2e.rs
+++ b/meerkat-mobkit/tests/identity_first_e2e.rs
@@ -58,6 +58,8 @@ fn make_spec(name: &str) -> DurableAgentSpec {
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
     }
 }
 

--- a/meerkat-mobkit/tests/identity_first_kitchen_sink.rs
+++ b/meerkat-mobkit/tests/identity_first_kitchen_sink.rs
@@ -85,6 +85,8 @@ fn spec(name: &str, addr: AgentAddressability, profile: &str) -> DurableAgentSpe
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
     }
 }
 

--- a/meerkat-mobkit/tests/identity_first_ob3_smoke.rs
+++ b/meerkat-mobkit/tests/identity_first_ob3_smoke.rs
@@ -80,6 +80,8 @@ fn spec(name: &str, addr: AgentAddressability, profile: &str) -> DurableAgentSpe
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
     }
 }
 

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -52,6 +52,8 @@ fn make_spec(name: &str) -> DurableAgentSpec {
         labels: BTreeMap::new(),
         context: None,
         additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
     }
 }
 
@@ -676,6 +678,129 @@ async fn identity_first_runtime_restore_flow_resumes_ready() {
         }
         other => panic!("expected Resumed, got: {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn identity_first_runtime_restore_flow_reconciles_resume_returned_session_id() {
+    struct ResumeFallbackBridge {
+        actual_session_id: meerkat_core::types::SessionId,
+    }
+
+    #[async_trait]
+    impl SessionBridge for ResumeFallbackBridge {
+        async fn create_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            session_id: &meerkat_core::types::SessionId,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(session_id.clone())
+        }
+
+        async fn resume_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            _session_id: &meerkat_core::types::SessionId,
+            _snapshot: &SessionSnapshot,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(self.actual_session_id.clone())
+        }
+
+        async fn deliver(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _content: &meerkat_core::ContentInput,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(self.actual_session_id.clone())
+        }
+
+        async fn checkpoint_session(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _session_id: &meerkat_core::types::SessionId,
+        ) -> Result<SessionSnapshot, BridgeError> {
+            Ok(SessionSnapshot {
+                data: b"bridge checkpoint".to_vec(),
+            })
+        }
+
+        async fn retire_member(&self, _runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
+            Ok(())
+        }
+    }
+
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let actual_session_id = meerkat_core::types::SessionId::new();
+    let runtime = IdentityRuntime::new(IdentityRuntimeConfig {
+        continuity_store: store.clone(),
+        lease_provider: lease_prov,
+        runtime_instance_id: "test-runtime".to_string(),
+        has_runtime_store: true,
+        durability_policy: DurabilityPolicy::SyncWriteThrough,
+        bridge: Some(Arc::new(ResumeFallbackBridge {
+            actual_session_id: actual_session_id.clone(),
+        })),
+        default_timeout: None,
+    });
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 0);
+    assert_ne!(record.session_id, actual_session_id);
+    store
+        .upsert_continuity_record(&record, FencingToken::new(0))
+        .await
+        .unwrap();
+    store
+        .save_session_snapshot(
+            &id,
+            &record.session_id,
+            record.generation,
+            CheckpointVersion::new(1),
+            FencingToken::new(0),
+            &SessionSnapshot {
+                data: b"old snapshot".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let roster = vec![make_spec("triage:main")];
+    let result = restore_flow(&runtime, &roster, None, None).await.unwrap();
+    match result.outcomes.get(&id).unwrap() {
+        RestoreOutcome::Resumed { record, .. } => {
+            assert_eq!(record.session_id, actual_session_id);
+            assert_eq!(record.checkpoint_version, CheckpointVersion::new(1));
+        }
+        other => panic!("expected Resumed, got: {other:?}"),
+    }
+
+    let status = runtime.status(&id).await.unwrap();
+    assert_eq!(status.session_id, Some(actual_session_id.clone()));
+    assert_eq!(status.checkpoint_version, Some(CheckpointVersion::new(1)));
+
+    let next_version = runtime
+        .checkpoint(
+            &id,
+            &SessionSnapshot {
+                data: b"new snapshot".to_vec(),
+            },
+        )
+        .await
+        .expect("checkpoint should use returned resume session id and current version");
+    assert_eq!(next_version, CheckpointVersion::new(2));
+
+    let resolved = store.resolve_many(std::slice::from_ref(&id)).await.unwrap();
+    let ContinuityResolveState::Ready { record } = resolved.get(&id).unwrap() else {
+        panic!("expected ready record");
+    };
+    assert_eq!(record.session_id, actual_session_id);
+    assert_eq!(record.checkpoint_version, CheckpointVersion::new(2));
 }
 
 #[tokio::test]
@@ -1420,8 +1545,9 @@ async fn identity_first_runtime_topology_materializes_runtime_peer_wires() {
             _runtime_id: &AgentRuntimeId,
             _spec: &DurableAgentSpec,
             _draft: &AgentBuildDraft,
+            session_id: &meerkat_core::types::SessionId,
         ) -> Result<meerkat_core::types::SessionId, BridgeError> {
-            Ok(meerkat_core::types::SessionId::new())
+            Ok(session_id.clone())
         }
 
         async fn resume_session(
@@ -1602,8 +1728,9 @@ async fn identity_first_runtime_topology_claims_persisted_wires_without_rebatchi
             _runtime_id: &AgentRuntimeId,
             _spec: &DurableAgentSpec,
             _draft: &AgentBuildDraft,
+            session_id: &meerkat_core::types::SessionId,
         ) -> Result<meerkat_core::types::SessionId, BridgeError> {
-            Ok(meerkat_core::types::SessionId::new())
+            Ok(session_id.clone())
         }
 
         async fn resume_session(

--- a/meerkat-mobkit/tests/identity_first_types.rs
+++ b/meerkat-mobkit/tests/identity_first_types.rs
@@ -349,6 +349,8 @@ fn identity_first_types_durable_agent_spec_roundtrip() {
         },
         context: Some(serde_json::json!({"key": "value"})),
         additional_instructions: vec!["Be helpful.".to_string()],
+        initial_message: None,
+        runtime_mode_override: None,
     };
     let json = serde_json::to_string(&spec).expect("serialize");
     let back: DurableAgentSpec = serde_json::from_str(&json).expect("deserialize");
@@ -505,6 +507,7 @@ fn identity_first_types_identity_status_full_roundtrip() {
         agent_runtime_id: Some(AgentRuntimeId::parse("rt:001").expect("parse")),
         session_id: Some(meerkat_core::types::SessionId::new()),
         profile: Some(meerkat_mob::ProfileName::from("lead")),
+        runtime_mode: None,
         addressability: AgentAddressability::Addressable,
         display_name: Some(DisplayName::parse("Triage Agent").expect("parse")),
         labels: {
@@ -580,6 +583,7 @@ fn identity_first_types_agent_build_context_roundtrip() {
             AgentIdentity::parse("b:main").expect("parse"),
         ],
         managed_edges: vec![edge],
+        runtime_services: Default::default(),
     };
     let json = serde_json::to_string(&ctx).expect("serialize");
     let back: AgentBuildContext = serde_json::from_str(&json).expect("deserialize");
@@ -603,6 +607,7 @@ fn identity_first_types_agent_build_draft_roundtrip() {
             description: "Search the web".to_string(),
             input_schema: serde_json::json!({"type": "object", "properties": {"query": {"type": "string"}}}),
         }],
+        local_external_tools: Default::default(),
     };
     let json = serde_json::to_string(&draft).expect("serialize");
     let back: AgentBuildDraft = serde_json::from_str(&json).expect("deserialize");
@@ -669,6 +674,8 @@ fn identity_first_types_topology_context_roundtrip() {
             labels: BTreeMap::new(),
             context: None,
             additional_instructions: vec![],
+            initial_message: None,
+            runtime_mode_override: None,
         }],
     };
     let json = serde_json::to_string(&ctx).expect("serialize");

--- a/meerkat-mobkit/tests/jwks_cache_and_auth.rs
+++ b/meerkat-mobkit/tests/jwks_cache_and_auth.rs
@@ -86,7 +86,10 @@ fn wait_for_connection(listener: &TcpListener, timeout: Duration) -> TcpStream {
     let deadline = Instant::now() + timeout;
     loop {
         match listener.accept() {
-            Ok((stream, _)) => return stream,
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false).expect("set stream blocking");
+                return stream;
+            }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 assert!(
                     Instant::now() < deadline,


### PR DESCRIPTION
## Summary

Implements first-class identity-first MobKit bootstrap so apps can rely on `UnifiedRuntimeBuilder` instead of hand-copying the gateway wiring pattern.

- adds identity-first builder setters for roster/topology providers, agent customizer, and runtime instance id, with automatic `restore_flow` and exposed runtime/context refresh APIs
- wires `AgentBuildDraft` into `SpawnMemberSpec`, including model/system prompt/runtime mode/initial message and a local Rust dispatcher overlay for in-process tools
- installs the continuity-backed session store in identity-first runtime paths and reconciles actual session ids/checkpoint versions across create, resume, resume fallback, and reset
- adds identity-native console send/stream plus JSON-RPC `mobkit/interact`
- exposes topology refresh/reconcile as the public app path

## Validation

- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo clippy --workspace --all-targets -- -D warnings -D clippy::expect-used -D clippy::panic`
- `make test` (559 passed, 160 skipped)
- two sequential read-only sub-agent reviews on final HEAD: GREEN, GREEN
