### PR TITLE
Release 0.7.9: resume lease fencing counter from persisted high-water on restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.8"
+version = "0.7.9"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.8",
+        "CARGO_PKG_VERSION": "0.7.9",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1761,6 +1761,13 @@ external_addressable = true
             }
             false => None,
         };
+    // The bundled local lease provider's monotonic fencing counter must resume
+    // ABOVE the persisted high-water on restart. Otherwise it resets to 1 and
+    // restore presents a stale token that the store's compare-and-set rejects
+    // ("stale fencing token: presented 1, current N"), aborting boot on every
+    // restart with existing history. Capture the local store's high-water here
+    // and seed the lease provider with it below.
+    let mut local_fencing_floor: u64 = 0;
     let identity_continuity_store: Option<
         Arc<dyn meerkat_mobkit::identity_first::ContinuityStore>,
     > = if has_roster_provider {
@@ -1768,33 +1775,22 @@ external_addressable = true
             Arc::new(meerkat_mobkit::identity_first::GatewayContinuityStore::new(
                 bridge.clone(),
             ))
-        } else if let Some(ref state_path) = persistent_state {
-            Arc::new(
-                meerkat_mobkit::identity_first::LocalContinuityStore::open(
-                    state_path.join("continuity.db"),
-                )
-                .unwrap_or_else(|e| {
-                    fail_init(
-                        &request_id,
-                        -32603,
-                        format!("failed to open continuity store: {e}"),
-                    );
-                }),
-            )
         } else {
-            Arc::new(
-                meerkat_mobkit::identity_first::LocalContinuityStore::open(
-                    std::env::temp_dir()
-                        .join(format!("mobkit-continuity-{}.db", std::process::id())),
-                )
+            let db_path = if let Some(ref state_path) = persistent_state {
+                state_path.join("continuity.db")
+            } else {
+                std::env::temp_dir().join(format!("mobkit-continuity-{}.db", std::process::id()))
+            };
+            let store = meerkat_mobkit::identity_first::LocalContinuityStore::open(&db_path)
                 .unwrap_or_else(|e| {
                     fail_init(
                         &request_id,
                         -32603,
                         format!("failed to open continuity store: {e}"),
                     );
-                }),
-            )
+                });
+            local_fencing_floor = store.max_fencing_token().unwrap_or(0);
+            Arc::new(store)
         })
     } else {
         None
@@ -1807,7 +1803,12 @@ external_addressable = true
                 bridge.clone(),
             ))
         } else {
-            Arc::new(meerkat_mobkit::identity_first::LocalLeaseProvider::new())
+            // Resume the fencing counter above the persisted high-water so a
+            // restart with existing continuity history never presents a stale
+            // token (see `local_fencing_floor` above).
+            Arc::new(
+                meerkat_mobkit::identity_first::LocalLeaseProvider::with_floor(local_fencing_floor),
+            )
         })
     } else {
         None

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1789,7 +1789,15 @@ external_addressable = true
                         format!("failed to open continuity store: {e}"),
                     );
                 });
