### PR TITLE
Release 0.7.8: ship rpc_gateway, gateway --version + fail-loud guard, backfill livelock fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,21 +153,31 @@ jobs:
             # root to get the real file (this was the v0.7.5 attach bug).
             package_bin() {
               local bazel_target="$1" archive_prefix="$2"
-              local relbin bin
-              relbin=$(bb --output_base="${ob}" cquery --config="${cfg}" --compilation_mode=opt \
-                  "${hdr[@]}" --output=files "${bazel_target}" 2>/dev/null | tail -1)
+              local binname="${bazel_target##*:}"
+              local relbin bin files
+              files=$(bb --output_base="${ob}" cquery --config="${cfg}" --compilation_mode=opt \
+                  "${hdr[@]}" --output=files "${bazel_target}" 2>/dev/null)
+              # Prefer the output whose basename is the bin target (so we never pick
+              # an aux output like a windows .pdb); fall back to the last line.
+              relbin=$(printf '%s\n' "${files}" | grep -E "/${binname}(\.exe)?$" | tail -1)
+              [ -n "${relbin}" ] || relbin=$(printf '%s\n' "${files}" | tail -1)
               bin="${execroot}/${relbin}"
               if [ -z "${relbin}" ] || [ ! -f "${bin}" ]; then
                 echo "::error::missing binary ${bazel_target} for ${target}: '${bin}'"; tail -40 "${log}"; return 1
               fi
               local name="${archive_prefix}-${VERSION}-${target}.${ext}"
+              local out="${GITHUB_WORKSPACE}/dist/${name}"
               if [ "${ext}" = "zip" ]; then
                 # The self-hosted runner has no `zip`; build the archive with python.
-                python3 -c 'import sys,os,zipfile; z=zipfile.ZipFile(sys.argv[2],"w",zipfile.ZIP_DEFLATED); z.write(sys.argv[1],arcname=os.path.basename(sys.argv[1])); z.close()' "${bin}" "${GITHUB_WORKSPACE}/dist/${name}"
+                python3 -c 'import sys,os,zipfile; z=zipfile.ZipFile(sys.argv[2],"w",zipfile.ZIP_DEFLATED); z.write(sys.argv[1],arcname=os.path.basename(sys.argv[1])); z.close()' "${bin}" "${out}" \
+                  || { echo "::error::failed to zip ${name}"; return 1; }
               else
-                tar -czf "dist/${name}" -C "$(dirname "${bin}")" "$(basename "${bin}")"
+                tar -czf "${out}" -C "$(dirname "${bin}")" "$(basename "${bin}")" \
+                  || { echo "::error::failed to tar ${name}"; return 1; }
               fi
-              echo "packaged dist/${name} ($(du -h "dist/${name}" | cut -f1))"
+              # Catch silent packaging failure / truncation before reporting success.
+              [ -s "${out}" ] || { echo "::error::archive ${name} missing or empty after packaging"; return 1; }
+              echo "packaged dist/${name} ($(du -h "${out}" | cut -f1))"
             }
             # Ship BOTH: the console/HTTP gateway (mobkit_gateway) and the SDK
             # stdin-RPC gateway (rpc_gateway). SDK users need rpc_gateway; before

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,35 +134,48 @@ jobs:
             # Retry the whole invocation: hosted RBE occasionally drops a task
             # ("stream closed with task still claimed") and fails after bazel's own
             # per-action retries; re-invoking resumes from cache and usually succeeds.
+            # Build BOTH gateways in one invocation so they share the (expensive)
+            # meerkat-mobkit lib compile; linking the second bin is cheap.
             until bb --output_base="${ob}" build --config="${cfg}" --compilation_mode=opt \
                 --jobs=200 "${hdr[@]}" --remote_download_outputs=toplevel \
-                //meerkat-mobkit:mobkit_gateway_bin >"${log}" 2>&1; do
+                //meerkat-mobkit:mobkit_gateway_bin //meerkat-mobkit:rpc_gateway_bin >"${log}" 2>&1; do
               n=$((n+1))
               if [ "${n}" -ge 3 ]; then
                 echo "::error::build ${target} failed after ${n} attempts"; tail -40 "${log}"; return 1
               fi
               echo "::warning::transient RBE failure on ${target}; retry ${n}/3"; sleep 20
             done
