### PR TITLE
[codex] Add lazy identity materialization

### DIFF
--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -153,6 +153,7 @@ struct RuntimeEntry {
     runtime_key: String,
     identity_namespace: String,
     runtime: MobRuntime,
+    identity_runtime: Option<Arc<crate::identity_first::IdentityRuntime>>,
     console_events: ConsoleEventStore,
     visibility_policy: Arc<dyn ConsoleVisibilityPolicy>,
 }
@@ -268,10 +269,12 @@ impl MobKitConsoleAggregator {
     }
 
     pub fn register_runtime(&self, registration: ConsoleRuntimeRegistration) {
+        let identity_runtime = registration.runtime.identity_runtime().cloned();
         self.register_runtime_handles_with_policy(
             registration.runtime_key,
             registration.identity_namespace,
             registration.runtime.mob_runtime().clone(),
+            identity_runtime,
             registration.runtime.console_events(),
             registration.visibility_policy,
         );
@@ -282,6 +285,7 @@ impl MobKitConsoleAggregator {
         runtime_key: impl Into<String>,
         identity_namespace: impl Into<String>,
         runtime: MobRuntime,
+        identity_runtime: Option<Arc<crate::identity_first::IdentityRuntime>>,
         console_events: ConsoleEventStore,
         visibility_policy: Arc<dyn ConsoleVisibilityPolicy>,
     ) {
@@ -291,6 +295,7 @@ impl MobKitConsoleAggregator {
             runtime_key: runtime_key.clone(),
             identity_namespace,
             runtime,
+            identity_runtime,
             console_events: console_events.clone(),
             visibility_policy,
         };
@@ -389,38 +394,71 @@ impl MobKitConsoleAggregator {
         &self,
         identity: &str,
     ) -> ConsoleLogResult<Option<ConsoleIdentityInspection>> {
-        let Some(resolved) = self.resolve_member(identity).await else {
-            return Ok(None);
-        };
-        let Some(record) =
-            identity_record_for_member(&resolved.entry, &resolved.handle, &resolved.member).await
-        else {
-            return Ok(None);
-        };
-        if !resolved.entry.visibility_policy.identity_visible(&record) {
-            return Ok(None);
+        if let Some(resolved) = self.resolve_member(identity).await {
+            let Some(record) =
+                identity_record_for_member(&resolved.entry, &resolved.handle, &resolved.member)
+                    .await
+            else {
+                return Ok(None);
+            };
+            if !resolved.entry.visibility_policy.identity_visible(&record) {
+                return Ok(None);
+            }
+            if let Some(session_id) = record.session_id.clone() {
+                spawn_session_history_backfill_target(
+                    self.inner.clone(),
+                    SessionBackfillTarget {
+                        entry: resolved.entry.clone(),
+                        record: record.clone(),
+                        session_id,
+                    },
+                    false,
+                );
+            }
+            let peers = resolved
+                .member
+                .wired_to
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            return Ok(Some(ConsoleIdentityInspection {
+                identity: record,
+                peers,
+            }));
         }
-        if let Some(session_id) = record.session_id.clone() {
-            spawn_session_history_backfill_target(
-                self.inner.clone(),
-                SessionBackfillTarget {
-                    entry: resolved.entry.clone(),
-                    record: record.clone(),
-                    session_id,
-                },
-                false,
-            );
+
+        let entries = self
+            .inner
+            .runtimes
+            .read()
+            .map_err(|_| runtime_registry_lock_error())?
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for entry in entries {
+            let Some(identity_runtime) = entry.identity_runtime.clone() else {
+                continue;
+            };
+            let Some(raw_identity) = strip_namespace(identity, &entry.identity_namespace) else {
+                continue;
+            };
+            let Ok(parsed_identity) = crate::identity_first::AgentIdentity::parse(&raw_identity)
+            else {
+                continue;
+            };
+            let Ok(status) = identity_runtime.status(&parsed_identity).await else {
+                continue;
+            };
+            let record = identity_record_for_status(&entry, &status);
+            if !entry.visibility_policy.identity_visible(&record) {
+                return Ok(None);
+            }
+            return Ok(Some(ConsoleIdentityInspection {
+                identity: record,
+                peers: Vec::new(),
+            }));
         }
-        let peers = resolved
-            .member
-            .wired_to
-            .iter()
-            .map(ToString::to_string)
-            .collect();
-        Ok(Some(ConsoleIdentityInspection {
-            identity: record,
-            peers,
-        }))
+        Ok(None)
     }
 
     pub async fn retire_identity(&self, identity: &str) -> ConsoleLogResult<bool> {
@@ -934,6 +972,14 @@ async fn collect_identity_records(
                 identities.push(record);
             }
         }
+        if let Some(identity_runtime) = entry.identity_runtime.as_ref() {
+            for status in identity_runtime.statuses().await {
+                let record = identity_record_for_status(entry, &status);
+                if entry.visibility_policy.identity_visible(&record) {
+                    identities.push(record);
+                }
+            }
+        }
     }
     Ok(dedupe_identity_records(identities))
 }
@@ -950,6 +996,9 @@ fn spawn_identity_backfills_for_records(
         Err(_) => return,
     };
     for record in records {
+        if record.health == "dormant" || record.health == "uninitialized" {
+            continue;
+        }
         let Some(entry) = entries.get(&record.runtime_key).cloned() else {
             continue;
         };
@@ -2328,6 +2377,64 @@ async fn identity_record_for_member(
     })
 }
 
+fn identity_record_for_status(
+    entry: &RuntimeEntry,
+    status: &crate::identity_first::IdentityStatus,
+) -> ConsoleIdentityRecord {
+    let identity = apply_namespace(status.identity.as_str(), &entry.identity_namespace);
+    let runtime_member_id = status
+        .agent_runtime_id
+        .as_ref()
+        .map(crate::identity_first::AgentRuntimeId::as_str)
+        .unwrap_or_else(|| status.identity.as_str())
+        .to_string();
+    let addressable = status.addressability
+        == crate::identity_first::AgentAddressability::Addressable
+        && matches!(
+            status.state,
+            crate::identity_first::IdentityLifecycleState::Active
+                | crate::identity_first::IdentityLifecycleState::Dormant
+                | crate::identity_first::IdentityLifecycleState::Uninitialized
+        );
+    let visibility = match status.state {
+        crate::identity_first::IdentityLifecycleState::Retiring => {
+            ConsoleVisibility::RetiredReadable
+        }
+        crate::identity_first::IdentityLifecycleState::Broken
+        | crate::identity_first::IdentityLifecycleState::Suspended => {
+            ConsoleVisibility::Unreachable
+        }
+        _ if addressable => ConsoleVisibility::Addressable,
+        _ => ConsoleVisibility::Hidden,
+    };
+    let health = match status.state {
+        crate::identity_first::IdentityLifecycleState::Active => "ready",
+        crate::identity_first::IdentityLifecycleState::Dormant => "dormant",
+        crate::identity_first::IdentityLifecycleState::Uninitialized => "uninitialized",
+        crate::identity_first::IdentityLifecycleState::Broken => "broken",
+        crate::identity_first::IdentityLifecycleState::Suspended => "suspended",
+        crate::identity_first::IdentityLifecycleState::Retiring => "retired",
+    }
+    .to_string();
+    let display_name = status
+        .display_name
+        .as_ref()
+        .map(crate::identity_first::DisplayName::as_str)
+        .unwrap_or_else(|| status.identity.as_str())
+        .to_string();
+    ConsoleIdentityRecord {
+        identity,
+        display_name,
+        runtime_key: entry.runtime_key.clone(),
+        runtime_member_id,
+        session_id: status.session_id.as_ref().map(ToString::to_string),
+        visibility,
+        addressable,
+        health,
+        labels: status.labels.clone(),
+    }
+}
+
 pub(crate) fn is_implicit_delegate_member(
     role: &str,
     labels: &std::collections::BTreeMap<String, String>,
@@ -2877,6 +2984,7 @@ comms = true
             runtime_key: runtime_key.to_string(),
             identity_namespace: "test".to_string(),
             runtime: runtime.mob_runtime().clone(),
+            identity_runtime: runtime.identity_runtime().cloned(),
             console_events: runtime.console_events(),
             visibility_policy: Arc::new(AllowAllConsoleVisibilityPolicy),
         }
@@ -2924,6 +3032,7 @@ comms = true
             runtime_key: "runtime-a".to_string(),
             identity_namespace: String::new(),
             runtime: runtime.mob_runtime().clone(),
+            identity_runtime: runtime.identity_runtime().cloned(),
             console_events: runtime.console_events(),
             visibility_policy: Arc::new(AllowAllConsoleVisibilityPolicy),
         };

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -3179,6 +3179,14 @@ async fn handle_console_runtime_rpc(
             }
             let flow_id = meerkat_mob::FlowId::from(flow_id_str);
             let flow_params = request.params.get("params").cloned().unwrap_or(Value::Null);
+            if let Some(identity_runtime) = &identity_runtime
+                && let Err(err) = identity_runtime.materialize_all().await
+            {
+                return internal_error(
+                    response_id,
+                    format!("identity-first flow materialization failed: {err}"),
+                );
+            }
             match runtime.handle().run_flow(flow_id, flow_params).await {
                 Ok(run_id) => response_value(
                     response_id,

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -298,6 +298,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
                 "default",
                 "",
                 runtime.clone(),
+                identity_runtime.clone(),
                 events,
                 visibility_policy.clone(),
             );
@@ -308,6 +309,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
                 "default",
                 "",
                 runtime.clone(),
+                identity_runtime.clone(),
                 events,
                 visibility_policy.clone(),
             );
@@ -4492,6 +4494,7 @@ comms = true
             "runtime-reset",
             "reset",
             runtime.clone(),
