### PR TITLE
[codex] Preserve identity checkpoint version on rebind

### DIFF
--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -276,6 +276,10 @@ External identity providers follow the Rust gateway's authoritative path: set
 `.continuity_store(provider)`, `.lease_provider(provider)`, and
 `.scratch_dir(path)` together. The Python callback dispatcher speaks the Rust
 wire contract for leases (`result` tags and `ttl`) and continuity deletes.
+For continuity stores, `checkpoint_version` is monotonic per identity and
+continuity generation. A live session rebind changes `session_id` without
+resetting the version; only destructive reset advances `generation` and starts
+the version stream over.
 
 Gateway memory config currently accepts Elephant as `{backend, endpoint}`.
 `memory(stores=...)` is intentionally rejected because the Rust gateway does not

--- a/docs/sdks/typescript.mdx
+++ b/docs/sdks/typescript.mdx
@@ -155,6 +155,7 @@ for (const run of runs) {
 The TypeScript SDK targets the JSON-RPC gateway. Rust also exposes lower-level native builder options for in-process embedding; those remain Rust-native and are not mirrored one-for-one in the gateway SDKs.
 
 External identity providers are all-or-nothing: configure `continuityStore()`, `leaseProvider()`, and `scratchDir()` together. The SDK sends the corresponding init flags to Rust, and provider callbacks use Rust's wire shape (`result` tags and `ttl`).
+Continuity stores should treat `checkpoint_version` as monotonic per identity and continuity generation. A live session rebind changes `session_id` without resetting the version; only destructive reset advances `generation` and starts the version stream over.
 
 Gateway memory config currently accepts the Elephant backend as `{ backend, endpoint }`. Store, collection, and space selectors are retained on the helper object for app code but are not sent to the Rust gateway. Gateway auth config supports JWT validation; Google/OIDC helpers are model objects, not accepted by `mobkit/init` today.
 

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1976,17 +1976,18 @@ external_addressable = true
     }
 
     // 5b. Wire error hook — forwards ErrorEvents to Python as JSON-RPC notifications
-    {
+    let gateway_error_hook: meerkat_mobkit::ErrorHook = {
         let error_bridge = bridge.clone();
-        runtime.set_error_hook(Arc::new(move |event| {
+        Arc::new(move |event| {
             let b = error_bridge.clone();
             Box::pin(async move {
                 if let Ok(params) = serde_json::to_value(&event) {
                     b.notify("mobkit/on_error", params);
                 }
             })
-        }));
-    }
+        })
+    };
+    runtime.set_error_hook(gateway_error_hook.clone());
 
     // 5c. Build identity-first runtime if providers are configured
     let identity_ctx: Option<meerkat_mobkit::rpc::IdentityFirstContext> = if has_roster_provider {
@@ -2042,6 +2043,7 @@ external_addressable = true
             default_timeout: None,
         })
         .with_runtime_services(AgentRuntimeServices::new(mob_handle));