-            # cquery returns a path relative to the execution root; with
-            # --symlink_prefix=/ there is NO bazel-out convenience symlink in the
-            # workspace, so the relative path doesn't resolve from cwd. Prepend the
-            # execution root to get the real file (this was the v0.7.5 attach bug).
-            local relbin execroot bin
-            relbin=$(bb --output_base="${ob}" cquery --config="${cfg}" --compilation_mode=opt \
-                "${hdr[@]}" --output=files //meerkat-mobkit:mobkit_gateway_bin 2>/dev/null | tail -1)
+            local execroot
             execroot=$(bb --output_base="${ob}" info execution_root 2>/dev/null)
-            bin="${execroot}/${relbin}"
-            if [ -z "${relbin}" ] || [ ! -f "${bin}" ]; then
-              echo "::error::missing binary for ${target}: '${bin}'"; tail -40 "${log}"; return 1
-            fi
-            local name="mobkit-gateway-${VERSION}-${target}.${ext}"
-            if [ "${ext}" = "zip" ]; then
-              # The self-hosted runner has no `zip`; build the archive with python.
-              python3 -c 'import sys,os,zipfile; z=zipfile.ZipFile(sys.argv[2],"w",zipfile.ZIP_DEFLATED); z.write(sys.argv[1],arcname=os.path.basename(sys.argv[1])); z.close()' "${bin}" "${GITHUB_WORKSPACE}/dist/${name}"
-            else
-              tar -czf "dist/${name}" -C "$(dirname "${bin}")" "$(basename "${bin}")"
-            fi
-            echo "packaged dist/${name} ($(du -h "dist/${name}" | cut -f1))"
+            # Package one bazel binary target into its own archive. cquery returns a
+            # path relative to the execution root; with --symlink_prefix=/ there is NO
+            # bazel-out convenience symlink in the workspace, so prepend the execution
+            # root to get the real file (this was the v0.7.5 attach bug).
+            package_bin() {
+              local bazel_target="$1" archive_prefix="$2"
+              local relbin bin
+              relbin=$(bb --output_base="${ob}" cquery --config="${cfg}" --compilation_mode=opt \
+                  "${hdr[@]}" --output=files "${bazel_target}" 2>/dev/null | tail -1)
+              bin="${execroot}/${relbin}"
+              if [ -z "${relbin}" ] || [ ! -f "${bin}" ]; then
+                echo "::error::missing binary ${bazel_target} for ${target}: '${bin}'"; tail -40 "${log}"; return 1
+              fi
+              local name="${archive_prefix}-${VERSION}-${target}.${ext}"
+              if [ "${ext}" = "zip" ]; then
+                # The self-hosted runner has no `zip`; build the archive with python.
+                python3 -c 'import sys,os,zipfile; z=zipfile.ZipFile(sys.argv[2],"w",zipfile.ZIP_DEFLATED); z.write(sys.argv[1],arcname=os.path.basename(sys.argv[1])); z.close()' "${bin}" "${GITHUB_WORKSPACE}/dist/${name}"
+              else
+                tar -czf "dist/${name}" -C "$(dirname "${bin}")" "$(basename "${bin}")"
+              fi
+              echo "packaged dist/${name} ($(du -h "dist/${name}" | cut -f1))"
+            }
+            # Ship BOTH: the console/HTTP gateway (mobkit_gateway) and the SDK
+            # stdin-RPC gateway (rpc_gateway). SDK users need rpc_gateway; before
+            # 0.7.8 only the console gateway was published, so SDK setups that
+            # grabbed the release binary ran the wrong one and hung on the first
+            # post-init RPC (the HomeCore reconcile "deadlock").
+            package_bin //meerkat-mobkit:mobkit_gateway_bin mobkit-gateway || return 1
+            package_bin //meerkat-mobkit:rpc_gateway_bin mobkit-rpc-gateway || return 1
           }
 
           pids=(); labels=()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.4",
+        "CARGO_PKG_VERSION": "0.7.8",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -537,6 +537,16 @@ fn init_error(request_id: Value, code: i64, message: String) -> Value {
 }
 
 fn main() {
+    if std::env::args()
+        .skip(1)
+        .any(|a| a == "--version" || a == "-V")
+    {
+        println!(
+            "mobkit_gateway {} (meerkat-mobkit console/HTTP gateway)",
+            env!("CARGO_PKG_VERSION")
+        );
+        return;
+    }
     // Meerkat 0.7's generated machine-authority apply path needs deep worker
     // stacks (mirrors meerkat-rpc's explicit 16 MiB tokio worker sizing).
     let runtime = match tokio::runtime::Builder::new_multi_thread()
@@ -817,12 +827,56 @@ async fn run() -> anyhow::Result<()> {
     ));
 
     let decisions = runtime_decision_state(&runtime_id, console_ui, console_read_only);
