### PR TITLE
[codex] Fix tolerant topology restore recovery

### DIFF
--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -25,6 +25,7 @@ use meerkat_mob::{
 use crate::mob_handle_runtime::{
     is_recoverable_lifecycle_cleanup_error, member_entry_to_json,
     model_capabilities_for_member_entry, model_capabilities_for_role,
+    topology_restore_failed_peer_ids, topology_restore_warning_json,
 };
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
@@ -3019,26 +3020,40 @@ fn lifecycle_archive_cleanup_completed(error: &str) -> bool {
 async fn respawn_console_member(
     handle: &MobHandle,
     runtime_member_id: &MeerkatId,
-) -> Result<(), String> {
+) -> Result<Option<Value>, String> {
     let entry_before_respawn = handle.get_member(runtime_member_id).await;
     match handle.respawn(runtime_member_id.clone(), None).await {
-        Ok(_receipt) => Ok(()),
-        Err(err) if lifecycle_archive_cleanup_completed(&err.to_string()) => {
-            if handle.get_member(runtime_member_id).await.is_none()
-                && let Some(entry) = entry_before_respawn
-            {
-                let mut spec = SpawnMemberSpec::new(entry.role.clone(), runtime_member_id.clone());
-                if !entry.labels.is_empty() {
-                    spec = spec.with_labels(entry.labels.clone());
-                }
-                handle
-                    .ensure_member(spec)
-                    .await
-                    .map_err(|ensure_err| ensure_err.to_string())?;
+        Ok(_receipt) => Ok(None),
+        Err(err) => {
+            if let Some(failed_peer_ids) = topology_restore_failed_peer_ids(&err) {
+                tracing::warn!(
+                    member_id = %runtime_member_id,
+                    failed_peer_count = failed_peer_ids.len(),
+                    failed_peer_ids = ?failed_peer_ids,
+                    "console member respawn restored member with isolated peer edges; continuing degraded respawn"
+                );
+                return Ok(Some(topology_restore_warning_json(&failed_peer_ids)));
             }
-            Ok(())
+
+            if lifecycle_archive_cleanup_completed(&err.to_string()) {
+                if handle.get_member(runtime_member_id).await.is_none()
+                    && let Some(entry) = entry_before_respawn
+                {
+                    let mut spec =
+                        SpawnMemberSpec::new(entry.role.clone(), runtime_member_id.clone());
+                    if !entry.labels.is_empty() {
+                        spec = spec.with_labels(entry.labels.clone());
+                    }
+                    handle
+                        .ensure_member(spec)
+                        .await
+                        .map_err(|ensure_err| ensure_err.to_string())?;
+                }
+                return Ok(None);
+            }
+
+            Err(err.to_string())
         }
-        Err(err) => Err(err.to_string()),
     }
 }
 
@@ -4197,7 +4212,7 @@ async fn handle_console_runtime_rpc_with_visibility(
                         )
                         .await
                         {
-                            Ok(()) => {
+                            Ok(topology_restore_warning) => {
                                 let live_session_id = handle
                                     .resolve_bridge_session_id_observation(&MeerkatId::from(
                                         record.agent_runtime_id.as_str(),
@@ -4213,7 +4228,7 @@ async fn handle_console_runtime_rpc_with_visibility(
                                     {
                                         Ok(updated_record) => {
                                             record = updated_record;
-                                            None
+                                            topology_restore_warning
                                         }
                                         Err(err) => Some(json!({
                                             "kind": "identity_rebind_failed_after_member_respawn",
@@ -4224,7 +4239,7 @@ async fn handle_console_runtime_rpc_with_visibility(
                                         })),
                                     }
                                 } else {
-                                    None
+                                    topology_restore_warning
                                 }
                             }
                             Err(err) => Some(json!({
@@ -4316,13 +4331,17 @@ async fn handle_console_runtime_rpc_with_visibility(
             }
             let mid = MeerkatId::from(alias.runtime_member_id.as_str());
             match respawn_console_member(&handle, &mid).await {
-                Ok(()) => {
+                Ok(topology_restore_warning) => {
                     if let Some(store) = &console_events {
                         store
-                            .record_lifecycle(&alias.identity, "identity_respawned", json!({}))
+                            .record_lifecycle(
+                                &alias.identity,
+                                "identity_respawned",
+                                json!({ "topology_restore_warning": topology_restore_warning.clone() }),
+                            )
                             .await;
                     }
-                    let body = match lookup_member_with_session(&handle, &mid).await {
+                    let mut body = match lookup_member_with_session(&handle, &mid).await {
                         Some((entry, session_id)) => console_identity_status_json_for_identity(
                             &alias.identity,
                             &entry,
@@ -4331,6 +4350,9 @@ async fn handle_console_runtime_rpc_with_visibility(
                         ),
                         None => json!({ "identity": alias.identity }),
                     };
+                    if let Some(warning) = topology_restore_warning {
+                        body["topology_restore_warning"] = warning;
+                    }
                     response_value(response_id, Some(body), None)
                 }
                 Err(err) => internal_error(response_id, format!("respawn failed: {err}")),
@@ -4392,17 +4414,18 @@ async fn handle_console_runtime_rpc_with_visibility(
                         }
                         let mid = MeerkatId::from(alias.runtime_member_id.as_str());
                         let response = match respawn_console_member(&handle, &mid).await {
-                            Ok(()) => {
+                            Ok(topology_restore_warning) => {
                                 if let Some(store) = &console_events {
                                     store
                                         .record_lifecycle(
                                             &alias.identity,
                                             "identity_reset",
-                                            json!({}),
+                                            json!({ "topology_restore_warning": topology_restore_warning.clone() }),
                                         )
                                         .await;
                                 }
-                                let body = match lookup_member_with_session(&handle, &mid).await {
+                                let mut body = match lookup_member_with_session(&handle, &mid).await
+                                {
                                     Some((entry, session_id)) => {
                                         console_identity_status_json_for_identity(
                                             &alias.identity,
@@ -4413,6 +4436,9 @@ async fn handle_console_runtime_rpc_with_visibility(
                                     }
                                     None => json!({ "identity": alias.identity }),
                                 };
+                                if let Some(warning) = topology_restore_warning {
+                                    body["topology_restore_warning"] = warning;
+                                }
                                 response_value(response_id, Some(body), None)
                             }
                             Err(err) => internal_error(response_id, format!("reset failed: {err}")),
@@ -4919,7 +4945,26 @@ async fn handle_console_runtime_rpc_with_visibility(
                     Some(serde_json::json!({ "accepted": true })),
                     None,
                 ),
-                Err(err) => internal_error(response_id, format!("respawn_member failed: {err}")),
+                Err(err) => {
+                    if let Some(failed_peer_ids) = topology_restore_failed_peer_ids(&err) {
+                        tracing::warn!(
+                            member_id = %member_id,
+                            failed_peer_count = failed_peer_ids.len(),
+                            failed_peer_ids = ?failed_peer_ids,
+                            "console member respawn restored member with isolated peer edges; accepting degraded respawn"
+                        );
+                        response_value(
+                            response_id,
+                            Some(serde_json::json!({
+                                "accepted": true,
+                                "topology_restore_warning": topology_restore_warning_json(&failed_peer_ids),
+                            })),
+                            None,
+                        )
+                    } else {
+                        internal_error(response_id, format!("respawn_member failed: {err}"))
+                    }
+                }
             }
         }
         "mobkit/reconcile_edges" => response_value(
@@ -6358,18 +6403,25 @@ async fn reset_all_live_console_agents(
                 continue;
             }
             match respawn_console_member(&handle, &MeerkatId::from(runtime_member_id)).await {
-                Ok(()) => {
+                Ok(topology_restore_warning) => {
                     if let Some(store) = console_events {
                         store
                             .record_lifecycle(
                                 &identity,
                                 "identity_reset",
-                                json!({ "scope": "reset_all" }),
+                                json!({
+                                    "scope": "reset_all",
+                                    "topology_restore_warning": topology_restore_warning.clone(),
+                                }),
                             )
                             .await;
                     }
                     reset_main.push(identity.clone());
-                    reset_details.push(json!({ "identity": identity }));
+                    let mut detail = json!({ "identity": identity });
+                    if let Some(warning) = topology_restore_warning {
+                        detail["topology_restore_warning"] = warning;
+                    }
+                    reset_details.push(detail);
                 }
                 Err(err) => failures.push(json!({
                     "identity": identity,

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -1,7 +1,7 @@
 //! Session bridge: connects the identity-first control plane to the Meerkat
 //! session pipeline for real session creation, delivery, and retirement.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -16,6 +16,7 @@ use meerkat_mob::{
 use crate::mob_handle_runtime::{
     content_input_has_images, is_previous_member_cleanup_ambiguous_error,
     is_recoverable_lifecycle_cleanup_error, model_capabilities_for_member,
+    topology_restore_failed_peer_ids,
 };
 
 use super::adapters::{ContinuitySessionStoreAdapter, SessionRuntimeState};
@@ -40,6 +41,25 @@ fn is_repairable_bridge_delivery_error(error: &str) -> bool {
 
 fn is_recoverable_bridge_respawn_cleanup_error(error: &str) -> bool {
     is_recoverable_lifecycle_cleanup_error(error)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum MemberRepairRespawnFailure {
+    DegradedTopologyRestore { failed_peer_ids: Vec<String> },
+    RecoverableCleanup,
+    Fatal(String),
+}
+
+fn classify_member_repair_respawn_failure(
+    error: &meerkat_mob::MobRespawnError,
+) -> MemberRepairRespawnFailure {
+    if let Some(failed_peer_ids) = topology_restore_failed_peer_ids(error) {
+        return MemberRepairRespawnFailure::DegradedTopologyRestore { failed_peer_ids };
+    }
+    if is_recoverable_bridge_respawn_cleanup_error(&error.to_string()) {
+        return MemberRepairRespawnFailure::RecoverableCleanup;
+    }
+    MemberRepairRespawnFailure::Fatal(error.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -437,6 +457,46 @@ impl MobSessionBridge {
 
         Err(BridgeError::Mob(missing_message.to_string()))
     }
+
+    async fn repair_member_for_delivery(
+        &self,
+        runtime_id: &AgentRuntimeId,
+        member_id: &MeerkatId,
+        member_entry_before_delivery: Option<(meerkat_mob::ProfileName, BTreeMap<String, String>)>,
+    ) -> Result<(), BridgeError> {
+        match self.handle.respawn(member_id.clone(), None).await {
+            Ok(_) => Ok(()),
+            Err(respawn_err) => match classify_member_repair_respawn_failure(&respawn_err) {
+                MemberRepairRespawnFailure::DegradedTopologyRestore { failed_peer_ids } => {
+                    tracing::warn!(
+                        runtime_id = %runtime_id,
+                        member_id = %member_id,
+                        failed_peer_count = failed_peer_ids.len(),
+                        failed_peer_ids = ?failed_peer_ids,
+                        "identity bridge respawn restored member with isolated peer edges; continuing delivery"
+                    );
+                    // meerkat-mob raises this only after the member/session is live; only peer edges are incomplete.
+                    Ok(())
+                }
+                MemberRepairRespawnFailure::RecoverableCleanup => {
+                    if self.handle.get_member(member_id).await.is_none()
+                        && let Some((role, labels)) = member_entry_before_delivery
+                    {
+                        let mut spec = SpawnMemberSpec::new(role, member_id.clone());
+                        if !labels.is_empty() {
+                            spec = spec.with_labels(labels);
+                        }
+                        self.handle
+                            .ensure_member(spec)
+                            .await
+                            .map_err(|e| BridgeError::Mob(e.to_string()))?;
+                    }
+                    Ok(())
+                }
+                MemberRepairRespawnFailure::Fatal(message) => Err(BridgeError::Mob(message)),
+            },
+        }
+    }
 }
 
 fn spec_uses_external_binding(spec: &DurableAgentSpec) -> bool {
@@ -633,7 +693,11 @@ impl SessionBridge for MobSessionBridge {
         content: &meerkat_core::ContentInput,
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         let mid = self.member_id_for_runtime_id(runtime_id).await;
-        let member_entry_before_delivery = self.handle.get_member(&mid).await;
+        let member_entry_before_delivery = self
+            .handle
+            .get_member(&mid)
+            .await
+            .map(|entry| (entry.role, entry.labels));
         if content_input_has_images(content) {
             let member_entry = self.handle.get_member(&mid).await.ok_or_else(|| {
                 BridgeError::Mob("member not found while checking image capability".to_string())
@@ -664,28 +728,8 @@ impl SessionBridge for MobSessionBridge {
                     error = %err,
                     "identity bridge delivery found stale runtime state; repairing member before retry"
                 );
-                match self.handle.respawn(mid.clone(), None).await {
-                    Ok(_) => {}
-                    Err(respawn_err)
-                        if is_recoverable_bridge_respawn_cleanup_error(
-                            &respawn_err.to_string(),
-                        ) =>
-                    {
-                        if self.handle.get_member(&mid).await.is_none()
-                            && let Some(entry) = member_entry_before_delivery
-                        {
-                            let mut spec = SpawnMemberSpec::new(entry.role.clone(), mid.clone());
-                            if !entry.labels.is_empty() {
-                                spec = spec.with_labels(entry.labels.clone());
-                            }
-                            self.handle
-                                .ensure_member(spec)
-                                .await
-                                .map_err(|e| BridgeError::Mob(e.to_string()))?;
-                        }
-                    }
-                    Err(respawn_err) => return Err(BridgeError::Mob(respawn_err.to_string())),
-                }
+                self.repair_member_for_delivery(runtime_id, &mid, member_entry_before_delivery)
+                    .await?;
                 submit_internal_bridge_work(&self.handle, &mid, content, HandlingMode::Queue)
                     .await?;
             }
@@ -709,7 +753,11 @@ impl SessionBridge for MobSessionBridge {
         handling_mode: HandlingMode,
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         let mid = self.member_id_for_runtime_id(runtime_id).await;
-        let member_entry_before_delivery = self.handle.get_member(&mid).await;
+        let member_entry_before_delivery = self
+            .handle
+            .get_member(&mid)
+            .await
+            .map(|entry| (entry.role, entry.labels));
         if content_input_has_images(content) {
             let member_entry = self.handle.get_member(&mid).await.ok_or_else(|| {
                 BridgeError::Mob("member not found while checking image capability".to_string())
@@ -735,28 +783,8 @@ impl SessionBridge for MobSessionBridge {
                     error = %err,
                     "identity bridge delivery found stale runtime state; repairing member before retry"
                 );
-                match self.handle.respawn(mid.clone(), None).await {
-                    Ok(_) => {}
-                    Err(respawn_err)
-                        if is_recoverable_bridge_respawn_cleanup_error(
-                            &respawn_err.to_string(),
-                        ) =>
-                    {
-                        if self.handle.get_member(&mid).await.is_none()
-                            && let Some(entry) = member_entry_before_delivery
-                        {
-                            let mut spec = SpawnMemberSpec::new(entry.role.clone(), mid.clone());
-                            if !entry.labels.is_empty() {
-                                spec = spec.with_labels(entry.labels.clone());
-                            }
-                            self.handle
-                                .ensure_member(spec)
-                                .await
-                                .map_err(|e| BridgeError::Mob(e.to_string()))?;
-                        }
-                    }
-                    Err(respawn_err) => return Err(BridgeError::Mob(respawn_err.to_string())),
-                }
+                self.repair_member_for_delivery(runtime_id, &mid, member_entry_before_delivery)
+                    .await?;
                 submit_internal_bridge_work(&self.handle, &mid, content, handling_mode).await?;
             }
             Err(err) => return Err(BridgeError::Mob(err.to_string())),
@@ -975,7 +1003,7 @@ mod tests {
     use meerkat_core::agent::AgentToolDispatcher;
     use meerkat_core::types::ToolCallView;
     use meerkat_core::{ToolDef, error::ToolError, ops::ToolDispatchOutcome};
-    use meerkat_mob::MobRuntimeMode;
+    use meerkat_mob::{MobRespawnError, MobRuntimeMode};
 
     use super::*;
     use crate::identity_first::{AgentAddressability, LocalExternalToolOverlay};
@@ -1135,6 +1163,38 @@ mod tests {
         assert!(
             !is_repairable_bridge_delivery_error("model provider returned rate limit"),
             "ordinary turn failures must not trigger member repair"
+        );
+    }
+
+    #[test]
+    fn bridge_delivery_repair_classifies_topology_restore_failure_as_degraded() {
+        let identity = meerkat_mob::AgentIdentity::from("rt:review:singleton:0");
+        let receipt = meerkat_mob::MemberRespawnReceipt::new(
+            identity.clone(),
+            meerkat_mob::AgentRuntimeId::new(identity, meerkat_mob::ids::Generation::INITIAL),
+            meerkat_mob::FenceToken::new(1),
+            meerkat_mob::FenceToken::new(2),
+        );
+        let err = MobRespawnError::TopologyRestoreFailed {
+            receipt,
+            failed_peer_ids: vec![meerkat_mob::AgentIdentity::from("initiative:broken")],
+        };
+
+        assert_eq!(
+            classify_member_repair_respawn_failure(&err),
+            MemberRepairRespawnFailure::DegradedTopologyRestore {
+                failed_peer_ids: vec!["initiative:broken".to_string()]
+            },
+            "failed peer edges should degrade bridge repair instead of bricking delivery"
+        );
+        assert!(
+            matches!(
+                classify_member_repair_respawn_failure(&MobRespawnError::NoRuntimeControl {
+                    identity: meerkat_mob::AgentIdentity::from("rt:review:singleton:0"),
+                }),
+                MemberRepairRespawnFailure::Fatal(_)
+            ),
+            "ordinary respawn failures must still fail bridge repair"
         );
     }
 }

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -595,9 +595,16 @@ impl IdentityRuntime {
             .collect();
 
         let managed_snapshot = self.managed_peer_edges.read().await.clone();
+        let edge_is_managed_and_live = |edge: &(AgentIdentity, AgentIdentity)| {
+            // Managed-but-missing live edges are retried deliberately so tolerant topology restores self-heal.
+            managed_snapshot.contains(edge)
+                && current_logical_edges
+                    .as_ref()
+                    .is_none_or(|edges| edges.contains(edge))
+        };
         let retained_logical_edges: Vec<(AgentIdentity, AgentIdentity)> = desired
             .iter()
-            .filter(|edge| !managed_snapshot.contains(*edge))
+            .filter(|edge| !edge_is_managed_and_live(edge))
             .filter(|edge| {
                 current_logical_edges
                     .as_ref()
@@ -608,7 +615,7 @@ impl IdentityRuntime {
             .collect();
         let to_wire: Vec<(AgentIdentity, AgentIdentity, AgentRuntimeId, AgentRuntimeId)> = desired
             .iter()
-            .filter(|edge| !managed_snapshot.contains(*edge))
+            .filter(|edge| !edge_is_managed_and_live(edge))
             .filter(|edge| {
                 current_logical_edges
                     .as_ref()
@@ -683,7 +690,12 @@ impl IdentityRuntime {
 
         for (a, b) in stale {
             let key = (a.clone(), b.clone());
-            if !active_runtimes.contains_key(&a) || !active_runtimes.contains_key(&b) {
+            if !active_runtimes.contains_key(&a)
+                || !active_runtimes.contains_key(&b)
+                || current_logical_edges
+                    .as_ref()
+                    .is_some_and(|edges| !edges.contains(&key))
+            {
                 managed.remove(&key);
             }
         }

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -42,6 +42,25 @@ pub(crate) fn is_recoverable_lifecycle_cleanup_error(error: &str) -> bool {
             && error.contains("Runtime not ready: running"))
 }
 
+pub(crate) fn topology_restore_failed_peer_ids(
+    error: &meerkat_mob::MobRespawnError,
+) -> Option<Vec<String>> {
+    match error {
+        meerkat_mob::MobRespawnError::TopologyRestoreFailed {
+            receipt: _,
+            failed_peer_ids,
+        } => Some(failed_peer_ids.iter().map(ToString::to_string).collect()),
+        _ => None,
+    }
+}
+
+pub(crate) fn topology_restore_warning_json(failed_peer_ids: &[String]) -> Value {
+    serde_json::json!({
+        "kind": "topology_restore_degraded",
+        "failed_peer_ids": failed_peer_ids,
+    })
+}
+
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 
@@ -4690,6 +4709,45 @@ image_generation = true
 
         assert!(is_previous_member_cleanup_ambiguous_error(error));
         assert!(is_recoverable_lifecycle_cleanup_error(error));
+    }
+
+    #[test]
+    fn topology_restore_failed_peer_ids_extracts_tolerated_peers() {
+        let identity = meerkat_mob::AgentIdentity::from("rt:review:singleton:0");
+        let receipt = meerkat_mob::MemberRespawnReceipt::new(
+            identity.clone(),
+            meerkat_mob::AgentRuntimeId::new(identity, meerkat_mob::ids::Generation::INITIAL),
+            meerkat_mob::FenceToken::new(1),
+            meerkat_mob::FenceToken::new(2),
+        );
+        let err = meerkat_mob::MobRespawnError::TopologyRestoreFailed {
+            receipt,
+            failed_peer_ids: vec![meerkat_mob::AgentIdentity::from("initiative:broken")],
+        };
+
+        assert_eq!(
+            topology_restore_failed_peer_ids(&err),
+            Some(vec!["initiative:broken".to_string()])
+        );
+        assert_eq!(
+            topology_restore_failed_peer_ids(&meerkat_mob::MobRespawnError::NoRuntimeControl {
+                identity: meerkat_mob::AgentIdentity::from("rt:review:singleton:0"),
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn topology_restore_warning_json_surfaces_isolated_peers() {
+        let failed_peer_ids = vec!["initiative:broken".to_string(), "helper:cold".to_string()];
+
+        assert_eq!(
+            topology_restore_warning_json(&failed_peer_ids),
+            serde_json::json!({
+                "kind": "topology_restore_degraded",
+                "failed_peer_ids": ["initiative:broken", "helper:cold"],
+            })
+        );
     }
 
     #[test]

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::console_aggregator::is_implicit_delegate_member;
+use crate::mob_handle_runtime::{topology_restore_failed_peer_ids, topology_restore_warning_json};
 use crate::runtime::{
     BigQuerySessionStoreAdapter, BigQuerySessionStoreError, ConsoleRestJsonRequest,
     ConsoleRestJsonResponse, DeliveryHistoryRequest, DeliverySendError, DeliverySendRequest,
@@ -2423,6 +2424,10 @@ async fn handle_unified_rpc_json_inner(
                     .await
                     {
                         Ok(live_result) => {
+                            let topology_restore_warning = live_result
+                                .get("topology_restore_warning")
+                                .filter(|warning| !warning.is_null())
+                                .cloned();
                             let live_session_id =
                                 live_result.get("session_id").and_then(Value::as_str);
                             if let Some(live_session_id) = live_session_id {
@@ -2436,7 +2441,7 @@ async fn handle_unified_rpc_json_inner(
                                         {
                                             Ok(updated_record) => {
                                                 record = updated_record;
-                                                None
+                                                topology_restore_warning
                                             }
                                             Err(err) => Some(serde_json::json!({
                                                 "kind": "identity_rebind_failed_after_member_respawn",
@@ -2456,7 +2461,7 @@ async fn handle_unified_rpc_json_inner(
                                     })),
                                 }
                             } else {
-                                None
+                                topology_restore_warning
                             }
                         }
                         Err(err) => Some(serde_json::json!({
@@ -3820,24 +3825,36 @@ async fn respawn_rpc_runtime_member_id(
     let handle = runtime.mob_handle();
     let member_id = meerkat_mob::ids::MeerkatId::from(runtime_member_id);
     let entry_before_respawn = handle.get_member(&member_id).await;
+    let mut topology_restore_warning = None;
     match handle.respawn(member_id.clone(), None).await {
         Ok(_receipt) => {}
-        Err(err) if mob_methods::lifecycle_archive_cleanup_completed(&err.to_string()) => {
-            if handle.get_member(&member_id).await.is_none()
-                && let Some(entry) = entry_before_respawn
-            {
-                let mut spec =
-                    meerkat_mob::SpawnMemberSpec::new(entry.role.clone(), member_id.clone());
-                if !entry.labels.is_empty() {
-                    spec = spec.with_labels(entry.labels.clone());
+        Err(err) => {
+            if let Some(failed_peer_ids) = topology_restore_failed_peer_ids(&err) {
+                tracing::warn!(
+                    member_id = %member_id,
+                    failed_peer_count = failed_peer_ids.len(),
+                    failed_peer_ids = ?failed_peer_ids,
+                    "rpc member respawn restored member with isolated peer edges; continuing degraded respawn"
+                );
+                topology_restore_warning = Some(topology_restore_warning_json(&failed_peer_ids));
+            } else if mob_methods::lifecycle_archive_cleanup_completed(&err.to_string()) {
+                if handle.get_member(&member_id).await.is_none()
+                    && let Some(entry) = entry_before_respawn
+                {
+                    let mut spec =
+                        meerkat_mob::SpawnMemberSpec::new(entry.role.clone(), member_id.clone());
+                    if !entry.labels.is_empty() {
+                        spec = spec.with_labels(entry.labels.clone());
+                    }
+                    handle
+                        .ensure_member(spec)
+                        .await
+                        .map_err(|ensure_err| ensure_err.to_string())?;
                 }
-                handle
-                    .ensure_member(spec)
-                    .await
-                    .map_err(|ensure_err| ensure_err.to_string())?;
+            } else {
+                return Err(err.to_string());
             }
         }
-        Err(err) => return Err(err.to_string()),
     }
     let session_id = handle
         .resolve_bridge_session_id_observation(&member_id)
@@ -3848,6 +3865,7 @@ async fn respawn_rpc_runtime_member_id(
         "session_id": session_id,
         "generation": Value::Null,
         "checkpoint_version": Value::Null,
+        "topology_restore_warning": topology_restore_warning,
     }))
 }
 

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use crate::blob_store::is_valid_blob_id_value;
 use crate::mob_handle_runtime::{
     assert_member_accepts_images, is_recoverable_lifecycle_cleanup_error, member_entry_to_json,
-    send_message_on_mob_with_mode,
+    send_message_on_mob_with_mode, topology_restore_failed_peer_ids, topology_restore_warning_json,
 };
 use crate::unified_runtime::UnifiedRuntime;
 
@@ -761,6 +761,7 @@ pub(super) async fn handle_respawn_member(
             let handle = runtime.mob_handle();
             let identity = MeerkatId::from(mid);
             let entry_before_respawn = handle.get_member(&identity).await;
+            let mut topology_restore_warning = None;
             match handle.respawn(identity.clone(), None).await {
                 Ok(_receipt) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
@@ -768,44 +769,61 @@ pub(super) async fn handle_respawn_member(
                     result: Some(serde_json::json!({"accepted": true})),
                     error: None,
                 },
-                Err(err) if lifecycle_archive_cleanup_completed(&err.to_string()) => {
-                    if handle.get_member(&identity).await.is_none()
-                        && let Some(entry) = entry_before_respawn
-                    {
-                        let mut spec = SpawnMemberSpec::new(entry.role.clone(), identity.clone());
-                        if !entry.labels.is_empty() {
-                            spec = spec.with_labels(entry.labels.clone());
+                Err(err) => {
+                    if let Some(failed_peer_ids) = topology_restore_failed_peer_ids(&err) {
+                        tracing::warn!(
+                            member_id = %identity,
+                            failed_peer_count = failed_peer_ids.len(),
+                            failed_peer_ids = ?failed_peer_ids,
+                            "rpc member respawn restored member with isolated peer edges; accepting degraded respawn"
+                        );
+                        topology_restore_warning =
+                            Some(topology_restore_warning_json(&failed_peer_ids));
+                    } else if lifecycle_archive_cleanup_completed(&err.to_string()) {
+                        if handle.get_member(&identity).await.is_none()
+                            && let Some(entry) = entry_before_respawn
+                        {
+                            let mut spec =
+                                SpawnMemberSpec::new(entry.role.clone(), identity.clone());
+                            if !entry.labels.is_empty() {
+                                spec = spec.with_labels(entry.labels.clone());
+                            }
+                            if let Err(ensure_err) = handle.ensure_member(spec).await {
+                                return JsonRpcResponse {
+                                    jsonrpc: JSONRPC_VERSION.to_string(),
+                                    id: response_id,
+                                    result: None,
+                                    error: Some(JsonRpcError {
+                                        code: -32000,
+                                        message: format!("respawn_member failed: {ensure_err}"),
+                                        data: None,
+                                    }),
+                                };
+                            }
                         }
-                        if let Err(ensure_err) = handle.ensure_member(spec).await {
-                            return JsonRpcResponse {
-                                jsonrpc: JSONRPC_VERSION.to_string(),
-                                id: response_id,
-                                result: None,
-                                error: Some(JsonRpcError {
-                                    code: -32000,
-                                    message: format!("respawn_member failed: {ensure_err}"),
-                                    data: None,
-                                }),
-                            };
-                        }
+                    } else {
+                        return JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION.to_string(),
+                            id: response_id,
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32000,
+                                message: format!("respawn_member failed: {err}"),
+                                data: None,
+                            }),
+                        };
                     }
+
                     JsonRpcResponse {
                         jsonrpc: JSONRPC_VERSION.to_string(),
                         id: response_id,
-                        result: Some(serde_json::json!({"accepted": true})),
+                        result: Some(serde_json::json!({
+                            "accepted": true,
+                            "topology_restore_warning": topology_restore_warning,
+                        })),
                         error: None,
                     }
                 }
-                Err(err) => JsonRpcResponse {
-                    jsonrpc: JSONRPC_VERSION.to_string(),
-                    id: response_id,
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32000,
-                        message: format!("respawn_member failed: {err}"),
-                        data: None,
-                    }),
-                },
             }
         }
         _ => JsonRpcResponse {

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -6494,6 +6494,20 @@ async fn identity_first_runtime_topology_claims_persisted_wires_without_rebatchi
             Ok(())
         }
 
+        async fn wire_peers_batch(
+            &self,
+            edges: &[(AgentRuntimeId, AgentRuntimeId)],
+        ) -> Result<(), BridgeError> {
+            for (a, b) in edges {
+                self.wire_peer(a, b).await?;
+                self.current_wires
+                    .lock()
+                    .await
+                    .push((a.as_str().to_string(), b.as_str().to_string()));
+            }
+            Ok(())
+        }
+
         async fn unwire_peer(
             &self,
             a: &AgentRuntimeId,
@@ -6574,6 +6588,22 @@ async fn identity_first_runtime_topology_claims_persisted_wires_without_rebatchi
     assert!(
         bridge.wires.lock().await.is_empty(),
         "persisted wires should be claimed as managed without re-sending a batch"
+    );
+
+    bridge.current_wires.lock().await.clear();
+    restore_flow(
+        &runtime,
+        &roster,
+        Some(&StaticTopology(vec![("a:main", "b:main")])),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        bridge.wires.lock().await.as_slice(),
+        &[("rt:a:main:0".to_string(), "rt:b:main:0".to_string())],
+        "managed edges missing from the live wire snapshot should be retried"
     );
 
     restore_flow(&runtime, &roster, Some(&StaticTopology(Vec::new())), None)


### PR DESCRIPTION
## Summary

- Treat `MobRespawnError::TopologyRestoreFailed` as degraded-but-live in MobKit repair/respawn paths instead of failing the whole delivery or operator respawn.
- Share typed extraction of isolated `failed_peer_ids` for structured warnings across bridge, RPC, and console surfaces.
- Make managed peer reconciliation retry edges that MobKit believed were managed but are absent from the live wire snapshot.

## Root Cause

Pinned `meerkat-mob` can return `TopologyRestoreFailed` after the member/session has already been restored, when only some peer edges failed to rewire. MobKit previously propagated that as fatal in the bridge repair path, which could brick future turns even though the target member was usable.

## Validation

- `cargo check -p meerkat-mobkit --no-default-features`
- `cargo clippy -p meerkat-mobkit --no-default-features --all-targets -- -D warnings`
- `cargo test -p meerkat-mobkit bridge_delivery_repair --no-default-features`
- `cargo test -p meerkat-mobkit topology_restore_failed_peer_ids_extracts_tolerated_peers --no-default-features`
- `cargo test -p meerkat-mobkit identity_first_runtime_topology_claims_persisted_wires_without_rebatching --no-default-features`
- `cargo test -p meerkat-mobkit identity_first_runtime_send_and_dispatch_continue_when_reachable_peer_materialize_fails --no-default-features`
- `cargo test -p meerkat-mobkit identity_first_runtime_reachable_peer_materialization_backoff_coalesces_concurrent_sends --no-default-features`
- pre-push hooks: secrets, whitespace, EOF, merge conflicts, large files, `cargo fmt --check`, `cargo clippy (changed crates)`, workspace unit gate
