### PR TITLE
Fix ambiguous lifecycle cleanup recovery

### DIFF
--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -20,7 +20,8 @@ use tokio::sync::{Semaphore, broadcast};
 use crate::blob_store::BinaryBlobStore;
 use crate::console_contracts::SYSTEM_EVENT_IDENTITY;
 use crate::mob_handle_runtime::{
-    MobRuntime, MobRuntimeError, assert_member_accepts_images, send_message_on_mob_with_mode,
+    MobRuntime, MobRuntimeError, assert_member_accepts_images,
+    is_recoverable_lifecycle_cleanup_error, send_message_on_mob_with_mode,
 };
 use crate::runtime::ConsoleMember;
 use crate::unified_runtime::{ConsoleEventStore, UnifiedRuntime};
@@ -2110,9 +2111,7 @@ async fn retire_stale_console_members_for_runtime_entry(
 }
 
 fn lifecycle_archive_cleanup_completed(error: &str) -> bool {
-    error.contains("disposal completed but ArchiveSession failed")
-        && error.contains("cancel-before-retire failed")
-        && error.contains("Runtime not ready: running")
+    is_recoverable_lifecycle_cleanup_error(error)
 }
 
 fn explicit_identity_query_needs_session_history_backfill(frames: &[ConsoleFrame]) -> bool {

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -18,7 +18,8 @@ use meerkat_mob::runtime::reconcile::MemberFilter;
 use meerkat_mob::{MobHandle, PeerTarget, ProfileName, SpawnMemberSpec};
 
 use crate::mob_handle_runtime::{
-    member_entry_to_json, model_capabilities_for_member_entry, model_capabilities_for_role,
+    is_recoverable_lifecycle_cleanup_error, member_entry_to_json,
+    model_capabilities_for_member_entry, model_capabilities_for_role,
 };
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
@@ -2830,9 +2831,7 @@ fn console_identity_inspect_json_from_record(
 }
 
 fn lifecycle_archive_cleanup_completed(error: &str) -> bool {
-    error.contains("disposal completed but ArchiveSession failed")
-        && error.contains("cancel-before-retire failed")
-        && error.contains("Runtime not ready: running")
+    is_recoverable_lifecycle_cleanup_error(error)
 }
 
 async fn respawn_console_member(

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -12,7 +12,10 @@ use meerkat_mob::{
     WorkSpec,
 };
 
-use crate::mob_handle_runtime::{content_input_has_images, model_capabilities_for_member};
+use crate::mob_handle_runtime::{
+    content_input_has_images, is_previous_member_cleanup_ambiguous_error,
+    is_recoverable_lifecycle_cleanup_error, model_capabilities_for_member,
+};
 
 use super::adapters::{ContinuitySessionStoreAdapter, SessionRuntimeState};
 use super::types::{
@@ -29,13 +32,13 @@ fn is_missing_bridge_session_snapshot_error(error: &str) -> bool {
 }
 
 fn is_repairable_bridge_delivery_error(error: &str) -> bool {
-    is_missing_event_injector_error(error) || is_missing_bridge_session_snapshot_error(error)
+    is_missing_event_injector_error(error)
+        || is_missing_bridge_session_snapshot_error(error)
+        || is_previous_member_cleanup_ambiguous_error(error)
 }
 
-fn is_archive_not_found_cleanup_error(error: &str) -> bool {
-    error.contains("disposal completed but ArchiveSession failed")
-        && error.contains("cancel-before-retire failed")
-        && error.contains("Runtime not ready: running")
+fn is_recoverable_bridge_respawn_cleanup_error(error: &str) -> bool {
+    is_recoverable_lifecycle_cleanup_error(error)
 }
 
 // ---------------------------------------------------------------------------
@@ -519,7 +522,9 @@ impl SessionBridge for MobSessionBridge {
                 match self.handle.respawn(mid.clone(), None).await {
                     Ok(_) => {}
                     Err(respawn_err)
-                        if is_archive_not_found_cleanup_error(&respawn_err.to_string()) =>
+                        if is_recoverable_bridge_respawn_cleanup_error(
+                            &respawn_err.to_string(),
+                        ) =>
                     {
                         if self.handle.get_member(&mid).await.is_none()
                             && let Some(entry) = member_entry_before_delivery
@@ -588,7 +593,9 @@ impl SessionBridge for MobSessionBridge {
                 match self.handle.respawn(mid.clone(), None).await {
                     Ok(_) => {}
                     Err(respawn_err)
-                        if is_archive_not_found_cleanup_error(&respawn_err.to_string()) =>
+                        if is_recoverable_bridge_respawn_cleanup_error(
+                            &respawn_err.to_string(),
+                        ) =>
                     {
                         if self.handle.get_member(&mid).await.is_none()
                             && let Some(entry) = member_entry_before_delivery
@@ -649,7 +656,7 @@ impl SessionBridge for MobSessionBridge {
         let mid = MeerkatId::from(runtime_id.as_str());
         match self.handle.retire(mid).await {
             Ok(()) => Ok(()),
-            Err(err) if is_archive_not_found_cleanup_error(&err.to_string()) => Ok(()),
+            Err(err) if is_recoverable_lifecycle_cleanup_error(&err.to_string()) => Ok(()),
             Err(err) => Err(BridgeError::Mob(err.to_string())),
         }
     }
@@ -901,6 +908,12 @@ mod tests {
         assert!(
             is_repairable_bridge_delivery_error("missing event injector capability for member"),
             "existing stale event-injector repair path must remain covered"
+        );
+        assert!(
+            is_repairable_bridge_delivery_error(
+                "previous member cleanup ambiguous for member rt:deep-investigator:singleton:0"
+            ),
+            "ambiguous Meerkat respawn cleanup should trigger bridge repair instead of failing delivery"
         );
         assert!(
             !is_repairable_bridge_delivery_error("model provider returned rate limit"),

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -31,6 +31,17 @@ use crate::blob_store::{
 pub(crate) const DELEGATE_IDLE_RETIRE_SECS_LABEL: &str = "implicit_delegate_idle_retire_secs";
 pub(crate) const DELEGATE_IDLE_RETIRE_DISABLED_LABEL: &str = "disabled";
 
+pub(crate) fn is_previous_member_cleanup_ambiguous_error(error: &str) -> bool {
+    error.contains("previous member cleanup ambiguous for member ")
+}
+
+pub(crate) fn is_recoverable_lifecycle_cleanup_error(error: &str) -> bool {
+    is_previous_member_cleanup_ambiguous_error(error)
+        || (error.contains("disposal completed but ArchiveSession failed")
+            && error.contains("cancel-before-retire failed")
+            && error.contains("Runtime not ready: running"))
+}
+
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 
@@ -4668,5 +4679,32 @@ image_generation = true
         hook.before_create(&mut req).await.unwrap();
         assert_eq!(req.model, "hook-overridden");
         assert_eq!(req.system_prompt.as_deref(), Some("injected by hook"));
+    }
+
+    #[test]
+    fn recoverable_lifecycle_cleanup_accepts_ambiguous_member_cleanup() {
+        let error = "previous member cleanup ambiguous for member rt:deep-investigator:singleton:0";
+
+        assert!(is_previous_member_cleanup_ambiguous_error(error));
+        assert!(is_recoverable_lifecycle_cleanup_error(error));
+    }
+
+    #[test]
+    fn recoverable_lifecycle_cleanup_preserves_archive_cancel_race() {
+        let error = "internal error: disposal completed but ArchiveSession failed: \
+            session error: agent error: Internal error: runtime cancel-before-retire failed \
+            for 019e3c52-0f1b-73d3-a5c7-4b21c2bbf131: Runtime not ready: running";
+
+        assert!(is_recoverable_lifecycle_cleanup_error(error));
+    }
+
+    #[test]
+    fn recoverable_lifecycle_cleanup_rejects_unrelated_errors() {
+        assert!(!is_recoverable_lifecycle_cleanup_error(
+            "actor task dropped"
+        ));
+        assert!(!is_recoverable_lifecycle_cleanup_error(
+            "model provider returned rate limit"
+        ));
     }
 }

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -10,16 +10,15 @@ use serde_json::Value;
 
 use crate::blob_store::is_valid_blob_id_value;
 use crate::mob_handle_runtime::{
-    assert_member_accepts_images, member_entry_to_json, send_message_on_mob_with_mode,
+    assert_member_accepts_images, is_recoverable_lifecycle_cleanup_error, member_entry_to_json,
+    send_message_on_mob_with_mode,
 };
 use crate::unified_runtime::UnifiedRuntime;
 
 use super::{JSONRPC_VERSION, JsonRpcError, JsonRpcResponse};
 
 pub(super) fn lifecycle_archive_cleanup_completed(error: &str) -> bool {
-    error.contains("disposal completed but ArchiveSession failed")
-        && error.contains("cancel-before-retire failed")
-        && error.contains("Runtime not ready: running")
+    is_recoverable_lifecycle_cleanup_error(error)
 }
 
 /// Parse HelperOptions from an optional JSON "options" object.
@@ -2163,10 +2162,10 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_archive_cleanup_completed_rejects_ambiguous_cleanup() {
+    fn lifecycle_archive_cleanup_completed_accepts_ambiguous_cleanup() {
         let error = "previous member cleanup ambiguous for member rt:review:singleton:0";
 
-        assert!(!lifecycle_archive_cleanup_completed(error));
+        assert!(lifecycle_archive_cleanup_completed(error));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat Meerkat `previous member cleanup ambiguous for member ...` as a recoverable lifecycle cleanup result across MobKit console/RPC/identity bridge paths
- make identity bridge delivery repair stale runtime bindings after ambiguous cleanup instead of bubbling the lifecycle mutation failure
- centralize the cleanup predicate and keep unrelated failures such as `actor task dropped` non-recoverable

## Verification
- `git diff --check`
- `./scripts/repo-cargo fmt --all --check`
- `./scripts/repo-cargo test -p meerkat-mobkit --lib`
- `./scripts/repo-cargo test -p meerkat-mobkit --test governance_contracts -- governance_contracts_rejects_invalid_governance_state`

Note: full `./scripts/repo-cargo test -p meerkat-mobkit` passed the crate unit tests and many integration suites, then failed in `governance_contracts` because this worktree lacks `.rct/spec.yaml`.