-    axum::serve(listener, runtime.build_reference_app_router(decisions))
-        .with_graceful_shutdown(async {
+    let app = runtime.build_reference_app_router(decisions);
+
+    // `mobkit_gateway` serves the console/admin API over HTTP. It is NOT the
+    // SDK's stdin JSON-RPC gateway — that is the separate `rpc_gateway` binary.
+    // The SDK's PersistentTransport drives a gateway by sending JSON-RPC lines
+    // (init, then reconcile_identity, send, ...) over stdin; we already consumed
+    // the single init line above. If more JSON-RPC arrives on stdin, this binary
+    // was misconfigured as the SDK gateway (a common mix-up, since the SDK env
+    // var is named MOBKIT_RPC_GATEWAY_BIN and the release ships this binary).
+    // Answer each such line with a clear JSON-RPC error instead of silently
+    // ignoring it, so the SDK surfaces an actionable failure immediately rather
+    // than blocking forever waiting for a response that never comes.
+    let stdin_guard = async move {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) | Err(_) => break, // launching parent closed stdin
+                Ok(_) => {}
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let id = serde_json::from_str::<Value>(trimmed)
+                .ok()
+                .and_then(|value| value.get("id").cloned())
+                .unwrap_or(Value::Null);
+            print_json_line(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": -32601,
+                    "message": "mobkit_gateway serves the console/admin API over HTTP and does not handle SDK stdin JSON-RPC after init. Point your SDK gateway path (MOBKIT_RPC_GATEWAY_BIN) at the 'rpc_gateway' binary instead."
+                }
+            }));
+        }
+        // stdin ended: keep serving HTTP until ctrl-c rather than tearing down
+        // the console out from under any live HTTP clients.
+        std::future::pending::<()>().await;
+    };
+
+    tokio::select! {
+        result = axum::serve(listener, app).with_graceful_shutdown(async {
             let _ = tokio::signal::ctrl_c().await;
-        })
-        .await
-        .context("gateway HTTP server failed")?;
+        }) => {
+            result.context("gateway HTTP server failed")?;
+        }
+        () = stdin_guard => {}
+    }
 
     let mut registry = load_registry(&registry_file);
     registry.entries.retain(|entry| entry.key != key);

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -2341,6 +2341,13 @@ external_addressable = true
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!(
+            "rpc_gateway {} (meerkat-mobkit SDK stdin-RPC gateway)",
+            env!("CARGO_PKG_VERSION")
+        );
+        return;
+    }
     if args.iter().any(|a| a == "--persistent") {
         run_persistent();
     } else {

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -2341,7 +2341,7 @@ external_addressable = true
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    if args.iter().any(|a| a == "--version" || a == "-V") {
+    if args.iter().skip(1).any(|a| a == "--version" || a == "-V") {
         println!(
             "rpc_gateway {} (meerkat-mobkit SDK stdin-RPC gateway)",
             env!("CARGO_PKG_VERSION")

--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -3068,7 +3068,23 @@ async fn backfill_one_session_history(
                 append_and_emit(&inner, frame).await?;
             }
         }
-        offset = base_offset + messages.len();
+        let Some(next_offset) = advance_backfill_offset(offset, base_offset, messages.len()) else {
+            // Forward-progress guard: a session store that returns a page whose
+            // (base_offset + len) does not advance past the offset we requested
+            // — e.g. a cursor that resets to 0 while still reporting has_more —
+            // would make this loop re-read the same page forever, re-recording
+            // the same watermark (a livelock observed on an orphaned gateway).
+            // Stop instead of spinning; the last good watermark stands.
+            tracing::warn!(
+                session_id = %session_id,
+                requested_offset = offset,
+                page_base_offset = base_offset,
+                page_len = messages.len(),
+                "session history backfill made no forward progress; stopping to avoid a livelock"
+            );
+            break;
+        };
+        offset = next_offset;
         record_session_history_watermark(&inner, &watermark_runtime_key, &session_id, offset)
             .await?;
         let has_more = page_value
@@ -3080,6 +3096,19 @@ async fn backfill_one_session_history(
         }
     }
     Ok(())
+}
+
+/// Compute the next session-history backfill offset, enforcing strict forward
+/// progress. Returns `None` when the page (`base_offset + page_len`) does not
+/// advance past `requested_offset` — a non-advancing/looping cursor — which
+/// signals the caller to stop rather than re-read the same page forever.
+fn advance_backfill_offset(
+    requested_offset: usize,
+    base_offset: usize,
+    page_len: usize,
+) -> Option<usize> {
+    let next = base_offset.saturating_add(page_len);
+    (next > requested_offset).then_some(next)
 }
 
 async fn record_session_history_watermark(
@@ -8780,6 +8809,28 @@ comms = true
             session_history_watermark_runtime_key("runtime-a", "session-1"),
             session_history_watermark_runtime_key("runtime-a", "session-2")
         );
+    }
+
+    #[test]
+    fn backfill_offset_advances_only_on_strict_forward_progress() {
+        // Normal full-page advance from the start.
+        assert_eq!(advance_backfill_offset(0, 0, 500), Some(500));
+        // Subsequent full page from a correct cursor advances.
+        assert_eq!(advance_backfill_offset(500, 500, 500), Some(1000));
+        // A partial page that still moves forward advances.
+        assert_eq!(advance_backfill_offset(500, 500, 3), Some(503));
+        // One element past the requested offset still counts as progress.
+        assert_eq!(advance_backfill_offset(499, 0, 500), Some(500));
+
+        // Livelock shapes: the store re-serves a page whose (base + len) does
+        // NOT advance past what we asked for. These must stop the loop.
+        assert_eq!(advance_backfill_offset(500, 0, 500), None); // cursor reset to 0, full page
+        assert_eq!(advance_backfill_offset(500, 0, 400), None); // strictly behind
+        assert_eq!(advance_backfill_offset(1000, 500, 500), None); // lands exactly on offset
+        assert_eq!(advance_backfill_offset(10, 10, 0), None); // empty page at same offset
+
+        // Saturating add: a pathological base near usize::MAX cannot panic.
+        assert_eq!(advance_backfill_offset(0, usize::MAX, 5), Some(usize::MAX));
     }
 
     #[test]

