### PR TITLE
MobKit 0.7.2: lifecycle hot-loop / wedge hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -2983,10 +2983,13 @@ async fn backfill_one_session_history(
         {
             Ok(page) => page,
             Err(err) => {
-                append_backfill_gap(
+                record_session_history_backfill_failure(
                     &inner,
+                    &watermark_runtime_key,
                     &entry.runtime_key,
                     &record.identity,
+                    &session_id,
+                    offset,
                     err.to_string(),
                 )
                 .await?;
@@ -2996,10 +2999,13 @@ async fn backfill_one_session_history(
         let page_value = match serde_json::to_value(page) {
             Ok(value) => value,
             Err(err) => {
-                append_backfill_gap(
+                record_session_history_backfill_failure(
                     &inner,
+                    &watermark_runtime_key,
                     &entry.runtime_key,
                     &record.identity,
+                    &session_id,
+                    offset,
                     err.to_string(),
                 )
                 .await?;
@@ -3011,10 +3017,13 @@ async fn backfill_one_session_history(
             .and_then(Value::as_u64)
             .unwrap_or(offset as u64) as usize;
         let Some(messages) = page_value.get("messages").and_then(Value::as_array) else {
-            append_backfill_gap(
+            record_session_history_backfill_failure(
                 &inner,
+                &watermark_runtime_key,
                 &entry.runtime_key,
                 &record.identity,
+                &session_id,
+                offset,
                 "session history page missing messages".to_string(),
             )
             .await?;
@@ -3368,25 +3377,50 @@ async fn append_source_gap(
     Ok(())
 }
 
+/// Record a session-history backfill failure: stamp a watermark at the current
+/// offset so the freshness gate throttles retries to once per
+/// `SESSION_HISTORY_REFRESH_TTL_MS` (without it the 5s discovery loop re-reads
+/// a persistently-failing session forever), and append a single gap frame.
+async fn record_session_history_backfill_failure(
+    inner: &AggregatorInner,
+    watermark_runtime_key: &str,
+    runtime_key: &str,
+    identity: &str,
+    session_id: &str,
+    offset: usize,
+    reason: String,
+) -> ConsoleLogResult<()> {
+    record_session_history_watermark(inner, watermark_runtime_key, session_id, offset).await?;
+    append_backfill_gap(inner, runtime_key, identity, session_id, reason).await
+}
+
+/// Stable dedupe key for a session-history backfill gap frame: a persistently
+/// failing session collapses to a single gap frame across retries.
+fn backfill_gap_dedupe_key(runtime_key: &str, identity: &str, session_id: &str) -> String {
+    format!("session-backfill-gap:{runtime_key}:{identity}:{session_id}")
+}
+
 async fn append_backfill_gap(
     inner: &AggregatorInner,
     runtime_key: &str,
     identity: &str,
+    session_id: &str,
     reason: String,
 ) -> ConsoleLogResult<()> {
     append_and_emit(
         inner,
         NewConsoleFrame {
             id: None,
-            dedupe_key: format!(
-                "session-backfill-gap:{runtime_key}:{identity}:{}",
-                current_time_ms()
-            ),
+            // Stable per (runtime, identity, session): repeated failures for
+            // the same session collapse to one gap frame instead of minting a
+            // fresh one (timestamped) on every retry — which grew the timeline
+            // store unbounded.
+            dedupe_key: backfill_gap_dedupe_key(runtime_key, identity, session_id),
             timestamp_ms: current_time_ms(),
             runtime_key: runtime_key.to_string(),
             identity: identity.to_string(),
             conversation_id: Some(identity.to_string()),
-            session_id: None,
+            session_id: Some(session_id.to_string()),
             kind: "replay_unavailable".to_string(),
             status: ConsoleFrameStatus::DeliveryFailed,
             payload: json!({
@@ -4528,6 +4562,23 @@ fn runtime_registry_lock_error() -> ConsoleLogError {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::large_futures, clippy::panic)]
 mod tests {
+    /// Regression: a session that keeps failing backfill must collapse to ONE
+    /// gap frame. The dedupe key is stable per (runtime, identity, session) —
+    /// independent of wall-clock — so repeated failures don't mint a fresh
+    /// timestamped frame each retry and grow the timeline store unbounded.
+    #[test]
+    fn backfill_gap_dedupe_key_is_stable_per_session() {
+        use super::backfill_gap_dedupe_key;
+        let a = backfill_gap_dedupe_key("default", "worker:1", "sess-9");
+        let b = backfill_gap_dedupe_key("default", "worker:1", "sess-9");
+        assert_eq!(a, b, "same target must reuse one gap frame");
+        assert_ne!(a, backfill_gap_dedupe_key("default", "worker:1", "sess-10"));
+        assert_ne!(a, backfill_gap_dedupe_key("default", "worker:2", "sess-9"));
+        // The key carries no wall-clock component (the pre-fix bug appended
+        // current_time_ms, so every retry was a unique frame).
+        assert_eq!(a, "session-backfill-gap:default:worker:1:sess-9");
+    }
+
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -3671,7 +3671,7 @@ mod lease_renewal_backoff_tests {
     /// backoff grows from a 1s base and caps at the max poll interval.
     #[test]
     fn lease_renewal_failure_backoff_grows_and_caps() {
-        let max = Duration::from_secs(60);
+        let max = Duration::from_mins(1);
         assert_eq!(
             lease_renewal_failure_backoff(0, max),
             LEASE_RENEWAL_FAILURE_BACKOFF_BASE

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -224,6 +224,21 @@ pub enum IdentityEvent {
 const IDENTITY_EVENT_CHANNEL_CAPACITY: usize = 64;
 const DEFAULT_LEASE_RENEWAL_MAX_POLL_INTERVAL: Duration = Duration::from_mins(1);
 const DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Base delay for the lease-renewal failure backoff. The renewal tick's
+/// normal cadence is TTL-derived (down to a 10ms floor), so a lease provider
+/// that errors persistently would otherwise retry — and warn — at that floor
+/// rate. On failure we back off from this base, doubling toward the max poll
+/// interval, so a backend outage can't spin the renewal task.
+const LEASE_RENEWAL_FAILURE_BACKOFF_BASE: Duration = Duration::from_secs(1);
+
+fn lease_renewal_failure_backoff(
+    consecutive_failures: u32,
+    max_poll_interval: Duration,
+) -> Duration {
+    LEASE_RENEWAL_FAILURE_BACKOFF_BASE
+        .saturating_mul(1u32 << consecutive_failures.min(6))
+        .min(max_poll_interval)
+}
 
 // ---------------------------------------------------------------------------
 // IdentityRuntime
@@ -421,17 +436,43 @@ impl IdentityRuntime {
     ) -> JoinHandle<()> {
         let max_poll_interval = max_poll_interval.max(DEFAULT_LEASE_RENEWAL_MIN_POLL_INTERVAL);
         tokio::spawn(async move {
+            let mut consecutive_failures: u32 = 0;
             loop {
-                let sleep = self.lease_renewal_sleep_interval(max_poll_interval).await;
+                let base = self.lease_renewal_sleep_interval(max_poll_interval).await;
+                // While the provider is failing, hold off at least the backoff
+                // delay so a persistent outage retries at a bounded rate
+                // instead of the TTL-derived floor (down to 10ms).
+                let sleep = if consecutive_failures > 0 {
+                    base.max(lease_renewal_failure_backoff(
+                        consecutive_failures,
+                        max_poll_interval,
+                    ))
+                } else {
+                    base
+                };
                 tokio::select! {
                     () = tokio::time::sleep(sleep) => {}
                     () = self.lease_renewal_notify.notified() => {}
                 }
-                if let Err(err) = self.renew_due_leases_once().await {
-                    tracing::warn!(
-                        error = %err,
-                        "identity-first proactive lease renewal tick failed"
-                    );
+                match self.renew_due_leases_once().await {
+                    Ok(_) => consecutive_failures = 0,
+                    Err(err) => {
+                        // Warn once, then debounce to debug so a backend outage
+                        // can't flood the log at the renewal cadence.
+                        if consecutive_failures == 0 {
+                            tracing::warn!(
+                                error = %err,
+                                "identity-first proactive lease renewal tick failed; backing off"
+                            );
+                        } else {
+                            tracing::debug!(
+                                error = %err,
+                                consecutive_failures,
+                                "identity-first lease renewal still failing; backing off"
+                            );
+                        }
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                    }
                 }
             }
         })
@@ -3619,4 +3660,29 @@ pub async fn wire_cross_mob_by_identity(
     Box::pin(local_unified.wire_cross_mob(local_rt.as_str(), remote_rt.as_str(), remote_mob_id))
         .await
         .map_err(|e| IdentityRuntimeError::Internal(format!("wire_cross_mob: {e}")))
+}
+
+#[cfg(test)]
+mod lease_renewal_backoff_tests {
+    use super::*;
+
+    /// Regression: a lease provider that errors persistently must not spin the
+    /// renewal task at the TTL-derived floor (down to 10ms). The failure
+    /// backoff grows from a 1s base and caps at the max poll interval.
+    #[test]
+    fn lease_renewal_failure_backoff_grows_and_caps() {
+        let max = Duration::from_secs(60);
+        assert_eq!(
+            lease_renewal_failure_backoff(0, max),
+            LEASE_RENEWAL_FAILURE_BACKOFF_BASE
+        );
+        assert_eq!(
+            lease_renewal_failure_backoff(1, max),
+            LEASE_RENEWAL_FAILURE_BACKOFF_BASE * 2
+        );
+        assert_eq!(lease_renewal_failure_backoff(6, max), max);
+        // Saturates at the cap for arbitrarily many failures (no shift overflow).
+        assert_eq!(lease_renewal_failure_backoff(99, max), max);
+        assert!(lease_renewal_failure_backoff(2, max) > lease_renewal_failure_backoff(1, max));
+    }
 }

--- a/meerkat-mobkit/src/runtime.rs
+++ b/meerkat-mobkit/src/runtime.rs
@@ -1388,6 +1388,12 @@ const DELIVERY_RATE_WINDOW_MS: u64 = 60_000;
 const DELIVERY_RATE_WINDOWS_RETAINED: u64 = 2;
 const DELIVERY_CLOCK_STEP_MS: u64 = 1_000;
 const GATING_APPROVAL_TIMEOUT_DEFAULT_MS: u64 = 60_000;
+/// Upper bound on a caller-supplied R3 approval timeout. Without it a huge
+/// `approval_timeout_ms` makes `created_at_ms.saturating_add(timeout_ms)`
+/// saturate to `u64::MAX`, so `now_ms >= deadline_at_ms` is never true and the
+/// pending approval can never time out to a safe draft. 7 days is far beyond
+/// any real human-approval window.
+const GATING_APPROVAL_TIMEOUT_MAX_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const GATING_AUDIT_MAX_RETAINED: usize = 512;
 const GATING_PENDING_MAX_RETAINED: usize = 512;
 const MEMORY_ASSERTIONS_MAX_RETAINED: usize = 4_096;

--- a/meerkat-mobkit/src/runtime/gating.rs
+++ b/meerkat-mobkit/src/runtime/gating.rs
@@ -313,9 +313,13 @@ impl MobkitRuntimeHandle {
                 let pending_sequence = self.next_gating_sequence();
                 let pending_id = format!("gate-pending-{pending_sequence:06}");
                 let created_at_ms = current_time_ms();
+                // Clamp so a caller can't set a deadline that saturates past
+                // `u64::MAX` and never expires (the timeout-fallback guarantee
+                // must always be reachable).
                 let timeout_ms = request
                     .approval_timeout_ms
-                    .unwrap_or(GATING_APPROVAL_TIMEOUT_DEFAULT_MS);
+                    .unwrap_or(GATING_APPROVAL_TIMEOUT_DEFAULT_MS)
+                    .min(GATING_APPROVAL_TIMEOUT_MAX_MS);
                 let mut approval_route_id = None;
                 let mut approval_delivery_id = None;
                 let mut approval_notification_error = None;

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -1,6 +1,6 @@
 //! Unified runtime — combines mob lifecycle, module management, and operational subsystems.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -11,8 +11,8 @@ use futures::stream::{BoxStream, SelectAll, StreamExt};
 use meerkat_core::comms::EventStream;
 use meerkat_core::event::{AgentEvent, agent_event_type};
 use meerkat_mob::{
-    AgentIdentity, AgentRuntimeId, AttributedEvent, FenceToken, MobError, MobHandle, ProfileName,
-    SpawnMemberSpec,
+    AgentIdentity, AgentRuntimeId, AttributedEvent, FenceToken, MobError, MobHandle,
+    MobMemberStatus, ProfileName, SpawnMemberSpec,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
@@ -687,6 +687,37 @@ enum ForwardedAgentEvent {
 type TrackedAgentEventStream = (String, AgentIdentity, AgentRuntimeId, FenceToken);
 type TaggedAgentEventStream = BoxStream<'static, ForwardedAgentEvent>;
 
+/// Per-member subscribe-failure backoff for the console agent-event
+/// forwarder. The forwarder reconciles every 250ms; without backoff a
+/// member that keeps failing `subscribe_agent_events` is retried 4×/s
+/// indefinitely and floods the log (observed: ~49k "failed to subscribe"
+/// warnings over 3.4h on a single wedged-retiring alias). We retry with
+/// exponential backoff and warn only on the first failure.
+struct SubscribeBackoff {
+    next_attempt: tokio::time::Instant,
+    consecutive_failures: u32,
+}
+
+/// First retry waits one reconcile tick; subsequent retries double up to a
+/// cap so a persistently-unsubscribable member costs at most ~1 attempt per
+/// `SUBSCRIBE_BACKOFF_MAX` instead of one per tick.
+const SUBSCRIBE_BACKOFF_BASE: Duration = Duration::from_millis(250);
+const SUBSCRIBE_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+fn subscribe_backoff_delay(consecutive_failures: u32) -> Duration {
+    SUBSCRIBE_BACKOFF_BASE
+        .saturating_mul(1u32 << consecutive_failures.min(7))
+        .min(SUBSCRIBE_BACKOFF_MAX)
+}
+
+/// Whether the console forwarder should hold a live agent-event subscription
+/// for a member in this lifecycle state. Only `Active` members have a live
+/// runtime delta stream; subscribing a `Retiring`/`Broken`/`Completed` member
+/// (which can still carry stale binding atoms) fails every reconcile tick.
+fn forwarder_should_subscribe(status: MobMemberStatus) -> bool {
+    matches!(status, MobMemberStatus::Active)
+}
+
 async fn run_resilient_mob_agent_event_forwarder(
     handle: MobHandle,
     agent_mob_mcp_state: Option<Arc<meerkat_mob_mcp::MobMcpState>>,
@@ -695,6 +726,7 @@ async fn run_resilient_mob_agent_event_forwarder(
 ) {
     let mut streams: SelectAll<TaggedAgentEventStream> = SelectAll::new();
     let mut tracked = HashSet::new();
+    let mut subscribe_failures: HashMap<TrackedAgentEventStream, SubscribeBackoff> = HashMap::new();
     let mut reconcile_interval = tokio::time::interval(Duration::from_millis(250));
     #[cfg(not(target_arch = "wasm32"))]
     reconcile_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -703,6 +735,7 @@ async fn run_resilient_mob_agent_event_forwarder(
         &handle,
         &agent_mob_mcp_state,
         &mut tracked,
+        &mut subscribe_failures,
         &mut streams,
     ))
     .await;
@@ -739,7 +772,7 @@ async fn run_resilient_mob_agent_event_forwarder(
                 }
             }
             _ = reconcile_interval.tick() => {
-                Box::pin(reconcile_agent_event_streams(&handle, &agent_mob_mcp_state, &mut tracked, &mut streams)).await;
+                Box::pin(reconcile_agent_event_streams(&handle, &agent_mob_mcp_state, &mut tracked, &mut subscribe_failures, &mut streams)).await;
             }
         }
     }
@@ -749,6 +782,7 @@ async fn reconcile_agent_event_streams(
     handle: &MobHandle,
     agent_mob_mcp_state: &Option<Arc<meerkat_mob_mcp::MobMcpState>>,
     tracked: &mut HashSet<TrackedAgentEventStream>,
+    subscribe_failures: &mut HashMap<TrackedAgentEventStream, SubscribeBackoff>,
     streams: &mut SelectAll<TaggedAgentEventStream>,
 ) {
     let mut handles = vec![handle.clone()];
@@ -787,6 +821,9 @@ async fn reconcile_agent_event_streams(
     }
 
     tracked.retain(|tracked_key| current.contains(tracked_key));
+    // Drop backoff bookkeeping for members that have left the roster so the
+    // map can't grow without bound across the runtime's lifetime.
+    subscribe_failures.retain(|key, _| current.contains(key));
 
     for handle in handles {
         let mob_id = handle.mob_id().to_string();
@@ -806,11 +843,34 @@ async fn reconcile_agent_event_streams(
                 continue;
             }
 
+            // Only Active members have a live runtime delta stream to attach
+            // to. A Retiring/Broken/Completed member can still carry stale
+            // binding atoms (so `binding_atoms()` is Some) while its session
+            // injector is already gone, which makes `subscribe_agent_events`
+            // fail every reconcile tick — the source of the 4×/s forwarder
+            // hot-loop. Such members are skipped here; their final events
+            // arrive via the structural ledger / session-history backfill and
+            // their streams age out through `tracked.retain`.
+            if !forwarder_should_subscribe(entry.status) {
+                subscribe_failures.remove(&tracked_key);
+                continue;
+            }
+
+            // Back off an Active member that keeps failing to subscribe (a
+            // genuinely stuck injector), so even that case can't spin the log.
+            let now = tokio::time::Instant::now();
+            if let Some(backoff) = subscribe_failures.get(&tracked_key)
+                && now < backoff.next_attempt
+            {
+                continue;
+            }
+
             let role = entry.role.clone();
 
             match subscribe_agent_events_for_console_forwarder(&handle, &identity).await {
                 Ok(stream) => {
                     let close_key = tracked_key.clone();
+                    subscribe_failures.remove(&tracked_key);
                     tracked.insert(tracked_key);
                     let mapped = stream
                         .map(move |envelope| {
@@ -828,15 +888,36 @@ async fn reconcile_agent_event_streams(
                     streams.push(mapped);
                 }
                 Err(error) => {
-                    // This can be a short-lived spawn/resume race while Meerkat
-                    // finishes installing the session event injector. Leave the
-                    // identity untracked so the next reconcile tick tries again.
-                    tracing::warn!(
-                        mob_id = %mob_id,
-                        identity = %identity,
-                        error = %error,
-                        "mobkit agent event forwarder: failed to subscribe; will retry"
-                    );
+                    // Usually a short-lived spawn/resume race while Meerkat
+                    // finishes installing the session event injector. Retry
+                    // with exponential backoff and warn only on the first
+                    // failure so a persistent failure can't flood the log.
+                    let backoff =
+                        subscribe_failures
+                            .entry(tracked_key)
+                            .or_insert(SubscribeBackoff {
+                                next_attempt: now,
+                                consecutive_failures: 0,
+                            });
+                    if backoff.consecutive_failures == 0 {
+                        tracing::warn!(
+                            mob_id = %mob_id,
+                            identity = %identity,
+                            error = %error,
+                            "mobkit agent event forwarder: failed to subscribe; will retry with backoff"
+                        );
+                    } else {
+                        tracing::debug!(
+                            mob_id = %mob_id,
+                            identity = %identity,
+                            error = %error,
+                            consecutive_failures = backoff.consecutive_failures,
+                            "mobkit agent event forwarder: subscribe still failing; backing off"
+                        );
+                    }
+                    backoff.next_attempt =
+                        now + subscribe_backoff_delay(backoff.consecutive_failures);
+                    backoff.consecutive_failures = backoff.consecutive_failures.saturating_add(1);
                 }
             }
         }
@@ -1025,5 +1106,33 @@ mod tests {
             panic!("expected agent event");
         };
         assert_eq!(agent_id, "worker-one:0");
+    }
+
+    /// Regression: the console forwarder must only hold a live subscription
+    /// for Active members. A Retiring member can keep stale binding atoms
+    /// while its session injector is gone, so subscribing it fails every
+    /// 250ms reconcile tick — the 4×/s "failed to subscribe" hot-loop
+    /// (observed ~49k warnings over 3.4h on one wedged-retiring alias).
+    #[test]
+    fn forwarder_only_subscribes_active_members() {
+        assert!(forwarder_should_subscribe(MobMemberStatus::Active));
+        assert!(!forwarder_should_subscribe(MobMemberStatus::Retiring));
+        assert!(!forwarder_should_subscribe(MobMemberStatus::Broken));
+        assert!(!forwarder_should_subscribe(MobMemberStatus::Completed));
+        assert!(!forwarder_should_subscribe(MobMemberStatus::Unknown));
+    }
+
+    /// The backoff for a persistently-failing Active subscribe must grow from
+    /// one reconcile tick and cap, so even a genuinely stuck member retries at
+    /// most ~once per cap instead of 4×/s.
+    #[test]
+    fn subscribe_backoff_grows_and_caps() {
+        assert_eq!(subscribe_backoff_delay(0), SUBSCRIBE_BACKOFF_BASE);
+        assert_eq!(subscribe_backoff_delay(1), SUBSCRIBE_BACKOFF_BASE * 2);
+        assert_eq!(subscribe_backoff_delay(3), SUBSCRIBE_BACKOFF_BASE * 8);
+        assert_eq!(subscribe_backoff_delay(7), SUBSCRIBE_BACKOFF_MAX);
+        // Saturates at the cap for arbitrarily many failures (no shift overflow).
+        assert_eq!(subscribe_backoff_delay(50), SUBSCRIBE_BACKOFF_MAX);
+        assert!(subscribe_backoff_delay(2) > subscribe_backoff_delay(1));
     }
 }

--- a/meerkat-mobkit/tests/gating_policy.rs
+++ b/meerkat-mobkit/tests/gating_policy.rs
@@ -478,6 +478,52 @@ fn phase12_risk_tiers_and_timeout_fallback_are_wired_with_audit() {
     );
 }
 
+/// Regression: a caller-supplied R3 approval timeout must be clamped so the
+/// deadline can't saturate past `u64::MAX` and become a never-expiring pending
+/// approval. With a huge `approval_timeout_ms` the pending entry's
+/// `deadline_at_ms` must stay finite (≈ now + 7d), keeping the
+/// timeout-to-safe-draft fallback reachable.
+#[test]
+fn r3_approval_timeout_is_clamped_so_deadline_never_saturates() {
+    let mut runtime = runtime_for_gating();
+    let _evaluated = parse_response(&handle_mobkit_rpc_json(
+        &mut runtime,
+        &json!({
+            "jsonrpc":"2.0",
+            "id":"clamp-r3",
+            "method":"mobkit/gating/evaluate",
+            "params":{
+                "action":"delete_prod_data",
+                "actor_id":"agent-clamp",
+                "risk_tier":"r3",
+                "approval_timeout_ms": u64::MAX
+            }
+        })
+        .to_string(),
+        Duration::from_secs(1),
+    ));
+    let pending = parse_response(&handle_mobkit_rpc_json(
+        &mut runtime,
+        r#"{"jsonrpc":"2.0","id":"clamp-pending","method":"mobkit/gating/pending","params":{}}"#,
+        Duration::from_secs(1),
+    ));
+    runtime.shutdown();
+
+    let entry = pending["result"]["pending"]
+        .as_array()
+        .and_then(|entries| entries.first())
+        .expect("one pending approval");
+    let created = entry["created_at_ms"].as_u64().expect("created_at_ms");
+    let deadline = entry["deadline_at_ms"].as_u64().expect("deadline_at_ms");
+    assert!(
+        deadline < u64::MAX,
+        "deadline must not saturate: {deadline}"
+    );
+    // Clamped to the 7-day ceiling, not the u64::MAX request.
+    let seven_days_ms = 7 * 24 * 60 * 60 * 1_000;
+    assert_eq!(deadline, created.saturating_add(seven_days_ms));
+}
+
 #[test]
 #[ignore]
 fn phase12_r3_notification_records_error_when_delivery_status_not_sent() {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.1"
+version = "0.7.2"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Follow-up to 0.7.1. Fixes the console agent-event forwarder hot-loop
(reported: ~49k "failed to subscribe" warnings over 3.4h on a single
wedged-retiring alias) plus three more same-family lifecycle bugs found
in a wedging-bug sweep.

- **Forwarder** (`unified_runtime`): only subscribe `Active` members; a
  retiring member with stale binding atoms no longer spins subscribe at
  the 250ms tick (4×/s). Active-member failures get exponential backoff +
  first-failure-only logging.
- **Lease renewal** (`identity_first/runtime`): persistent provider
  failure backs off (1s→60s) instead of retrying at the TTL-derived
  floor (down to 10ms).
- **Session-history backfill** (`console_aggregator`): read-error stamps
  a watermark (freshness gate throttles retries to once/30s) and the gap
  dedupe key is stable per (runtime, identity, session) — was unbounded
  timeline growth.
- **Gating R3** (`runtime/gating`): clamp `approval_timeout_ms` to 7 days
  so the deadline can't saturate to `u64::MAX` and never expire.

Regression tests for each. Version bumped to 0.7.2 (SDKs lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)