+            None,
             ConsoleEventStore::new(),
             Arc::new(AllowAllConsoleVisibilityPolicy),
         );

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -53,6 +53,47 @@ impl std::fmt::Display for BridgeError {
 
 impl std::error::Error for BridgeError {}
 
+/// Typed reason a requested resume could not reuse the persisted runtime
+/// binding and had to fall back to a fresh member spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResumeFallbackReason {
+    /// The persisted session/runtime identity is incompatible with the current
+    /// mob runtime binding.
+    RuntimeIdentityIncompatible { detail: String },
+}
+
+/// Result of attempting to materialize a persisted identity through resume.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResumeSessionOutcome {
+    /// The persisted session was resumed as-is.
+    Resumed {
+        session_id: meerkat_core::types::SessionId,
+    },
+    /// Resume was rejected for a typed compatibility reason and a fresh member
+    /// was spawned instead.
+    FreshSpawned {
+        session_id: meerkat_core::types::SessionId,
+        reason: ResumeFallbackReason,
+    },
+}
+
+impl ResumeSessionOutcome {
+    #[must_use]
+    pub fn session_id(&self) -> &meerkat_core::types::SessionId {
+        match self {
+            Self::Resumed { session_id } | Self::FreshSpawned { session_id, .. } => session_id,
+        }
+    }
+
+    #[must_use]
+    pub fn fallback_reason(&self) -> Option<&ResumeFallbackReason> {
+        match self {
+            Self::Resumed { .. } => None,
+            Self::FreshSpawned { reason, .. } => Some(reason),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SessionBridge trait
 // ---------------------------------------------------------------------------
@@ -87,7 +128,7 @@ pub trait SessionBridge: Send + Sync {
         draft: &AgentBuildDraft,
         session_id: &meerkat_core::types::SessionId,
         snapshot: &SessionSnapshot,
-    ) -> Result<meerkat_core::types::SessionId, BridgeError>;
+    ) -> Result<ResumeSessionOutcome, BridgeError>;
 
     /// Deliver content to an active mob member.
     async fn deliver(
@@ -328,7 +369,7 @@ impl SessionBridge for MobSessionBridge {
         draft: &AgentBuildDraft,
         session_id: &meerkat_core::types::SessionId,
         _snapshot: &SessionSnapshot,
-    ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+    ) -> Result<ResumeSessionOutcome, BridgeError> {
         // Try MemberLaunchMode::Resume first — this loads the existing session
         // from the session store (conversation history intact).
         let mut spawn_spec = build_spawn_spec(runtime_id, spec, draft);
@@ -337,7 +378,9 @@ impl SessionBridge for MobSessionBridge {
         };
 
         match self.handle.spawn_spec(spawn_spec).await {
-            Ok(_) => Ok(session_id.clone()),
+            Ok(_) => Ok(ResumeSessionOutcome::Resumed {
+                session_id: session_id.clone(),
+            }),
             Err(e) => {
                 // Resume can fail if the old session's comms identity is still
                 // claimed (e.g., in-process restart where the previous mob actor
@@ -346,7 +389,8 @@ impl SessionBridge for MobSessionBridge {
                     identity = %_identity,
                     session_id = %session_id,
                     error = %e,
-                    "resume_session failed, falling back to fresh spawn"
+                    reason = "runtime_identity_incompatible",
+                    "resume_session incompatible with current runtime binding, falling back to fresh spawn"
                 );
                 let fresh_spec = build_spawn_spec(runtime_id, spec, draft);
                 self.handle
@@ -355,14 +399,21 @@ impl SessionBridge for MobSessionBridge {
                     .map_err(|e2| BridgeError::Mob(e2.to_string()))?;
 
                 let mid = MeerkatId::from(runtime_id.as_str());
-                self.handle
+                let session_id = self
+                    .handle
                     .resolve_bridge_session_id(&mid)
                     .await
                     .ok_or_else(|| {
                         BridgeError::Mob(
                             "member spawned (fresh fallback) but has no session ID".to_string(),
                         )
-                    })
+                    })?;
+                Ok(ResumeSessionOutcome::FreshSpawned {
+                    session_id,
+                    reason: ResumeFallbackReason::RuntimeIdentityIncompatible {
+                        detail: e.to_string(),
+                    },
+                })
             }
         }
     }

--- a/meerkat-mobkit/src/identity_first/mod.rs
+++ b/meerkat-mobkit/src/identity_first/mod.rs
@@ -14,7 +14,10 @@ pub use adapters::{
     ContinuitySessionStoreAdapter, DiscoveryRosterAdapter, EdgeDiscoveryTopologyAdapter,
     SessionHookCustomizerAdapter, agent_discovery_to_durable,
 };
-pub use bridge::{BridgeError, MemberInspection, MobSessionBridge, SessionBridge};
+pub use bridge::{
+    BridgeError, MemberInspection, MobSessionBridge, ResumeFallbackReason, ResumeSessionOutcome,
+    SessionBridge,
+};
 pub use contracts::*;
 pub use gateway_bridges::{
     CallbackBridge, GatewayAgentCustomizer, GatewayContinuityStore, GatewayLeaseProvider,
@@ -23,7 +26,8 @@ pub use gateway_bridges::{
 pub use local_lease::LocalLeaseProvider;
 pub use local_store::LocalContinuityStore;
 pub use orchestrator::{
-    ReconcileAction, RestoreFlowResult, RestoreOutcome, compute_reconcile_actions, restore_flow,
+    ReconcileAction, RestoreFlowResult, RestoreOutcome, compute_reconcile_actions,
+    lazy_register_flow, restore_flow,
 };
 pub use runtime::{
     IdentityFirstRuntimeContext, IdentityRuntime, IdentityRuntimeConfig, IdentityRuntimeError,

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -22,6 +22,12 @@ use super::types::{
 /// Result of the restore flow for a single identity.
 #[derive(Debug, Clone)]
 pub enum RestoreOutcome {
+    /// Lazy bootstrap registered identity metadata without materializing a
+    /// concrete mob member/session.
+    Dormant {
+        record: Option<ContinuityRecord>,
+        draft: AgentBuildDraft,
+    },
     /// Fresh-created: new AgentRuntimeId, new SessionId.
     Created {
         record: ContinuityRecord,
@@ -372,7 +378,9 @@ pub async fn restore_flow(
                                 IdentityRuntimeError::Internal(format!(
                                     "bridge resume_session: {e}"
                                 ))
-                            })?,
+                            })?
+                            .session_id()
+                            .clone(),
                         None => {
                             // No snapshot but record exists — resume from session
                             // store using the session_id from the continuity record.
@@ -393,6 +401,8 @@ pub async fn restore_flow(
                                         "bridge resume_session (no snapshot): {e}"
                                     ))
                                 })?
+                                .session_id()
+                                .clone()
                         }
                     };
                     record.session_id = resumed_session_id;
@@ -460,6 +470,118 @@ pub async fn restore_flow(
 
             // Step 11: Broken → fail loudly (REQ-13)
             ContinuityResolveState::Broken { failure } => {
+                outcomes.insert(identity.clone(), RestoreOutcome::Broken(failure.clone()));
+            }
+        }
+    }
+
+    runtime.reconcile_managed_peer_edges(&managed_edges).await?;
+
+    Ok(RestoreFlowResult {
+        outcomes,
+        managed_edges,
+    })
+}
+
+/// Register the roster/topology metadata without materializing members.
+///
+/// This is the identity-first lazy bootstrap path: it validates the roster,
+/// resolves cheap continuity metadata, records desired topology, and exposes
+/// status/inspection surfaces. It deliberately does not acquire leases, call
+/// customizers, load session snapshots, create sessions, or resume sessions.
+pub async fn lazy_register_flow(
+    runtime: &IdentityRuntime,
+    roster: &[DurableAgentSpec],
+    topology_provider: Option<&dyn TopologyProvider>,
+) -> Result<RestoreFlowResult, IdentityRuntimeError> {
+    IdentityRuntime::validate_roster_uniqueness(roster)?;
+
+    let identities: Vec<AgentIdentity> = roster.iter().map(|s| s.identity.clone()).collect();
+    let resolved = runtime
+        .continuity_store()
+        .resolve_many(&identities)
+        .await
+        .map_err(IdentityRuntimeError::Store)?;
+
+    let topology_context = TopologyContext {
+        roster: roster.to_vec(),
+    };
+    let managed_edges = if let Some(tp) = topology_provider {
+        tp.compute_edges(&identities, &topology_context)
+            .await
+            .map_err(|e| IdentityRuntimeError::Internal(format!("topology: {e}")))?
+    } else {
+        Vec::new()
+    };
+    runtime.set_desired_peer_edges(managed_edges.clone()).await;
+
+    let mut outcomes = BTreeMap::new();
+    for spec in roster {
+        let identity = &spec.identity;
+        let currently_active = runtime
+            .status(identity)
+            .await
+            .is_ok_and(|status| status.state == IdentityLifecycleState::Active);
+        let draft = AgentBuildDraft {
+            model: None,
+            system_prompt: None,
+            additional_instructions: spec.additional_instructions.clone(),
+            labels: spec.labels.clone(),
+            app_context: spec.context.clone(),
+            external_tools: Vec::new(),
+            local_external_tools: Default::default(),
+        };
+        match resolved.get(identity).ok_or_else(|| {
+            IdentityRuntimeError::Internal(format!(
+                "resolve_many did not return state for {identity}"
+            ))
+        })? {
+            ContinuityResolveState::Uninitialized => {
+                if currently_active {
+                    runtime.update_spec(spec.clone()).await?;
+                } else {
+                    runtime
+                        .register(spec.clone(), IdentityLifecycleState::Dormant, None, None)
+                        .await;
+                }
+                outcomes.insert(
+                    identity.clone(),
+                    RestoreOutcome::Dormant {
+                        record: None,
+                        draft,
+                    },
+                );
+            }
+            ContinuityResolveState::Ready { record } => {
+                if currently_active {
+                    runtime.update_spec(spec.clone()).await?;
+                } else {
+                    runtime
+                        .register(
+                            spec.clone(),
+                            IdentityLifecycleState::Dormant,
+                            Some(record.clone()),
+                            None,
+                        )
+                        .await;
+                }
+                outcomes.insert(
+                    identity.clone(),
+                    RestoreOutcome::Dormant {
+                        record: Some(record.clone()),
+                        draft,
+                    },
+                );
+            }
+            ContinuityResolveState::Broken { failure } => {
+                runtime
+                    .register(
+                        spec.clone(),
+                        IdentityLifecycleState::Broken,
+                        failure.record.clone(),
+                        None,
+                    )
+                    .await;
                 outcomes.insert(identity.clone(), RestoreOutcome::Broken(failure.clone()));
             }
         }

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -11,17 +11,18 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast};
 
 use super::bridge::SessionBridge;
 use super::contracts::{
     AgentCustomizer, ContinuityStore, LeaseProvider, RosterProvider, TopologyProvider,
 };
 use super::types::{
-    AgentAddressability, AgentIdentity, AgentRuntimeId, AgentRuntimeServices, CheckpointVersion,
-    ContinuityGeneration, ContinuityHealth, ContinuityRecord, ContinuityStoreError, DispatchInput,
-    DurabilityPolicy, DurableAgentSpec, FencingToken, IdentityLifecycleState, IdentityStatus,
-    LeaseGrant, LeaseInfo, ManagedPeerEdge, NotAddressable, RosterContext, SessionSnapshot,
+    AgentAddressability, AgentBuildContext, AgentIdentity, AgentRuntimeId, AgentRuntimeServices,
+    CheckpointVersion, ContinuityGeneration, ContinuityHealth, ContinuityRecord,
+    ContinuityStoreError, DispatchInput, DurabilityPolicy, DurableAgentSpec, FencingToken,
+    IdentityLifecycleState, IdentityStatus, LeaseGrant, LeaseInfo, ManagedPeerEdge, NotAddressable,
+    RosterContext, SessionSnapshot,
 };
 
 const MANAGED_PEER_RECONCILE_CONCURRENCY: usize = 64;
@@ -200,6 +201,12 @@ pub enum IdentityEvent {
         identity: AgentIdentity,
         version: CheckpointVersion,
     },
+    /// Resume could not reuse a persisted runtime binding and materialization
+    /// fresh-spawned a member instead.
+    ResumeFallback {
+        identity: AgentIdentity,
+        reason: super::bridge::ResumeFallbackReason,
+    },
 }
 
 /// Per-identity event channel capacity.
