### PR TITLE
[codex] Fix bridge delivery repair for injector capability errors

### DIFF
--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -26,6 +26,8 @@ use super::types::{
 
 fn is_missing_event_injector_error(error: &str) -> bool {
     error.contains("missing event injector capability")
+        || (error.contains("missing required capability")
+            && error.contains("interaction_event_injector"))
 }
 
 fn is_missing_bridge_session_snapshot_error(error: &str) -> bool {
@@ -1125,6 +1127,12 @@ mod tests {
         assert!(
             is_repairable_bridge_delivery_error("missing event injector capability for member"),
             "existing stale event-injector repair path must remain covered"
+        );
+        assert!(
+            is_repairable_bridge_delivery_error(
+                "mob member rt:us-president:0 missing required capability interaction_event_injector: autonomous member dispatch"
+            ),
+            "newer autonomous member dispatch wording should repair and retry instead of dropping the event"
         );
         assert!(
             is_repairable_bridge_delivery_error(


### PR DESCRIPTION
## Summary

- Treat the newer `missing required capability interaction_event_injector` bridge delivery error as repairable stale member state.
- Extend the existing bridge repair unit coverage to include the autonomous member dispatch wording observed in live console delivery.

## Root Cause

The identity bridge already repaired older `missing event injector capability` errors, but the runtime can now surface the same stale-member condition as `missing required capability interaction_event_injector: autonomous member dispatch`. Because that wording was not classified as repairable, delivery could fail instead of respawning and retrying the member.

## Validation

- `npm --prefix examples run escalation:smoke --silent`
- `./scripts/repo-cargo test -p meerkat-mobkit bridge_delivery_repair_covers_missing_bridge_session_snapshot -- --nocapture`
- Pre-push hook: cargo fmt check, changed-crate clippy, workspace unit gate
