### PR TITLE
[codex] fix identity-first lease renewal

### DIFF
--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 use futures::stream::{self, StreamExt};
 use meerkat_core::types::{HandlingMode, SessionId};
 use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::task::JoinHandle;
 
 use super::bridge::SessionBridge;
 use super::contracts::{
@@ -212,6 +213,8 @@ pub enum IdentityEvent {
 
 /// Per-identity event channel capacity.
 const IDENTITY_EVENT_CHANNEL_CAPACITY: usize = 64;
+const DEFAULT_LEASE_RENEWAL_MAX_POLL_INTERVAL: Duration = Duration::from_secs(60);
+const DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 // ---------------------------------------------------------------------------
 // IdentityRuntime
@@ -365,6 +368,82 @@ impl IdentityRuntime {
 
     pub async fn set_agent_customizer(&self, customizer: Option<Arc<dyn AgentCustomizer>>) {
         *self.customizer.write().await = customizer;
+    }
+
+    /// Spawn a background supervisor that renews active identity leases before
+    /// they reach their TTL deadline.
+    pub fn spawn_lease_renewal_task(self: Arc<Self>) -> JoinHandle<()> {
+        self.spawn_lease_renewal_task_with_poll_interval(DEFAULT_LEASE_RENEWAL_MAX_POLL_INTERVAL)
+    }
+
+    /// Spawn a lease renewal supervisor with a caller-provided maximum poll
+    /// interval. Embedders can use this for shorter external lease TTLs; tests
+    /// use it to exercise renewal without waiting on wall-clock TTLs.
+    pub fn spawn_lease_renewal_task_with_poll_interval(
+        self: Arc<Self>,
+        max_poll_interval: Duration,
+    ) -> JoinHandle<()> {
+        let max_poll_interval = max_poll_interval.max(DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(self.lease_renewal_sleep_interval(max_poll_interval).await)
+                    .await;
+                if let Err(err) = self.renew_due_leases_once().await {
+                    tracing::warn!(
+                        error = %err,
+                        "identity-first proactive lease renewal tick failed"
+                    );
+                }
+            }
+        })
+    }
+
+    async fn lease_renewal_sleep_interval(&self, max_poll_interval: Duration) -> Duration {
+        let entries = self.entries.read().await;
+        entries
+            .values()
+            .filter(|entry| entry.state == IdentityLifecycleState::Active)
+            .filter_map(|entry| entry.lease.as_ref())
+            .map(|lease| (lease.ttl / 10).max(DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL))
+            .min()
+            .unwrap_or(max_poll_interval)
+            .min(max_poll_interval)
+    }
+
+    /// Renew every active lease that has entered the runtime's renewal window.
+    pub async fn renew_due_leases_once(&self) -> Result<usize, IdentityRuntimeError> {
+        let due = {
+            let entries = self.entries.read().await;
+            entries
+                .iter()
+                .filter(|(_, entry)| entry.state == IdentityLifecycleState::Active)
+                .filter_map(|(identity, entry)| {
+                    entry
+                        .lease
+                        .as_ref()
+                        .filter(|lease| !lease.is_healthy())
+                        .map(|_| identity.clone())
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut renewed = 0;
+        let mut first_error = None;
+        for identity in due {
+            match self.ensure_active_lease(&identity).await {
+                Ok(_) => renewed += 1,
+                Err(err) => {
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
+                }
+            }
+        }
+        if let Some(err) = first_error {
+            Err(err)
+        } else {
+            Ok(renewed)
+        }
     }
 
     async fn release_uninstalled_materialize_lease(&self, grant: &LeaseGrant) -> Option<String> {

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -213,7 +213,7 @@ pub enum IdentityEvent {
 
 /// Per-identity event channel capacity.
 const IDENTITY_EVENT_CHANNEL_CAPACITY: usize = 64;
-const DEFAULT_LEASE_RENEWAL_MAX_POLL_INTERVAL: Duration = Duration::from_secs(60);
+const DEFAULT_LEASE_RENEWAL_MAX_POLL_INTERVAL: Duration = Duration::from_mins(1);
 const DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 // ---------------------------------------------------------------------------

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -1391,6 +1391,91 @@ impl IdentityRuntime {
         }
     }
 
+    async fn ensure_active_lease(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Result<FencingToken, IdentityRuntimeError> {
+        let (grant, continuity) = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            let lease = match &entry.lease {
+                Some(lease) if lease.is_healthy() => return Ok(lease.fencing_token),
+                Some(lease) => lease,
+                None => return Err(IdentityRuntimeError::NoActiveLease(identity.clone())),
+            };
+            (
+                LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: lease.fencing_token,
+                    ttl: lease.ttl,
+                },
+                entry.continuity.clone(),
+            )
+        };
+
+        let renewed = self
+            .lease_provider
+            .renew_leases(std::slice::from_ref(&grant))
+            .await
+            .map_err(IdentityRuntimeError::Lease)?;
+        let renewed_grant = match renewed.get(identity) {
+            Some(super::types::LeaseRenewResult::Renewed(grant)) => grant.clone(),
+            Some(super::types::LeaseRenewResult::Lost { .. }) | None => {
+                self.mark_lease_lost(identity).await?;
+                return Err(IdentityRuntimeError::LeaseLost(identity.clone()));
+            }
+        };
+
+        if let Some(record) = continuity.as_ref() {
+            self.continuity_store
+                .upsert_continuity_record(record, renewed_grant.fencing_token)
+                .await
+                .map_err(IdentityRuntimeError::Store)?;
+            if let Some(bridge) = self.bridge.as_ref() {
+                bridge
+                    .register_session_runtime_state(
+                        &record.session_id,
+                        identity,
+                        record.generation,
+                        record.checkpoint_version,
+                        renewed_grant.fencing_token,
+                    )
+                    .await
+                    .map_err(|err| {
+                        IdentityRuntimeError::Internal(format!(
+                            "bridge refresh session runtime state after lease renewal: {err}"
+                        ))
+                    })?;
+            }
+        }
+
+        let fencing_token = renewed_grant.fencing_token;
+        let mut entries = self.entries.write().await;
+        let entry = entries
+            .get_mut(identity)
+            .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+        match entry.lease.as_ref() {
+            Some(current) if current.fencing_token == grant.fencing_token => {
+                entry.lease = Some(Self::lease_entry_from_grant(&renewed_grant));
+            }
+            Some(current) => return Ok(current.fencing_token),
+            None => return Err(IdentityRuntimeError::NoActiveLease(identity.clone())),
+        }
+        drop(entries);
+
+        self.emit_event(
+            identity,
+            IdentityEvent::LeaseUpdated {
+                identity: identity.clone(),
+                fencing_token,
+            },
+        )
+        .await;
+        Ok(fencing_token)
+    }
+
     async fn mark_lifecycle_in_progress(
         &self,
         identity: &AgentIdentity,
@@ -1732,12 +1817,11 @@ impl IdentityRuntime {
 
         let lifecycle_lock = self.lifecycle_lock_for(identity).await;
         let _lifecycle_guard = lifecycle_lock.lock().await;
-        let (token, runtime_id) = {
+        {
             let entries = self.entries.read().await;
             let entry = entries
                 .get(identity)
                 .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
-
             if entry.state != IdentityLifecycleState::Active {
                 return Err(IdentityRuntimeError::InvalidState {
                     identity: identity.clone(),
@@ -1745,16 +1829,18 @@ impl IdentityRuntime {
                     operation: "send",
                 });
             }
+        }
 
-            // INV-01 / INV-02: require active lease
-            let token = Self::check_lease(entry)?;
-
-            let runtime_id = entry
+        let token = self.ensure_active_lease(identity).await?;
+        let runtime_id = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            entry
                 .continuity
                 .as_ref()
-                .map(|c| c.agent_runtime_id.clone());
-
-            (token, runtime_id)
+                .map(|c| c.agent_runtime_id.clone())
         };
 
         // Deliver through the session bridge when available.
@@ -1801,12 +1887,11 @@ impl IdentityRuntime {
 
         let lifecycle_lock = self.lifecycle_lock_for(identity).await;
         let _lifecycle_guard = lifecycle_lock.lock().await;
-        let (token, is_durable, runtime_id) = {
+        {
             let entries = self.entries.read().await;
             let entry = entries
                 .get(identity)
                 .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
-
             if entry.state != IdentityLifecycleState::Active {
                 return Err(IdentityRuntimeError::InvalidState {
                     identity: identity.clone(),
@@ -1814,10 +1899,14 @@ impl IdentityRuntime {
                     operation: "dispatch",
                 });
             }
+        }
 
-            // INV-01 / INV-02: require active lease
-            let token = Self::check_lease(entry)?;
-
+        let token = self.ensure_active_lease(identity).await?;
+        let (is_durable, runtime_id) = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
             // REQ-04: durability depends on runtime_store
             let is_durable = entry.has_runtime_store;
 
@@ -1826,7 +1915,7 @@ impl IdentityRuntime {
                 .as_ref()
                 .map(|c| c.agent_runtime_id.clone());
 
-            (token, is_durable, runtime_id)
+            (is_durable, runtime_id)
         };
 
         // Deliver through the session bridge when available.
@@ -1924,6 +2013,7 @@ impl IdentityRuntime {
     ) -> Result<FencingToken, IdentityRuntimeError> {
         let lifecycle_lock = self.lifecycle_lock_for(identity).await;
         let _lifecycle_guard = lifecycle_lock.lock().await;
+        self.ensure_active_lease(identity).await?;
         let registered_entry = self
             .mark_lifecycle_in_progress(identity, IdentityLifecycleState::Retiring)
             .await?;
@@ -2820,7 +2910,7 @@ impl IdentityRuntime {
     ) -> Result<CheckpointVersion, IdentityRuntimeError> {
         let lifecycle_lock = self.lifecycle_lock_for(identity).await;
         let _lifecycle_guard = lifecycle_lock.lock().await;
-        let (record, token, new_version) = {
+        {
             let entries = self.entries.read().await;
             let entry = entries
                 .get(identity)
@@ -2832,10 +2922,14 @@ impl IdentityRuntime {
                     operation: "checkpoint",
                 });
             }
+        }
 
-            // INV-01: require active lease
-            let token = Self::check_lease(entry)?;
-
+        let token = self.ensure_active_lease(identity).await?;
+        let (record, new_version) = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
             let record = entry
                 .continuity
                 .as_ref()
@@ -2845,7 +2939,7 @@ impl IdentityRuntime {
                 .clone();
 
             let new_version = CheckpointVersion::new(entry.checkpoint_version.get() + 1);
-            (record, token, new_version)
+            (record, new_version)
         };
 
         // REQ-15 + REQ-16: store enforces version ordering and fencing

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -725,6 +725,9 @@ impl UnifiedRuntimeBuilder {
         } else {
             None
         };
+        let identity_lease_renewal_task = identity_first_context
+            .as_ref()
+            .map(|context| context.runtime.clone().spawn_lease_renewal_task());
 
         // Set immutable outer fields by rebuilding the struct
         let runtime = UnifiedRuntime {
@@ -737,6 +740,7 @@ impl UnifiedRuntimeBuilder {
             contact_directory: self.contact_directory,
             session_bridge,
             identity_first_context,
+            identity_lease_renewal_task: tokio::sync::Mutex::new(identity_lease_renewal_task),
             console_log_store,
             ..runtime
         };

--- a/meerkat-mobkit/src/unified_runtime/lifecycle.rs
+++ b/meerkat-mobkit/src/unified_runtime/lifecycle.rs
@@ -159,6 +159,9 @@ impl UnifiedRuntime {
         if let Some(task) = self.implicit_delegate_retirement_task.lock().await.take() {
             task.abort();
         }
+        if let Some(task) = self.identity_lease_renewal_task.lock().await.take() {
+            task.abort();
+        }
 
         // Phase 1: Drain in-flight events
         let drain_start = std::time::Instant::now();

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -135,6 +135,7 @@ pub struct UnifiedRuntime {
     mob_events: MobEventsStore,
     mob_events_subscriber_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
     implicit_delegate_retirement_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
+    identity_lease_renewal_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
 
     // Cross-mob communication
     contact_directory: Option<crate::contact_directory::ContactDirectory>,
@@ -213,6 +214,7 @@ impl UnifiedRuntime {
             mob_events: mob_events_store,
             mob_events_subscriber_task: tokio::sync::Mutex::new(mob_events_task),
             implicit_delegate_retirement_task: tokio::sync::Mutex::new(None),
+            identity_lease_renewal_task: tokio::sync::Mutex::new(None),
             contact_directory: None,
             peer_mob_handles: tokio::sync::RwLock::new(BTreeMap::new()),
             gateway_peer_keys: None,

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -5033,6 +5033,123 @@ async fn identity_first_runtime_healthy_lease_does_not_call_renew_provider() {
 }
 
 #[tokio::test]
+async fn identity_first_runtime_background_renewal_refreshes_idle_active_lease() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(20),
+        Duration::from_mins(5),
+        RenewBehavior::RenewRotatedToken,
+    ));
+    let runtime = Arc::new(make_runtime(store, lease.clone()));
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant.clone()),
+        )
+        .await;
+    let mut events = runtime.subscribe(&identity).await.unwrap();
+    let task = runtime
+        .clone()
+        .spawn_lease_renewal_task_with_poll_interval(Duration::from_millis(10));
+
+    tokio::time::sleep(Duration::from_millis(45)).await;
+    task.abort();
+
+    let status = runtime.status(&identity).await.unwrap();
+    let renewed = status.lease.unwrap().fencing_token;
+    assert!(
+        renewed > grant.fencing_token,
+        "idle background renewal should rotate the expired lease"
+    );
+    assert!(lease.renew_calls() >= 1);
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        IdentityEvent::LeaseUpdated { fencing_token, .. } if fencing_token == renewed
+    ));
+}
+
+#[tokio::test]
+async fn identity_first_runtime_background_renewal_does_not_touch_healthy_lease() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_mins(5),
+        Duration::from_mins(5),
+        RenewBehavior::RenewRotatedToken,
+    ));
+    let runtime = Arc::new(make_runtime(store, lease.clone()));
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant.clone()),
+        )
+        .await;
+    let task = runtime
+        .clone()
+        .spawn_lease_renewal_task_with_poll_interval(Duration::from_millis(10));
+
+    tokio::time::sleep(Duration::from_millis(35)).await;
+    task.abort();
+
+    assert_eq!(lease.renew_calls(), 0);
+    assert_eq!(
+        runtime
+            .status(&identity)
+            .await
+            .unwrap()
+            .lease
+            .unwrap()
+            .fencing_token,
+        grant.fencing_token
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_background_lost_renewal_marks_lease_lost() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(20),
+        Duration::from_mins(5),
+        RenewBehavior::Lost,
+    ));
+    let runtime = Arc::new(make_runtime(store, lease.clone()));
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant),
+        )
+        .await;
+    let mut events = runtime.subscribe(&identity).await.unwrap();
+    let task = runtime
+        .clone()
+        .spawn_lease_renewal_task_with_poll_interval(Duration::from_millis(10));
+
+    tokio::time::sleep(Duration::from_millis(45)).await;
+    task.abort();
+
+    assert!(lease.renew_calls() >= 1);
+    assert!(runtime.status(&identity).await.unwrap().lease.is_none());
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        IdentityEvent::LeaseLost { .. }
+    ));
+}
+
+#[tokio::test]
 async fn identity_first_runtime_lost_renewal_marks_lease_lost_and_blocks_send() {
     let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
     let lease = Arc::new(ControlledLeaseProvider::new(

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -13,8 +13,8 @@
 //! to match the `test(identity_first)` filter.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -154,6 +154,136 @@ impl LeaseProvider for MissingLeaseProvider {
     }
 
     async fn release_leases(&self, _grants: &[LeaseGrant]) -> Result<(), LeaseError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RenewBehavior {
+    RenewSameToken,
+    RenewRotatedToken,
+    Lost,
+    MissingResult,
+}
+
+struct ControlledLeaseProvider {
+    state: Mutex<BTreeMap<AgentIdentity, FencingToken>>,
+    next_token: AtomicUsize,
+    acquire_ttl: Duration,
+    renew_ttl: Duration,
+    renew_behavior: RenewBehavior,
+    renew_calls: AtomicUsize,
+}
+
+impl ControlledLeaseProvider {
+    fn new(acquire_ttl: Duration, renew_ttl: Duration, renew_behavior: RenewBehavior) -> Self {
+        Self {
+            state: Mutex::new(BTreeMap::new()),
+            next_token: AtomicUsize::new(1),
+            acquire_ttl,
+            renew_ttl,
+            renew_behavior,
+            renew_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn renew_calls(&self) -> usize {
+        self.renew_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl LeaseProvider for ControlledLeaseProvider {
+    async fn acquire_leases(
+        &self,
+        identities: &[AgentIdentity],
+        _runtime_instance: &str,
+    ) -> Result<BTreeMap<AgentIdentity, LeaseAcquireResult>, LeaseError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut result = BTreeMap::new();
+        for identity in identities {
+            let token = FencingToken::new(self.next_token.fetch_add(1, Ordering::SeqCst) as u64);
+            state.insert(identity.clone(), token);
+            result.insert(
+                identity.clone(),
+                LeaseAcquireResult::Acquired(LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: token,
+                    ttl: self.acquire_ttl,
+                }),
+            );
+        }
+        Ok(result)
+    }
+
+    async fn renew_leases(
+        &self,
+        grants: &[LeaseGrant],
+    ) -> Result<BTreeMap<AgentIdentity, LeaseRenewResult>, LeaseError> {
+        self.renew_calls.fetch_add(1, Ordering::SeqCst);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut result = BTreeMap::new();
+        for grant in grants {
+            if matches!(self.renew_behavior, RenewBehavior::MissingResult) {
+                continue;
+            }
+            let Some(current) = state.get(&grant.identity).copied() else {
+                result.insert(
+                    grant.identity.clone(),
+                    LeaseRenewResult::Lost {
+                        identity: grant.identity.clone(),
+                    },
+                );
+                continue;
+            };
+            if current != grant.fencing_token || matches!(self.renew_behavior, RenewBehavior::Lost)
+            {
+                result.insert(
+                    grant.identity.clone(),
+                    LeaseRenewResult::Lost {
+                        identity: grant.identity.clone(),
+                    },
+                );
+                continue;
+            }
+            let token = match self.renew_behavior {
+                RenewBehavior::RenewSameToken => current,
+                RenewBehavior::RenewRotatedToken => {
+                    let token =
+                        FencingToken::new(self.next_token.fetch_add(1, Ordering::SeqCst) as u64);
+                    state.insert(grant.identity.clone(), token);
+                    token
+                }
+                RenewBehavior::Lost | RenewBehavior::MissingResult => unreachable!(),
+            };
+            result.insert(
+                grant.identity.clone(),
+                LeaseRenewResult::Renewed(LeaseGrant {
+                    identity: grant.identity.clone(),
+                    fencing_token: token,
+                    ttl: self.renew_ttl,
+                }),
+            );
+        }
+        Ok(result)
+    }
+
+    async fn release_leases(&self, grants: &[LeaseGrant]) -> Result<(), LeaseError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for grant in grants {
+            if state.get(&grant.identity) == Some(&grant.fencing_token) {
+                state.remove(&grant.identity);
+            }
+        }
         Ok(())
     }
 }
@@ -694,6 +824,20 @@ fn make_dispatch_input() -> DispatchInput {
         origin: DispatchOrigin::Connector,
         correlation_id: None,
         idempotency_key: None,
+    }
+}
+
+async fn acquire_controlled_grant(
+    provider: &ControlledLeaseProvider,
+    identity: &AgentIdentity,
+) -> LeaseGrant {
+    let acquired = provider
+        .acquire_leases(std::slice::from_ref(identity), "test-runtime")
+        .await
+        .unwrap();
+    match acquired.get(identity).unwrap() {
+        LeaseAcquireResult::Acquired(grant) => grant.clone(),
+        other => panic!("expected acquired controlled lease, got {other:?}"),
     }
 }
 
@@ -4732,6 +4876,232 @@ async fn identity_first_runtime_inv01_checkpoint_without_lease_rejected() {
 // ===========================================================================
 // Task 2.19 — INV-02: Lease loss blocks new work
 // ===========================================================================
+
+#[tokio::test]
+async fn identity_first_runtime_renews_expired_lease_before_send() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(1),
+        Duration::from_mins(5),
+        RenewBehavior::RenewRotatedToken,
+    ));
+    let runtime = make_runtime(store, lease.clone());
+    let identity = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 0);
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(record),
+            Some(grant.clone()),
+        )
+        .await;
+    let mut events = runtime.subscribe(&identity).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let token = runtime.send(&identity, &make_content()).await.unwrap();
+
+    assert!(
+        token > grant.fencing_token,
+        "send should use the renewed fencing token"
+    );
+    assert_eq!(lease.renew_calls(), 1);
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        IdentityEvent::LeaseUpdated { fencing_token, .. } if fencing_token == token
+    ));
+    let status = runtime.status(&identity).await.unwrap();
+    assert_eq!(status.lease.unwrap().fencing_token, token);
+}
+
+#[tokio::test]
+async fn identity_first_runtime_renews_expired_lease_before_dispatch() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(1),
+        Duration::from_mins(5),
+        RenewBehavior::RenewSameToken,
+    ));
+    let runtime = make_runtime(store, lease.clone());
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant.clone()),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let (token, durable) = runtime
+        .dispatch(&identity, &make_dispatch_input())
+        .await
+        .unwrap();
+
+    assert_eq!(token, grant.fencing_token);
+    assert!(!durable);
+    assert_eq!(lease.renew_calls(), 1);
+    assert!(
+        runtime
+            .status(&identity)
+            .await
+            .unwrap()
+            .lease
+            .unwrap()
+            .healthy
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_renewed_checkpoint_advances_store_fence() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(1),
+        Duration::from_mins(5),
+        RenewBehavior::RenewRotatedToken,
+    ));
+    let runtime = make_runtime(store.clone(), lease.clone());
+    let identity = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 0);
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+    store
+        .upsert_continuity_record(&record, grant.fencing_token)
+        .await
+        .unwrap();
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(record.clone()),
+            Some(grant.clone()),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let version = runtime
+        .checkpoint(
+            &identity,
+            &SessionSnapshot {
+                data: b"renewed".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(version, CheckpointVersion::new(1));
+    assert_eq!(lease.renew_calls(), 1);
+    assert_old_token_snapshot_write_rejected(
+        store.as_ref(),
+        &identity,
+        &record,
+        grant.fencing_token,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn identity_first_runtime_healthy_lease_does_not_call_renew_provider() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_mins(5),
+        Duration::from_mins(5),
+        RenewBehavior::MissingResult,
+    ));
+    let runtime = make_runtime(store, lease.clone());
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant.clone()),
+        )
+        .await;
+
+    let token = runtime.send(&identity, &make_content()).await.unwrap();
+
+    assert_eq!(token, grant.fencing_token);
+    assert_eq!(lease.renew_calls(), 0);
+}
+
+#[tokio::test]
+async fn identity_first_runtime_lost_renewal_marks_lease_lost_and_blocks_send() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(1),
+        Duration::from_mins(5),
+        RenewBehavior::Lost,
+    ));
+    let runtime = make_runtime(store, lease.clone());
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant),
+        )
+        .await;
+    let mut events = runtime.subscribe(&identity).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let err = runtime.send(&identity, &make_content()).await.unwrap_err();
+
+    assert!(matches!(err, IdentityRuntimeError::LeaseLost(_)));
+    assert_eq!(lease.renew_calls(), 1);
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        IdentityEvent::LeaseLost { .. }
+    ));
+    assert!(runtime.status(&identity).await.unwrap().lease.is_none());
+}
+
+#[tokio::test]
+async fn identity_first_runtime_missing_renew_result_is_treated_as_lease_lost() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(1),
+        Duration::from_mins(5),
+        RenewBehavior::MissingResult,
+    ));
+    let runtime = make_runtime(store, lease.clone());
+    let identity = make_identity("triage:main");
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let err = runtime
+        .checkpoint(
+            &identity,
+            &SessionSnapshot {
+                data: b"missing".to_vec(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, IdentityRuntimeError::LeaseLost(_)));
+    assert_eq!(lease.renew_calls(), 1);
+    assert!(runtime.status(&identity).await.unwrap().lease.is_none());
+}
 
 #[tokio::test]
 async fn identity_first_runtime_inv02_lease_loss_blocks_send() {


### PR DESCRIPTION
## Summary
- renew identity-first leases before active work instead of treating an expired local TTL as immediate lease loss
- add a proactive background renewal supervisor for UnifiedRuntime identity-first deployments, with shutdown cleanup
- advance continuity fencing and bridge session runtime state when renewal returns a fresh fencing token
- add defensive runtime tests for expired renewal success, rotated tokens, healthy no-op renewal, missing renewal results, true lease loss, and idle background renewal

## Root cause
MobKit's identity-first runtime enforced the TTL on its local `LeaseEntry`, but the runtime never called the `LeaseProvider::renew_leases` contract before `send`, `dispatch`, `checkpoint`, or `retire`. The bundled `LocalLeaseProvider` does not expire records internally, but it returned a 24-hour TTL. Long-lived agents could therefore be rejected by MobKit as `LeaseLost` after roughly 24 hours even though the local provider still held the lease.

The first fix renews on active work. This follow-up also starts a UnifiedRuntime-owned renewal supervisor so idle long-running agents renew proactively before the next operator action or checkpoint.

This is a MobKit identity-first runtime bug, not a Meerkat core agent/model/image-generation bug.

## Validation
- `./scripts/repo-cargo fmt --check`
- `git diff --check`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime identity_first_runtime_background`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_contracts`
- `./scripts/repo-cargo check -p meerkat-mobkit`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hooks: hardcoded secrets, whitespace, merge-conflict/large-file checks, `cargo fmt --check`, cargo clippy for changed crates, workspace unit gate