@@ -232,6 +239,7 @@ pub struct IdentityFirstRuntimeContext {
     pub topology_provider: Option<Arc<dyn TopologyProvider>>,
     pub customizer: Option<Arc<dyn AgentCustomizer>>,
     mob_definition: Option<meerkat_mob::MobDefinition>,
+    lazy_materialization: bool,
 }
 
 impl IdentityFirstRuntimeContext {
@@ -242,12 +250,31 @@ impl IdentityFirstRuntimeContext {
         customizer: Option<Arc<dyn AgentCustomizer>>,
         mob_definition: Option<meerkat_mob::MobDefinition>,
     ) -> Self {
+        Self::new_with_lazy_materialization(
+            runtime,
+            roster_provider,
+            topology_provider,
+            customizer,
+            mob_definition,
+            false,
+        )
+    }
+
+    pub fn new_with_lazy_materialization(
+        runtime: Arc<IdentityRuntime>,
+        roster_provider: Arc<dyn RosterProvider>,
+        topology_provider: Option<Arc<dyn TopologyProvider>>,
+        customizer: Option<Arc<dyn AgentCustomizer>>,
+        mob_definition: Option<meerkat_mob::MobDefinition>,
+        lazy_materialization: bool,
+    ) -> Self {
         Self {
             runtime,
             roster_provider,
             topology_provider,
             customizer,
             mob_definition,
+            lazy_materialization,
         }
     }
 
@@ -263,13 +290,22 @@ impl IdentityFirstRuntimeContext {
             .await
             .map_err(|err| IdentityRuntimeError::Internal(format!("roster provider: {err}")))?;
 
-        super::orchestrator::restore_flow(
-            &self.runtime,
-            &roster,
-            self.topology_provider.as_deref(),
-            self.customizer.as_deref(),
-        )
-        .await
+        if self.lazy_materialization {
+            super::orchestrator::lazy_register_flow(
+                &self.runtime,
+                &roster,
+                self.topology_provider.as_deref(),
+            )
+            .await
+        } else {
+            super::orchestrator::restore_flow(
+                &self.runtime,
+                &roster,
+                self.topology_provider.as_deref(),
+                self.customizer.as_deref(),
+            )
+            .await
+        }
     }
 }
 
@@ -286,6 +322,9 @@ pub struct IdentityRuntime {
     bridge: Option<Arc<dyn SessionBridge>>,
     runtime_services: AgentRuntimeServices,
     managed_peer_edges: RwLock<BTreeSet<(AgentIdentity, AgentIdentity)>>,
+    desired_peer_edges: RwLock<Vec<ManagedPeerEdge>>,
+    materialization_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
+    customizer: RwLock<Option<Arc<dyn AgentCustomizer>>>,
     default_timeout: Duration,
 }
 
@@ -303,6 +342,9 @@ impl IdentityRuntime {
             bridge: config.bridge,
             runtime_services: AgentRuntimeServices::empty(),
             managed_peer_edges: RwLock::new(BTreeSet::new()),
+            desired_peer_edges: RwLock::new(Vec::new()),
+            materialization_locks: RwLock::new(BTreeMap::new()),
+            customizer: RwLock::new(None),
             default_timeout: config.default_timeout.unwrap_or(Duration::from_secs(90)),
         }
     }
