### PR TITLE
chore: release v0.6.49

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
             target: aarch64-apple-darwin
             archive_ext: tar.gz
             cargo_jobs: 0
-          - runs-on: macos-15-large
+          - runs-on: macos-15-intel
             target: x86_64-apple-darwin
             archive_ext: tar.gz
             cargo_jobs: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.6.48"
+version = "0.6.49"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.6.48"
+version = "0.6.49"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.6.48"
+version = "0.6.49"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.6.48",
+  "version": "0.6.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.6.48",
+      "version": "0.6.49",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.6.48",
+  "version": "0.6.49",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- release MobKit 0.6.49 across Cargo, Python, and TypeScript packages
- switch the x86_64 macOS release binary job from the larger-runner label `macos-15-large` to the standard Intel label `macos-15-intel`

## Why
- v0.6.48 registry publishing completed, but GitHub release asset publishing was blocked when GitHub refused the `macos-15-large` job for account billing/spend-limit reasons
- GitHub currently documents `macos-15-intel` as the standard Intel macOS runner label, which is the right target for the x86_64 Darwin binary

## Verification
- `./scripts/verify-version-parity.sh`
- `git diff --check`
- `./scripts/repo-cargo metadata --locked --format-version 1 --no-deps`
- `npm --prefix sdk/typescript test`
- `cargo publish -p meerkat-mobkit --locked --dry-run --allow-dirty`