-            local_fencing_floor = store.max_fencing_token().unwrap_or(0);
+            // Fail loudly rather than silently degrading to floor 0 — a 0 floor
+            // would re-arm the very restart-abort this seeding prevents.
+            local_fencing_floor = store.max_fencing_token().unwrap_or_else(|e| {
+                fail_init(
+                    &request_id,
+                    -32603,
+                    format!("failed to read continuity fencing high-water: {e}"),
+                )
+            });
             Arc::new(store)
         })
     } else {

--- a/meerkat-mobkit/src/identity_first/local_lease.rs
+++ b/meerkat-mobkit/src/identity_first/local_lease.rs
@@ -46,12 +46,26 @@ struct LocalLeaseState {
 }
 
 impl LocalLeaseProvider {
-    /// Create a new local lease provider.
+    /// Create a new local lease provider whose fencing counter starts at 1.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_floor(0)
+    }
+
+    /// Create a local lease provider whose monotonic fencing counter resumes
+    /// strictly above `floor` (the persisted high-water mark), so fencing tokens
+    /// keep advancing across process restarts instead of resetting to 1.
+    ///
+    /// Seed `floor` from
+    /// [`LocalContinuityStore::max_fencing_token`](super::local_store::LocalContinuityStore::max_fencing_token)
+    /// at startup. Without this, a restart re-issues token 1 and restore presents
+    /// a stale token that the store's compare-and-set rejects (the v0.7.8
+    /// "stale fencing token: presented 1, current N" restart abort).
+    #[must_use]
+    pub fn with_floor(floor: u64) -> Self {
         Self {
             state: Mutex::new(LocalLeaseState {
-                next_token: 1,
+                next_token: floor.saturating_add(1),
                 leases: BTreeMap::new(),
             }),
         }
@@ -157,5 +171,43 @@ impl LeaseProvider for LocalLeaseProvider {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    async fn first_token(provider: &LocalLeaseProvider, holder: &str) -> u64 {
+        let id = AgentIdentity::parse("identity:parent-1").unwrap();
+        let result = provider
+            .acquire_leases(std::slice::from_ref(&id), holder)
+            .await
+            .unwrap();
+        match result.get(&id) {
+            Some(LeaseAcquireResult::Acquired(grant)) => grant.fencing_token.get(),
+            _ => panic!("expected an acquired lease"),
+        }
+    }
+
+    #[tokio::test]
+    async fn new_starts_the_fencing_counter_at_one() {
+        assert_eq!(first_token(&LocalLeaseProvider::new(), "rt").await, 1);
+    }
+
+    #[tokio::test]
+    async fn with_floor_resumes_strictly_above_the_persisted_high_water() {
+        // Restart regression: seeded from a high-water of 15, the first issued
+        // token must be 16 — never 1, which restore would present as stale.
+        assert_eq!(
+            first_token(&LocalLeaseProvider::with_floor(15), "rt").await,
+            16
+        );
+        // floor 0 is equivalent to new().
+        assert_eq!(
+            first_token(&LocalLeaseProvider::with_floor(0), "rt").await,
+            1
+        );
     }
 }

--- a/meerkat-mobkit/src/identity_first/local_store.rs
+++ b/meerkat-mobkit/src/identity_first/local_store.rs
@@ -90,6 +90,36 @@ impl LocalContinuityStore {
             conn: Mutex::new(conn),
         })
     }
+
+    /// The highest fencing token ever committed to this store, across BOTH
+    /// `continuity_records` and `session_snapshots` (0 if the store is empty).
+    ///
+    /// The bundled [`LocalLeaseProvider`](super::local_lease::LocalLeaseProvider)
+    /// seeds its monotonic counter from this on startup so fencing tokens keep
+    /// advancing across process restarts. Without it the provider's in-memory
+    /// counter resets to 1 and restore presents a stale token that this store's
+    /// compare-and-set rejects — the v0.7.8 "stale fencing token: presented 1,
+    /// current N" restart abort.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ContinuityStoreError::Io` on a query failure.
+    pub fn max_fencing_token(&self) -> Result<u64, ContinuityStoreError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| ContinuityStoreError::Io(format!("lock: {e}")))?;
+        conn.query_row(
+            "SELECT COALESCE(MAX(t), 0) FROM (
+                SELECT MAX(fencing_token) AS t FROM continuity_records
+                UNION ALL
+                SELECT MAX(fencing_token) AS t FROM session_snapshots
+            )",
+            [],
+            |row| row.get::<_, u64>(0),
+        )
+        .map_err(|e| ContinuityStoreError::Io(format!("max_fencing_token: {e}")))
+    }
 }
 
 #[async_trait]