@@ -314,6 +356,14 @@ impl IdentityRuntime {
 
     pub(crate) fn runtime_services(&self) -> AgentRuntimeServices {
         self.runtime_services.clone()
+    }
+
+    pub async fn set_agent_customizer(&self, customizer: Option<Arc<dyn AgentCustomizer>>) {
+        *self.customizer.write().await = customizer;
+    }
+
+    pub async fn set_desired_peer_edges(&self, edges: Vec<ManagedPeerEdge>) {
+        *self.desired_peer_edges.write().await = edges;
     }
 
     #[must_use]
@@ -530,6 +580,243 @@ impl IdentityRuntime {
         self.event_channels.write().await.insert(identity, tx);
     }
 
+    async fn materialization_lock_for(&self, identity: &AgentIdentity) -> Arc<Mutex<()>> {
+        if let Some(lock) = self.materialization_locks.read().await.get(identity) {
+            return lock.clone();
+        }
+        let mut locks = self.materialization_locks.write().await;
+        locks
+            .entry(identity.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    /// Materialize a dormant identity into a concrete mob member/session.
+    ///
+    /// This is the lazy counterpart to eager `restore_flow`: it performs the
+    /// expensive bridge create/resume and snapshot load only when an identity is
+    /// actually touched. Parallel calls for one identity coalesce on a
+    /// per-identity lock and re-check state after acquiring it.
+    pub async fn materialize(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Result<ContinuityRecord, IdentityRuntimeError> {
+        let lock = self.materialization_lock_for(identity).await;
+        let _guard = lock.lock().await;
+
+        let (spec, continuity, state) = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            if entry.state == IdentityLifecycleState::Active {
+                return entry.continuity.clone().ok_or_else(|| {
+                    IdentityRuntimeError::Internal(format!(
+                        "active identity {identity} has no continuity record"
+                    ))
+                });
+            }
+            (entry.spec.clone(), entry.continuity.clone(), entry.state)
+        };
+
+        match state {
+            IdentityLifecycleState::Dormant | IdentityLifecycleState::Uninitialized => {}
+            IdentityLifecycleState::Broken
+            | IdentityLifecycleState::Retiring
+            | IdentityLifecycleState::Suspended => {
+                return Err(IdentityRuntimeError::InvalidState {
+                    identity: identity.clone(),
+                    state,
+                    operation: "materialize",
+                });
+            }
+            IdentityLifecycleState::Active => unreachable!("active handled above"),
+        }
+
+        let lease_results = self
+            .lease_provider
+            .acquire_leases(std::slice::from_ref(identity), &self.runtime_instance_id)
+            .await
+            .map_err(IdentityRuntimeError::Lease)?;
+        let grant = match lease_results.get(identity) {
+            Some(super::types::LeaseAcquireResult::Acquired(grant)) => grant.clone(),
+            _ => return Err(IdentityRuntimeError::NoActiveLease(identity.clone())),
+        };
+
+        let active_peers = self.entries.read().await.keys().cloned().collect();
+        let managed_edges = self.desired_peer_edges.read().await.clone();
+        let build_context = AgentBuildContext {
+            identity: identity.clone(),
+            active_peers,
+            managed_edges,
+            runtime_services: self.runtime_services(),
+        };
+        let mut draft = super::types::AgentBuildDraft {
+            model: None,
+            system_prompt: None,
+            additional_instructions: spec.additional_instructions.clone(),
+            labels: spec.labels.clone(),
+            app_context: spec.context.clone(),
+            external_tools: Vec::new(),
+            local_external_tools: Default::default(),
+        };
+        if let Some(customizer) = self.customizer.read().await.clone() {
+            customizer
+                .customize_build(&build_context, &spec, &mut draft)
+                .await
+                .map_err(|err| IdentityRuntimeError::Internal(format!("customizer: {err}")))?;
+        }
+
+        let mut record = if let Some(mut record) = continuity {
+            let snapshot = self
+                .continuity_store
+                .load_session_snapshot(&record.session_id)
+                .await
+                .map_err(IdentityRuntimeError::Store)?;
+
+            if let Some(bridge) = self.bridge.as_ref() {
+                bridge
+                    .register_session_runtime_state(
+                        &record.session_id,
+                        identity,
+                        record.generation,
+                        record.checkpoint_version,
+                        grant.fencing_token,
+                    )
+                    .await
+                    .map_err(|err| {
+                        IdentityRuntimeError::Internal(format!(
+                            "bridge register_session_runtime_state: {err}"
+                        ))
+                    })?;
+                let snapshot = snapshot.unwrap_or(SessionSnapshot { data: Vec::new() });
+                let outcome = bridge
+                    .resume_session(
+                        identity,
+                        &record.agent_runtime_id,
+                        &spec,
+                        &draft,
+                        &record.session_id,
+                        &snapshot,
+                    )
+                    .await
+                    .map_err(|err| {
+                        IdentityRuntimeError::Internal(format!("bridge resume_session: {err}"))
+                    })?;
+                if let Some(reason) = outcome.fallback_reason().cloned() {
+                    tracing::warn!(
+                        %identity,
+                        reason = ?reason,
+                        "lazy identity materialization fresh-spawned after typed resume fallback"
+                    );
+                    self.emit_event(
+                        identity,
+                        IdentityEvent::ResumeFallback {
+                            identity: identity.clone(),
+                            reason,
+                        },
+                    )
+                    .await;
+                }
+                record.session_id = outcome.session_id().clone();
+            }
+            record
+        } else {
+            let new_runtime_id =
+                AgentRuntimeId::parse(&format!("rt:{identity}:0")).map_err(|err| {
+                    IdentityRuntimeError::Internal(format!("failed to mint runtime id: {err}"))
+                })?;
+            let mut record = ContinuityRecord {
+                identity: identity.clone(),
+                agent_runtime_id: new_runtime_id,
+                session_id: meerkat_core::types::SessionId::new(),
+                generation: ContinuityGeneration::new(0),
+                checkpoint_version: CheckpointVersion::new(0),
+            };
+            self.continuity_store
+                .upsert_continuity_record(&record, grant.fencing_token)
+                .await?;
+            if let Some(bridge) = self.bridge.as_ref() {
+                bridge
+                    .register_session_runtime_state(
+                        &record.session_id,
+                        identity,
+                        record.generation,
+                        record.checkpoint_version,
+                        grant.fencing_token,
+                    )
+                    .await
+                    .map_err(|err| {
+                        IdentityRuntimeError::Internal(format!(
+                            "bridge register_session_runtime_state: {err}"
+                        ))
+                    })?;
+                record.session_id = bridge
+                    .create_session(
+                        identity,
+                        &record.agent_runtime_id,
+                        &spec,
+                        &draft,
+                        &record.session_id,
+                    )
+                    .await
+                    .map_err(|err| {
+                        IdentityRuntimeError::Internal(format!("bridge create_session: {err}"))
+                    })?;
+            }
+            record
+        };
+
+        self.continuity_store
+            .upsert_continuity_record(&record, grant.fencing_token)
+            .await?;
+        if let Some(bridge) = self.bridge.as_ref() {
+            let effective_checkpoint_version = bridge
+                .register_session_runtime_state(
+                    &record.session_id,
+                    identity,
+                    record.generation,
+                    record.checkpoint_version,
+                    grant.fencing_token,
+                )
+                .await
+                .map_err(|err| {
+                    IdentityRuntimeError::Internal(format!(
+                        "bridge register actual session runtime state: {err}"
+                    ))
+                })?;
+            record.checkpoint_version = effective_checkpoint_version;
+        }
+
+        {
+            let mut entries = self.entries.write().await;
+            let entry = entries
+                .get_mut(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            entry.continuity = Some(record.clone());
+            entry.lease = Some(LeaseEntry {
+                fencing_token: grant.fencing_token,
+                ttl: grant.ttl,
+                acquired_at: Instant::now(),
+            });
+            entry.state = IdentityLifecycleState::Active;
+            entry.checkpoint_version = record.checkpoint_version;
+        }
+        self.emit_event(
+            identity,
+            IdentityEvent::StateChanged {
+                identity: identity.clone(),
+                new_state: IdentityLifecycleState::Active,
+            },
+        )
+        .await;
+        let desired_edges = self.desired_peer_edges.read().await.clone();
+        if !desired_edges.is_empty() {
+            self.reconcile_managed_peer_edges(&desired_edges).await?;
+        }
+        Ok(record)
+    }
+
     // -----------------------------------------------------------------------
     // Subscribe — REQ-06
     // -----------------------------------------------------------------------
@@ -672,7 +959,7 @@ impl IdentityRuntime {
         identity: &AgentIdentity,
         content: &meerkat_core::ContentInput,
     ) -> Result<FencingToken, IdentityRuntimeError> {
-        let (token, runtime_id) = {
+        let should_materialize = {
             let entries = self.entries.read().await;
             let entry = entries
                 .get(identity)
@@ -684,6 +971,26 @@ impl IdentityRuntime {
                     identity: identity.clone(),
                     addressability: entry.spec.addressability,
                 }));
+            }
+            entry.state == IdentityLifecycleState::Dormant
+                || entry.state == IdentityLifecycleState::Uninitialized
+        };
+        if should_materialize {
+            self.materialize(identity).await?;
+        }
+
+        let (token, runtime_id) = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+
+            if entry.state != IdentityLifecycleState::Active {
+                return Err(IdentityRuntimeError::InvalidState {
+                    identity: identity.clone(),
+                    state: entry.state,
+                    operation: "send",
+                });
             }
 
             // INV-01 / INV-02: require active lease
@@ -726,11 +1033,31 @@ impl IdentityRuntime {
         identity: &AgentIdentity,
         input: &DispatchInput,
     ) -> Result<(FencingToken, bool), IdentityRuntimeError> {
+        let should_materialize = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            entry.state == IdentityLifecycleState::Dormant
+                || entry.state == IdentityLifecycleState::Uninitialized
+        };
+        if should_materialize {
+            self.materialize(identity).await?;
+        }
+
         let (token, is_durable, runtime_id) = {
             let entries = self.entries.read().await;
             let entry = entries
                 .get(identity)
                 .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+
+            if entry.state != IdentityLifecycleState::Active {
+                return Err(IdentityRuntimeError::InvalidState {
+                    identity: identity.clone(),
+                    state: entry.state,
+                    operation: "dispatch",
+                });
+            }
 
             // INV-01 / INV-02: require active lease
             let token = Self::check_lease(entry)?;
@@ -809,6 +1136,25 @@ impl IdentityRuntime {
             lease: lease_info,
             continuity_health,
         })
+    }
+
+    /// Return statuses for every registered identity without materializing
+    /// dormant members.
+    pub async fn statuses(&self) -> Vec<IdentityStatus> {
+        let identities = self
+            .entries
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut statuses = Vec::with_capacity(identities.len());
+        for identity in identities {
+            if let Ok(status) = self.status(&identity).await {
+                statuses.push(status);
+            }
+        }
+        statuses
     }
 
     // -----------------------------------------------------------------------

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -322,6 +322,7 @@ pub struct IdentityRuntime {
     bridge: Option<Arc<dyn SessionBridge>>,
     runtime_services: AgentRuntimeServices,
     managed_peer_edges: RwLock<BTreeSet<(AgentIdentity, AgentIdentity)>>,
+    managed_peer_reconcile_lock: Mutex<()>,
     desired_peer_edges: RwLock<Vec<ManagedPeerEdge>>,
     materialization_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
     customizer: RwLock<Option<Arc<dyn AgentCustomizer>>>,
@@ -342,6 +343,7 @@ impl IdentityRuntime {
             bridge: config.bridge,
             runtime_services: AgentRuntimeServices::empty(),
             managed_peer_edges: RwLock::new(BTreeSet::new()),
+            managed_peer_reconcile_lock: Mutex::new(()),
             desired_peer_edges: RwLock::new(Vec::new()),
             materialization_locks: RwLock::new(BTreeMap::new()),
             customizer: RwLock::new(None),
@@ -366,6 +368,29 @@ impl IdentityRuntime {
         *self.desired_peer_edges.write().await = edges;
     }
 
+    async fn registered_identities(&self) -> Vec<AgentIdentity> {
+        self.entries.read().await.keys().cloned().collect()
+    }
+
+    async fn reachable_peer_identities(&self, identity: &AgentIdentity) -> Vec<AgentIdentity> {
+        self.desired_peer_edges
+            .read()
+            .await
+            .iter()
+            .filter_map(|edge| {
+                if edge.a() == identity {
+                    Some(edge.b().clone())
+                } else if edge.b() == identity {
+                    Some(edge.a().clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
     #[must_use]
     pub fn has_session_bridge(&self) -> bool {
         self.bridge.is_some()
@@ -380,6 +405,7 @@ impl IdentityRuntime {
         &self,
         desired_edges: &[ManagedPeerEdge],
     ) -> Result<(), IdentityRuntimeError> {
+        let _guard = self.managed_peer_reconcile_lock.lock().await;
         let Some(bridge) = self.bridge.clone() else {
             return Ok(());
         };
@@ -817,6 +843,65 @@ impl IdentityRuntime {
         Ok(record)
     }
 
+    /// Materialize all identities currently registered with the runtime.
+    ///
+    /// Lazy bootstrap keeps `build()` metadata-only, but flow execution still
+    /// enters the mob runtime through concrete member IDs. This helper gives
+    /// flow entrypoints a single choke point to hydrate the concrete mob graph
+    /// before calling `run_flow`.
+    pub async fn materialize_all(&self) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
+        let identities = self.registered_identities().await;
+        let results = stream::iter(
+            identities
+                .into_iter()
+                .map(|identity| async move { self.materialize(&identity).await }),
+        )
+        .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+        let mut records = Vec::with_capacity(results.len());
+        for result in results {
+            records.push(result?);
+        }
+
+        let desired_edges = self.desired_peer_edges.read().await.clone();
+        if !desired_edges.is_empty() {
+            self.reconcile_managed_peer_edges(&desired_edges).await?;
+        }
+
+        Ok(records)
+    }
+
+    /// Ensure an active identity's desired peer neighborhood exists in the
+    /// concrete mob graph before ordinary communication starts.
+    pub async fn materialize_reachable_peers(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
+        let peers = self.reachable_peer_identities(identity).await;
+        let results = stream::iter(
+            peers
+                .into_iter()
+                .map(|peer| async move { self.materialize(&peer).await }),
+        )
+        .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+        let mut records = Vec::with_capacity(results.len());
+        for result in results {
+            records.push(result?);
+        }
+
+        let desired_edges = self.desired_peer_edges.read().await.clone();
+        if !desired_edges.is_empty() {
+            self.reconcile_managed_peer_edges(&desired_edges).await?;
+        }
+
+        Ok(records)
+    }
+
     // -----------------------------------------------------------------------
     // Subscribe — REQ-06
     // -----------------------------------------------------------------------
@@ -978,6 +1063,7 @@ impl IdentityRuntime {
         if should_materialize {
             self.materialize(identity).await?;
         }
+        self.materialize_reachable_peers(identity).await?;
 
         let (token, runtime_id) = {
             let entries = self.entries.read().await;
@@ -1044,6 +1130,7 @@ impl IdentityRuntime {
         if should_materialize {
             self.materialize(identity).await?;
         }
+        self.materialize_reachable_peers(identity).await?;
 
         let (token, is_durable, runtime_id) = {
             let entries = self.entries.read().await;

--- a/meerkat-mobkit/src/identity_first/types.rs
+++ b/meerkat-mobkit/src/identity_first/types.rs
@@ -579,9 +579,15 @@ pub struct DurableAgentSpec {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IdentityLifecycleState {
+    /// Identity metadata is registered and addressable, but no concrete mob
+    /// member/session has been spawned or resumed in this runtime yet.
+    Dormant,
+    /// Identity has a concrete mob member/session in this runtime.
     Active,
     Retiring,
     Suspended,
+    /// Continuity exists but cannot currently be materialized safely.
+    Broken,
     Uninitialized,
 }
 

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -135,11 +135,11 @@ pub use types::{
 pub use unified_runtime::{
     DEFAULT_REFERENCE_APP_MAX_CONCURRENT_REQUESTS, DesiredPeerEdge, DesiredPeerEdgeError,
     Discovery, EdgeDiscovery, EdgeReconcileFailure, ErrorEvent, ErrorHook, EventLogConfig,
-    EventLogStore, EventQuery, PersistedEvent, PostReconcileHook, PostSpawnHook, PreSpawnContext,
-    PreSpawnHook, RediscoverReport, ShutdownDrainReport, UnifiedRuntime,
-    UnifiedRuntimeBootstrapError, UnifiedRuntimeBuilder, UnifiedRuntimeBuilderError,
-    UnifiedRuntimeBuilderField, UnifiedRuntimeError, UnifiedRuntimeReconcileEdgesReport,
-    UnifiedRuntimeReconcileError, UnifiedRuntimeReconcileReport,
-    UnifiedRuntimeReconcileRoutingReport, UnifiedRuntimeRunReport, UnifiedRuntimeShutdownReport,
-    discovery_spec_to_spawn_spec,
+    EventLogStore, EventQuery, IdentityBootstrapMode, PersistedEvent, PostReconcileHook,
+    PostSpawnHook, PreSpawnContext, PreSpawnHook, RediscoverReport, ShutdownDrainReport,
+    UnifiedRuntime, UnifiedRuntimeBootstrapError, UnifiedRuntimeBuilder,
+    UnifiedRuntimeBuilderError, UnifiedRuntimeBuilderField, UnifiedRuntimeError,
+    UnifiedRuntimeReconcileEdgesReport, UnifiedRuntimeReconcileError,
+    UnifiedRuntimeReconcileReport, UnifiedRuntimeReconcileRoutingReport, UnifiedRuntimeRunReport,
+    UnifiedRuntimeShutdownReport, discovery_spec_to_spawn_spec,
 };

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -2487,6 +2487,17 @@ pub async fn handle_unified_rpc_json(
                                         "generation": record.generation.get(),
                                     })
                                 }
+                                crate::identity_first::RestoreOutcome::Dormant {
+                                    record, ..
+                                } => {
+                                    serde_json::json!({
+                                        "outcome": "dormant",
+                                        "identity": id.as_str(),
+                                        "agent_runtime_id": record.as_ref().map(|record| record.agent_runtime_id.as_str()),
+                                        "session_id": record.as_ref().map(|record| record.session_id.to_string()),
+                                        "generation": record.as_ref().map(|record| record.generation.get()),
+                                    })
+                                }
                                 crate::identity_first::RestoreOutcome::Resumed {
                                     record, ..
                                 } => {

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -1571,6 +1571,18 @@ pub(super) async fn handle_run_flow(
     match flow_id_str {
         Some(fid) if !fid.is_empty() => {
             let flow_id = meerkat_mob::FlowId::from(fid);
+            if let Err(err) = runtime.materialize_identity_first_for_flow().await {
+                return JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: response_id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32000,
+                        message: format!("identity-first flow materialization failed: {err}"),
+                        data: None,
+                    }),
+                };
+            }
             match runtime.mob_handle().run_flow(flow_id, flow_params).await {
                 Ok(run_id) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::stream::{self, StreamExt};
 use meerkat_client::LlmClient;
 use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
 
@@ -12,7 +13,7 @@ use crate::contact_directory::ContactDirectory;
 use crate::identity_first::{
     AgentCustomizer, AgentRuntimeServices, ContinuitySessionStoreAdapter, DurabilityPolicy,
     IdentityFirstRuntimeContext, IdentityRuntime, IdentityRuntimeConfig, RosterContext,
-    RosterProvider, TopologyProvider, restore_flow,
+    RosterProvider, TopologyProvider, lazy_register_flow, restore_flow,
 };
 use crate::mob_handle_runtime::{
     CapabilityFlags, MobBootstrapOptions, MobBootstrapSpec, SessionHook,
@@ -43,6 +44,22 @@ const DEFAULT_MAX_SESSIONS: usize = 64;
 /// Default builder timeout.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Controls how identity-first durable agents are materialized during
+/// `UnifiedRuntime::build()`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum IdentityBootstrapMode {
+    /// Compatibility mode: `build()` synchronously creates/resumes every
+    /// identity in the roster.
+    #[default]
+    EagerMaterialize,
+    /// Register roster/topology/continuity metadata only; create/resume a
+    /// concrete member on first send/dispatch/explicit materialize.
+    LazyMaterialize,
+    /// Return from `build()` after lazy metadata registration and warm
+    /// identities in a background task with bounded concurrency.
+    LazyWithBackgroundWarm { concurrency: usize },
+}
+
 #[derive(Default)]
 pub struct UnifiedRuntimeBuilder {
     // --- Legacy path (mob_spec directly) ---
@@ -63,6 +80,7 @@ pub struct UnifiedRuntimeBuilder {
     roster_provider: Option<Arc<dyn RosterProvider>>,
     topology_provider: Option<Arc<dyn TopologyProvider>>,
     agent_customizer: Option<Arc<dyn AgentCustomizer>>,
+    identity_bootstrap_mode: IdentityBootstrapMode,
     identity_runtime_instance_id: Option<String>,
     scratch_dir: Option<PathBuf>,
     blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
@@ -180,6 +198,12 @@ impl UnifiedRuntimeBuilder {
     /// Set the identity-first build customizer.
     pub fn agent_customizer(mut self, customizer: Arc<dyn AgentCustomizer>) -> Self {
         self.agent_customizer = Some(customizer);
+        self
+    }
+
+    /// Set how identity-first durable agents are materialized during build.
+    pub fn identity_bootstrap_mode(mut self, mode: IdentityBootstrapMode) -> Self {
+        self.identity_bootstrap_mode = mode;
         self
     }
 
@@ -579,6 +603,9 @@ impl UnifiedRuntimeBuilder {
                 })
                 .with_runtime_services(AgentRuntimeServices::new(runtime.mob_runtime.handle())),
             );
+            identity_runtime
+                .set_agent_customizer(self.agent_customizer.clone())
+                .await;
 
             let roster_specs = roster_provider
                 .roster(&RosterContext {
@@ -594,26 +621,95 @@ impl UnifiedRuntimeBuilder {
                     )
                 })?;
 
-            restore_flow(
-                &identity_runtime,
-                &roster_specs,
-                self.topology_provider.as_deref(),
-                self.agent_customizer.as_deref(),
-            )
-            .await
-            .map_err(|err| {
-                UnifiedRuntimeBuilderError::Bootstrap(UnifiedRuntimeBootstrapError::IdentityFirst(
-                    format!("restore_flow failed: {err}"),
-                ))
-            })?;
+            match self.identity_bootstrap_mode.clone() {
+                IdentityBootstrapMode::EagerMaterialize => {
+                    restore_flow(
+                        &identity_runtime,
+                        &roster_specs,
+                        self.topology_provider.as_deref(),
+                        self.agent_customizer.as_deref(),
+                    )
+                    .await
+                    .map_err(|err| {
+                        UnifiedRuntimeBuilderError::Bootstrap(
+                            UnifiedRuntimeBootstrapError::IdentityFirst(format!(
+                                "restore_flow failed: {err}"
+                            )),
+                        )
+                    })?;
+                }
+                IdentityBootstrapMode::LazyMaterialize => {
+                    lazy_register_flow(
+                        &identity_runtime,
+                        &roster_specs,
+                        self.topology_provider.as_deref(),
+                    )
+                    .await
+                    .map_err(|err| {
+                        UnifiedRuntimeBuilderError::Bootstrap(
+                            UnifiedRuntimeBootstrapError::IdentityFirst(format!(
+                                "lazy_register_flow failed: {err}"
+                            )),
+                        )
+                    })?;
+                }
+                IdentityBootstrapMode::LazyWithBackgroundWarm { concurrency } => {
+                    if concurrency == 0 {
+                        return Err(UnifiedRuntimeBuilderError::ConflictingConfiguration(
+                            "LazyWithBackgroundWarm concurrency must be greater than 0".to_string(),
+                        ));
+                    }
+                    lazy_register_flow(
+                        &identity_runtime,
+                        &roster_specs,
+                        self.topology_provider.as_deref(),
+                    )
+                    .await
+                    .map_err(|err| {
+                        UnifiedRuntimeBuilderError::Bootstrap(
+                            UnifiedRuntimeBootstrapError::IdentityFirst(format!(
+                                "lazy_register_flow failed: {err}"
+                            )),
+                        )
+                    })?;
+                    let warm_runtime = identity_runtime.clone();
+                    let warm_identities = roster_specs
+                        .iter()
+                        .map(|spec| spec.identity.clone())
+                        .collect::<Vec<_>>();
+                    tokio::spawn(async move {
+                        stream::iter(warm_identities.into_iter().map(|identity| {
+                            let runtime = warm_runtime.clone();
+                            async move {
+                                if let Err(err) = runtime.materialize(&identity).await {
+                                    tracing::warn!(
+                                        %identity,
+                                        error = %err,
+                                        "identity-first background warm failed"
+                                    );
+                                }
+                            }
+                        }))
+                        .buffer_unordered(concurrency)
+                        .collect::<Vec<_>>()
+                        .await;
+                    });
+                }
+            }
 
-            Some(Arc::new(IdentityFirstRuntimeContext::new(
-                identity_runtime,
-                roster_provider,
-                self.topology_provider.clone(),
-                self.agent_customizer.clone(),
-                Some(runtime.mob_runtime.handle().definition().clone()),
-            )))
+            Some(Arc::new(
+                IdentityFirstRuntimeContext::new_with_lazy_materialization(
+                    identity_runtime,
+                    roster_provider,
+                    self.topology_provider.clone(),
+                    self.agent_customizer.clone(),
+                    Some(runtime.mob_runtime.handle().definition().clone()),
+                    !matches!(
+                        self.identity_bootstrap_mode,
+                        IdentityBootstrapMode::EagerMaterialize
+                    ),
+                ),
+            ))
         } else {
             None
         };

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -370,6 +370,20 @@ impl UnifiedRuntime {
         }
     }
 
+    /// Hydrate identity-first lazy members before handing control to concrete
+    /// mob APIs that operate on already-materialized runtime members.
+    pub async fn materialize_identity_first_for_flow(
+        &self,
+    ) -> Result<
+        Vec<crate::identity_first::ContinuityRecord>,
+        crate::identity_first::IdentityRuntimeError,
+    > {
+        match self.identity_runtime() {
+            Some(runtime) => runtime.materialize_all().await,
+            None => Ok(Vec::new()),
+        }
+    }
+
     /// Return the mob/run label sidecar table.
     ///
     /// Mobkit owns this table — meerkat-mob has no concept of mob- or

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -39,7 +39,7 @@ pub mod mob_ops;
 pub mod module_ops;
 pub mod types;
 
-pub use builder::UnifiedRuntimeBuilder;
+pub use builder::{IdentityBootstrapMode, UnifiedRuntimeBuilder};
 pub use edge_types::{
     DesiredPeerEdge, DesiredPeerEdgeError, Discovery, EdgeDiscovery, EdgeReconcileFailure,
     PreSpawnContext, PreSpawnHook,

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -28,8 +28,9 @@ use meerkat_mobkit::identity_first::{
 use meerkat_mobkit::unified_runtime::{IdentityBootstrapMode, UnifiedRuntimeBuilder};
 use meerkat_mobkit::{
     AllowAllConsoleVisibilityPolicy, ConsoleRuntimeRegistration, ConsoleVisibility,
-    MobKitConsoleAggregator,
+    JsonRpcResponse, MobKitConsoleAggregator, handle_unified_rpc_json,
 };
+use serde_json::json;
 
 // ---------------------------------------------------------------------------
 // Minimal mock implementations for builder testing
@@ -244,6 +245,30 @@ runtime_mode = "turn_driven"
 
 [profiles.default.tools]
 comms = true
+"#,
+    )
+    .unwrap()
+}
+
+fn review_flow_definition() -> meerkat_mob::MobDefinition {
+    meerkat_mob::MobDefinition::from_toml(
+        r#"
+[mob]
+id = "identity-builder-flow-test"
+
+[profiles.default]
+model = "gpt-5.5"
+runtime_mode = "turn_driven"
+
+[profiles.default.tools]
+comms = true
+
+[flows.review_cycle]
+description = "OB3-shaped review flow"
+
+[flows.review_cycle.steps.review]
+role = "default"
+message = "run review cycle"
 "#,
     )
     .unwrap()
@@ -645,6 +670,122 @@ async fn identity_first_builder_lazy_topology_refresh_stays_metadata_only() {
         .await
         .unwrap();
     assert_eq!(status.state, IdentityLifecycleState::Dormant);
+}
+
+#[tokio::test]
+async fn identity_first_builder_lazy_run_flow_materializes_ob3_shaped_roster_before_flow_start() {
+    let tmp = tempfile::tempdir().unwrap();
+    let specs = vec![
+        durable_spec("review:singleton"),
+        durable_spec("initiative:alpha"),
+        durable_spec("initiative:beta"),
+    ];
+    let topology = Arc::new(StubTopologyProvider {
+        edges: Arc::new(tokio::sync::Mutex::new(vec![
+            ManagedPeerEdge::new(
+                AgentIdentity::parse("review:singleton").unwrap(),
+                AgentIdentity::parse("initiative:alpha").unwrap(),
+            )
+            .unwrap(),
+            ManagedPeerEdge::new(
+                AgentIdentity::parse("review:singleton").unwrap(),
+                AgentIdentity::parse("initiative:beta").unwrap(),
+            )
+            .unwrap(),
+        ])),
+    });
+
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(review_flow_definition())
+        .continuity_store(Arc::new(StubContinuityStore))
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(Arc::new(StubRosterProvider::new(specs)))
+        .topology_provider(topology)
+        .scratch_dir(tmp.path())
+        .identity_runtime_instance_id("builder-lazy-flow-test")
+        .identity_bootstrap_mode(IdentityBootstrapMode::LazyMaterialize)
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("lazy builder should bootstrap");
+
+    assert!(
+        runtime
+            .mob_handle()
+            .list_members_including_retiring()
+            .await
+            .is_empty(),
+        "lazy build must still start without concrete members"
+    );
+
+    let response: JsonRpcResponse = serde_json::from_str(
+        &handle_unified_rpc_json(
+            &runtime,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": "review-flow",
+                "method": "mobkit/run_flow",
+                "params": {
+                    "flow_id": "review_cycle",
+                    "params": { "source": "ob3" }
+                }
+            })
+            .to_string(),
+            Duration::from_secs(2),
+            None,
+            None,
+        )
+        .await,
+    )
+    .expect("json-rpc response");
+
+    assert!(
+        response.error.is_none(),
+        "run_flow should hydrate lazy identities before concrete flow execution: {:?}",
+        response.error
+    );
+    assert!(
+        response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("run_id"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|run_id| !run_id.is_empty()),
+        "run_flow should return a concrete run id"
+    );
+
+    let members = runtime.mob_handle().list_members_including_retiring().await;
+    let member_ids = members
+        .iter()
+        .map(|member| member.agent_identity.to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        member_ids.len(),
+        3,
+        "flow entrypoint must materialize the full review roster, got {member_ids:?}"
+    );
+    for expected in [
+        "rt:review:singleton:0",
+        "rt:initiative:alpha:0",
+        "rt:initiative:beta:0",
+    ] {
+        assert!(
+            member_ids.iter().any(|member_id| member_id == expected),
+            "expected materialized member {expected}, got {member_ids:?}"
+        );
+    }
+
+    let identity_runtime = runtime.identity_runtime().unwrap();
+    for identity in ["review:singleton", "initiative:alpha", "initiative:beta"] {
+        assert_eq!(
+            identity_runtime
+                .status(&AgentIdentity::parse(identity).unwrap())
+                .await
+                .unwrap()
+                .state,
+            IdentityLifecycleState::Active
+        );
+    }
 }
 
 #[tokio::test]

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -11,6 +11,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -20,10 +21,15 @@ use meerkat_mobkit::identity_first::contracts::{
 use meerkat_mobkit::identity_first::{
     AgentAddressability, AgentIdentity, CheckpointVersion, ContinuityGeneration, ContinuityRecord,
     ContinuityResolveState, ContinuityStoreError, DurableAgentSpec, FencingToken,
-    LeaseAcquireResult, LeaseError, LeaseGrant, LeaseRenewResult, LocalContinuityStore,
-    ManagedPeerEdge, RosterContext, RosterError, SessionSnapshot, TopologyContext, TopologyError,
+    IdentityLifecycleState, LeaseAcquireResult, LeaseError, LeaseGrant, LeaseRenewResult,
+    LocalContinuityStore, ManagedPeerEdge, RosterContext, RosterError, SessionSnapshot,
+    TopologyContext, TopologyError,
 };
-use meerkat_mobkit::unified_runtime::UnifiedRuntimeBuilder;
+use meerkat_mobkit::unified_runtime::{IdentityBootstrapMode, UnifiedRuntimeBuilder};
+use meerkat_mobkit::{
+    AllowAllConsoleVisibilityPolicy, ConsoleRuntimeRegistration, ConsoleVisibility,
+    MobKitConsoleAggregator,
+};
 
 // ---------------------------------------------------------------------------
 // Minimal mock implementations for builder testing
@@ -66,6 +72,88 @@ impl ContinuityStore for StubContinuityStore {
     ) -> Result<(), ContinuityStoreError> {
         Ok(())
     }
+    async fn delete_continuity_record(
+        &self,
+        _identity: &AgentIdentity,
+        _ft: FencingToken,
+    ) -> Result<(), ContinuityStoreError> {
+        Ok(())
+    }
+}
+
+struct CountingReadyContinuityStore {
+    records: BTreeMap<AgentIdentity, ContinuityRecord>,
+    load_snapshot_calls: AtomicUsize,
+    upsert_calls: AtomicUsize,
+}
+
+impl CountingReadyContinuityStore {
+    fn new(records: BTreeMap<AgentIdentity, ContinuityRecord>) -> Self {
+        Self {
+            records,
+            load_snapshot_calls: AtomicUsize::new(0),
+            upsert_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn load_snapshot_calls(&self) -> usize {
+        self.load_snapshot_calls.load(Ordering::SeqCst)
+    }
+
+    fn upsert_calls(&self) -> usize {
+        self.upsert_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ContinuityStore for CountingReadyContinuityStore {
+    async fn resolve_many(
+        &self,
+        identities: &[AgentIdentity],
+    ) -> Result<BTreeMap<AgentIdentity, ContinuityResolveState>, ContinuityStoreError> {
+        Ok(identities
+            .iter()
+            .map(|id| {
+                let state = self
+                    .records
+                    .get(id)
+                    .cloned()
+                    .map(|record| ContinuityResolveState::Ready { record })
+                    .unwrap_or(ContinuityResolveState::Uninitialized);
+                (id.clone(), state)
+            })
+            .collect())
+    }
+
+    async fn load_session_snapshot(
+        &self,
+        _sid: &meerkat_core::types::SessionId,
+    ) -> Result<Option<SessionSnapshot>, ContinuityStoreError> {
+        self.load_snapshot_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }
+
+    async fn save_session_snapshot(
+        &self,
+        _identity: &AgentIdentity,
+        _sid: &meerkat_core::types::SessionId,
+        _gen: ContinuityGeneration,
+        _ver: CheckpointVersion,
+        _ft: FencingToken,
+        _snap: &SessionSnapshot,
+    ) -> Result<(), ContinuityStoreError> {
+        Ok(())
+    }
+
+    async fn upsert_continuity_record(
+        &self,
+        _record: &ContinuityRecord,
+        _ft: FencingToken,
+    ) -> Result<(), ContinuityStoreError> {
+        self.upsert_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
     async fn delete_continuity_record(
         &self,
         _identity: &AgentIdentity,
@@ -172,6 +260,19 @@ fn durable_spec(identity: &str) -> DurableAgentSpec {
         additional_instructions: Vec::new(),
         initial_message: None,
         runtime_mode_override: Some(meerkat_mob::MobRuntimeMode::TurnDriven),
+    }
+}
+
+fn continuity_record(identity: &str) -> ContinuityRecord {
+    ContinuityRecord {
+        identity: AgentIdentity::parse(identity).unwrap(),
+        agent_runtime_id: meerkat_mobkit::identity_first::AgentRuntimeId::parse(&format!(
+            "rt:{identity}:0"
+        ))
+        .unwrap(),
+        session_id: meerkat_core::types::SessionId::new(),
+        generation: ContinuityGeneration::new(0),
+        checkpoint_version: CheckpointVersion::new(1),
     }
 }
 
@@ -326,6 +427,224 @@ async fn identity_first_builder_bootstraps_and_exposes_identity_runtime() {
         status.runtime_mode,
         Some(meerkat_mob::MobRuntimeMode::TurnDriven)
     );
+}
+
+#[tokio::test]
+async fn identity_first_builder_lazy_materialize_registers_large_ready_roster_without_hydration() {
+    let tmp = tempfile::tempdir().unwrap();
+    let specs = (0..1_000)
+        .map(|index| durable_spec(&format!("agent:{index}")))
+        .collect::<Vec<_>>();
+    let records = specs
+        .iter()
+        .map(|spec| {
+            (
+                spec.identity.clone(),
+                continuity_record(spec.identity.as_str()),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let continuity_store = Arc::new(CountingReadyContinuityStore::new(records));
+
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(continuity_store.clone())
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(Arc::new(StubRosterProvider::new(specs)))
+        .scratch_dir(tmp.path())
+        .identity_runtime_instance_id("builder-lazy-test")
+        .identity_bootstrap_mode(IdentityBootstrapMode::LazyMaterialize)
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("lazy builder should bootstrap identity metadata");
+
+    assert_eq!(
+        continuity_store.load_snapshot_calls(),
+        0,
+        "lazy build must not hydrate session snapshots"
+    );
+    assert_eq!(
+        continuity_store.upsert_calls(),
+        0,
+        "lazy build must not rewrite continuity records"
+    );
+    assert!(
+        runtime
+            .mob_handle()
+            .list_members_including_retiring()
+            .await
+            .is_empty(),
+        "lazy build must not spawn/resume mob members"
+    );
+    let identity_runtime = runtime
+        .identity_runtime()
+        .expect("identity runtime should be exposed");
+    let status = identity_runtime
+        .status(&AgentIdentity::parse("agent:42").unwrap())
+        .await
+        .expect("dormant identity should be inspectable");
+    assert_eq!(status.state, IdentityLifecycleState::Dormant);
+    assert_eq!(status.profile.unwrap().as_str(), "default");
+}
+
+#[tokio::test]
+async fn identity_first_builder_lazy_console_lists_and_inspects_dormant_identities() {
+    let tmp = tempfile::tempdir().unwrap();
+    let specs = vec![durable_spec("agent:alpha"), durable_spec("agent:beta")];
+    let alpha_record = continuity_record("agent:alpha");
+    let expected_alpha_session_id = alpha_record.session_id.to_string();
+    let beta_record = continuity_record("agent:beta");
+    let records = BTreeMap::from([
+        (AgentIdentity::parse("agent:alpha").unwrap(), alpha_record),
+        (AgentIdentity::parse("agent:beta").unwrap(), beta_record),
+    ]);
+    let continuity_store = Arc::new(CountingReadyContinuityStore::new(records));
+
+    let runtime = Arc::new(
+        UnifiedRuntimeBuilder::default()
+            .definition(test_definition())
+            .continuity_store(continuity_store.clone())
+            .lease_provider(Arc::new(StubLeaseProvider))
+            .roster_provider(Arc::new(StubRosterProvider::new(specs)))
+            .scratch_dir(tmp.path())
+            .identity_runtime_instance_id("builder-lazy-console-test")
+            .identity_bootstrap_mode(IdentityBootstrapMode::LazyMaterialize)
+            .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+            .build()
+            .await
+            .expect("lazy builder should bootstrap identity metadata"),
+    );
+    let aggregator = MobKitConsoleAggregator::in_memory();
+    aggregator.register_runtime(ConsoleRuntimeRegistration {
+        runtime_key: "runtime-a".to_string(),
+        runtime: runtime.clone(),
+        identity_namespace: "prod".to_string(),
+        visibility_policy: Arc::new(AllowAllConsoleVisibilityPolicy),
+    });
+
+    let records = aggregator
+        .list_identities()
+        .await
+        .expect("console identity list should work");
+    let alpha = records
+        .iter()
+        .find(|record| record.identity == "prod/agent:alpha")
+        .expect("dormant alpha should be visible");
+    assert_eq!(alpha.health, "dormant");
+    assert_eq!(alpha.visibility, ConsoleVisibility::Addressable);
+    assert_eq!(alpha.session_id, Some(expected_alpha_session_id));
+    assert!(
+        runtime
+            .mob_handle()
+            .list_members_including_retiring()
+            .await
+            .is_empty(),
+        "console listing must not materialize dormant identities"
+    );
+    assert_eq!(
+        continuity_store.load_snapshot_calls(),
+        0,
+        "console listing must not load session snapshots"
+    );
+
+    let inspection = aggregator
+        .inspect_identity("prod/agent:alpha")
+        .await
+        .expect("console inspect should not fail")
+        .expect("dormant alpha should be inspectable");
+    assert_eq!(inspection.identity.health, "dormant");
+    assert!(inspection.peers.is_empty());
+    assert!(
+        runtime
+            .mob_handle()
+            .list_members_including_retiring()
+            .await
+            .is_empty(),
+        "console inspection must not materialize dormant identities"
+    );
+}
+
+#[tokio::test]
+async fn identity_first_builder_rejects_zero_background_warm_concurrency() {
+    let tmp = tempfile::tempdir().unwrap();
+    let builder = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(Arc::new(StubContinuityStore))
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(Arc::new(StubRosterProvider::new(vec![durable_spec(
+            "agent:alpha",
+        )])))
+        .scratch_dir(tmp.path())
+        .identity_bootstrap_mode(IdentityBootstrapMode::LazyWithBackgroundWarm { concurrency: 0 })
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()));
+
+    assert_build_err_contains(builder, "concurrency").await;
+}
+
+#[tokio::test]
+async fn identity_first_builder_lazy_topology_refresh_stays_metadata_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let specs = vec![durable_spec("agent:a"), durable_spec("agent:b")];
+    let records = specs
+        .iter()
+        .map(|spec| {
+            (
+                spec.identity.clone(),
+                continuity_record(spec.identity.as_str()),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let continuity_store = Arc::new(CountingReadyContinuityStore::new(records));
+    let topology = Arc::new(StubTopologyProvider {
+        edges: Arc::new(tokio::sync::Mutex::new(vec![
+            ManagedPeerEdge::new(
+                AgentIdentity::parse("agent:a").unwrap(),
+                AgentIdentity::parse("agent:b").unwrap(),
+            )
+            .unwrap(),
+        ])),
+    });
+
+    let runtime = UnifiedRuntimeBuilder::default()
+        .definition(test_definition())
+        .continuity_store(continuity_store.clone())
+        .lease_provider(Arc::new(StubLeaseProvider))
+        .roster_provider(Arc::new(StubRosterProvider::new(specs)))
+        .topology_provider(topology)
+        .scratch_dir(tmp.path())
+        .identity_runtime_instance_id("builder-lazy-refresh-test")
+        .identity_bootstrap_mode(IdentityBootstrapMode::LazyMaterialize)
+        .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+        .build()
+        .await
+        .expect("lazy builder should bootstrap");
+
+    runtime
+        .refresh_desired_topology()
+        .await
+        .expect("lazy refresh should succeed");
+
+    assert_eq!(
+        continuity_store.load_snapshot_calls(),
+        0,
+        "lazy topology refresh must not hydrate snapshots"
+    );
+    assert!(
+        runtime
+            .mob_handle()
+            .list_members_including_retiring()
+            .await
+            .is_empty(),
+        "lazy topology refresh must not spawn members"
+    );
+    let status = runtime
+        .identity_runtime()
+        .unwrap()
+        .status(&AgentIdentity::parse("agent:a").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(status.state, IdentityLifecycleState::Dormant);
 }
 
 #[tokio::test]

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -14,6 +14,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -21,7 +22,7 @@ use meerkat_mobkit::identity_first::contracts::{
     AgentCustomizer, ContinuityStore, LeaseProvider, TopologyProvider,
 };
 use meerkat_mobkit::identity_first::orchestrator::{
-    ReconcileAction, RestoreOutcome, compute_reconcile_actions, restore_flow,
+    ReconcileAction, RestoreOutcome, compute_reconcile_actions, lazy_register_flow, restore_flow,
 };
 use meerkat_mobkit::identity_first::runtime::IdentityEvent;
 use meerkat_mobkit::identity_first::{
@@ -107,6 +108,205 @@ fn make_runtime_with_store(
         bridge: None,
         default_timeout: None,
     })
+}
+
+fn make_runtime_with_bridge(
+    store: Arc<dyn ContinuityStore>,
+    lease: Arc<dyn LeaseProvider>,
+    bridge: Arc<dyn SessionBridge>,
+) -> Arc<IdentityRuntime> {
+    Arc::new(IdentityRuntime::new(IdentityRuntimeConfig {
+        continuity_store: store,
+        lease_provider: lease,
+        runtime_instance_id: "test-runtime".to_string(),
+        has_runtime_store: true,
+        durability_policy: DurabilityPolicy::SyncWriteThrough,
+        bridge: Some(bridge),
+        default_timeout: None,
+    }))
+}
+
+struct CountingContinuityStore {
+    inner: Arc<LocalContinuityStore>,
+    resolve_many_calls: AtomicUsize,
+    load_snapshot_calls: AtomicUsize,
+}
+
+impl CountingContinuityStore {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(LocalContinuityStore::in_memory().unwrap()),
+            resolve_many_calls: AtomicUsize::new(0),
+            load_snapshot_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn reset_counts(&self) {
+        self.resolve_many_calls.store(0, Ordering::SeqCst);
+        self.load_snapshot_calls.store(0, Ordering::SeqCst);
+    }
+
+    fn resolve_many_calls(&self) -> usize {
+        self.resolve_many_calls.load(Ordering::SeqCst)
+    }
+
+    fn load_snapshot_calls(&self) -> usize {
+        self.load_snapshot_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ContinuityStore for CountingContinuityStore {
+    async fn resolve_many(
+        &self,
+        identities: &[AgentIdentity],
+    ) -> Result<BTreeMap<AgentIdentity, ContinuityResolveState>, ContinuityStoreError> {
+        self.resolve_many_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.resolve_many(identities).await
+    }
+
+    async fn load_session_snapshot(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> Result<Option<SessionSnapshot>, ContinuityStoreError> {
+        self.load_snapshot_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.load_session_snapshot(session_id).await
+    }
+
+    async fn save_session_snapshot(
+        &self,
+        identity: &AgentIdentity,
+        session_id: &meerkat_core::types::SessionId,
+        generation: ContinuityGeneration,
+        version: CheckpointVersion,
+        fencing_token: FencingToken,
+        snapshot: &SessionSnapshot,
+    ) -> Result<(), ContinuityStoreError> {
+        self.inner
+            .save_session_snapshot(
+                identity,
+                session_id,
+                generation,
+                version,
+                fencing_token,
+                snapshot,
+            )
+            .await
+    }
+
+    async fn upsert_continuity_record(
+        &self,
+        record: &ContinuityRecord,
+        fencing_token: FencingToken,
+    ) -> Result<(), ContinuityStoreError> {
+        self.inner
+            .upsert_continuity_record(record, fencing_token)
+            .await
+    }
+
+    async fn delete_continuity_record(
+        &self,
+        identity: &AgentIdentity,
+        fencing_token: FencingToken,
+    ) -> Result<(), ContinuityStoreError> {
+        self.inner
+            .delete_continuity_record(identity, fencing_token)
+            .await
+    }
+}
+
+#[derive(Default)]
+struct CountingBridge {
+    create_calls: AtomicUsize,
+    resume_calls: AtomicUsize,
+    deliver_calls: AtomicUsize,
+    force_resume_fallback: AtomicBool,
+    resume_delay: tokio::sync::Mutex<Option<Duration>>,
+    fallback_session_id: tokio::sync::Mutex<Option<meerkat_core::types::SessionId>>,
+}
+
+impl CountingBridge {
+    async fn set_resume_delay(&self, delay: Duration) {
+        *self.resume_delay.lock().await = Some(delay);
+    }
+
+    async fn set_force_resume_fallback(&self, session_id: meerkat_core::types::SessionId) {
+        self.force_resume_fallback.store(true, Ordering::SeqCst);
+        *self.fallback_session_id.lock().await = Some(session_id);
+    }
+}
+
+#[async_trait]
+impl SessionBridge for CountingBridge {
+    async fn create_session(
+        &self,
+        _identity: &AgentIdentity,
+        _runtime_id: &AgentRuntimeId,
+        _spec: &DurableAgentSpec,
+        _draft: &AgentBuildDraft,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+        self.create_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(session_id.clone())
+    }
+
+    async fn resume_session(
+        &self,
+        _identity: &AgentIdentity,
+        _runtime_id: &AgentRuntimeId,
+        _spec: &DurableAgentSpec,
+        _draft: &AgentBuildDraft,
+        session_id: &meerkat_core::types::SessionId,
+        _snapshot: &SessionSnapshot,
+    ) -> Result<meerkat_mobkit::identity_first::ResumeSessionOutcome, BridgeError> {
+        self.resume_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(delay) = *self.resume_delay.lock().await {
+            tokio::time::sleep(delay).await;
+        }
+        if self.force_resume_fallback.load(Ordering::SeqCst) {
+            let fallback_session_id = self
+                .fallback_session_id
+                .lock()
+                .await
+                .clone()
+                .unwrap_or_else(meerkat_core::types::SessionId::new);
+            return Ok(
+                meerkat_mobkit::identity_first::ResumeSessionOutcome::FreshSpawned {
+                    session_id: fallback_session_id,
+                    reason:
+                        meerkat_mobkit::identity_first::ResumeFallbackReason::RuntimeIdentityIncompatible {
+                            detail: "test mismatch".to_string(),
+                        },
+                },
+            );
+        }
+        Ok(
+            meerkat_mobkit::identity_first::ResumeSessionOutcome::Resumed {
+                session_id: session_id.clone(),
+            },
+        )
+    }
+
+    async fn deliver(
+        &self,
+        _runtime_id: &AgentRuntimeId,
+        _content: &meerkat_core::ContentInput,
+    ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+        self.deliver_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(meerkat_core::types::SessionId::new())
+    }
+
+    async fn checkpoint_session(
+        &self,
+        _runtime_id: &AgentRuntimeId,
+        _session_id: &meerkat_core::types::SessionId,
+    ) -> Result<SessionSnapshot, BridgeError> {
+        Ok(SessionSnapshot { data: Vec::new() })
+    }
+
+    async fn retire_member(&self, _runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
+        Ok(())
+    }
 }
 
 fn make_content() -> meerkat_core::ContentInput {
@@ -606,6 +806,229 @@ async fn identity_first_runtime_delete_identity_removes_from_runtime() {
 }
 
 // ===========================================================================
+// Lazy materialization — build registers identity metadata, first touch hydrates
+// ===========================================================================
+
+#[tokio::test]
+async fn identity_first_runtime_lazy_register_does_not_load_snapshots_or_spawn_members() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    let roster = (0..1_000)
+        .map(|index| {
+            let name = format!("agent:{index}");
+            let record = make_record(&name, 0, 1);
+            let store = store.clone();
+            async move {
+                store
+                    .upsert_continuity_record(&record, FencingToken::new(1))
+                    .await
+                    .unwrap();
+                make_spec(&name)
+            }
+        })
+        .collect::<Vec<_>>();
+    let roster = futures::future::join_all(roster).await;
+    store.reset_counts();
+
+    let result = lazy_register_flow(&runtime, &roster, None).await.unwrap();
+
+    assert_eq!(result.outcomes.len(), 1_000);
+    assert_eq!(store.resolve_many_calls(), 1);
+    assert_eq!(store.load_snapshot_calls(), 0);
+    assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(bridge.resume_calls.load(Ordering::SeqCst), 0);
+    let status = runtime.status(&make_identity("agent:42")).await.unwrap();
+    assert_eq!(status.state, IdentityLifecycleState::Dormant);
+    assert_eq!(
+        status.agent_runtime_id,
+        Some(AgentRuntimeId::parse("rt:agent:42:0").unwrap())
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_lazy_first_send_materializes_only_target_once() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    for name in ["agent:a", "agent:b"] {
+        let record = make_record(name, 0, 1);
+        store
+            .upsert_continuity_record(&record, FencingToken::new(1))
+            .await
+            .unwrap();
+        store
+            .save_session_snapshot(
+                &make_identity(name),
+                &record.session_id,
+                record.generation,
+                CheckpointVersion::new(2),
+                FencingToken::new(1),
+                &SessionSnapshot {
+                    data: format!("snapshot-{name}").into_bytes(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+    let roster = vec![make_spec("agent:a"), make_spec("agent:b")];
+    lazy_register_flow(&runtime, &roster, None).await.unwrap();
+    store.reset_counts();
+
+    runtime
+        .send(&make_identity("agent:a"), &make_content())
+        .await
+        .unwrap();
+
+    assert_eq!(store.load_snapshot_calls(), 1);
+    assert_eq!(bridge.resume_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(bridge.deliver_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        runtime
+            .status(&make_identity("agent:a"))
+            .await
+            .unwrap()
+            .state,
+        IdentityLifecycleState::Active
+    );
+    assert_eq!(
+        runtime
+            .status(&make_identity("agent:b"))
+            .await
+            .unwrap()
+            .state,
+        IdentityLifecycleState::Dormant
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_parallel_sends_to_dormant_identity_coalesce_materialization() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    bridge.set_resume_delay(Duration::from_millis(50)).await;
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    let record = make_record("agent:coalesce", 0, 1);
+    store
+        .upsert_continuity_record(&record, FencingToken::new(1))
+        .await
+        .unwrap();
+    lazy_register_flow(&runtime, &[make_spec("agent:coalesce")], None)
+        .await
+        .unwrap();
+    store.reset_counts();
+
+    let mut tasks = Vec::new();
+    for _ in 0..10 {
+        let runtime = runtime.clone();
+        tasks.push(tokio::spawn(async move {
+            runtime
+                .send(&make_identity("agent:coalesce"), &make_content())
+                .await
+                .unwrap();
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+
+    assert_eq!(store.load_snapshot_calls(), 1);
+    assert_eq!(bridge.resume_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(bridge.deliver_calls.load(Ordering::SeqCst), 10);
+    assert_eq!(
+        runtime
+            .status(&make_identity("agent:coalesce"))
+            .await
+            .unwrap()
+            .state,
+        IdentityLifecycleState::Active
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_lazy_dispatch_materializes_internal_only_identity() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    lazy_register_flow(&runtime, &[make_internal_spec("agent:internal")], None)
+        .await
+        .unwrap();
+    runtime
+        .dispatch(&make_identity("agent:internal"), &make_dispatch_input())
+        .await
+        .unwrap();
+
+    assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(bridge.deliver_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        runtime
+            .status(&make_identity("agent:internal"))
+            .await
+            .unwrap()
+            .state,
+        IdentityLifecycleState::Active
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_lazy_resume_incompatible_fallback_is_typed_and_visible() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let fallback_session_id = meerkat_core::types::SessionId::new();
+    bridge
+        .set_force_resume_fallback(fallback_session_id.clone())
+        .await;
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    let record = make_record("agent:legacy", 0, 1);
+    store
+        .upsert_continuity_record(&record, FencingToken::new(1))
+        .await
+        .unwrap();
+    lazy_register_flow(&runtime, &[make_spec("agent:legacy")], None)
+        .await
+        .unwrap();
+    let mut events = runtime
+        .subscribe(&make_identity("agent:legacy"))
+        .await
+        .unwrap();
+
+    runtime
+        .send(&make_identity("agent:legacy"), &make_content())
+        .await
+        .unwrap();
+
+    let event = events.recv().await.unwrap();
+    match event {
+        IdentityEvent::ResumeFallback { identity, reason } => {
+            assert_eq!(identity, make_identity("agent:legacy"));
+            assert!(matches!(
+                reason,
+                meerkat_mobkit::identity_first::ResumeFallbackReason::RuntimeIdentityIncompatible { .. }
+            ));
+        }
+        other => panic!("expected ResumeFallback, got {other:?}"),
+    }
+    assert_eq!(
+        runtime
+            .status(&make_identity("agent:legacy"))
+            .await
+            .unwrap()
+            .session_id,
+        Some(fallback_session_id)
+    );
+}
+
+// ===========================================================================
 // Task 2.11 — Full restore flow with sequencing (REQ-12)
 // ===========================================================================
 
@@ -707,8 +1130,12 @@ async fn identity_first_runtime_restore_flow_reconciles_resume_returned_session_
             _draft: &AgentBuildDraft,
             _session_id: &meerkat_core::types::SessionId,
             _snapshot: &SessionSnapshot,
-        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
-            Ok(self.actual_session_id.clone())
+        ) -> Result<meerkat_mobkit::identity_first::ResumeSessionOutcome, BridgeError> {
+            Ok(
+                meerkat_mobkit::identity_first::ResumeSessionOutcome::Resumed {
+                    session_id: self.actual_session_id.clone(),
+                },
+            )
         }
 
         async fn deliver(
@@ -1558,8 +1985,12 @@ async fn identity_first_runtime_topology_materializes_runtime_peer_wires() {
             _draft: &AgentBuildDraft,
             session_id: &meerkat_core::types::SessionId,
             _snapshot: &SessionSnapshot,
-        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
-            Ok(session_id.clone())
+        ) -> Result<meerkat_mobkit::identity_first::ResumeSessionOutcome, BridgeError> {
+            Ok(
+                meerkat_mobkit::identity_first::ResumeSessionOutcome::Resumed {
+                    session_id: session_id.clone(),
+                },
+            )
         }
 
         async fn deliver(
@@ -1741,8 +2172,12 @@ async fn identity_first_runtime_topology_claims_persisted_wires_without_rebatchi
             _draft: &AgentBuildDraft,
             session_id: &meerkat_core::types::SessionId,
             _snapshot: &SessionSnapshot,
-        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
-            Ok(session_id.clone())
+        ) -> Result<meerkat_mobkit::identity_first::ResumeSessionOutcome, BridgeError> {
+            Ok(
+                meerkat_mobkit::identity_first::ResumeSessionOutcome::Resumed {
+                    session_id: session_id.clone(),
+                },
+            )
         }
 
         async fn deliver(

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -220,14 +220,22 @@ struct CountingBridge {
     create_calls: AtomicUsize,
     resume_calls: AtomicUsize,
     deliver_calls: AtomicUsize,
+    wire_calls: AtomicUsize,
     force_resume_fallback: AtomicBool,
     resume_delay: tokio::sync::Mutex<Option<Duration>>,
+    resume_barrier: tokio::sync::Mutex<Option<Arc<tokio::sync::Barrier>>>,
     fallback_session_id: tokio::sync::Mutex<Option<meerkat_core::types::SessionId>>,
+    wires: tokio::sync::Mutex<Vec<(String, String)>>,
+    current_wires: tokio::sync::Mutex<Vec<(String, String)>>,
 }
 
 impl CountingBridge {
     async fn set_resume_delay(&self, delay: Duration) {
         *self.resume_delay.lock().await = Some(delay);
+    }
+
+    async fn set_resume_barrier(&self, barrier: Arc<tokio::sync::Barrier>) {
+        *self.resume_barrier.lock().await = Some(barrier);
     }
 
     async fn set_force_resume_fallback(&self, session_id: meerkat_core::types::SessionId) {
@@ -262,6 +270,10 @@ impl SessionBridge for CountingBridge {
         self.resume_calls.fetch_add(1, Ordering::SeqCst);
         if let Some(delay) = *self.resume_delay.lock().await {
             tokio::time::sleep(delay).await;
+        }
+        let barrier = self.resume_barrier.lock().await.clone();
+        if let Some(barrier) = barrier {
+            barrier.wait().await;
         }
         if self.force_resume_fallback.load(Ordering::SeqCst) {
             let fallback_session_id = self
@@ -306,6 +318,46 @@ impl SessionBridge for CountingBridge {
 
     async fn retire_member(&self, _runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
         Ok(())
+    }
+
+    async fn wire_peer(&self, a: &AgentRuntimeId, b: &AgentRuntimeId) -> Result<(), BridgeError> {
+        self.wire_calls.fetch_add(1, Ordering::SeqCst);
+        self.wires
+            .lock()
+            .await
+            .push((a.as_str().to_string(), b.as_str().to_string()));
+        Ok(())
+    }
+
+    async fn wire_peers_batch(
+        &self,
+        edges: &[(AgentRuntimeId, AgentRuntimeId)],
+    ) -> Result<(), BridgeError> {
+        for (a, b) in edges {
+            self.wire_peer(a, b).await?;
+            self.current_wires
+                .lock()
+                .await
+                .push((a.as_str().to_string(), b.as_str().to_string()));
+        }
+        Ok(())
+    }
+
+    async fn current_member_wires(
+        &self,
+    ) -> Result<Vec<(AgentRuntimeId, AgentRuntimeId)>, BridgeError> {
+        Ok(self
+            .current_wires
+            .lock()
+            .await
+            .iter()
+            .filter_map(|(a, b)| {
+                Some((
+                    AgentRuntimeId::parse(a).ok()?,
+                    AgentRuntimeId::parse(b).ok()?,
+                ))
+            })
+            .collect())
     }
 }
 
@@ -976,6 +1028,144 @@ async fn identity_first_runtime_lazy_dispatch_materializes_internal_only_identit
             .state,
         IdentityLifecycleState::Active
     );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_lazy_first_send_materializes_reachable_peers_and_wires_topology() {
+    struct StaticTopology(Vec<(&'static str, &'static str)>);
+
+    #[async_trait]
+    impl TopologyProvider for StaticTopology {
+        async fn compute_edges(
+            &self,
+            _target_identities: &[AgentIdentity],
+            _context: &TopologyContext,
+        ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+            self.0
+                .iter()
+                .map(|(a, b)| {
+                    ManagedPeerEdge::new(make_identity(a), make_identity(b))
+                        .map_err(|err| TopologyError::InvalidEdge(format!("{err}")))
+                })
+                .collect()
+        }
+    }
+
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+    let roster = vec![
+        make_spec("review:singleton"),
+        make_spec("initiative:alpha"),
+        make_spec("initiative:beta"),
+    ];
+
+    lazy_register_flow(
+        &runtime,
+        &roster,
+        Some(&StaticTopology(vec![
+            ("review:singleton", "initiative:alpha"),
+            ("review:singleton", "initiative:beta"),
+        ])),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(bridge.wire_calls.load(Ordering::SeqCst), 0);
+
+    runtime
+        .send(&make_identity("review:singleton"), &make_content())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        bridge.create_calls.load(Ordering::SeqCst),
+        3,
+        "first review send must hydrate review plus its initiative peers"
+    );
+    assert_eq!(bridge.deliver_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(bridge.wire_calls.load(Ordering::SeqCst), 2);
+    for identity in ["review:singleton", "initiative:alpha", "initiative:beta"] {
+        assert_eq!(
+            runtime
+                .status(&make_identity(identity))
+                .await
+                .unwrap()
+                .state,
+            IdentityLifecycleState::Active
+        );
+    }
+
+    let wires = bridge.wires.lock().await.clone();
+    assert!(
+        wires.contains(&(
+            "rt:initiative:alpha:0".to_string(),
+            "rt:review:singleton:0".to_string()
+        )),
+        "review must be concretely wired to initiative:alpha, got {wires:?}"
+    );
+    assert!(
+        wires.contains(&(
+            "rt:initiative:beta:0".to_string(),
+            "rt:review:singleton:0".to_string()
+        )),
+        "review must be concretely wired to initiative:beta, got {wires:?}"
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_materialize_all_hydrates_registered_identities_in_parallel() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+    let agent_count = 8;
+    let roster = (0..agent_count)
+        .map(|index| make_spec(&format!("agent:{index}")))
+        .collect::<Vec<_>>();
+
+    for spec in &roster {
+        let record = make_record(spec.identity.as_str(), 0, 1);
+        store
+            .upsert_continuity_record(&record, FencingToken::new(1))
+            .await
+            .unwrap();
+        store
+            .save_session_snapshot(
+                &spec.identity,
+                &record.session_id,
+                record.generation,
+                CheckpointVersion::new(2),
+                FencingToken::new(1),
+                &SessionSnapshot {
+                    data: format!("snapshot-{}", spec.identity).into_bytes(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+    lazy_register_flow(&runtime, &roster, None).await.unwrap();
+    store.reset_counts();
+    bridge
+        .set_resume_barrier(Arc::new(tokio::sync::Barrier::new(agent_count)))
+        .await;
+
+    let records = tokio::time::timeout(Duration::from_secs(2), runtime.materialize_all())
+        .await
+        .expect("parallel materialize_all should not block behind one pending resume")
+        .unwrap();
+
+    assert_eq!(records.len(), agent_count);
+    assert_eq!(store.load_snapshot_calls(), agent_count);
+    assert_eq!(bridge.resume_calls.load(Ordering::SeqCst), agent_count);
+    for spec in &roster {
+        assert_eq!(
+            runtime.status(&spec.identity).await.unwrap().state,
+            IdentityLifecycleState::Active
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `IdentityBootstrapMode` with lazy and lazy-with-background-warm modes for identity-first MobKit bootstraps
- register durable identities as dormant metadata without synchronously loading snapshots, leasing, spawning, or resuming every roster entry
- materialize dormant identities on first send/dispatch with per-identity coalescing, typed resume fallback events, and desired topology reconciliation
- expose dormant identity-first members in the console list/inspect paths without spawning agents or opportunistically loading snapshots

## Why
OB3-sized durable rosters should not make `UnifiedRuntime::build()` hydrate the entire fleet before HTTP readiness. The runtime now keeps identity metadata visible immediately and defers expensive session work until the identity is actually touched.

## Validation
- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_builder_lazy -- --nocapture`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat-mobkit --all-targets -- -D warnings`
- push hooks: secret scan, whitespace, merge conflict check, cargo fmt, changed-crate clippy, workspace unit gate