+        irt.set_error_hook(Some(gateway_error_hook.clone()));
 
         // Build provider bridges for callbacks to Python
         let roster: Arc<dyn meerkat_mobkit::identity_first::contracts::RosterProvider> =

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -5102,7 +5102,7 @@ async fn handle_console_runtime_rpc_with_visibility(
             let flow_id = meerkat_mob::FlowId::from(flow_id_str);
             let flow_params = request.params.get("params").cloned().unwrap_or(Value::Null);
             if let Some(identity_runtime) = &identity_runtime
-                && let Err(err) = identity_runtime.materialize_all().await
+                && let Err(err) = identity_runtime.materialize_all_required().await
             {
                 return internal_error(
                     response_id,

--- a/meerkat-mobkit/src/identity_first/contracts.rs
+++ b/meerkat-mobkit/src/identity_first/contracts.rs
@@ -28,6 +28,13 @@ use crate::mob_handle_runtime::SessionCreatedContext;
 /// Implementations are responsible for persisting `ContinuityRecord`s and
 /// `SessionSnapshot`s. The store treats `FencingToken` as an opaque monotonic
 /// write-precondition — stale tokens are rejected via compare-and-set.
+/// `CheckpointVersion` is the monotonic snapshot/version counter for
+/// `(AgentIdentity, ContinuityGeneration)`: it advances across session
+/// rotations and resets only when a destructive continuity reset advances the
+/// generation. Session-local snapshot storage may still be keyed by
+/// `SessionId`, but stale snapshot rejection must compare against the current
+/// identity/generation head rather than treating a rebind as a fresh version
+/// stream.
 ///
 /// `resolve_many` MUST return an entry for every requested identity. Missing
 /// entries are treated as a provider error, not implicit `Uninitialized`.
@@ -60,7 +67,7 @@ pub trait ContinuityStore: Send + Sync {
         Ok(false)
     }
 
-    /// Save a session snapshot with fencing and version preconditions.
+    /// Save a session snapshot with fencing and identity-generation version preconditions.
     async fn save_session_snapshot(
         &self,
         identity: &AgentIdentity,
@@ -72,6 +79,9 @@ pub trait ContinuityStore: Send + Sync {
     ) -> Result<(), ContinuityStoreError>;
 
     /// Upsert a continuity record with fencing precondition.
+    ///
+    /// Rebinding an identity to a new session without changing
+    /// `ContinuityGeneration` must not rewind `record.checkpoint_version`.
     async fn upsert_continuity_record(
         &self,
         record: &ContinuityRecord,

--- a/meerkat-mobkit/src/identity_first/local_store.rs
+++ b/meerkat-mobkit/src/identity_first/local_store.rs
@@ -238,7 +238,9 @@ impl ContinuityStore for LocalContinuityStore {
             .map_err(|e| ContinuityStoreError::Io(format!("begin tx: {e}")))?;
 
         // Check fencing token and checkpoint version against the current
-        // continuity record for this exact session stream.
+        // continuity record for this identity/generation stream. The session
+        // id must match the current binding, but a rebind does not reset the
+        // generation-scoped checkpoint counter.
         let mut stmt = tx
             .prepare_cached(
                 "SELECT session_id, generation, fencing_token, checkpoint_version

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -1304,18 +1304,26 @@ impl IdentityRuntime {
     /// before calling `run_flow`.
     pub async fn materialize_all(&self) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
         let identities = self.registered_identities().await;
-        let results = stream::iter(
-            identities
-                .into_iter()
-                .map(|identity| async move { self.materialize(&identity).await }),
-        )
+        let results = stream::iter(identities.into_iter().map(|identity| async move {
+            let result = self.materialize(&identity).await;
+            (identity, result)
+        }))
         .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
         .collect::<Vec<_>>()
         .await;
 
         let mut records = Vec::with_capacity(results.len());
-        for result in results {
-            records.push(result?);
+        for (identity, result) in results {
+            match result {
+                Ok(record) => records.push(record),
+                Err(err) => {
+                    tracing::warn!(
+                        identity = %identity,
+                        error = %err,
+                        "identity materialize_all skipped identity after materialization failure"
+                    );
+                }
+            }
         }
 
         let desired_edges = self.desired_peer_edges.read().await.clone();
@@ -1338,18 +1346,27 @@ impl IdentityRuntime {
         identity: &AgentIdentity,
     ) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
         let peers = self.reachable_peer_identities(identity).await;
-        let results = stream::iter(
-            peers
-                .into_iter()
-                .map(|peer| async move { self.materialize(&peer).await }),
-        )
+        let results = stream::iter(peers.into_iter().map(|peer| async move {
+            let result = self.materialize(&peer).await;
+            (peer, result)
+        }))
         .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
         .collect::<Vec<_>>()
         .await;
 
         let mut records = Vec::with_capacity(results.len());
-        for result in results {
-            records.push(result?);
+        for (peer, result) in results {
+            match result {
+                Ok(record) => records.push(record),
+                Err(err) => {
+                    tracing::warn!(
+                        identity = %identity,
+                        peer = %peer,
+                        error = %err,
+                        "identity reachable-peer materialization skipped peer after materialization failure"
+                    );
+                }
+            }
         }
 
         let desired_edges = self.desired_peer_edges.read().await.clone();

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -2452,7 +2452,6 @@ impl IdentityRuntime {
         }
         let previous_session_id = record.session_id.clone();
         record.session_id = session_id;
-        record.checkpoint_version = CheckpointVersion::new(0);
 
         if let Err(err) = self
             .continuity_store

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -7,7 +7,7 @@
 //! - Ownership: lease tracking, fencing, and invariant enforcement
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as StdRwLock};
 use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
@@ -28,6 +28,7 @@ use super::types::{
 };
 
 const MANAGED_PEER_RECONCILE_CONCURRENCY: usize = 64;
+const MATERIALIZATION_FAILURE_BACKOFF: Duration = Duration::from_secs(30);
 
 fn durable_spec_uses_external_binding(spec: &DurableAgentSpec) -> bool {
     matches!(spec.backend, Some(meerkat_mob::MobBackendKind::External))
@@ -337,10 +338,19 @@ pub struct IdentityRuntime {
     managed_peer_reconcile_lock: Mutex<()>,
     desired_peer_edges: RwLock<Vec<ManagedPeerEdge>>,
     materialization_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
+    best_effort_materialization_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
     lifecycle_locks: RwLock<BTreeMap<AgentIdentity, Arc<Mutex<()>>>>,
     customizer: RwLock<Option<Arc<dyn AgentCustomizer>>>,
     lease_renewal_notify: Notify,
     default_timeout: Duration,
+    materialization_failure_backoff: RwLock<BTreeMap<AgentIdentity, MaterializationFailureBackoff>>,
+    error_hook: StdRwLock<Option<crate::unified_runtime::ErrorHook>>,
+}
+
+#[derive(Debug, Clone)]
+struct MaterializationFailureBackoff {
+    suppress_until: Instant,
+    error: String,
 }
 
 impl IdentityRuntime {
@@ -360,10 +370,13 @@ impl IdentityRuntime {
             managed_peer_reconcile_lock: Mutex::new(()),
             desired_peer_edges: RwLock::new(Vec::new()),
             materialization_locks: RwLock::new(BTreeMap::new()),
+            best_effort_materialization_locks: RwLock::new(BTreeMap::new()),
             lifecycle_locks: RwLock::new(BTreeMap::new()),
             customizer: RwLock::new(None),
             lease_renewal_notify: Notify::new(),
             default_timeout: config.default_timeout.unwrap_or(Duration::from_secs(90)),
+            materialization_failure_backoff: RwLock::new(BTreeMap::new()),
+            error_hook: StdRwLock::new(None),
         }
     }
 
@@ -378,6 +391,19 @@ impl IdentityRuntime {
 
     pub async fn set_agent_customizer(&self, customizer: Option<Arc<dyn AgentCustomizer>>) {
         *self.customizer.write().await = customizer;
+    }
+
+    /// Attach a best-effort operational error hook used for alerting.
+    pub fn set_error_hook(&self, hook: Option<crate::unified_runtime::ErrorHook>) {
+        match self.error_hook.write() {
+            Ok(mut stored_hook) => *stored_hook = hook,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "identity runtime error hook lock poisoned; dropping hook update"
+                );
+            }
+        }
     }
 
     /// Spawn a background supervisor that renews active identity leases before
@@ -678,6 +704,67 @@ impl IdentityRuntime {
         }
     }
 
+    fn emit_error(&self, event: crate::unified_runtime::types::ErrorEvent) {
+        let hook = match self.error_hook.read() {
+            Ok(stored_hook) => stored_hook.clone(),
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "identity runtime error hook lock poisoned; dropping error event"
+                );
+                None
+            }
+        };
+        if let Some(hook) = hook {
+            tokio::spawn(async move {
+                let () = hook(event).await;
+            });
+        }
+    }
+
+    async fn materialization_backoff_error(&self, identity: &AgentIdentity) -> Option<String> {
+        let backoffs = self.materialization_failure_backoff.read().await;
+        let backoff = backoffs.get(identity)?;
+        if Instant::now() < backoff.suppress_until {
+            Some(backoff.error.clone())
+        } else {
+            None
+        }
+    }
+
+    async fn clear_materialization_backoff(&self, identity: &AgentIdentity) {
+        self.materialization_failure_backoff
+            .write()
+            .await
+            .remove(identity);
+    }
+
+    async fn record_best_effort_materialization_failure(
+        &self,
+        identity: &AgentIdentity,
+        initiator: Option<&AgentIdentity>,
+        operation: &'static str,
+        err: &IdentityRuntimeError,
+    ) {
+        let error = err.to_string();
+        let suppress_until = Instant::now() + MATERIALIZATION_FAILURE_BACKOFF;
+        self.materialization_failure_backoff.write().await.insert(
+            identity.clone(),
+            MaterializationFailureBackoff {
+                suppress_until,
+                error: error.clone(),
+            },
+        );
+        self.emit_error(
+            crate::unified_runtime::types::ErrorEvent::IdentityMaterializationFailure {
+                identity: identity.to_string(),
+                initiator: initiator.map(ToString::to_string),
+                operation: operation.to_string(),
+                error,
+            },
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Registration / activation
     // -----------------------------------------------------------------------
@@ -734,6 +821,25 @@ impl IdentityRuntime {
             .clone()
     }
 
+    async fn best_effort_materialization_lock_for(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Arc<Mutex<()>> {
+        if let Some(lock) = self
+            .best_effort_materialization_locks
+            .read()
+            .await
+            .get(identity)
+        {
+            return lock.clone();
+        }
+        let mut locks = self.best_effort_materialization_locks.write().await;
+        locks
+            .entry(identity.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     async fn lifecycle_lock_for(&self, identity: &AgentIdentity) -> Arc<Mutex<()>> {
         if let Some(lock) = self.lifecycle_locks.read().await.get(identity) {
             return lock.clone();
@@ -766,11 +872,14 @@ impl IdentityRuntime {
                 .get(identity)
                 .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
             if entry.state == IdentityLifecycleState::Active {
-                return entry.continuity.clone().ok_or_else(|| {
+                let continuity = entry.continuity.clone().ok_or_else(|| {
                     IdentityRuntimeError::Internal(format!(
                         "active identity {identity} has no continuity record"
                     ))
-                });
+                })?;
+                drop(entries);
+                self.clear_materialization_backoff(identity).await;
+                return Ok(continuity);
             }
             (entry.spec.clone(), entry.continuity.clone(), entry.state)
         };
@@ -1293,38 +1402,81 @@ impl IdentityRuntime {
                 "identity materialized with topology reconcile warning"
             );
         }
+        self.clear_materialization_backoff(identity).await;
         Ok(record)
     }
 
-    /// Materialize all identities currently registered with the runtime.
-    ///
-    /// Lazy bootstrap keeps `build()` metadata-only, but flow execution still
-    /// enters the mob runtime through concrete member IDs. This helper gives
-    /// flow entrypoints a single choke point to hydrate the concrete mob graph
-    /// before calling `run_flow`.
-    pub async fn materialize_all(&self) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
+    async fn best_effort_materialize_identity(
+        &self,
+        identity: AgentIdentity,
+        initiator: Option<&AgentIdentity>,
+        operation: &'static str,
+    ) -> Option<ContinuityRecord> {
+        let attempt_lock = self.best_effort_materialization_lock_for(&identity).await;
+        let _attempt_guard = attempt_lock.lock().await;
+
+        if let Some(error) = self.materialization_backoff_error(&identity).await {
+            tracing::debug!(
+                identity = %identity,
+                initiator = initiator.map(ToString::to_string).as_deref(),
+                error = %error,
+                "identity best-effort materialization skipped due to materialization backoff"
+            );
+            return None;
+        }
+
+        match self.materialize(&identity).await {
+            Ok(record) => {
+                self.clear_materialization_backoff(&identity).await;
+                Some(record)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    identity = %identity,
+                    initiator = initiator.map(ToString::to_string).as_deref(),
+                    error = %err,
+                    "identity best-effort materialization skipped identity after materialization failure"
+                );
+                self.record_best_effort_materialization_failure(
+                    &identity, initiator, operation, &err,
+                )
+                .await;
+                None
+            }
+        }
+    }
+
+    async fn materialize_all_records(
+        &self,
+    ) -> Vec<(
+        AgentIdentity,
+        Result<ContinuityRecord, IdentityRuntimeError>,
+    )> {
         let identities = self.registered_identities().await;
-        let results = stream::iter(identities.into_iter().map(|identity| async move {
+        stream::iter(identities.into_iter().map(|identity| async move {
             let result = self.materialize(&identity).await;
             (identity, result)
         }))
         .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
         .collect::<Vec<_>>()
-        .await;
+        .await
+    }
 
-        let mut records = Vec::with_capacity(results.len());
-        for (identity, result) in results {
-            match result {
-                Ok(record) => records.push(record),
-                Err(err) => {
-                    tracing::warn!(
-                        identity = %identity,
-                        error = %err,
-                        "identity materialize_all skipped identity after materialization failure"
-                    );
-                }
-            }
-        }
+    /// Materialize all identities currently registered with the runtime.
+    ///
+    /// Fleet hydration is best-effort: one member that cannot build is skipped
+    /// and surfaced through logs/error hooks rather than aborting unrelated
+    /// members.
+    pub async fn materialize_all(&self) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
+        let identities = self.registered_identities().await;
+        let records = stream::iter(identities.into_iter().map(|identity| async move {
+            self.best_effort_materialize_identity(identity, None, "materialize_all")
+                .await
+        }))
+        .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
+        .filter_map(async move |record| record)
+        .collect::<Vec<_>>()
+        .await;
 
         let desired_edges = self.desired_peer_edges.read().await.clone();
         if !desired_edges.is_empty()
@@ -1339,6 +1491,44 @@ impl IdentityRuntime {
         Ok(records)
     }
 
+    /// Materialize all identities and fail if any registered identity cannot
+    /// hydrate. Flow admission uses this strict variant so a run is not accepted
+    /// with a partially materialized identity-first fleet.
+    pub async fn materialize_all_required(
+        &self,
+    ) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
+        let results = self.materialize_all_records().await;
+        let mut records = Vec::with_capacity(results.len());
+        let mut failures = Vec::new();
+
+        for (identity, result) in results {
+            match result {
+                Ok(record) => records.push(record),
+                Err(err) => failures.push(format!("{identity}: {err}")),
+            }
+        }
+
+        if !failures.is_empty() {
+            return Err(IdentityRuntimeError::Internal(format!(
+                "identity-first required materialization failed for {} identities: {}",
+                failures.len(),
+                failures.join("; ")
+            )));
+        }
+
+        let desired_edges = self.desired_peer_edges.read().await.clone();
+        if !desired_edges.is_empty() {
+            self.reconcile_managed_peer_edges(&desired_edges).await?;
+        }
+
+        Ok(records)
+    }
+
+    pub(crate) async fn best_effort_background_warm_identity(&self, identity: AgentIdentity) {
+        self.best_effort_materialize_identity(identity, None, "background_warm")
+            .await;
+    }
+
     /// Ensure an active identity's desired peer neighborhood exists in the
     /// concrete mob graph before ordinary communication starts.
     pub async fn materialize_reachable_peers(
@@ -1346,28 +1536,18 @@ impl IdentityRuntime {
         identity: &AgentIdentity,
     ) -> Result<Vec<ContinuityRecord>, IdentityRuntimeError> {
         let peers = self.reachable_peer_identities(identity).await;
-        let results = stream::iter(peers.into_iter().map(|peer| async move {
-            let result = self.materialize(&peer).await;
-            (peer, result)
+        let records = stream::iter(peers.into_iter().map(|peer| async move {
+            self.best_effort_materialize_identity(
+                peer,
+                Some(identity),
+                "materialize_reachable_peers",
+            )
+            .await
         }))
         .buffer_unordered(MANAGED_PEER_RECONCILE_CONCURRENCY)
+        .filter_map(async move |record| record)
         .collect::<Vec<_>>()
         .await;
-
-        let mut records = Vec::with_capacity(results.len());
-        for (peer, result) in results {
-            match result {
-                Ok(record) => records.push(record),
-                Err(err) => {
-                    tracing::warn!(
-                        identity = %identity,
-                        peer = %peer,
-                        error = %err,
-                        "identity reachable-peer materialization skipped peer after materialization failure"
-                    );
-                }
-            }
-        }
 
         let desired_edges = self.desired_peer_edges.read().await.clone();
         if !desired_edges.is_empty()

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -618,6 +618,7 @@ impl UnifiedRuntimeBuilder {
             identity_runtime
                 .set_agent_customizer(self.agent_customizer.clone())
                 .await;
+            identity_runtime.set_error_hook(self.error_hook.clone());
 
             let roster_specs = roster_provider
                 .roster(&RosterContext {
@@ -693,13 +694,7 @@ impl UnifiedRuntimeBuilder {
                         stream::iter(warm_identities.into_iter().map(|identity| {
                             let runtime = warm_runtime.clone();
                             async move {
-                                if let Err(err) = runtime.materialize(&identity).await {
-                                    tracing::warn!(
-                                        %identity,
-                                        error = %err,
-                                        "identity-first background warm failed"
-                                    );
-                                }
+                                runtime.best_effort_background_warm_identity(identity).await;
                             }
                         }))
                         .buffer_unordered(concurrency)

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -312,7 +312,10 @@ impl UnifiedRuntime {
     /// Register an error hook after construction. Useful when the runtime
     /// is built via `bootstrap()` rather than the builder.
     pub fn set_error_hook(&mut self, hook: ErrorHook) {
-        self.error_hook = Some(hook);
+        self.error_hook = Some(hook.clone());
+        if let Some(identity_runtime) = self.identity_runtime() {
+            identity_runtime.set_error_hook(Some(hook));
+        }
     }
 
     /// Start the event log ingestion engine. Must be called after
@@ -385,7 +388,7 @@ impl UnifiedRuntime {
         crate::identity_first::IdentityRuntimeError,
     > {
         match self.identity_runtime() {
-            Some(runtime) => runtime.materialize_all().await,
+            Some(runtime) => runtime.materialize_all_required().await,
             None => Ok(Vec::new()),
         }
     }

--- a/meerkat-mobkit/src/unified_runtime/types.rs
+++ b/meerkat-mobkit/src/unified_runtime/types.rs
@@ -335,6 +335,7 @@ pub struct ShutdownDrainReport {
 /// - `RediscoverFailure` — `lifecycle.rs` rediscover error path
 /// - `HostLoopCrash` — `lifecycle.rs` detects `run_failed` agent events during drain
 /// - `CheckpointFailure` — via `run_periodic_gc_with_error_callback` in session store
+/// - `IdentityMaterializationFailure` — identity-first peer/fleet hydration skipped a member
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "category", rename_all = "snake_case")]
@@ -360,6 +361,12 @@ pub enum ErrorEvent {
         error: String,
     },
     EventLogFlushFailure {
+        error: String,
+    },
+    IdentityMaterializationFailure {
+        identity: String,
+        initiator: Option<String>,
+        operation: String,
         error: String,
     },
 }
@@ -389,6 +396,24 @@ impl Display for ErrorEvent {
             }
             Self::EventLogFlushFailure { error } => {
                 write!(f, "event_log_flush_failure: {error}")
+            }
+            Self::IdentityMaterializationFailure {
+                identity,
+                initiator,
+                operation,
+                error,
+            } => {
+                if let Some(initiator) = initiator {
+                    write!(
+                        f,
+                        "identity_materialization_failure: {identity} for {initiator} during {operation}: {error}"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "identity_materialization_failure: {identity} during {operation}: {error}"
+                    )
+                }
             }
         }
     }

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -36,6 +36,7 @@ use meerkat_mobkit::identity_first::{
     ManagedPeerEdge, SessionBridge, SessionSnapshot, TopologyContext, TopologyError,
 };
 use meerkat_mobkit::identity_first::{LocalContinuityStore, LocalLeaseProvider};
+use meerkat_mobkit::{ErrorEvent, ErrorHook};
 
 // ===========================================================================
 // Helpers
@@ -3358,14 +3359,31 @@ async fn identity_first_runtime_send_and_dispatch_continue_when_reachable_peer_m
     )
     .await
     .unwrap();
+    let captured_errors: Arc<tokio::sync::Mutex<Vec<ErrorEvent>>> =
+        Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let captured = captured_errors.clone();
+    let hook: ErrorHook = Arc::new(move |event| {
+        let captured = captured.clone();
+        Box::pin(async move {
+            captured.lock().await.push(event);
+        })
+    });
+    runtime.set_error_hook(Some(hook));
     runtime.materialize(&initiator).await.unwrap();
     bridge.fail_create();
 
     runtime.send(&initiator, &make_content()).await.unwrap();
+    let create_calls_after_first_failure = bridge.create_calls.load(Ordering::SeqCst);
     let (_token, is_durable) = runtime
         .dispatch(&initiator, &make_dispatch_input())
         .await
         .unwrap();
+    for _ in 0..10 {
+        if !captured_errors.lock().await.is_empty() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
 
     assert!(is_durable);
     assert_eq!(
@@ -3374,6 +3392,28 @@ async fn identity_first_runtime_send_and_dispatch_continue_when_reachable_peer_m
         "send and dispatch must still deliver to the healthy initiator"
     );
     assert_eq!(
+        bridge.create_calls.load(Ordering::SeqCst),
+        create_calls_after_first_failure,
+        "immediate dispatch should skip the broken peer through materialization backoff"
+    );
+    let captured_errors = captured_errors.lock().await;
+    assert_eq!(captured_errors.len(), 1);
+    match &captured_errors[0] {
+        ErrorEvent::IdentityMaterializationFailure {
+            identity,
+            initiator: Some(event_initiator),
+            operation,
+            error,
+        } => {
+            assert_eq!(identity, "initiative:broken");
+            assert_eq!(event_initiator, "review:singleton");
+            assert_eq!(operation, "materialize_reachable_peers");
+            assert!(error.contains("bridge create_session"));
+        }
+        other => panic!("expected IdentityMaterializationFailure, got {other:?}"),
+    }
+    drop(captured_errors);
+    assert_eq!(
         runtime.status(&initiator).await.unwrap().state,
         IdentityLifecycleState::Active
     );
@@ -3381,6 +3421,114 @@ async fn identity_first_runtime_send_and_dispatch_continue_when_reachable_peer_m
         runtime.status(&broken_peer).await.unwrap().state,
         IdentityLifecycleState::Dormant,
         "failed peer hydration must not become the initiator's failure"
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_reachable_peer_materialization_backoff_coalesces_concurrent_sends()
+{
+    struct StaticTopology(Vec<(&'static str, &'static str)>);
+
+    #[async_trait]
+    impl TopologyProvider for StaticTopology {
+        async fn compute_edges(
+            &self,
+            _target_identities: &[AgentIdentity],
+            _context: &TopologyContext,
+        ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+            self.0
+                .iter()
+                .map(|(a, b)| {
+                    ManagedPeerEdge::new(make_identity(a), make_identity(b))
+                        .map_err(|err| TopologyError::InvalidEdge(format!("{err}")))
+                })
+                .collect()
+        }
+    }
+
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+    let initiator = make_identity("review:singleton");
+    let broken_peer = make_identity("initiative:broken");
+
+    lazy_register_flow(
+        &runtime,
+        &[
+            make_spec("review:singleton"),
+            make_spec("initiative:broken"),
+        ],
+        Some(&StaticTopology(vec![(
+            "review:singleton",
+            "initiative:broken",
+        )])),
+    )
+    .await
+    .unwrap();
+
+    let captured_errors: Arc<tokio::sync::Mutex<Vec<ErrorEvent>>> =
+        Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let captured = captured_errors.clone();
+    let hook: ErrorHook = Arc::new(move |event| {
+        let captured = captured.clone();
+        Box::pin(async move {
+            captured.lock().await.push(event);
+        })
+    });
+    runtime.set_error_hook(Some(hook));
+
+    runtime.materialize(&initiator).await.unwrap();
+    bridge.fail_create();
+
+    let sends = (0..8)
+        .map(|_| {
+            let runtime = runtime.clone();
+            let initiator = initiator.clone();
+            async move { runtime.send(&initiator, &make_content()).await }
+        })
+        .collect::<Vec<_>>();
+    for result in futures::future::join_all(sends).await {
+        result.unwrap();
+    }
+
+    for _ in 0..10 {
+        if !captured_errors.lock().await.is_empty() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(
+        bridge.create_calls.load(Ordering::SeqCst),
+        2,
+        "only the initiator and one failed peer attempt should reach create_session"
+    );
+    assert_eq!(
+        bridge.deliver_calls.load(Ordering::SeqCst),
+        8,
+        "all sends must still deliver to the healthy initiator"
+    );
+    let captured_errors = captured_errors.lock().await;
+    assert_eq!(
+        captured_errors.len(),
+        1,
+        "concurrent sends should coalesce repeated peer build failures behind one alert"
+    );
+    assert!(matches!(
+        &captured_errors[0],
+        ErrorEvent::IdentityMaterializationFailure {
+            identity,
+            initiator: Some(event_initiator),
+            operation,
+            ..
+        } if identity == "initiative:broken"
+            && event_initiator == "review:singleton"
+            && operation == "materialize_reachable_peers"
+    ));
+    assert_eq!(
+        runtime.status(&broken_peer).await.unwrap().state,
+        IdentityLifecycleState::Dormant
     );
 }
 
@@ -3598,6 +3746,42 @@ async fn identity_first_runtime_materialize_all_continues_when_one_identity_fail
     let records = runtime.materialize_all().await.unwrap();
 
     assert_eq!(records, vec![healthy_record]);
+    assert_eq!(
+        runtime.status(&healthy).await.unwrap().state,
+        IdentityLifecycleState::Active
+    );
+    assert_eq!(
+        runtime.status(&broken).await.unwrap().state,
+        IdentityLifecycleState::Dormant
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_materialize_all_required_fails_on_partial_hydration() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+    let healthy = make_identity("agent:healthy");
+    let broken = make_identity("agent:broken");
+
+    lazy_register_flow(
+        &runtime,
+        &[make_spec("agent:healthy"), make_spec("agent:broken")],
+        None,
+    )
+    .await
+    .unwrap();
+    runtime.materialize(&healthy).await.unwrap();
+    bridge.fail_create();
+
+    let err = runtime.materialize_all_required().await.unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("identity-first required materialization failed")
+    );
+    assert!(err.to_string().contains("agent:broken"));
     assert_eq!(
         runtime.status(&healthy).await.unwrap().state,
         IdentityLifecycleState::Active

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -549,6 +549,113 @@ impl FaultyContinuityStore {
     }
 }
 
+struct IdentityScopedVersionStore {
+    inner: Arc<LocalContinuityStore>,
+    heads: Mutex<BTreeMap<(AgentIdentity, ContinuityGeneration), CheckpointVersion>>,
+}
+
+impl IdentityScopedVersionStore {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(LocalContinuityStore::in_memory().unwrap()),
+            heads: Mutex::new(BTreeMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl ContinuityStore for IdentityScopedVersionStore {
+    async fn resolve_many(
+        &self,
+        identities: &[AgentIdentity],
+    ) -> Result<BTreeMap<AgentIdentity, ContinuityResolveState>, ContinuityStoreError> {
+        self.inner.resolve_many(identities).await
+    }
+
+    async fn load_session_snapshot(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> Result<Option<SessionSnapshot>, ContinuityStoreError> {
+        self.inner.load_session_snapshot(session_id).await
+    }
+
+    async fn save_session_snapshot(
+        &self,
+        identity: &AgentIdentity,
+        session_id: &meerkat_core::types::SessionId,
+        generation: ContinuityGeneration,
+        version: CheckpointVersion,
+        fencing_token: FencingToken,
+        snapshot: &SessionSnapshot,
+    ) -> Result<(), ContinuityStoreError> {
+        {
+            let heads = self
+                .heads
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(current) = heads.get(&(identity.clone(), generation))
+                && version <= *current
+            {
+                return Err(ContinuityStoreError::StaleCheckpointVersion {
+                    identity: identity.clone(),
+                    presented: version,
+                    current: *current,
+                });
+            }
+        }
+        self.inner
+            .save_session_snapshot(
+                identity,
+                session_id,
+                generation,
+                version,
+                fencing_token,
+                snapshot,
+            )
+            .await?;
+        self.heads
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert((identity.clone(), generation), version);
+        Ok(())
+    }
+
+    async fn upsert_continuity_record(
+        &self,
+        record: &ContinuityRecord,
+        fencing_token: FencingToken,
+    ) -> Result<(), ContinuityStoreError> {
+        self.inner
+            .upsert_continuity_record(record, fencing_token)
+            .await?;
+        let mut heads = self
+            .heads
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let key = (record.identity.clone(), record.generation);
+        heads
+            .entry(key)
+            .and_modify(|current| *current = (*current).max(record.checkpoint_version))
+            .or_insert(record.checkpoint_version);
+        Ok(())
+    }
+
+    async fn delete_continuity_record(
+        &self,
+        identity: &AgentIdentity,
+        fencing_token: FencingToken,
+    ) -> Result<(), ContinuityStoreError> {
+        self.inner
+            .delete_continuity_record(identity, fencing_token)
+            .await?;
+        self.heads
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|(head_identity, _), _| head_identity != identity);
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl ContinuityStore for FaultyContinuityStore {
     async fn resolve_many(
@@ -1110,7 +1217,7 @@ async fn identity_first_runtime_send_rebinds_rotated_bridge_session() {
         panic!("expected rebound continuity record");
     };
     assert_eq!(record.session_id, live_session_id);
-    assert_eq!(record.checkpoint_version, CheckpointVersion::new(0));
+    assert_eq!(record.checkpoint_version, CheckpointVersion::new(2));
     let unregistered = bridge.unregistered_session_ids.lock().await.clone();
     assert!(
         unregistered.contains(&original_session_id.to_string()),
@@ -1741,9 +1848,59 @@ async fn identity_first_runtime_rebind_after_live_respawn_updates_session() {
     assert_eq!(rebound.agent_runtime_id, record.agent_runtime_id);
     assert_eq!(rebound.generation, record.generation);
     assert_eq!(rebound.session_id, live_session_id);
+    assert_eq!(rebound.checkpoint_version, record.checkpoint_version);
 
     let status = runtime.status(&id).await.unwrap();
     assert_eq!(status.session_id, Some(live_session_id));
+    assert_eq!(status.checkpoint_version, Some(record.checkpoint_version));
+}
+
+#[tokio::test]
+async fn identity_first_runtime_rebind_preserves_identity_scoped_checkpoint_head() {
+    let store = Arc::new(IdentityScopedVersionStore::new());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let runtime = make_runtime(store.clone(), lease_prov.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 1473);
+    store
+        .upsert_continuity_record(&record, FencingToken::new(1))
+        .await
+        .unwrap();
+    runtime
+        .register(
+            make_spec("triage:main"),
+            IdentityLifecycleState::Active,
+            Some(record.clone()),
+            Some(make_grant("triage:main", 1)),
+        )
+        .await;
+
+    let live_session_id = meerkat_core::types::SessionId::new();
+    let rebound = runtime
+        .rebind_session_after_live_respawn(&id, live_session_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(rebound.session_id, live_session_id);
+    assert_eq!(rebound.checkpoint_version, CheckpointVersion::new(1473));
+
+    let next_version = runtime
+        .checkpoint(
+            &id,
+            &SessionSnapshot {
+                data: b"post-rebind".to_vec(),
+            },
+        )
+        .await
+        .expect("post-rebind checkpoint must advance the identity-generation head");
+    assert_eq!(next_version, CheckpointVersion::new(1474));
+
+    let resolved = store.resolve_many(std::slice::from_ref(&id)).await.unwrap();
+    let ContinuityResolveState::Ready { record } = resolved.get(&id).unwrap() else {
+        panic!("expected ready record after rebind checkpoint");
+    };
+    assert_eq!(record.session_id, live_session_id);
+    assert_eq!(record.checkpoint_version, CheckpointVersion::new(1474));
 }
 
 #[tokio::test]

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -3318,6 +3318,73 @@ async fn identity_first_runtime_lazy_first_send_materializes_reachable_peers_and
 }
 
 #[tokio::test]
+async fn identity_first_runtime_send_and_dispatch_continue_when_reachable_peer_materialize_fails() {
+    struct StaticTopology(Vec<(&'static str, &'static str)>);
+
+    #[async_trait]
+    impl TopologyProvider for StaticTopology {
+        async fn compute_edges(
+            &self,
+            _target_identities: &[AgentIdentity],
+            _context: &TopologyContext,
+        ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+            self.0
+                .iter()
+                .map(|(a, b)| {
+                    ManagedPeerEdge::new(make_identity(a), make_identity(b))
+                        .map_err(|err| TopologyError::InvalidEdge(format!("{err}")))
+                })
+                .collect()
+        }
+    }
+
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+    let initiator = make_identity("review:singleton");
+    let broken_peer = make_identity("initiative:broken");
+
+    lazy_register_flow(
+        &runtime,
+        &[
+            make_spec("review:singleton"),
+            make_spec("initiative:broken"),
+        ],
+        Some(&StaticTopology(vec![(
+            "review:singleton",
+            "initiative:broken",
+        )])),
+    )
+    .await
+    .unwrap();
+    runtime.materialize(&initiator).await.unwrap();
+    bridge.fail_create();
+
+    runtime.send(&initiator, &make_content()).await.unwrap();
+    let (_token, is_durable) = runtime
+        .dispatch(&initiator, &make_dispatch_input())
+        .await
+        .unwrap();
+
+    assert!(is_durable);
+    assert_eq!(
+        bridge.deliver_calls.load(Ordering::SeqCst),
+        2,
+        "send and dispatch must still deliver to the healthy initiator"
+    );
+    assert_eq!(
+        runtime.status(&initiator).await.unwrap().state,
+        IdentityLifecycleState::Active
+    );
+    assert_eq!(
+        runtime.status(&broken_peer).await.unwrap().state,
+        IdentityLifecycleState::Dormant,
+        "failed peer hydration must not become the initiator's failure"
+    );
+}
+
+#[tokio::test]
 async fn identity_first_runtime_lazy_register_warns_on_topology_reconcile_failure() {
     struct StaticTopology(Vec<(&'static str, &'static str)>);
 
@@ -3507,6 +3574,38 @@ async fn identity_first_runtime_materialize_all_hydrates_registered_identities_i
             IdentityLifecycleState::Active
         );
     }
+}
+
+#[tokio::test]
+async fn identity_first_runtime_materialize_all_continues_when_one_identity_fails() {
+    let store = Arc::new(CountingContinuityStore::new());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease, bridge.clone());
+    let healthy = make_identity("agent:healthy");
+    let broken = make_identity("agent:broken");
+
+    lazy_register_flow(
+        &runtime,
+        &[make_spec("agent:healthy"), make_spec("agent:broken")],
+        None,
+    )
+    .await
+    .unwrap();
+    let healthy_record = runtime.materialize(&healthy).await.unwrap();
+    bridge.fail_create();
+
+    let records = runtime.materialize_all().await.unwrap();
+
+    assert_eq!(records, vec![healthy_record]);
+    assert_eq!(
+        runtime.status(&healthy).await.unwrap().state,
+        IdentityLifecycleState::Active
+    );
+    assert_eq!(
+        runtime.status(&broken).await.unwrap().state,
+        IdentityLifecycleState::Dormant
+    );
 }
 
 #[tokio::test]

--- a/sdk/python/meerkat_mobkit/identity_first_providers.py
+++ b/sdk/python/meerkat_mobkit/identity_first_providers.py
@@ -12,6 +12,13 @@ from typing import Any, Protocol, runtime_checkable
 
 @dataclass(frozen=True)
 class ContinuityRecord:
+    """Durable identity binding.
+
+    checkpoint_version is monotonic for (identity, generation). It advances
+    across session_id rotations and resets only after a destructive reset
+    advances generation.
+    """
+
     identity: str
     agent_runtime_id: str
     session_id: str
@@ -210,11 +217,15 @@ class ContinuityStoreProvider(Protocol):
     async def save_session_snapshot(
         self, identity: str, session_id: str, generation: int,
         version: int, fencing_token: int, snapshot: SessionSnapshot,
-    ) -> None: ...
+    ) -> None:
+        """Persist a snapshot if fencing_token is current and version advances the identity/generation head."""
+        ...
 
     async def upsert_continuity_record(
         self, record: ContinuityRecord, fencing_token: int,
-    ) -> None: ...
+    ) -> None:
+        """Persist the current binding without rewinding checkpoint_version on session rebind."""
+        ...
 
     async def delete_continuity_record(
         self, identity: str, fencing_token: int,

--- a/sdk/python/meerkat_mobkit/types.py
+++ b/sdk/python/meerkat_mobkit/types.py
@@ -1058,6 +1058,12 @@ class ErrorEvent:
             message = f"{member_id}: {error}" if member_id else error
         elif category == ErrorCategory.REDISCOVER_FAILURE:
             message = error
+        elif category == "identity_materialization_failure":
+            identity = context.get("identity", "")
+            initiator = context.get("initiator", "")
+            operation = context.get("operation", "")
+            target = f"{identity} for {initiator}" if initiator else identity
+            message = ": ".join(str(part) for part in (target, operation, error) if part)
         else:
             message = str(data)
         return cls(category=category, message=message, context=context)

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -576,6 +576,23 @@ class TestErrorEvent:
         assert "a1" in r.message
         assert "profile not found" in r.message
 
+    def test_identity_materialization_failure_from_dict(self):
+        r = ErrorEvent.from_dict(
+            {
+                "category": "identity_materialization_failure",
+                "identity": "initiative:broken",
+                "initiator": "review:singleton",
+                "operation": "materialize_reachable_peers",
+                "error": "bridge create_session: missing skill",
+            }
+        )
+        assert r.category == "identity_materialization_failure"
+        assert (
+            r.message
+            == "initiative:broken for review:singleton: materialize_reachable_peers: bridge create_session: missing skill"
+        )
+        assert r.context["identity"] == "initiative:broken"
+
 
 class TestEventQuery:
     def test_to_dict_all_fields(self):

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1630,6 +1630,10 @@ export interface ContinuityRecord {
   readonly agentRuntimeId: string;
   readonly sessionId: string;
   readonly generation: number;
+  /**
+   * Monotonic for (identity, generation). It advances across session rotations
+   * and resets only after destructive reset advances generation.
+   */
   readonly checkpointVersion: number;
 }
 
@@ -1832,6 +1836,7 @@ export function leaseRenewResultToDict(
 export interface ContinuityStore {
   resolveMany(identities: string[]): Promise<Record<string, ContinuityResolveState>>;
   loadSessionSnapshot(sessionId: string): Promise<SessionSnapshot | null>;
+  /** Save only if fencingToken is current and version advances the identity/generation head. */
   saveSessionSnapshot(
     identity: string,
     sessionId: string,
@@ -1840,6 +1845,7 @@ export interface ContinuityStore {
     fencingToken: number,
     snapshot: SessionSnapshot,
   ): Promise<void>;
+  /** Persist the binding without rewinding checkpointVersion on session rebind. */
   upsertContinuityRecord(record: ContinuityRecord, fencingToken: number): Promise<void>;
   deleteContinuityRecord(identity: string, fencingToken: number): Promise<void>;
   deleteSessionSnapshotIfCurrentRevision?(

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1167,6 +1167,14 @@ export function parseErrorEvent(raw: unknown): ErrorEvent {
     case ErrorCategory.REDISCOVER_FAILURE:
       message = error;
       break;
+    case "identity_materialization_failure": {
+      const identity = String(context.identity ?? "");
+      const initiator = String(context.initiator ?? "");
+      const operation = String(context.operation ?? "");
+      const target = initiator ? `${identity} for ${initiator}` : identity;
+      message = [target, operation, error].filter(Boolean).join(": ");
+      break;
+    }
     default:
       message = JSON.stringify(d);
       break;

--- a/sdk/typescript/tests/types.test.ts
+++ b/sdk/typescript/tests/types.test.ts
@@ -1040,6 +1040,22 @@ describe("parseErrorEvent", () => {
     assert.equal(result.message, "network unreachable");
   });
 
+  it("parses identity_materialization_failure", () => {
+    const result = parseErrorEvent({
+      category: "identity_materialization_failure",
+      identity: "initiative:broken",
+      initiator: "review:singleton",
+      operation: "materialize_reachable_peers",
+      error: "bridge create_session: missing skill",
+    });
+    assert.equal(result.category, "identity_materialization_failure");
+    assert.equal(
+      result.message,
+      "initiative:broken for review:singleton: materialize_reachable_peers: bridge create_session: missing skill",
+    );
+    assert.equal(result.context.identity, "initiative:broken");
+  });
+
   it("parses unknown category as JSON", () => {
     const result = parseErrorEvent({
       category: "alien_invasion",


### PR DESCRIPTION
## Summary

- Preserve the existing generation-scoped checkpoint head when identity-first live respawn rebinds an identity to a new session.
- Document the continuity contract: `CheckpointVersion` is monotonic for `(AgentIdentity, ContinuityGeneration)`, advances across session rotations, and resets only when destructive reset advances generation.
- Isolate reachable-peer and full-fleet materialization failures so one unbuildable peer/member is warned and skipped instead of failing an unrelated initiator send/dispatch or aborting `materialize_all()`.
- Add regressions for identity-scoped checkpoint heads, reachable-peer send/dispatch isolation, and best-effort `materialize_all()`.

## Root Cause

PR #162's deliver-time rebind path changed `session_id` while resetting `checkpoint_version` to `0` without changing `ContinuityGeneration`. Identity-first embedders that fence snapshots per durable identity/generation could reasonably reject every post-rebind checkpoint as stale, causing snapshot quarantine and respawn churn.

A separate identity-first materialization path treated reachable-peer hydration as a hard precondition for ordinary send/dispatch: `materialize_reachable_peers()` propagated the first peer error, so an unrelated broken peer could fail the initiator interaction. `materialize_all()` had the same fatal pattern for fleet hydration.

## Validation

- `./scripts/repo-cargo fmt --all`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_runtime_rebind --test identity_first_runtime --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_runtime_checkpoint_version_ordering --test identity_first_runtime --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_runtime_send_and_dispatch_continue_when_reachable_peer_materialize_fails --test identity_first_runtime --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit identity_first_runtime_materialize_all_continues_when_one_identity_fails --test identity_first_runtime --quiet`
- `./scripts/repo-cargo test -p meerkat-mobkit --test identity_first_runtime --quiet` (`127 passed`)
- `python3 -m py_compile sdk/python/meerkat_mobkit/identity_first_providers.py`
- `git diff --check`
- pre-push hooks passed through `cargo clippy (changed crates)`; the workspace unit gate repeatedly timed out only `console_aggregator::tests::explicit_identity_timeline_query_does_not_resolve_roster_per_frame` under full nextest load (`306/307 passed`), and that exact test passed alone with `./scripts/repo-cargo test -p meerkat-mobkit console_aggregator::tests::explicit_identity_timeline_query_does_not_resolve_roster_per_frame --lib --quiet`.
