### PR TITLE
Expose Meerkat config on unified runtime builder

### DIFF
--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -2015,6 +2015,7 @@ impl MobBootstrapSpec {
             store_path,
             max_sessions,
             session_store,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -2044,6 +2045,7 @@ impl MobBootstrapSpec {
             store_path,
             max_sessions,
             session_store,
+            Config::default(),
             Some(Arc::new(hook)),
             CapabilityFlags::default(),
             None,
@@ -2057,6 +2059,7 @@ impl MobBootstrapSpec {
         store_path: PathBuf,
         max_sessions: usize,
         session_store: Option<Arc<dyn AgentSessionStore>>,
+        config: Config,
         hook: Option<PreBuildHook>,
         mut caps: CapabilityFlags,
         after_create_hook: Option<AfterCreateHook>,
@@ -2084,7 +2087,6 @@ impl MobBootstrapSpec {
         if let Some(machine) = runtime_adapter.clone() {
             factory = factory.with_image_generation_machine(machine);
         }
-        let config = Config::default();
         let mut builder = FactoryAgentBuilder::new(factory, config);
         builder.default_blob_store = Some(blob_store);
         if let Some(store) = session_store {
@@ -2153,6 +2155,7 @@ impl MobBootstrapSpec {
             max_sessions,
             session_store,
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -2183,6 +2186,7 @@ impl MobBootstrapSpec {
             max_sessions,
             session_store,
             None,
+            Config::default(),
             Some(Arc::new(hook)),
             CapabilityFlags::default(),
             None,
@@ -2197,6 +2201,7 @@ impl MobBootstrapSpec {
         max_sessions: usize,
         session_store: Arc<dyn SessionStore>,
         custom_blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
+        config: Config,
         hook: Option<PreBuildHook>,
         mut caps: CapabilityFlags,
         after_create_hook: Option<AfterCreateHook>,
@@ -2251,7 +2256,6 @@ impl MobBootstrapSpec {
         if caps.image_generation {
             factory = factory.with_image_generation_machine(runtime_adapter.clone());
         }
-        let config = Config::default();
         let mut builder = FactoryAgentBuilder::new(factory, config);
         builder.default_session_store = Some(Arc::new(StoreAdapter::new(session_store.clone())));
         builder.default_blob_store = Some(blob_store.clone());
@@ -2293,12 +2297,12 @@ impl MobBootstrapSpec {
         max_sessions: usize,
         custom_session_store: Option<Arc<dyn SessionStore>>,
         custom_blob_store: Option<Arc<dyn meerkat_core::BlobStore>>,
+        config: Config,
         hook: Option<PreBuildHook>,
         mut caps: CapabilityFlags,
         after_create_hook: Option<AfterCreateHook>,
     ) -> Self {
         caps.image_generation |= mob_definition_may_use_image_generation(&definition);
-        let config = Config::default();
         let session_store: Arc<dyn SessionStore> = custom_session_store
             .clone()
             .unwrap_or_else(|| Arc::new(meerkat_store::MemoryStore::new()));
@@ -4003,6 +4007,7 @@ realm_profile = "worker-v2"
             4,
             None,
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -4034,6 +4039,7 @@ realm_profile = "worker-v2"
             4,
             None,
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -4085,6 +4091,7 @@ realm_profile = "worker-v2"
             4,
             None,
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -4136,6 +4143,7 @@ realm_profile = "worker-v2"
             4,
             Some(custom_store.clone()),
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -4186,6 +4194,7 @@ realm_profile = "worker-v2"
             4,
             Some(custom_store.clone()),
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -4221,6 +4230,7 @@ realm_profile = "worker-v2"
             4,
             Some(custom_store),
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,
@@ -4266,6 +4276,7 @@ realm_profile = "worker-v2"
             store_path,
             4,
             None,
+            Config::default(),
             None,
             CapabilityFlags::default(),
             None,

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
+use meerkat::Config as MeerkatConfig;
 use meerkat_client::LlmClient;
 use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
 
@@ -73,6 +74,7 @@ pub struct UnifiedRuntimeBuilder {
     default_llm_client: Option<Arc<dyn LlmClient>>,
     max_sessions: Option<usize>,
     capability_flags: CapabilityFlags,
+    meerkat_config: Option<MeerkatConfig>,
 
     // --- Identity-first external path ---
     continuity_store: Option<Arc<dyn crate::identity_first::contracts::ContinuityStore>>,
@@ -276,6 +278,15 @@ impl UnifiedRuntimeBuilder {
     /// visibility decision.
     pub fn image_generation(mut self, enabled: bool) -> Self {
         self.capability_flags.image_generation = enabled;
+        self
+    }
+
+    /// Set the Meerkat session-build configuration used for definition-based
+    /// runtimes. This is the right place for embedding apps to tune Meerkat
+    /// mechanics such as session compaction without changing app policy or
+    /// forking the lower-level runtime.
+    pub fn meerkat_config(mut self, config: MeerkatConfig) -> Self {
+        self.meerkat_config = Some(config);
         self
     }
 
@@ -795,6 +806,7 @@ impl UnifiedRuntimeBuilder {
         caps.image_generation |=
             crate::mob_handle_runtime::mob_definition_may_use_image_generation(&definition);
         let max_sessions = self.max_sessions.unwrap_or(DEFAULT_MAX_SESSIONS);
+        let meerkat_config = self.meerkat_config.clone().unwrap_or_default();
         if max_sessions == 0 {
             return Err(UnifiedRuntimeBuilderError::ConflictingConfiguration(
                 "max_sessions() must be greater than 0".to_string(),
@@ -858,6 +870,7 @@ impl UnifiedRuntimeBuilder {
                 max_sessions,
                 session_store,
                 self.blob_store.clone(),
+                meerkat_config,
                 hook,
                 caps,
                 after_hook.clone(),
@@ -877,6 +890,7 @@ impl UnifiedRuntimeBuilder {
                 max_sessions,
                 self.custom_session_store.clone(),
                 self.blob_store.clone(),
+                meerkat_config,
                 hook,
                 caps,
                 after_hook,
@@ -895,6 +909,7 @@ impl UnifiedRuntimeBuilder {
                 max_sessions,
                 self.custom_session_store.clone(),
                 self.blob_store.clone(),
+                meerkat_config,
                 hook,
                 caps,
                 after_hook,
@@ -1007,6 +1022,37 @@ runtime_mode = "autonomous_host"
             blocked.to_string().contains("Max sessions reached (65/65)"),
             "unexpected capacity error: {blocked}",
         );
+    }
+
+    #[tokio::test]
+    async fn definition_based_ephemeral_spec_accepts_meerkat_config() {
+        let definition = meerkat_mob::MobDefinition::from_toml(
+            r#"
+[mob]
+id = "builder-meerkat-config"
+
+[profiles.worker]
+model = "gpt-5.5"
+runtime_mode = "autonomous_host"
+"#,
+        )
+        .expect("definition parses");
+        let mut config = MeerkatConfig::default();
+        config.compaction.auto_compact_threshold = 42_000;
+        config.compaction.auto_compact_threshold_explicit = true;
+
+        let builder = UnifiedRuntimeBuilder::default()
+            .definition(definition)
+            .meerkat_config(config)
+            .max_sessions(1);
+        let spec = builder.resolve_mob_spec().await.expect("spec resolves");
+
+        SessionService::create_session(
+            spec.session_service.as_ref(),
+            deferred_capacity_request("custom config session"),
+        )
+        .await
+        .expect("custom Meerkat config should still build sessions");
     }
 
     #[tokio::test]

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -345,34 +345,45 @@ fn continuity_record(identity: &str) -> ContinuityRecord {
 }
 
 /// Helper: assert builder.build() returns Err and the error message contains the given substring.
-async fn assert_build_err_contains(builder: UnifiedRuntimeBuilder, expected: &str) {
-    match builder.build().await {
-        Err(e) => {
-            let msg = e.to_string();
-            assert!(
-                msg.contains(expected),
-                "expected error containing {expected:?}, got: {msg}"
-            );
+fn assert_build_err_contains<'a>(
+    builder: UnifiedRuntimeBuilder,
+    expected: &'a str,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>> {
+    Box::pin(async move {
+        match builder.build().await {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains(expected),
+                    "expected error containing {expected:?}, got: {msg}"
+                );
+            }
+            Ok(_) => panic!("expected builder error containing {expected:?}, but build succeeded"),
         }
-        Ok(_) => panic!("expected builder error containing {expected:?}, but build succeeded"),
-    }
+    })
 }
 
 /// Helper: assert builder.build() returns Err and the error message does NOT contain either substring.
-async fn assert_build_err_not_contains(builder: UnifiedRuntimeBuilder, not_a: &str, not_b: &str) {
-    match builder.build().await {
-        Err(e) => {
-            let msg = e.to_string();
-            assert!(
-                !msg.contains(not_a) && !msg.contains(not_b),
-                "expected error NOT containing {not_a:?} or {not_b:?}, got: {msg}"
-            );
+fn assert_build_err_not_contains<'a>(
+    builder: UnifiedRuntimeBuilder,
+    not_a: &'a str,
+    not_b: &'a str,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>> {
+    Box::pin(async move {
+        match builder.build().await {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains(not_a) && !msg.contains(not_b),
+                    "expected error NOT containing {not_a:?} or {not_b:?}, got: {msg}"
+                );
+            }
+            Ok(_) => {
+                // If it somehow succeeded, that's fine for this assertion
+                // (the point was that it shouldn't fail with conflicting config)
+            }
         }
-        Ok(_) => {
-            // If it somehow succeeded, that's fine for this assertion
-            // (the point was that it shouldn't fail with conflicting config)
-        }
-    }
+    })
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- add UnifiedRuntimeBuilder::meerkat_config for definition-based runtimes
- thread the Meerkat Config into persistent and runtime-backed MobBootstrapSpec construction
- keep existing public MobBootstrapSpec helpers on Config::default for compatibility
- box identity-first builder error-test helpers so the changed builder size stays clippy-clean

## Why
OB3 needs to set an explicit Meerkat session compaction threshold for long-lived coordinator chats. MobKit was hardcoding Config::default() inside definition-based runtime construction, which lets Meerkat's model-aware default expand the compaction threshold too far for chat-heavy coordinator sessions.

## Verification
- ./scripts/repo-cargo fmt --check
- ./scripts/repo-cargo clippy -p meerkat-mobkit --all-targets -- -D warnings
- ./scripts/repo-cargo test -p meerkat-mobkit definition_based -- --nocapture
- npm --prefix console run phase0:types --silent
- npm --prefix console run e2e:browser --silent
- git diff --check
- cargo package -p meerkat-mobkit --allow-dirty