### PR TITLE
[codex] fix identity delivery session rebind

### DIFF
--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -524,7 +524,12 @@ impl MobKitConsoleAggregator {
                         .cloned()
                         .unwrap_or_default();
                     if console_identity_record_visible(entry, &record).await {
-                        durable_matches.push((entry.clone(), record));
+                        durable_matches.push((
+                            entry.clone(),
+                            identity_runtime.clone(),
+                            parsed_identity,
+                            record,
+                        ));
                     }
                 }
             }
@@ -532,7 +537,7 @@ impl MobKitConsoleAggregator {
         if durable_matches.len() > 1 {
             let candidates = durable_matches
                 .iter()
-                .map(|(_, record)| record.runtime_member_id.clone())
+                .map(|(_, _, _, record)| record.runtime_member_id.clone())
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(format!(
@@ -540,7 +545,9 @@ impl MobKitConsoleAggregator {
             )
             .into());
         }
-        if let Some((entry, record)) = durable_matches.into_iter().next() {
+        if let Some((entry, identity_runtime, parsed_identity, mut record)) =
+            durable_matches.into_iter().next()
+        {
             let durable_live_records = self
                 .live_records_for_durable_record(&entry, identity, &record, &live_records)
                 .await;
@@ -550,6 +557,19 @@ impl MobKitConsoleAggregator {
                 ambiguous_live_alias_error(identity, &visible_durable_live_records)
             {
                 return Err(ambiguous_error.into());
+            }
+            if let Some(rebound_record) = self_heal_durable_session_mismatch(
+                &entry,
+                identity_runtime.as_ref(),
+                &parsed_identity,
+                identity,
+                &record,
+                &durable_live_records,
+            )
+            .await
+            .map_err(ConsoleLogError::from)?
+            {
+                record = rebound_record;
             }
             if let Some(stale_error) =
                 stale_durable_record_error(identity, &record, &durable_live_records)
@@ -601,13 +621,13 @@ impl MobKitConsoleAggregator {
                 .cloned()
                 .unwrap_or_default();
             if console_identity_record_visible(entry, &record).await {
-                runtime_id_matches.push((entry.clone(), record));
+                runtime_id_matches.push((entry.clone(), identity_runtime, status.identity, record));
             }
         }
         if runtime_id_matches.len() > 1 {
             let candidates = runtime_id_matches
                 .iter()
-                .map(|(_, record)| record.identity.clone())
+                .map(|(_, _, _, record)| record.identity.clone())
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(format!(
@@ -615,7 +635,9 @@ impl MobKitConsoleAggregator {
             )
             .into());
         }
-        if let Some((entry, record)) = runtime_id_matches.into_iter().next() {
+        if let Some((entry, identity_runtime, parsed_identity, mut record)) =
+            runtime_id_matches.into_iter().next()
+        {
             let durable_live_records = self
                 .live_records_for_durable_record(&entry, identity, &record, &live_records)
                 .await;
@@ -625,6 +647,19 @@ impl MobKitConsoleAggregator {
                 ambiguous_live_alias_error(&record.identity, &visible_durable_live_records)
             {
                 return Err(ambiguous_error.into());
+            }
+            if let Some(rebound_record) = self_heal_durable_session_mismatch(
+                &entry,
+                identity_runtime.as_ref(),
+                &parsed_identity,
+                identity,
+                &record,
+                &durable_live_records,
+            )
+            .await
+            .map_err(ConsoleLogError::from)?
+            {
+                record = rebound_record;
             }
             if let Some(stale_error) =
                 stale_durable_record_error(identity, &record, &durable_live_records)
@@ -665,7 +700,7 @@ impl MobKitConsoleAggregator {
                 return Ok(None);
             };
             if let Some(stale_error) =
-                stale_live_record_binding_error(&resolved.entry, identity, &record).await
+                reconcile_stale_live_record_binding(&resolved.entry, identity, &record).await
             {
                 return Err(stale_error.into());
             }
@@ -674,7 +709,7 @@ impl MobKitConsoleAggregator {
                     crate::identity_first::AgentIdentity::parse(&record.identity)
                 && let Ok(status) = identity_runtime.status(&parsed_identity).await
             {
-                let durable_record = identity_record_for_status(&resolved.entry, &status);
+                let mut durable_record = identity_record_for_status(&resolved.entry, &status);
                 let durable_live_records = self
                     .live_records_for_durable_record(
                         &resolved.entry,
@@ -689,6 +724,19 @@ impl MobKitConsoleAggregator {
                     ambiguous_live_alias_error(&record.identity, &visible_durable_live_records)
                 {
                     return Err(ambiguous_error.into());
+                }
+                if let Some(rebound_record) = self_heal_durable_session_mismatch(
+                    &resolved.entry,
+                    identity_runtime.as_ref(),
+                    &parsed_identity,
+                    identity,
+                    &durable_record,
+                    &durable_live_records,
+                )
+                .await
+                .map_err(ConsoleLogError::from)?
+                {
+                    durable_record = rebound_record;
                 }
                 if let Some(stale_error) =
                     stale_durable_record_error(identity, &durable_record, &durable_live_records)
@@ -781,7 +829,7 @@ impl MobKitConsoleAggregator {
             )
             .into());
         }
-        if let Some((entry, identity_runtime, parsed_identity, record)) =
+        if let Some((entry, identity_runtime, parsed_identity, mut record)) =
             durable_matches.into_iter().next()
         {
             let durable_live_records = self
@@ -793,6 +841,19 @@ impl MobKitConsoleAggregator {
                 ambiguous_live_alias_error(identity, &visible_durable_live_records)
             {
                 return Err(ambiguous_error.into());
+            }
+            if let Some(rebound_record) = self_heal_durable_session_mismatch(
+                &entry,
+                identity_runtime.as_ref(),
+                &parsed_identity,
+                identity,
+                &record,
+                &durable_live_records,
+            )
+            .await
+            .map_err(ConsoleLogError::from)?
+            {
+                record = rebound_record;
             }
             if let Some(stale_error) =
                 stale_durable_record_error(identity, &record, &durable_live_records)
@@ -845,7 +906,7 @@ impl MobKitConsoleAggregator {
                 continue;
             }
             if let Some(stale_error) =
-                stale_live_record_binding_error(&resolved.entry, identity, &record).await
+                reconcile_stale_live_record_binding(&resolved.entry, identity, &record).await
             {
                 return Err(stale_error.into());
             }
@@ -854,7 +915,7 @@ impl MobKitConsoleAggregator {
                     crate::identity_first::AgentIdentity::parse(&record.identity)
                 && let Ok(status) = identity_runtime.status(&parsed_identity).await
             {
-                let durable_record = identity_record_for_status(&resolved.entry, &status);
+                let mut durable_record = identity_record_for_status(&resolved.entry, &status);
                 let durable_live_records = self
                     .live_records_for_durable_record(
                         &resolved.entry,
@@ -869,6 +930,19 @@ impl MobKitConsoleAggregator {
                     ambiguous_live_alias_error(&record.identity, &visible_durable_live_records)
                 {
                     return Err(ambiguous_error.into());
+                }
+                if let Some(rebound_record) = self_heal_durable_session_mismatch(
+                    &resolved.entry,
+                    identity_runtime.as_ref(),
+                    &parsed_identity,
+                    identity,
+                    &durable_record,
+                    &durable_live_records,
+                )
+                .await
+                .map_err(ConsoleLogError::from)?
+                {
+                    durable_record = rebound_record;
                 }
                 if let Some(stale_error) =
                     stale_durable_record_error(identity, &durable_record, &durable_live_records)
@@ -1477,21 +1551,28 @@ impl MobKitConsoleAggregator {
                         hidden_durable_match = true;
                         continue;
                     }
-                    durable_matches.push((entry.clone(), record));
+                    durable_matches.push((
+                        entry.clone(),
+                        identity_runtime.clone(),
+                        parsed_identity,
+                        record,
+                    ));
                 }
             }
         }
         if durable_matches.len() > 1 {
             let candidates = durable_matches
                 .iter()
-                .map(|(entry, record)| format!("{}@{}", record.identity, entry.runtime_key))
+                .map(|(entry, _, _, record)| format!("{}@{}", record.identity, entry.runtime_key))
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(ConsoleSendError::InvalidRequest(format!(
                 "ambiguous durable identity alias {identity}: candidates [{candidates}]"
             )));
         }
-        if let Some((entry, record)) = durable_matches.into_iter().next() {
+        if let Some((entry, identity_runtime, parsed_identity, mut record)) =
+            durable_matches.into_iter().next()
+        {
             let live_records = self.live_records_for_identity(identity).await;
             let durable_live_records = self
                 .live_records_for_durable_record(&entry, identity, &record, &live_records)
@@ -1502,6 +1583,19 @@ impl MobKitConsoleAggregator {
                 ambiguous_live_alias_error(identity, &visible_durable_live_records)
             {
                 return Err(ConsoleSendError::InvalidRequest(ambiguous_error));
+            }
+            if let Some(rebound_record) = self_heal_durable_session_mismatch(
+                &entry,
+                identity_runtime.as_ref(),
+                &parsed_identity,
+                identity,
+                &record,
+                &durable_live_records,
+            )
+            .await
+            .map_err(ConsoleSendError::InvalidRequest)?
+            {
+                record = rebound_record;
             }
             if let Some(stale_error) =
                 stale_durable_record_error(identity, &record, &durable_live_records)
@@ -1637,7 +1731,7 @@ impl MobKitConsoleAggregator {
         };
         if let Some(record) = identity_record_for_resolved_member(&resolved).await
             && let Some(stale_error) =
-                stale_live_record_binding_error(&resolved.entry, identity, &record).await
+                reconcile_stale_live_record_binding(&resolved.entry, identity, &record).await
         {
             return Err(ConsoleSendError::InvalidRequest(stale_error));
         }
@@ -1681,13 +1775,18 @@ impl MobKitConsoleAggregator {
                 if !console_identity_record_visible(entry, &record).await {
                     continue;
                 }
-                durable_matches.push((entry.clone(), record));
+                durable_matches.push((
+                    entry.clone(),
+                    identity_runtime.clone(),
+                    parsed_identity,
+                    record,
+                ));
             }
         }
         if durable_matches.len() > 1 {
             let candidates = durable_matches
                 .iter()
-                .map(|(_, record)| record.runtime_member_id.clone())
+                .map(|(_, _, _, record)| record.runtime_member_id.clone())
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(ConsoleSendError::AmbiguousIdentity {
@@ -1695,7 +1794,9 @@ impl MobKitConsoleAggregator {
                 candidates,
             });
         }
-        let Some((entry, durable_record)) = durable_matches.into_iter().next() else {
+        let Some((entry, identity_runtime, parsed_identity, mut durable_record)) =
+            durable_matches.into_iter().next()
+        else {
             return Ok(None);
         };
         let durable_live_records = self
@@ -1707,6 +1808,19 @@ impl MobKitConsoleAggregator {
             ambiguous_live_alias_error(&durable_record.identity, &visible_durable_live_records)
         {
             return Err(ConsoleSendError::InvalidRequest(ambiguous_error));
+        }
+        if let Some(rebound_record) = self_heal_durable_session_mismatch(
+            &entry,
+            identity_runtime.as_ref(),
+            &parsed_identity,
+            identity,
+            &durable_record,
+            &durable_live_records,
+        )
+        .await
+        .map_err(ConsoleSendError::InvalidRequest)?
+        {
+            durable_record = rebound_record;
         }
         Ok(stale_durable_record_error(
             identity,
@@ -1946,7 +2060,7 @@ async fn visible_live_records_for_entry(
     visible
 }
 
-async fn stale_live_record_binding_error(
+async fn reconcile_stale_live_record_binding(
     entry: &RuntimeEntry,
     requested_identity: &str,
     live_record: &ConsoleIdentityRecord,
@@ -1961,6 +2075,39 @@ async fn stale_live_record_binding_error(
             continue;
         }
         let durable_record = identity_record_for_status(entry, &status);
+        if let Some(session_mismatch) =
+            stale_durable_session_mismatch(&durable_record, std::slice::from_ref(live_record))
+        {
+            let Some(live_session_id) = session_mismatch.session_id.as_deref() else {
+                continue;
+            };
+            let Ok(session_id) = meerkat_core::types::SessionId::parse(live_session_id) else {
+                return Some(format!(
+                    "stale durable identity alias {requested_identity}: live console alias resolves to invalid session {live_session_id}"
+                ));
+            };
+            return match identity_runtime
+                .rebind_session_after_live_respawn(&status.identity, session_id)
+                .await
+            {
+                Ok(_) => {
+                    tracing::warn!(
+                        requested_identity,
+                        identity = %durable_record.identity,
+                        runtime_member_id = %durable_record.runtime_member_id,
+                        old_session_id = durable_record.session_id.as_deref().unwrap_or("<none>"),
+                        new_session_id = session_mismatch.session_id.as_deref().unwrap_or("<none>"),
+                        "self-healed stale durable identity alias session mismatch"
+                    );
+                    None
+                }
+                Err(err) => Some(format!(
+                    "stale durable identity alias {requested_identity}: failed to rebind {} to live session {}: {err}",
+                    durable_record.identity,
+                    session_mismatch.session_id.as_deref().unwrap_or("<none>")
+                )),
+            };
+        }
         if let Some(stale_error) = stale_durable_record_error(
             requested_identity,
             &durable_record,
@@ -1970,6 +2117,67 @@ async fn stale_live_record_binding_error(
         }
     }
     None
+}
+
+async fn self_heal_durable_session_mismatch(
+    entry: &RuntimeEntry,
+    identity_runtime: &crate::identity_first::IdentityRuntime,
+    parsed_identity: &crate::identity_first::AgentIdentity,
+    requested_identity: &str,
+    durable: &ConsoleIdentityRecord,
+    live_records: &[ConsoleIdentityRecord],
+) -> Result<Option<ConsoleIdentityRecord>, String> {
+    let Some(session_mismatch) = stale_durable_session_mismatch(durable, live_records) else {
+        return Ok(None);
+    };
+    let Some(live_session_id) = session_mismatch.session_id.as_deref() else {
+        return Ok(None);
+    };
+    let session_id = meerkat_core::types::SessionId::parse(live_session_id).map_err(|err| {
+        format!(
+            "stale durable identity alias {requested_identity}: live console alias resolves to invalid session {live_session_id}: {err}"
+        )
+    })?;
+    identity_runtime
+        .rebind_session_after_live_respawn(parsed_identity, session_id)
+        .await
+        .map_err(|err| {
+            format!(
+                "stale durable identity alias {requested_identity}: failed to rebind {} to live session {}: {err}",
+                durable.identity, live_session_id
+            )
+        })?;
+    tracing::warn!(
+        requested_identity,
+        identity = %durable.identity,
+        runtime_member_id = %durable.runtime_member_id,
+        old_session_id = durable.session_id.as_deref().unwrap_or("<none>"),
+        new_session_id = live_session_id,
+        "self-healed stale durable identity alias session mismatch"
+    );
+    let status = identity_runtime
+        .status(parsed_identity)
+        .await
+        .map_err(|err| {
+            format!(
+                "stale durable identity alias {requested_identity}: failed to reload rebound identity {}: {err}",
+                durable.identity
+            )
+        })?;
+    Ok(Some(identity_record_for_status(entry, &status)))
+}
+
+fn stale_durable_session_mismatch<'a>(
+    durable: &ConsoleIdentityRecord,
+    live_records: &'a [ConsoleIdentityRecord],
+) -> Option<&'a ConsoleIdentityRecord> {
+    live_records.iter().find(|record| {
+        record.identity == durable.identity
+            && record.runtime_member_id == durable.runtime_member_id
+            && durable.session_id.is_some()
+            && record.session_id.is_some()
+            && durable.session_id != record.session_id
+    })
 }
 
 fn stale_durable_record_error(
@@ -1992,12 +2200,7 @@ fn stale_durable_record_error(
     if matching_live.is_empty() {
         return None;
     }
-    if let Some(session_mismatch) = matching_live.iter().find(|record| {
-        record.runtime_member_id == durable.runtime_member_id
-            && durable.session_id.is_some()
-            && record.session_id.is_some()
-            && durable.session_id != record.session_id
-    }) {
+    if let Some(session_mismatch) = stale_durable_session_mismatch(durable, live_records) {
         return Some(format!(
             "stale durable identity alias {requested_identity}: identity runtime binding for {} points at {} session {}, but live console alias resolves to session {}",
             durable.identity,
@@ -5372,6 +5575,130 @@ comms = true
                 .any(|record| record.identity == "review:singleton"
                     && record.runtime_member_id == "rt:review:singleton:1"),
             "stale durable binding should remain visible as split-brain evidence; records: {records:#?}"
+        );
+
+        let _ = runtime.mob_handle().stop().await;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn identity_first_alias_self_heals_session_only_split_brain()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let runtime = build_empty_runtime("identity-session-rebind-test").await;
+        let mut labels = BTreeMap::new();
+        labels.insert("agent_identity".to_string(), "review:singleton".to_string());
+        runtime
+            .spawn(
+                SpawnMemberSpec::from_wire(
+                    "worker".to_string(),
+                    "rt:review:singleton:0".to_string(),
+                    Some("You are the live Review Agent.".into()),
+                    None,
+                    None,
+                )
+                .with_labels(labels),
+            )
+            .await
+            .expect("member spawns");
+        let live_session_id = runtime
+            .mob_handle()
+            .resolve_bridge_session_id_observation(&MeerkatId::from("rt:review:singleton:0"))
+            .await
+            .expect("live member has bridge session");
+
+        let identity_runtime = Arc::new(crate::identity_first::IdentityRuntime::new(
+            crate::identity_first::IdentityRuntimeConfig {
+                continuity_store: Arc::new(
+                    crate::identity_first::LocalContinuityStore::in_memory()?
+                ),
+                lease_provider: Arc::new(crate::identity_first::LocalLeaseProvider::new()),
+                runtime_instance_id: "console-aggregator-session-rebind-test".to_string(),
+                has_runtime_store: true,
+                durability_policy: crate::identity_first::DurabilityPolicy::SyncWriteThrough,
+                bridge: None,
+                default_timeout: None,
+            },
+        ));
+        let identity = crate::identity_first::AgentIdentity::parse("review:singleton")?;
+        let stale_session_id = SessionId::new();
+        assert_ne!(stale_session_id, live_session_id);
+        let record = crate::identity_first::ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: crate::identity_first::AgentRuntimeId::parse(
+                "rt:review:singleton:0",
+            )?,
+            session_id: stale_session_id,
+            generation: crate::identity_first::ContinuityGeneration::new(1),
+            checkpoint_version: crate::identity_first::CheckpointVersion::new(3),
+        };
+        identity_runtime
+            .register(
+                crate::identity_first::DurableAgentSpec {
+                    identity: identity.clone(),
+                    profile: meerkat_mob::ProfileName::from("worker"),
+                    addressability: crate::identity_first::AgentAddressability::Addressable,
+                    display_name: None,
+                    labels: BTreeMap::new(),
+                    context: None,
+                    additional_instructions: Vec::new(),
+                    initial_message: None,
+                    runtime_mode_override: None,
+                    backend: None,
+                    binding: None,
+                },
+                crate::identity_first::IdentityLifecycleState::Active,
+                Some(record),
+                Some(crate::identity_first::LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: crate::identity_first::FencingToken::new(7),
+                    ttl: Duration::from_mins(5),
+                }),
+            )
+            .await;
+
+        let aggregator = MobKitConsoleAggregator::in_memory();
+        aggregator
+            .inner
+            .runtimes
+            .write()
+            .expect("runtime registry")
+            .insert(
+                "runtime-a".to_string(),
+                RuntimeEntry {
+                    runtime_key: "runtime-a".to_string(),
+                    identity_namespace: String::new(),
+                    runtime: runtime.mob_runtime().clone(),
+                    identity_runtime: Some(identity_runtime.clone()),
+                    console_events: runtime.console_events(),
+                    visibility_policy: Arc::new(AllowAllConsoleVisibilityPolicy),
+                },
+            );
+
+        aggregator
+            .reserve_identity_first_interaction(
+                ConsoleSendRequest {
+                    identity: "review:singleton".to_string(),
+                    content: json!("hello"),
+                    origin: "console:test".to_string(),
+                    idempotency_key: "session-rebind-reserve".to_string(),
+                    handling_mode: Some("queue".to_string()),
+                },
+                None,
+            )
+            .await
+            .expect("session-only split-brain should self-heal before reserve");
+
+        let rebound_status = identity_runtime.status(&identity).await?;
+        assert_eq!(rebound_status.session_id, Some(live_session_id.clone()));
+
+        let inspection = aggregator
+            .inspect_identity("review:singleton")
+            .await?
+            .expect("rebound identity should inspect");
+        let live_session_string = live_session_id.to_string();
+        assert_eq!(
+            inspection.identity.session_id.as_deref(),
+            Some(live_session_string.as_str())
         );
 
         let _ = runtime.mob_handle().stop().await;

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -1946,7 +1946,7 @@ impl IdentityRuntime {
             }
         }
 
-        let token = self.ensure_active_lease(identity).await?;
+        let mut token = self.ensure_active_lease(identity).await?;
         let runtime_id = {
             let entries = self.entries.read().await;
             let entry = entries
@@ -1960,10 +1960,16 @@ impl IdentityRuntime {
 
         // Deliver through the session bridge when available.
         if let (Some(bridge), Some(rid)) = (&self.bridge, &runtime_id) {
-            bridge
+            let delivered_session_id = bridge
                 .deliver_with_mode(rid, content, handling_mode)
                 .await
                 .map_err(|e| IdentityRuntimeError::Internal(format!("bridge deliver: {e}")))?;
+            if let Some(rebound_token) = self
+                .reconcile_delivered_session_locked(identity, delivered_session_id)
+                .await?
+            {
+                token = rebound_token;
+            }
         }
 
         Ok(token)
@@ -2016,7 +2022,7 @@ impl IdentityRuntime {
             }
         }
 
-        let token = self.ensure_active_lease(identity).await?;
+        let mut token = self.ensure_active_lease(identity).await?;
         let (is_durable, runtime_id) = {
             let entries = self.entries.read().await;
             let entry = entries
@@ -2035,10 +2041,16 @@ impl IdentityRuntime {
 
         // Deliver through the session bridge when available.
         if let (Some(bridge), Some(rid)) = (&self.bridge, &runtime_id) {
-            bridge
+            let delivered_session_id = bridge
                 .deliver(rid, &input.content)
                 .await
                 .map_err(|e| IdentityRuntimeError::Internal(format!("bridge dispatch: {e}")))?;
+            if let Some(rebound_token) = self
+                .reconcile_delivered_session_locked(identity, delivered_session_id)
+                .await?
+            {
+                token = rebound_token;
+            }
         }
 
         Ok((token, is_durable))
@@ -2337,6 +2349,54 @@ impl IdentityRuntime {
     ) -> Result<ContinuityRecord, IdentityRuntimeError> {
         let lifecycle_lock = self.lifecycle_lock_for(identity).await;
         let _lifecycle_guard = lifecycle_lock.lock().await;
+        self.rebind_session_after_live_respawn_locked(identity, session_id)
+            .await
+    }
+
+    async fn reconcile_delivered_session_locked(
+        &self,
+        identity: &AgentIdentity,
+        delivered_session_id: SessionId,
+    ) -> Result<Option<FencingToken>, IdentityRuntimeError> {
+        let current_session_id = {
+            let entries = self.entries.read().await;
+            let entry = entries
+                .get(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            entry
+                .continuity
+                .as_ref()
+                .map(|record| record.session_id.clone())
+        };
+
+        let Some(current_session_id) = current_session_id else {
+            return Ok(None);
+        };
+        if current_session_id == delivered_session_id {
+            return Ok(None);
+        }
+
+        tracing::warn!(
+            %identity,
+            old_session_id = %current_session_id,
+            new_session_id = %delivered_session_id,
+            "identity bridge delivery returned a rotated session; rebinding continuity"
+        );
+        self.rebind_session_after_live_respawn_locked(identity, delivered_session_id)
+            .await?;
+
+        let entries = self.entries.read().await;
+        let entry = entries
+            .get(identity)
+            .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+        Ok(entry.lease.as_ref().map(|lease| lease.fencing_token))
+    }
+
+    async fn rebind_session_after_live_respawn_locked(
+        &self,
+        identity: &AgentIdentity,
+        session_id: SessionId,
+    ) -> Result<ContinuityRecord, IdentityRuntimeError> {
         let registered_entry = self
             .mark_lifecycle_in_progress(identity, IdentityLifecycleState::Suspended)
             .await?;

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -740,6 +740,7 @@ struct CountingBridge {
     resume_barrier: tokio::sync::Mutex<Option<Arc<tokio::sync::Barrier>>>,
     create_session_id: tokio::sync::Mutex<Option<meerkat_core::types::SessionId>>,
     fallback_session_id: tokio::sync::Mutex<Option<meerkat_core::types::SessionId>>,
+    deliver_session_id: tokio::sync::Mutex<Option<meerkat_core::types::SessionId>>,
     unregistered_session_ids: tokio::sync::Mutex<Vec<String>>,
     wires: tokio::sync::Mutex<Vec<(String, String)>>,
     current_wires: tokio::sync::Mutex<Vec<(String, String)>>,
@@ -761,6 +762,10 @@ impl CountingBridge {
 
     async fn set_create_session_id(&self, session_id: meerkat_core::types::SessionId) {
         *self.create_session_id.lock().await = Some(session_id);
+    }
+
+    async fn set_deliver_session_id(&self, session_id: meerkat_core::types::SessionId) {
+        *self.deliver_session_id.lock().await = Some(session_id);
     }
 
     fn fail_create(&self) {
@@ -803,12 +808,14 @@ impl SessionBridge for CountingBridge {
         if self.fail_create.load(Ordering::SeqCst) {
             return Err(BridgeError::Mob("create failed".to_string()));
         }
-        Ok(self
+        let created_session_id = self
             .create_session_id
             .lock()
             .await
             .clone()
-            .unwrap_or_else(|| session_id.clone()))
+            .unwrap_or_else(|| session_id.clone());
+        *self.deliver_session_id.lock().await = Some(created_session_id.clone());
+        Ok(created_session_id)
     }
 
     async fn resume_session(
@@ -835,6 +842,7 @@ impl SessionBridge for CountingBridge {
                 .await
                 .clone()
                 .unwrap_or_else(meerkat_core::types::SessionId::new);
+            *self.deliver_session_id.lock().await = Some(fallback_session_id.clone());
             return Ok(
                 meerkat_mobkit::identity_first::ResumeSessionOutcome::FreshSpawned {
                     session_id: fallback_session_id,
@@ -845,6 +853,7 @@ impl SessionBridge for CountingBridge {
                 },
             );
         }
+        *self.deliver_session_id.lock().await = Some(session_id.clone());
         Ok(
             meerkat_mobkit::identity_first::ResumeSessionOutcome::Resumed {
                 session_id: session_id.clone(),
@@ -858,7 +867,12 @@ impl SessionBridge for CountingBridge {
         _content: &meerkat_core::ContentInput,
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         self.deliver_calls.fetch_add(1, Ordering::SeqCst);
-        Ok(meerkat_core::types::SessionId::new())
+        Ok(self
+            .deliver_session_id
+            .lock()
+            .await
+            .clone()
+            .unwrap_or_else(meerkat_core::types::SessionId::new))
     }
 
     async fn checkpoint_session(
@@ -1062,6 +1076,89 @@ async fn identity_first_runtime_send_to_addressable_delivers() {
 }
 
 #[tokio::test]
+async fn identity_first_runtime_send_rebinds_rotated_bridge_session() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 2);
+    let original_session_id = record.session_id.clone();
+    store
+        .upsert_continuity_record(&record, FencingToken::new(1))
+        .await
+        .unwrap();
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(record),
+            Some(make_grant("triage:main", 1)),
+        )
+        .await;
+
+    let live_session_id = meerkat_core::types::SessionId::new();
+    bridge.set_deliver_session_id(live_session_id.clone()).await;
+
+    runtime.send(&id, &make_content()).await.unwrap();
+
+    let status = runtime.status(&id).await.unwrap();
+    assert_eq!(status.session_id, Some(live_session_id.clone()));
+    let resolved = store.resolve_many(std::slice::from_ref(&id)).await.unwrap();
+    let ContinuityResolveState::Ready { record } = resolved.get(&id).unwrap() else {
+        panic!("expected rebound continuity record");
+    };
+    assert_eq!(record.session_id, live_session_id);
+    assert_eq!(record.checkpoint_version, CheckpointVersion::new(0));
+    let unregistered = bridge.unregistered_session_ids.lock().await.clone();
+    assert!(
+        unregistered.contains(&original_session_id.to_string()),
+        "rotated delivery must unregister the stale session runtime state; got {unregistered:?}"
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_send_keeps_matching_bridge_session_unchanged() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 2);
+    let original_session_id = record.session_id.clone();
+    store
+        .upsert_continuity_record(&record, FencingToken::new(1))
+        .await
+        .unwrap();
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(record),
+            Some(make_grant("triage:main", 1)),
+        )
+        .await;
+    bridge
+        .set_deliver_session_id(original_session_id.clone())
+        .await;
+
+    let token = runtime.send(&id, &make_content()).await.unwrap();
+
+    assert_eq!(token, FencingToken::new(1));
+    assert_eq!(
+        runtime.status(&id).await.unwrap().session_id,
+        Some(original_session_id)
+    );
+    assert_eq!(
+        bridge.unregister_calls.load(Ordering::SeqCst),
+        0,
+        "matching delivery session should not trigger a rebind cleanup"
+    );
+}
+
+#[tokio::test]
 async fn identity_first_runtime_send_to_internal_only_rejected() {
     let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
     let lease = Arc::new(LocalLeaseProvider::new());
@@ -1138,6 +1235,51 @@ async fn identity_first_runtime_dispatch_to_addressable_succeeds() {
     let (token, is_durable) = result.unwrap();
     assert_eq!(token, FencingToken::new(1));
     assert!(!is_durable); // no runtime_store
+}
+
+#[tokio::test]
+async fn identity_first_runtime_dispatch_rebinds_rotated_bridge_session() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 2);
+    let original_session_id = record.session_id.clone();
+    store
+        .upsert_continuity_record(&record, FencingToken::new(1))
+        .await
+        .unwrap();
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(record),
+            Some(make_grant("triage:main", 1)),
+        )
+        .await;
+
+    let live_session_id = meerkat_core::types::SessionId::new();
+    bridge.set_deliver_session_id(live_session_id.clone()).await;
+
+    let (_token, is_durable) = runtime.dispatch(&id, &make_dispatch_input()).await.unwrap();
+
+    assert!(is_durable);
+    assert_eq!(
+        runtime.status(&id).await.unwrap().session_id,
+        Some(live_session_id.clone())
+    );
+    let resolved = store.resolve_many(std::slice::from_ref(&id)).await.unwrap();
+    let ContinuityResolveState::Ready { record } = resolved.get(&id).unwrap() else {
+        panic!("expected rebound continuity record");
+    };
+    assert_eq!(record.session_id, live_session_id);
+    let unregistered = bridge.unregistered_session_ids.lock().await.clone();
+    assert!(
+        unregistered.contains(&original_session_id.to_string()),
+        "rotated dispatch must unregister the stale session runtime state; got {unregistered:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- capture the session id returned by identity-first bridge delivery for both `send_with_mode` and `dispatch`
- rebind continuity through the existing live-respawn reconciliation path when delivery repairs rotate the bridge session
- self-heal console alias routing when durable and live records agree on identity/runtime member but differ only by session id
- add regressions for rotated delivery, no-rotation no-op delivery, console session-only self-heal, and unsafe stale-alias rejection

## Root Cause

The delivery repair path can respawn the lower-level bridge member and return a fresh `SessionId`, but the identity runtime previously discarded that returned id. That left `entry.continuity.session_id` pinned to the retired session while the live console alias pointed at the replacement session, causing durable sends to trip the stale-alias `-32602` path on subsequent messages.

A related already-diverged state can also occur outside the delivery path. The console alias check now self-heals only the safe case where durable and live bindings match on durable identity and runtime member id, and only the session id has drifted. Runtime-member mismatches and wrong live identity projections still fail closed.

## Validation

- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_runtime_send_keeps_matching_bridge_session_unchanged --test identity_first_runtime --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_alias_self_heals_session_only_split_brain --lib --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit inspect_identity_rejects_stale_durable_binding_when_live_alias_disagrees --lib --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit inspect_identity_rejects_durable_binding_when_runtime_projects_wrong_identity --lib --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit --lib --quiet`
- `./scripts/repo-cargo check -p meerkat-mobkit --all-targets`
- pre-push hooks: hardcoded secrets, whitespace, EOF, YAML/TOML checks, merge conflict check, large file check, `cargo fmt --check`, changed-crate clippy, workspace unit gate
