### PR TITLE
Fix lease renewal supervisor races

### DIFF
--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use meerkat_core::types::{HandlingMode, SessionId};
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::sync::{Mutex, Notify, RwLock, broadcast};
 use tokio::task::JoinHandle;
 
 use super::bridge::SessionBridge;
@@ -331,6 +331,7 @@ pub struct IdentityRuntime {
     materialization_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
     lifecycle_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
     customizer: RwLock<Option<Arc<dyn AgentCustomizer>>>,
+    lease_renewal_notify: Notify,
     default_timeout: Duration,
 }
 
@@ -353,6 +354,7 @@ impl IdentityRuntime {
             materialization_locks: RwLock::new(BTreeMap::new()),
             lifecycle_locks: RwLock::new(BTreeMap::new()),
             customizer: RwLock::new(None),
+            lease_renewal_notify: Notify::new(),
             default_timeout: config.default_timeout.unwrap_or(Duration::from_secs(90)),
         }
     }
@@ -386,8 +388,11 @@ impl IdentityRuntime {
         let max_poll_interval = max_poll_interval.max(DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL);
         tokio::spawn(async move {
             loop {
-                tokio::time::sleep(self.lease_renewal_sleep_interval(max_poll_interval).await)
-                    .await;
+                let sleep = self.lease_renewal_sleep_interval(max_poll_interval).await;
+                tokio::select! {
+                    () = tokio::time::sleep(sleep) => {}
+                    () = self.lease_renewal_notify.notified() => {}
+                }
                 if let Err(err) = self.renew_due_leases_once().await {
                     tracing::warn!(
                         error = %err,
@@ -430,6 +435,8 @@ impl IdentityRuntime {
         let mut renewed = 0;
         let mut first_error = None;
         for identity in due {
+            let lifecycle_lock = self.lifecycle_lock_for(&identity).await;
+            let _lifecycle_guard = lifecycle_lock.lock().await;
             match self.ensure_active_lease(&identity).await {
                 Ok(_) => renewed += 1,
                 Err(err) => {
@@ -693,11 +700,19 @@ impl IdentityRuntime {
             checkpoint_version: cpv,
             has_runtime_store: self.has_runtime_store,
         };
+        let has_active_lease =
+            entry.state == IdentityLifecycleState::Active && entry.lease.is_some();
         self.entries.write().await.insert(identity.clone(), entry);
 
         // Create event channel for this identity
         let (tx, _) = broadcast::channel(IDENTITY_EVENT_CHANNEL_CAPACITY);
-        self.event_channels.write().await.insert(identity, tx);
+        self.event_channels
+            .write()
+            .await
+            .insert(identity.clone(), tx);
+        if has_active_lease {
+            self.lease_renewal_notify.notify_one();
+        }
     }
 
     async fn materialization_lock_for(&self, identity: &AgentIdentity) -> Arc<Mutex<()>> {
@@ -1384,6 +1399,7 @@ impl IdentityRuntime {
             acquired_at: Instant::now(),
         });
         drop(entries);
+        self.lease_renewal_notify.notify_one();
         self.emit_event(
             identity,
             IdentityEvent::LeaseUpdated {
@@ -1435,6 +1451,9 @@ impl IdentityRuntime {
             .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
         entry.state = state;
         drop(entries);
+        if state == IdentityLifecycleState::Active {
+            self.lease_renewal_notify.notify_one();
+        }
         self.emit_event(
             identity,
             IdentityEvent::StateChanged {
@@ -1543,6 +1562,7 @@ impl IdentityRuntime {
             None => return Err(IdentityRuntimeError::NoActiveLease(identity.clone())),
         }
         drop(entries);
+        self.lease_renewal_notify.notify_one();
 
         self.emit_event(
             identity,
@@ -1614,6 +1634,9 @@ impl IdentityRuntime {
             entry.lease = restore_live_lease.then(|| Self::lease_entry_from_grant(grant));
         }
         self.restore_entry(identity, entry).await;
+        if restore_live_lease {
+            self.lease_renewal_notify.notify_one();
+        }
     }
 
     pub(crate) async fn refresh_active_restore_grant(

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -288,6 +288,142 @@ impl LeaseProvider for ControlledLeaseProvider {
     }
 }
 
+struct BlockingRenewLeaseProvider {
+    state: Mutex<BTreeMap<AgentIdentity, FencingToken>>,
+    next_token: AtomicUsize,
+    acquire_ttl: Duration,
+    renew_ttl: Duration,
+    renew_calls: AtomicUsize,
+    first_renew_started: tokio::sync::Notify,
+    release_first_renew: tokio::sync::Notify,
+}
+
+impl BlockingRenewLeaseProvider {
+    fn new(acquire_ttl: Duration, renew_ttl: Duration) -> Self {
+        Self {
+            state: Mutex::new(BTreeMap::new()),
+            next_token: AtomicUsize::new(1),
+            acquire_ttl,
+            renew_ttl,
+            renew_calls: AtomicUsize::new(0),
+            first_renew_started: tokio::sync::Notify::new(),
+            release_first_renew: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn renew_calls(&self) -> usize {
+        self.renew_calls.load(Ordering::SeqCst)
+    }
+
+    async fn acquire_grant(&self, identity: &AgentIdentity) -> LeaseGrant {
+        let acquired = self
+            .acquire_leases(std::slice::from_ref(identity), "test-runtime")
+            .await
+            .unwrap();
+        match acquired.get(identity).unwrap() {
+            LeaseAcquireResult::Acquired(grant) => grant.clone(),
+            other => panic!("expected acquired blocking lease, got {other:?}"),
+        }
+    }
+
+    async fn wait_for_first_renew(&self) {
+        self.first_renew_started.notified().await;
+    }
+
+    fn release_first_renew(&self) {
+        self.release_first_renew.notify_one();
+    }
+}
+
+#[async_trait]
+impl LeaseProvider for BlockingRenewLeaseProvider {
+    async fn acquire_leases(
+        &self,
+        identities: &[AgentIdentity],
+        _runtime_instance: &str,
+    ) -> Result<BTreeMap<AgentIdentity, LeaseAcquireResult>, LeaseError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut result = BTreeMap::new();
+        for identity in identities {
+            let token = FencingToken::new(self.next_token.fetch_add(1, Ordering::SeqCst) as u64);
+            state.insert(identity.clone(), token);
+            result.insert(
+                identity.clone(),
+                LeaseAcquireResult::Acquired(LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: token,
+                    ttl: self.acquire_ttl,
+                }),
+            );
+        }
+        Ok(result)
+    }
+
+    async fn renew_leases(
+        &self,
+        grants: &[LeaseGrant],
+    ) -> Result<BTreeMap<AgentIdentity, LeaseRenewResult>, LeaseError> {
+        let call = self.renew_calls.fetch_add(1, Ordering::SeqCst);
+        if call == 0 {
+            self.first_renew_started.notify_one();
+            self.release_first_renew.notified().await;
+        }
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut result = BTreeMap::new();
+        for grant in grants {
+            let Some(current) = state.get(&grant.identity).copied() else {
+                result.insert(
+                    grant.identity.clone(),
+                    LeaseRenewResult::Lost {
+                        identity: grant.identity.clone(),
+                    },
+                );
+                continue;
+            };
+            if current != grant.fencing_token {
+                result.insert(
+                    grant.identity.clone(),
+                    LeaseRenewResult::Lost {
+                        identity: grant.identity.clone(),
+                    },
+                );
+                continue;
+            }
+            let token = FencingToken::new(self.next_token.fetch_add(1, Ordering::SeqCst) as u64);
+            state.insert(grant.identity.clone(), token);
+            result.insert(
+                grant.identity.clone(),
+                LeaseRenewResult::Renewed(LeaseGrant {
+                    identity: grant.identity.clone(),
+                    fencing_token: token,
+                    ttl: self.renew_ttl,
+                }),
+            );
+        }
+        Ok(result)
+    }
+
+    async fn release_leases(&self, grants: &[LeaseGrant]) -> Result<(), LeaseError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for grant in grants {
+            if state.get(&grant.identity) == Some(&grant.fencing_token) {
+                state.remove(&grant.identity);
+            }
+        }
+        Ok(())
+    }
+}
+
 impl CountingContinuityStore {
     fn new() -> Self {
         Self {
@@ -5071,6 +5207,100 @@ async fn identity_first_runtime_background_renewal_refreshes_idle_active_lease()
         events.try_recv().unwrap(),
         IdentityEvent::LeaseUpdated { fencing_token, .. } if fencing_token == renewed
     ));
+}
+
+#[tokio::test]
+async fn identity_first_runtime_background_renewal_wakes_for_new_short_lease() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(ControlledLeaseProvider::new(
+        Duration::from_millis(20),
+        Duration::from_mins(5),
+        RenewBehavior::RenewRotatedToken,
+    ));
+    let runtime = Arc::new(make_runtime(store, lease.clone()));
+    let identity = make_identity("triage:main");
+
+    let task = runtime
+        .clone()
+        .spawn_lease_renewal_task_with_poll_interval(Duration::from_mins(1));
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let grant = acquire_controlled_grant(&lease, &identity).await;
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant.clone()),
+        )
+        .await;
+    let mut events = runtime.subscribe(&identity).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(55)).await;
+    task.abort();
+
+    let status = runtime.status(&identity).await.unwrap();
+    let renewed = status.lease.unwrap().fencing_token;
+    assert!(
+        renewed > grant.fencing_token,
+        "new short leases should wake a supervisor already sleeping at max poll"
+    );
+    assert!(lease.renew_calls() >= 1);
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        IdentityEvent::LeaseUpdated { fencing_token, .. } if fencing_token == renewed
+    ));
+}
+
+#[tokio::test]
+async fn identity_first_runtime_background_renewal_serializes_with_foreground_renewal() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(BlockingRenewLeaseProvider::new(
+        Duration::from_millis(1),
+        Duration::from_mins(5),
+    ));
+    let runtime = Arc::new(make_runtime(store, lease.clone()));
+    let identity = make_identity("triage:main");
+    let grant = lease.acquire_grant(&identity).await;
+
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(make_record("triage:main", 0, 0)),
+            Some(grant.clone()),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let foreground = {
+        let runtime = runtime.clone();
+        let identity = identity.clone();
+        tokio::spawn(async move { runtime.send(&identity, &make_content()).await })
+    };
+    lease.wait_for_first_renew().await;
+
+    let blocked =
+        tokio::time::timeout(Duration::from_millis(20), runtime.renew_due_leases_once()).await;
+    assert!(
+        blocked.is_err(),
+        "background renewal should wait for the foreground lifecycle operation"
+    );
+    assert_eq!(
+        lease.renew_calls(),
+        1,
+        "background renewal must not enter the provider while foreground renewal is in flight"
+    );
+
+    lease.release_first_renew();
+    let token = foreground.await.unwrap().unwrap();
+
+    assert!(
+        token > grant.fencing_token,
+        "foreground renewal should still complete with the rotated token"
+    );
+    assert_eq!(lease.renew_calls(), 1);
+    assert_eq!(runtime.renew_due_leases_once().await.unwrap(), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- wake the proactive lease renewal supervisor when active leases are registered, updated, restored, or activated
- serialize background renewals with the same per-identity lifecycle lock used by foreground send/dispatch/checkpoint flows
- add defensive tests for supervisor-starts-before-identity and foreground/background rotating-renewal races

## Verification
- ./scripts/repo-cargo fmt --check
- git diff --check
- ./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime identity_first_runtime_background_renewal
- ./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime
- ./scripts/repo-cargo clippy -p meerkat-mobkit --all-targets -- -D warnings
- ./scripts/repo-cargo check -p meerkat-mobkit
- pre-push hook: cargo fmt --check, cargo clippy (changed crates), workspace unit gate