@@ -461,7 +491,7 @@ impl ContinuityStore for LocalContinuityStore {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
 
@@ -566,6 +596,115 @@ mod tests {
         assert!(!matches!(
             resolved.get(&identity),
             Some(ContinuityResolveState::Uninitialized)
+        ));
+    }
+
+    #[tokio::test]
+    async fn max_fencing_token_recovers_high_water_across_tables_and_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("continuity.db");
+        let identity = AgentIdentity::parse("identity:parent-1").unwrap();
+        let session_id = meerkat_core::types::SessionId::new();
+        {
+            let store = LocalContinuityStore::open(&path).unwrap();
+            assert_eq!(store.max_fencing_token().unwrap(), 0, "empty store -> 0");
+            // First boot: continuity record + session snapshot both at token 1.
+            store
+                .upsert_continuity_record(&record(&identity, &session_id), FencingToken::new(1))
+                .await
+                .unwrap();
+            store
+                .save_session_snapshot(
+                    &identity,
+                    &session_id,
+                    ContinuityGeneration::new(0),
+                    CheckpointVersion::new(1),
+                    FencingToken::new(1),
+                    &SessionSnapshot {
+                        data: vec![1, 2, 3],
+                    },
+                )
+                .await
+                .unwrap();
+            // Reconcile re-bumps the continuity record to 15; the snapshot stays
+            // at 1 — the two-table divergence from the field report.
+            store
+                .upsert_continuity_record(&record(&identity, &session_id), FencingToken::new(15))
+                .await
+                .unwrap();
+            assert_eq!(
+                store.max_fencing_token().unwrap(),
+                15,
+                "high-water = MAX over continuity_records (15) and session_snapshots (1)"
+            );
+        }
+        // Restart: the high-water must survive re-opening the same db file.
+        let store = LocalContinuityStore::open(&path).unwrap();
+        assert_eq!(
+            store.max_fencing_token().unwrap(),
+            15,
+            "high-water must persist across reopen"
+        );
+    }
+
+    /// The end-to-end restart regression: a lease provider seeded from the
+    /// persisted high-water issues a token that the store accepts on restore,
+    /// while a provider that reset to 1 (the v0.7.8 bug) is rejected as stale.
+    #[tokio::test]
+    async fn lease_fencing_resumes_above_high_water_on_restart() {
+        use super::super::contracts::LeaseProvider;
+        use super::super::local_lease::LocalLeaseProvider;
+        use super::super::types::LeaseAcquireResult;
+
+        let store = LocalContinuityStore::in_memory().unwrap();
+        let identity = AgentIdentity::parse("identity:parent-1").unwrap();
+        let session_id = meerkat_core::types::SessionId::new();
+        // Pre-restart history: reconcile bumped the continuity record to 15.
+        store
+            .upsert_continuity_record(&record(&identity, &session_id), FencingToken::new(15))
+            .await
+            .unwrap();
+
+        // Restart: seed a fresh lease provider from the persisted high-water.
+        let high_water = store.max_fencing_token().unwrap();
+        assert_eq!(high_water, 15);
+        let provider = LocalLeaseProvider::with_floor(high_water);
+        let acquired = provider
+            .acquire_leases(std::slice::from_ref(&identity), "rt-restart")
+            .await
+            .unwrap();
+        let token = match acquired.get(&identity) {
+            Some(LeaseAcquireResult::Acquired(grant)) => grant.fencing_token,
+            _ => panic!("expected an acquired lease"),
+        };
+        assert!(
+            token.get() > high_water,
+            "resumed token {} must exceed the high-water {high_water}",
+            token.get()
+        );
+        // The restore upsert with the resumed token SUCCEEDS (not stale).
+        store
+            .upsert_continuity_record(&record(&identity, &session_id), token)
+            .await
+            .expect("a token resumed above the high-water must be accepted");
+
+        // Prove the bug this fixes: a provider that reset to 1 IS rejected.
+        let reset_provider = LocalLeaseProvider::with_floor(0);
+        let reset_acquired = reset_provider
+            .acquire_leases(std::slice::from_ref(&identity), "rt-reset")
+            .await
+            .unwrap();
+        let reset_token = match reset_acquired.get(&identity) {
+            Some(LeaseAcquireResult::Acquired(grant)) => grant.fencing_token,
+            _ => panic!("expected an acquired lease"),
+        };
+        let err = store
+            .upsert_continuity_record(&record(&identity, &session_id), reset_token)
+            .await
+            .expect_err("a reset-to-1 token must be rejected as stale");
+        assert!(matches!(
+            err,
+            ContinuityStoreError::StaleFencingToken { .. }
         ));
     }
 }

