### PR TITLE
[codex] Project durable identities in console rows

### DIFF
--- a/console/src/lib/phase1-targets.test.ts
+++ b/console/src/lib/phase1-targets.test.ts
@@ -45,6 +45,34 @@ test("CHOKE-004 target: sidebar adapter chooses identity addressing once for com
   assert.equal(target.identity, "identity:luka");
 });
 
+test("sidebar adapter keeps durable chat identity when member id is runtime-scoped", () => {
+  const [agent] = normalizeAgents(
+    {
+      agent_sidebar: {
+        live_snapshot: {
+          agents: [
+            {
+              identity: "review:singleton",
+              member_id: "rt:review:singleton:0",
+              agent_id: "rt:review:singleton:0",
+              label: "Review Worker",
+              kind: "mob_agent",
+              labels: { agent_identity: "review:singleton" },
+            },
+          ],
+        },
+      },
+    } as ConsoleExperience,
+    [],
+  );
+
+  assert.ok(agent);
+  const target = buildDockTarget(agent);
+
+  assert.equal(target.identity, "review:singleton");
+  assert.equal(target.memberId, "rt:review:singleton:0");
+});
+
 test("CHOKE-003 target: refreshed experience metadata drives host refresh strategy instead of stale per-panel fetch assumptions", () => {
   const before = normalizeAgents(
     {

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -3642,6 +3642,7 @@ async fn build_live_snapshot(
     let agents = members
         .iter()
         .map(|member| async move {
+            let console_identity = console_member_console_identity(member);
             let label = member
                 .labels
                 .get("display_name")
@@ -3662,11 +3663,7 @@ async fn build_live_snapshot(
                 .map(|value: &String| value == "true");
             let degraded_reason = member.labels.get("console_degraded_reason").cloned();
             let response_phase = match console_events {
-                Some(store) => {
-                    store
-                        .response_phase_for_identity(&member.agent_identity)
-                        .await
-                }
+                Some(store) => store.response_phase_for_identity(console_identity).await,
                 None => None,
             };
             ConsoleAgentLiveSnapshot {
@@ -3674,7 +3671,7 @@ async fn build_live_snapshot(
                 member_id: member.agent_identity.clone(),
                 label,
                 kind: "meerkat".to_string(),
-                identity: Some(member.agent_identity.clone()),
+                identity: Some(console_identity.to_string()),
                 role: Some(member.role.clone()),
                 state: Some(member.state.clone()),
                 session_id: member.session_id.clone(),
@@ -4046,6 +4043,14 @@ async fn wait_for_reset_startup_history(
 fn dedupe_console_members_by_identity(members: &mut Vec<ConsoleMember>) {
     let mut seen_member_ids = BTreeSet::new();
     members.retain(|member| seen_member_ids.insert(member.agent_identity.clone()));
+}
+
+fn console_member_console_identity(member: &ConsoleMember) -> &str {
+    member
+        .labels
+        .get("agent_identity")
+        .filter(|value| !value.trim().is_empty())
+        .map_or(member.agent_identity.as_str(), String::as_str)
 }
 
 async fn project_console_members_from_handle(

--- a/meerkat-mobkit/src/runtime/console_ingress.rs
+++ b/meerkat-mobkit/src/runtime/console_ingress.rs
@@ -92,6 +92,14 @@ pub struct ConsoleLiveSnapshot {
     pub has_mob_runtime: bool,
 }
 
+fn console_member_console_identity(member: &ConsoleMember) -> &str {
+    member
+        .labels
+        .get("agent_identity")
+        .filter(|value| !value.trim().is_empty())
+        .map_or(member.agent_identity.as_str(), String::as_str)
+}
+
 impl ConsoleLiveSnapshot {
     pub fn new(
         runtime_id: Option<String>,
@@ -290,6 +298,7 @@ fn build_console_experience_contract(
         sorted_members
                 .iter()
                 .map(|member| {
+                    let console_identity = console_member_console_identity(member);
                     let label = member
                         .labels
                         .get("display_name")
@@ -329,7 +338,7 @@ fn build_console_experience_contract(
                     serde_json::json!({
                         "agent_id": member.agent_identity,
                         "member_id": member.agent_identity,
-                        "identity": member.agent_identity,
+                        "identity": console_identity,
                         "label": label,
                         "kind": "mob_agent",
                         "role": member.role,
@@ -541,7 +550,7 @@ fn build_console_experience_contract(
                     "singleton": "set \"true\" to prevent retire (e.g. review, summarizer agents)",
                     "group": "sidebar group name; overrides profile-based grouping",
                 },
-                "refresh_projection": "source_method returns ConsoleMember rows (agent_identity, role, state, model_capabilities, wired_to, labels). Clients must project: agent_id=agent_identity, member_id=agent_identity, label=labels.display_name||agent_identity, group=labels.group||role, addressable=labels.addressable!='false', model_capabilities.image_input default false, affordances derived from labels.singleton and addressable.",
+                "refresh_projection": "source_method returns ConsoleMember rows (agent_identity, role, state, model_capabilities, wired_to, labels). Clients must project: agent_id=agent_identity, member_id=agent_identity, identity=labels.agent_identity||agent_identity, label=labels.display_name||agent_identity, group=labels.group||role, addressable=labels.addressable!='false', model_capabilities.image_input default false, affordances derived from labels.singleton and addressable.",
             },
             "live_snapshot": {
                 "agents": sidebar_agents,

--- a/meerkat-mobkit/tests/console_experience.rs
+++ b/meerkat-mobkit/tests/console_experience.rs
@@ -15,6 +15,8 @@
     clippy::unwrap_in_result,
     clippy::useless_vec
 )]
+use std::collections::BTreeMap;
+
 use meerkat_mobkit::{
     AuthPolicy, AuthProvider, BigQueryNaming, ConsoleAccessRequest, ConsoleLiveSnapshot,
     ConsolePolicy, ConsoleRestJsonRequest, RuntimeDecisionInputs, RuntimeOpsPolicy,
@@ -315,6 +317,51 @@ fn console_experience_projects_fetch_timeout_policy() {
     assert_eq!(
         response.body["console_policy"]["fetch_timeout_ms"],
         json!(120_000)
+    );
+}
+
+#[test]
+fn console_experience_projects_durable_identity_for_runtime_member_rows() {
+    let state = decision_state(false);
+    let runtime_snapshot = ConsoleLiveSnapshot::new(
+        Some("ob3".to_string()),
+        true,
+        vec!["rt:review:singleton:0".to_string()],
+        vec![],
+        vec![meerkat_mobkit::runtime::ConsoleMember {
+            agent_identity: "rt:review:singleton:0".to_string(),
+            role: "review-worker".to_string(),
+            state: "active".to_string(),
+            model_capabilities: meerkat_mobkit::ConsoleModelCapabilities { image_input: false },
+            runtime_mode: Some("identity_first".to_string()),
+            session_id: Some("session-review".to_string()),
+            wired_to: Vec::new(),
+            labels: BTreeMap::from([
+                ("agent_identity".to_string(), "review:singleton".to_string()),
+                ("display_name".to_string(), "Review Worker".to_string()),
+            ]),
+        }],
+        true,
+    );
+
+    let response = handle_console_rest_json_route_with_snapshot(
+        &state,
+        &ConsoleRestJsonRequest {
+            method: "GET".to_string(),
+            path: "/console/experience".to_string(),
+            auth: None,
+        },
+        Some(&runtime_snapshot),
+    );
+
+    assert_eq!(response.status, 200);
+    let agent = &response.body["agent_sidebar"]["live_snapshot"]["agents"][0];
+    assert_eq!(agent["identity"], json!("review:singleton"));
+    assert_eq!(agent["member_id"], json!("rt:review:singleton:0"));
+    assert_eq!(agent["agent_id"], json!("rt:review:singleton:0"));
+    assert_eq!(
+        response.body["identity_status"]["rows"][0]["identity"],
+        json!("review:singleton")
     );
 }
 


### PR DESCRIPTION
## Summary
- Project `labels.agent_identity` as the console row `identity` while preserving runtime member ids as `member_id` / `agent_id`.
- Use the durable console identity for response-phase lookup in the HTTP snapshot path.
- Add backend and frontend regression coverage for `rt:*` member ids with durable chat/history identities.

## Root Cause
`/console/experience` could expose runtime-scoped member ids like `rt:review:singleton:0` as the chat target identity even when the stable identity existed in `labels.agent_identity`. The console then queried timeline history under the runtime member id instead of the durable session identity.

## Validation
- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-mobkit console_experience_projects_durable_identity_for_runtime_member_rows --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_record_uses_durable_agent_identity_label_for_identity_first_members --quiet`
- `npm --prefix console run phase0:types --silent`
- push hooks: cargo fmt, changed-crate clippy, workspace unit gate