--- a/meerkat-mobkit/src/member_comms_id.rs
+++ b/meerkat-mobkit/src/member_comms_id.rs
@@ -223,4 +223,230 @@ mod tests {
             );
         }
     }
+
+    // --- Defensive suite: map the whole id codec + reconciliation aliases ---
+
+    /// The exact identities + runtime-id forms from the HomeCore deployment
+    /// that surfaced the meerkat 0.7 comms-name regression, plus the escape
+    /// productions. Every entry must encode to a comms-safe id and round-trip.
+    fn defensive_corpus() -> Vec<String> {
+        let mut v: Vec<String> = [
+            // Plain definition-mob names (pass through unchanged).
+            "worker",
+            "worker-one",
+            "_internal",
+            "Agent7",
+            "a",
+            // HomeCore durable identities (colon-bearing).
+            "identity:parent-1",
+            "identity:parent-2",
+            "identity:child-1",
+            "identity:child-2",
+            "domain:calendar",
+            "domain:school",
+            "domain:health",
+            "domain:home",
+            "domain:home-automation",
+            "domain:finance",
+            "domain:discovery",
+            "family-group:main",
+            "triage:main",
+            "gate:main",
+            // Runtime-id shaped aliases (`rt:{identity}:{generation}`).
+            "rt:identity:parent-1:0",
+            "rt:domain:home-automation:3",
+            "rt:channel:C0SMOKEOB3:0",
+            "rt:review:singleton:12",
+            // Mixed punctuation / boundary shapes.
+            "a:b_c",
+            "with_underscore:and:colons",
+            "user@host",
+            "a.b:c",
+            "9starts-with-digit",
+            "::",
+            ":",
+            "-",
+            "mk--collision",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        // Non-ASCII, multi-byte, and control characters.
+        v.push("ünïcode:1".to_string());
+        v.push("emoji-😀:2".to_string());
+        v.push("Ω≈ç:3".to_string());
+        v.push("tab\tnl\n".to_string());
+        v.push("\u{0}\u{1f}x".to_string());
+        v.push("a b".to_string());
+        v.push(String::new());
+        v
+    }
+
+    #[test]
+    fn homecore_corpus_round_trips_and_is_comms_safe() {
+        for alias in defensive_corpus() {
+            let encoded = mob_member_id_str(&alias).into_owned();
+            assert!(
+                is_valid_comms_component(&encoded),
+                "encoded {encoded:?} (from {alias:?}) is not a valid comms component"
+            );
+            assert!(
+                !encoded.contains([':', '/']),
+                "encoded {encoded:?} leaks a routing separator"
+            );
+            assert_eq!(
+                runtime_alias_str(&encoded),
+                alias,
+                "round trip of {alias:?}"
+            );
+        }
+    }
+
+    /// The load-bearing guard: the codec's output must be accepted by meerkat
+    /// 0.7's own fail-closed comms-name validator — the exact check that
+    /// rejected `rt:identity:parent-1:0` before this codec existed. If meerkat
+    /// tightens `MemberCommsName` again, this test fails instead of HomeCore.
+    #[test]
+    fn encoded_ids_satisfy_meerkat_member_comms_name_validator() {
+        use meerkat_core::connection::MemberCommsName;
+        for alias in defensive_corpus() {
+            let encoded = mob_member_id_str(&alias).into_owned();
+            assert!(
+                MemberCommsName::new("homecore-mob", "worker", encoded.clone()).is_ok(),
+                "MemberCommsName::new rejected encoded id {encoded:?} (from alias {alias:?})"
+            );
+        }
+    }
+
+    /// Pin the on-the-wire encoding so an accidental codec change is caught.
+    #[test]
+    fn exact_wire_format_for_known_aliases() {
+        let cases = [
+            ("worker-one", "worker-one"), // already comms-safe -> pass through
+            ("identity:parent-1", "mk--identity_cparent-1"),
+            ("domain:home-automation", "mk--domain_chome-automation"),
+            ("family-group:main", "mk--family-group_cmain"),
+            ("rt:identity:parent-1:0", "mk--rt_cidentity_cparent-1_c0"),
+            ("triage:main", "mk--triage_cmain"),
+            ("a:b_c", "mk--a_cb__c"),
+            ("a b", "mk--a_x20_b"),
+            ("", "mk--"),
+        ];
+        for (alias, expected) in cases {
+            assert_eq!(mob_member_id_str(alias), expected, "encode {alias:?}");
+            assert_eq!(runtime_alias_str(expected), alias, "decode {expected:?}");
+        }
+    }
+
+    /// Ids that begin with the marker but are not well-formed escape productions
+    /// must decode to themselves (literal fallback) and never panic.
+    #[test]
+    fn malformed_encoded_bodies_decode_to_literal_without_panic() {
+        for bad in [
+            "mk--_",           // dangling underscore (no escape selector)
+            "mk--_z",          // invalid escape selector
+            "mk--_x",          // truncated hex escape (no terminator)
+            "mk--_x_",         // empty hex body
+            "mk--_xZZ_",       // non-hex digits
+            "mk--_x110000_",   // code point above the Unicode max
+            "mk--_xffffffff_", // parses as u32 but is not a valid char
+            "mk--abc_",        // trailing dangling underscore after a valid run
+        ] {
+            assert_eq!(runtime_alias_str(bad), bad, "literal fallback for {bad:?}");
+        }
+    }
+
+    /// Empty, single-character, and marker-adjacent inputs all round-trip.
+    #[test]
+    fn empty_and_boundary_strings_round_trip() {
+        // Empty alias is not a valid comms component, so it becomes the bare
+        // marker and decodes back to empty.
+        assert_eq!(mob_member_id_str(""), "mk--");
+        assert_eq!(runtime_alias_str("mk--"), "");
+        for alias in [":", "_", "-", "::", "_x", "mk", "mk-", "mk--"] {
+            let encoded = mob_member_id_str(alias).into_owned();
+            assert!(
+                is_valid_comms_component(&encoded),
+                "{encoded:?} not comms-safe"
+            );
+            assert_eq!(runtime_alias_str(&encoded), alias, "round trip {alias:?}");
+        }
+    }
+
+    /// Decode only applies inside the reserved marker namespace; a raw id that
+    /// merely *looks* like an escape body must pass through untouched.
+    #[test]
+    fn decode_is_identity_on_unencoded_ids() {
+        for id in [
+            "worker",
+            "worker-one",
+            "_internal",
+            "Agent7",
+            "rt-review-singleton-0",
+            "a_cb", // not marker-prefixed -> NOT decoded to "a:b"
+        ] {
+            assert_eq!(runtime_alias_str(id), id);
+        }
+    }
+
+    #[test]
+    fn runtime_event_alias_across_generations_and_forms() {
+        use meerkat_mob::ids::{AgentIdentity, AgentRuntimeId, Generation};
+
+        let encoded = mob_member_id_str("rt:identity:parent-1:0").into_owned();
+        let rid = AgentRuntimeId::new(AgentIdentity::from(encoded.as_str()), Generation::new(7));
+        assert_eq!(runtime_event_alias(&rid), "rt:identity:parent-1:0:7");
+
+        let encoded = mob_member_id_str("domain:home-automation").into_owned();
+        let rid = AgentRuntimeId::new(AgentIdentity::from(encoded.as_str()), Generation::new(1));
+        assert_eq!(runtime_event_alias(&rid), "domain:home-automation:1");
+
+        // Plain member name keeps its initial generation.
+        let rid = AgentRuntimeId::initial(AgentIdentity::from("triage-main"));
+        assert_eq!(runtime_event_alias(&rid), "triage-main:0");
+    }
+
+    /// Exhaustive total round-trip + comms-safety + injectivity over every
+    /// string of length 0..=3 from a charset that exercises every escape branch.
+    #[test]
+    fn round_trip_is_total_and_injective_over_generated_corpus() {
+        use meerkat_core::connection::MemberCommsName;
+        use std::collections::BTreeMap;
+
+        let charset = ['a', 'Z', '0', '-', '_', ':', '.', '@', ' ', 'ü', '😀'];
+        let mut aliases: Vec<String> = vec![String::new()];
+        let mut frontier = vec![String::new()];
+        for _ in 0..3 {
+            let mut next = Vec::new();
+            for prefix in &frontier {
+                for c in charset {
+                    let mut s = prefix.clone();
+                    s.push(c);
+                    aliases.push(s.clone());
+                    next.push(s);
+                }
+            }
+            frontier = next;
+        }
+
+        let mut encoded_to_alias: BTreeMap<String, String> = BTreeMap::new();
+        for alias in &aliases {
+            let encoded = mob_member_id_str(alias).into_owned();
+            assert!(
+                MemberCommsName::new("m", "r", encoded.clone()).is_ok(),
+                "encoded {encoded:?} (from {alias:?}) is not comms-safe"
+            );
+            assert_eq!(
+                &runtime_alias_str(&encoded).into_owned(),
+                alias,
+                "round trip of {alias:?}"
+            );
+            if let Some(prev) = encoded_to_alias.insert(encoded.clone(), alias.clone()) {
+                assert_eq!(
+                    &prev, alias,
+                    "collision: {prev:?} and {alias:?} both encode to {encoded:?}"
+                );
+            }
+        }
+    }
 }

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -121,3 +121,110 @@ fn mobkit_gateway_bootstraps_ephemeral_runtime() {
 fn mobkit_gateway_bootstraps_persistent_runtime() {
     assert_bootstraps(true);
 }
+
+/// Both gateway binaries must self-identify via `--version` (name + version),
+/// so operators can tell which of the two they have without hashing the file —
+/// the gap that turned a mislabeled binary into a multi-day investigation.
+#[test]
+fn gateways_report_name_and_version() {
+    for (bin, needle) in [
+        (env!("CARGO_BIN_EXE_mobkit_gateway"), "mobkit_gateway"),
+        (env!("CARGO_BIN_EXE_rpc_gateway"), "rpc_gateway"),
+    ] {
+        let out = Command::new(bin)
+            .arg("--version")
+            .output()
+            .expect("run --version");
+        assert!(out.status.success(), "{needle} --version exited non-zero");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains(needle) && stdout.chars().any(|c| c.is_ascii_digit()),
+            "{needle} --version did not print name + version: {stdout:?}"
+        );
+    }
+}
+
+/// `mobkit_gateway` is the console/HTTP gateway, not the SDK's stdin-RPC gateway
+/// (that is `rpc_gateway`). If the SDK — which drives a gateway by sending
+/// JSON-RPC over stdin — is misconfigured to spawn `mobkit_gateway`, init still
+/// succeeds (one stdin line), but the *next* RPC must get a clear error instead
+/// of an infinite hang. This is the regression test for the HomeCore reconcile
+/// "deadlock": before the fail-loud guard, `mobkit_gateway` read only the init
+/// line and then served HTTP forever, silently ignoring `reconcile_identity`.
+#[test]
+fn mobkit_gateway_rejects_post_init_stdin_rpc_loudly() {
+    let bin = env!("CARGO_BIN_EXE_mobkit_gateway");
+    let workspace = TempDir::new().expect("workspace tempdir");
+    let store = TempDir::new().expect("store tempdir");
+
+    let init = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "mobkit/init",
+        "params": {
+            "workspace_root": workspace.path().to_string_lossy(),
+            "store_path": store.path().join("store").to_string_lossy(),
+        }
+    });
+    let reconcile =
+        json!({ "jsonrpc": "2.0", "id": 2, "method": "mobkit/reconcile_identity", "params": {} });
+
+    let mut child = Command::new(bin)
+        .current_dir(workspace.path())
+        .env("ANTHROPIC_API_KEY", "sk-ant-regression-test")
+        .env("OPENAI_API_KEY", "sk-regression-test")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mobkit_gateway");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(l) => {
+                    if tx.send(l).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    writeln!(stdin, "{}", serde_json::to_string(&init).unwrap()).expect("write init");
+    stdin.flush().expect("flush init");
+    let init_resp = rx
+        .recv_timeout(Duration::from_secs(45))
+        .expect("no init response within 45s");
+    let init_v: Value = serde_json::from_str(init_resp.trim())
+        .unwrap_or_else(|e| panic!("non-JSON init response {init_resp:?}: {e}"));
+    assert!(
+        init_v.get("result").is_some(),
+        "init did not return a result (cannot exercise the post-init guard): {init_resp}"
+    );
+
+    writeln!(stdin, "{}", serde_json::to_string(&reconcile).unwrap()).expect("write reconcile");
+    stdin.flush().expect("flush reconcile");
+    let reconcile_resp = rx.recv_timeout(Duration::from_secs(20)).expect(
+        "mobkit_gateway did not answer a post-init stdin RPC within 20s — the silent-hang regressed",
+    );
+
+    drop(stdin);
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let v: Value = serde_json::from_str(reconcile_resp.trim())
+        .unwrap_or_else(|e| panic!("non-JSON reconcile response {reconcile_resp:?}: {e}"));
+    let msg = v
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("rpc_gateway"),
+        "post-init stdin RPC must fail loudly and point at rpc_gateway, got: {reconcile_resp}"
+    );
+}

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -137,9 +137,12 @@ fn gateways_report_name_and_version() {
             .expect("run --version");
         assert!(out.status.success(), "{needle} --version exited non-zero");
         let stdout = String::from_utf8_lossy(&out.stdout);
+        // Assert the ACTUAL crate version, not just "some digit", so this test
+        // catches a stale/wrong baked-in version (the BUILD.bazel drift class).
         assert!(
-            stdout.contains(needle) && stdout.chars().any(|c| c.is_ascii_digit()),
-            "{needle} --version did not print name + version: {stdout:?}"
+            stdout.contains(needle) && stdout.contains(env!("CARGO_PKG_VERSION")),
+            "{needle} --version did not print name + version {}: {stdout:?}",
+            env!("CARGO_PKG_VERSION")
         );
     }
 }