--- a/meerkat-mobkit/src/identity_first/local_store.rs
+++ b/meerkat-mobkit/src/identity_first/local_store.rs
@@ -645,6 +645,28 @@ mod tests {
             15,
             "high-water must persist across reopen"
         );
+
+        // The session_snapshots arm of the union must actually count: a snapshot
+        // whose token exceeds the continuity record (the crash-window case the
+        // MAX-over-both-tables query is for) becomes the high-water.
+        let snap_only = LocalContinuityStore::in_memory().unwrap();
+        let sid = meerkat_core::types::SessionId::new();
+        snap_only
+            .save_session_snapshot(
+                &identity,
+                &sid,
+                ContinuityGeneration::new(0),
+                CheckpointVersion::new(1),
+                FencingToken::new(7),
+                &SessionSnapshot { data: vec![9] },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            snap_only.max_fencing_token().unwrap(),
+            7,
+            "high-water must come from session_snapshots when no continuity record is present"
+        );
     }
 
     /// The end-to-end restart regression: a lease provider seeded from the

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.8"
+version = "0.7.9"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Bug (field report)

On restart with existing history, `restore_flow` aborted:
```
restore_flow failed: continuity upsert before restore resume:
stale fencing token for identity:parent-1: presented 1, current 15
```

## Root cause

The bundled `LocalLeaseProvider` (`local_lease.rs`) keeps its fencing-token counter (`next_token`) **in-memory** and `new()` resets it to **1** on every construction (i.e., every restart). On restart it re-issues token 1, which `LocalContinuityStore`'s compare-and-set rejects as stale vs the persisted high-water (e.g. 15), aborting boot. The doc even claims "FencingTokens are monotonic within the local store" — the implementation violated that across restarts. (`checkpoint_version` does *not* have this bug — it's loaded from the persisted record.)

## Fix

- **`LocalContinuityStore::max_fencing_token()`** — recovers the high-water across **both** `continuity_records` and `session_snapshots` (handles the two-table divergence the reporter saw, and the crash-window edge case where a snapshot token exceeds the record token).
- **`LocalLeaseProvider::with_floor(hw)`** — resumes the monotonic counter strictly above the high-water; `new()` == `with_floor(0)`.
- **`rpc_gateway`** seeds the local lease provider from the local continuity store's high-water on startup.

## Tests

- `with_floor` / `max_fencing_token` unit tests (incl. reopen-from-disk).
- End-to-end restart regression (`lease_fencing_resumes_above_high_water_on_restart`): record bumped to 15, restart, assert the resumed token is **accepted** while a reset-to-1 token is **rejected as stale**.

## Adjacent-issue sweep (parallel audit + adversarial verify)

- **`generation`** and **`checkpoint_version`** — *cleared*: both recover from the persisted continuity record on restart, not reset. No sibling reset-on-restart bug.
- **`acquire_leases` idempotency** (separate, lower-severity edge case) — re-acquire by the *same* holder bumps the token, which can diverge in error-recovery/retry. **Not** fixed here: `retire/respawn/reset/delete_identity` *legitimately* bump-on-acquire to fence the old session, so a safe fix needs splitting acquire into idempotent vs fencing variants across 6 call sites. Tracked as a follow-up; harmless for restart after this fix.

## Test status

`make ci`: fmt ✓ · version-parity ✓ (now also checks BUILD.bazel + package-lock) · clippy ✓ · python 496 ✓ · flow-editor ✓ · audit ✓. Rust: 1147/1150, the 3 failures are confirmed load flakes (`routing_delivery phase0_contract_009` + two `list_runs` tests — all pass in isolation; the GitHub `test` job runs on a cleaner runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)