### PR TITLE
MobKit 0.7.3: export member_comms_id codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -18,7 +18,7 @@ pub mod http_auth;
 pub mod http_console;
 pub mod http_flow_editor;
 pub mod http_sse;
-pub(crate) mod member_comms_id;
+pub mod member_comms_id;
 pub mod mob_handle_runtime;
 pub mod mobpack;
 pub mod mocks;

--- a/meerkat-mobkit/src/member_comms_id.rs
+++ b/meerkat-mobkit/src/member_comms_id.rs
@@ -26,6 +26,13 @@
 //!   on ids that were never encoded. The `mk--` prefix is a reserved
 //!   namespace: user-chosen member names must not start with it (encode
 //!   re-encodes such names so the round-trip still holds).
+//!
+//! This is a **public stability surface**: consumers that talk to raw
+//! `MobHandle` APIs (which speak the encoded roster-id space on meerkat 0.7+)
+//! must encode aliases on the way in and decode roster ids on the way out
+//! using exactly this codec — there is no separate "correct" encoding. Use
+//! [`mob_member_id`]/[`mob_member_id_str`] at the mobkit→meerkat-mob boundary
+//! and [`runtime_alias_str`]/[`runtime_event_alias`] at projection boundaries.
 
 use std::borrow::Cow;
 
@@ -94,7 +101,7 @@ fn unescape_body(s: &str) -> Option<String> {
 
 /// Map a public member alias (identity-first runtime id, durable identity, or
 /// plain member name) to the comms-safe mob roster member id string.
-pub(crate) fn mob_member_id_str(alias: &str) -> Cow<'_, str> {
+pub fn mob_member_id_str(alias: &str) -> Cow<'_, str> {
     if is_valid_comms_component(alias) && !alias.starts_with(MARKER) {
         Cow::Borrowed(alias)
     } else {
@@ -103,13 +110,13 @@ pub(crate) fn mob_member_id_str(alias: &str) -> Cow<'_, str> {
 }
 
 /// Map a public member alias to a typed mob roster member id.
-pub(crate) fn mob_member_id(alias: &str) -> meerkat_mob::ids::AgentIdentity {
+pub fn mob_member_id(alias: &str) -> meerkat_mob::ids::AgentIdentity {
     meerkat_mob::ids::AgentIdentity::from(mob_member_id_str(alias).as_ref())
 }
 
 /// Map a mob roster member id back to the public member alias. Identity on
 /// ids that were never encoded.
-pub(crate) fn runtime_alias_str(member_id: &str) -> Cow<'_, str> {
+pub fn runtime_alias_str(member_id: &str) -> Cow<'_, str> {
     match member_id.strip_prefix(MARKER) {
         Some(body) => match unescape_body(body) {
             Some(alias) => Cow::Owned(alias),
@@ -128,7 +135,7 @@ pub(crate) fn runtime_alias_str(member_id: &str) -> Cow<'_, str> {
 /// so it must be decoded before any console/SDK projection — console replay
 /// resolution, the `mobkit/events/subscribe` buffer, `/mob/events` SSE, and
 /// per-agent ABAC view checks all speak the alias space.
-pub(crate) fn runtime_event_alias(runtime_id: &meerkat_mob::ids::AgentRuntimeId) -> String {
+pub fn runtime_event_alias(runtime_id: &meerkat_mob::ids::AgentRuntimeId) -> String {
     format!(
         "{}:{}",
         runtime_alias_str(runtime_id.identity.as_str()),

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.2"
+version = "0.7.3"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Makes the `member_comms_id` alias↔roster-id codec a public, documented
stability surface (was `pub(crate)`). Consumers that drive raw
`MobHandle` APIs — which speak the encoded roster-id space on meerkat
0.7+ — can now call `meerkat_mobkit::member_comms_id::{mob_member_id,
mob_member_id_str, runtime_alias_str, runtime_event_alias}` instead of
vendoring a byte-for-byte copy of the encoder.

Pure visibility change (no behavior change); the escape productions stay
encapsulated behind the four mapping functions. Version 0.7.3 (SDKs
lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)