--- a/scripts/bump-sdk-versions.sh
+++ b/scripts/bump-sdk-versions.sh
@@ -42,6 +42,21 @@ fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
     echo "  TypeScript SDK: $VERSION"
 fi
 
+# TypeScript SDK lockfile — the root package version lives in two places
+# (top-level + packages['']). Keep it in lockstep so it can't drift (it was
+# stale at 0.7.4 across 0.7.5–0.7.7).
+if [ -f "$ROOT/sdk/typescript/package-lock.json" ]; then
+    node -e "
+const fs = require('fs');
+const p = '$ROOT/sdk/typescript/package-lock.json';
+const lock = JSON.parse(fs.readFileSync(p, 'utf8'));
+lock.version = '$VERSION';
+if (lock.packages && lock.packages['']) lock.packages[''].version = '$VERSION';
+fs.writeFileSync(p, JSON.stringify(lock, null, 2) + '\n');
+"
+    echo "  TypeScript SDK lockfile: $VERSION"
+fi
+
 # Bazel build rules embed the crate version via rustc_env, which feeds
 # env!("CARGO_PKG_VERSION") in the bazel-built RELEASE binaries (e.g. their
 # `--version` output). Keep it in lockstep so released gateways don't report a

--- a/scripts/bump-sdk-versions.sh
+++ b/scripts/bump-sdk-versions.sh
@@ -42,4 +42,13 @@ fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
     echo "  TypeScript SDK: $VERSION"
 fi
 
