### PR TITLE
chore: release v0.6.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.6.56"
+version = "0.6.57"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.6.56"
+version = "0.6.57"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.6.56"
+version = "0.6.57"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.6.56",
+  "version": "0.6.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.6.56",
+      "version": "0.6.57",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.6.56",
+  "version": "0.6.57",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump MobKit release surfaces from 0.6.56 to 0.6.57 after #172
- update Cargo and TypeScript lockfiles for the release version

## Local verification
- `./scripts/verify-version-parity.sh`
- `git diff --check`
- `./scripts/repo-cargo fmt --all --check`
- `./scripts/repo-cargo metadata --locked --format-version 1 --no-deps`
- `npm --prefix console run phase0:types --silent`
- `npm --prefix console run build --silent`
- `npm --prefix console run embedded:freshness --silent`
- `PYTHONPATH=sdk/python python3 -m pytest sdk/python/tests/ -q`
- `npm --prefix sdk/typescript run build --silent && npm --prefix sdk/typescript test --silent`
- `./scripts/repo-cargo test -p meerkat-mobkit --lib`
- `./examples/002-foresight-studio-pack/examples.sh --smoke`
- `./examples/002-foresight-studio-pack/examples.sh --browser-smoke`
- `cargo publish -p meerkat-mobkit --locked --dry-run --allow-dirty`