+# Bazel build rules embed the crate version via rustc_env, which feeds
+# env!("CARGO_PKG_VERSION") in the bazel-built RELEASE binaries (e.g. their
+# `--version` output). Keep it in lockstep so released gateways don't report a
+# stale version (this drifted to 0.7.4 across 0.7.5–0.7.7 before being caught).
+if [ -f "$ROOT/meerkat-mobkit/BUILD.bazel" ]; then
+    sedi -E "s/\"CARGO_PKG_VERSION\": \"[^\"]*\"/\"CARGO_PKG_VERSION\": \"$VERSION\"/g" "$ROOT/meerkat-mobkit/BUILD.bazel"
+    echo "  Bazel BUILD.bazel CARGO_PKG_VERSION: $VERSION"
+fi
+
 echo "Done"

--- a/scripts/release-hook.sh
+++ b/scripts/release-hook.sh
@@ -24,7 +24,9 @@ echo "release-hook: verifying version parity"
 echo "release-hook: staging SDK version files"
 git add \
   "$ROOT/sdk/python/pyproject.toml" \
-  "$ROOT/sdk/typescript/package.json"
+  "$ROOT/sdk/typescript/package.json" \
+  "$ROOT/sdk/typescript/package-lock.json" \
+  "$ROOT/meerkat-mobkit/BUILD.bazel"
 
 echo "$VERSION" > "$SENTINEL"
 echo "release-hook: done ($VERSION)"

--- a/scripts/verify-version-parity.sh
+++ b/scripts/verify-version-parity.sh
@@ -54,6 +54,34 @@ if $PKG_OK; then
     green "  Package versions: OK"
 fi
 
+# 2. Bazel rustc_env parity — drives env!("CARGO_PKG_VERSION") in the
+# bazel-built RELEASE binaries (and their --version). Drifted to 0.7.4 across
+# 0.7.5–0.7.7 because nothing checked it; now it does.
+BAZEL_FILE="$ROOT/meerkat-mobkit/BUILD.bazel"
+if [ -f "$BAZEL_FILE" ]; then
+    BAD_BAZEL=$(grep -oE '"CARGO_PKG_VERSION": "[^"]*"' "$BAZEL_FILE" \
+        | grep -v "\"$CARGO_VER\"" | sort -u || true)
+    if [ -n "$BAD_BAZEL" ]; then
+        red "FAIL: BUILD.bazel CARGO_PKG_VERSION entries != $CARGO_VER:"
+        printf '%s\n' "$BAD_BAZEL"
+        FAIL=1
+    else
+        green "  BUILD.bazel CARGO_PKG_VERSION: OK"
+    fi
+fi
+
+# 3. TypeScript SDK lockfile root version parity.
+LOCK_FILE="$ROOT/sdk/typescript/package-lock.json"
+if [ -f "$LOCK_FILE" ]; then
+    LOCK_VER=$(node -p "require('$LOCK_FILE').version" 2>/dev/null || echo "")
+    if [ -n "$LOCK_VER" ] && [ "$LOCK_VER" != "$CARGO_VER" ]; then
+        red "FAIL: package-lock.json version mismatch ($LOCK_VER != $CARGO_VER)"
+        FAIL=1
+    else
+        green "  package-lock.json version: OK"
+    fi
+fi
+
 echo ""
 if [ $FAIL -ne 0 ]; then
     red "Version parity check FAILED"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.7"
+version = "0.7.8"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.4",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.4",
+      "version": "0.7.8",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Root cause (proven)

The 0.7.7 "`reconcile_identity` deadlock" reported by HomeCore was **not** a reconcile/meerkat-mob/lock bug — it was a **gateway-binary mismatch**. The SDK drives a gateway entirely over **stdin JSON-RPC**, but HomeCore was running the **`mobkit_gateway`** binary (console/HTTP — reads one init line, then serves HTTP forever, **no post-init stdin loop**) under the `rpc_gateway` path. So `reconcile_identity` (the 2nd stdin line) was never read and the SDK blocked forever.

Underlying cause: **the release only ever shipped `mobkit_gateway`, never `rpc_gateway`** (the SDK's gateway), so SDK users who grabbed the release binary ran the wrong one. Evidence: init-response shape, `strings` source marker (`src/bin/mobkit_gateway.rs`), the deadlock sample (parked in `axum::serve`, zero reconcile frames), and an empirical init+reconcile probe (mobkit_gateway hangs; rpc_gateway answers in 0.02s).

## Changes

- **`release.yml`** builds + packages **both** gateways (`mobkit-gateway-*` and `mobkit-rpc-gateway-*` archives). The bazel `rpc_gateway_bin` target already existed.
- **`--version`** on both binaries (name + version + role) — tells you which binary you have without hashing it.
- **`mobkit_gateway` fail-loud guard** — a post-init stdin RPC now returns a clear error pointing at `rpc_gateway` instead of hanging.
- **Backfill livelock fix** — forward-progress guard in `console_aggregator::backfill_one_session_history` (the orphaned-gateway spin loop).
- **Defensive tests** — id codec (14, incl. parity vs `meerkat_core::connection::MemberCommsName`), backfill forward-progress, gateway `--version` + fail-loud regression.
- **BUILD.bazel `CARGO_PKG_VERSION`** was stale at `0.7.4` across 0.7.5–0.7.7 (the wrong baked-in `--version`); bumped to 0.7.8 and lockstepped via `bump-sdk-versions.sh`.

## Test status

`make ci` green: fmt ✓ · version-parity ✓ · clippy ✓ · Rust 1145/1146 (the 1 is the documented `routing_delivery phase0_contract_009` load flake — passes 3/3 in isolation) · python 496 ✓ · flow-editor ✓ · audit ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)