### PR TITLE
feat: customizer tool-handler registration + image-capable callback tool results (0.7.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.9"
+version = "0.7.10"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.9",
+        "CARGO_PKG_VERSION": "0.7.10",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1219,24 +1219,15 @@ impl AgentToolDispatcher for CallbackToolDispatcher {
             "arguments": args,
         });
         match self.bridge.call("callback/call_tool", params).await {
-            Ok(result) => {
-                let text = result
-                    .get("content")
-                    .map(|v| {
-                        if let Some(s) = v.as_str() {
-                            s.to_string()
-                        } else {
-                            serde_json::to_string(v).unwrap_or_default()
-                        }
-                    })
-                    .unwrap_or_else(|| serde_json::to_string(&result).unwrap_or_default());
-                Ok(ToolResult {
-                    tool_use_id: call.id.to_string(),
-                    content: vec![ContentBlock::Text { text }],
-                    is_error: false,
-                }
-                .into())
+            Ok(result) => Ok(ToolResult {
+                tool_use_id: call.id.to_string(),
+                content:
+                    meerkat_mobkit::identity_first::gateway_bridges::callback_result_to_content(
+                        &result,
+                    ),
+                is_error: false,
             }
+            .into()),
             Err(err) => Ok(ToolResult {
                 tool_use_id: call.id.to_string(),
                 content: vec![ContentBlock::Text {

--- a/meerkat-mobkit/src/identity_first/gateway_bridges.rs
+++ b/meerkat-mobkit/src/identity_first/gateway_bridges.rs
@@ -15,6 +15,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use meerkat_core::agent::AgentToolDispatcher;
@@ -337,14 +338,56 @@ impl RosterProvider for GatewayRosterProvider {
 /// Gateway-side `AgentCustomizer` that delegates to Python/TypeScript via JSON-RPC.
 pub struct GatewayAgentCustomizer {
     bridge: Arc<dyn CallbackBridge>,
+    /// Monotonic counter for minting a per-build tool-handler scope, so the SDK
+    /// can register external-tool handlers in `customize_build` (parity with the
+    /// `build_agent` scope). A fresh scope per call is correct: `customize_build`
+    /// is re-invoked on every restore/reconcile and the host re-registers under
+    /// the new scope.
+    next_scope: AtomicU64,
 }
 
 impl GatewayAgentCustomizer {
     pub fn new(bridge: impl CallbackBridge + 'static) -> Self {
         Self {
             bridge: Arc::new(bridge),
+            next_scope: AtomicU64::new(1),
         }
     }
+}
+
+/// Convert a `callback/call_tool` result envelope into model-facing content
+/// blocks.
+///
+/// Rich content is **opt-in**. The SDK sends a `content_blocks` field (an array
+/// of runtime `ContentBlock`s, e.g. `{"type":"image",...}`) ONLY when a handler
+/// explicitly returned rich content via `tool_content(...)` / `ToolResultContent`.
+/// When present and a valid, non-empty list, those blocks are used verbatim — so
+/// a callback/bridge tool can hand the model an image (parity with native tools
+/// like `generate_image`).
+///
+/// Otherwise the legacy `content` value becomes a single text block (a string
+/// as-is, any other JSON compact-serialized). A plain handler return therefore
+/// keeps its prior text behavior, and a tool that returns a JSON array of *data*
+/// is never silently reinterpreted as content blocks.
+pub fn callback_result_to_content(result: &Value) -> Vec<ContentBlock> {
+    if let Some(blocks_val) = result.get("content_blocks") {
+        match serde_json::from_value::<Vec<ContentBlock>>(blocks_val.clone()) {
+            Ok(blocks) if !blocks.is_empty() => return blocks,
+            _ => tracing::warn!(
+                "callback/call_tool `content_blocks` was not a non-empty list of valid \
+                 content blocks; falling back to text"
+            ),
+        }
+    }
+    let text = result
+        .get("content")
+        .map(|v| {
+            v.as_str()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| serde_json::to_string(v).unwrap_or_default())
+        })
+        .unwrap_or_else(|| serde_json::to_string(result).unwrap_or_default());
+    vec![ContentBlock::Text { text }]
 }
 
 struct GatewayCallbackToolDispatcher {
@@ -397,23 +440,12 @@ impl AgentToolDispatcher for GatewayCallbackToolDispatcher {
             "arguments": args,
         });
         match self.bridge.call("callback/call_tool", params).await {
-            Ok(result) => {
-                let text = result
-                    .get("content")
-                    .map(|value| {
-                        value
-                            .as_str()
-                            .map(ToString::to_string)
-                            .unwrap_or_else(|| serde_json::to_string(value).unwrap_or_default())
-                    })
-                    .unwrap_or_else(|| serde_json::to_string(&result).unwrap_or_default());
-                Ok(ToolResult {
-                    tool_use_id: call.id.to_string(),
-                    content: vec![ContentBlock::Text { text }],
-                    is_error: false,
-                }
-                .into())
+            Ok(result) => Ok(ToolResult {
+                tool_use_id: call.id.to_string(),
+                content: callback_result_to_content(&result),
+                is_error: false,
             }
+            .into()),
             Err(err) => Ok(ToolResult {
                 tool_use_id: call.id.to_string(),
                 content: vec![ContentBlock::Text {
@@ -434,7 +466,17 @@ impl AgentCustomizer for GatewayAgentCustomizer {
         spec: &DurableAgentSpec,
         draft: &mut AgentBuildDraft,
     ) -> Result<(), CustomizerError> {
+        // Mint a per-build scope so the SDK can register external-tool handlers
+        // in `customize_build` and have them dispatched back through
+        // `callback/call_tool` — the same mechanism `build_agent` uses. Keyed by
+        // identity for readability; the counter guarantees uniqueness per call.
+        let scope_id = format!(
+            "customize-{}-{}",
+            context.identity.as_str(),
+            self.next_scope.fetch_add(1, Ordering::Relaxed)
+        );
         let params = json!({
+            "scope_id": scope_id,
             "context": serde_json::to_value(context)
                 .map_err(|e| CustomizerError::Io(format!("serialize context: {e}")))?,
             "spec": serde_json::to_value(spec)
@@ -455,7 +497,7 @@ impl AgentCustomizer for GatewayAgentCustomizer {
             returned_draft.local_external_tools =
                 LocalExternalToolOverlay::new(Arc::new(GatewayCallbackToolDispatcher::new(
                     self.bridge.clone(),
-                    context.identity.as_str().to_string(),
+                    scope_id,
                     returned_draft.external_tools.clone(),
                 )));
         }
@@ -1219,6 +1261,201 @@ mod tests {
         assert_eq!(params["spec"]["identity"].as_str().unwrap(), "agent:alpha");
         // draft does NOT include resume_session
         assert!(params["draft"].get("resume_session").is_none());
+
+        // customize_build mints a per-build tool-handler scope and ships it to
+        // the SDK (parity with build_agent), so the SDK can register external-tool
+        // handlers keyed by (scope_id, tool). The scope is identity-prefixed.
+        let scope_id = params["scope_id"]
+            .as_str()
+            .expect("customize_build params must carry a scope_id")
+            .to_string();
+        assert!(
+            scope_id.starts_with("customize-agent:alpha-"),
+            "scope_id should be identity-prefixed, got {scope_id}"
+        );
+
+        // The installed dispatcher must route callback/call_tool to that SAME
+        // per-build scope — NOT the bare identity — so the SDK handler map hits.
+        let raw_args = serde_json::value::RawValue::from_string("{}".to_string()).unwrap();
+        let call = ToolCallView {
+            id: "call-1",
+            name: "my_tool",
+            args: &raw_args,
+        };
+        dispatcher.dispatch(call).await.unwrap();
+        let (call_method, call_params) = mock.last_call().await;
+        assert_eq!(call_method, "callback/call_tool");
+        assert_eq!(call_params["scope_id"].as_str().unwrap(), scope_id);
+        assert_eq!(call_params["tool"].as_str().unwrap(), "my_tool");
+    }
+
+    #[tokio::test]
+    async fn test_identity_first_gateway_customizer_scope_increments_per_build() {
+        // customize_build is re-invoked on every restore/reconcile; each call must
+        // mint a FRESH scope so the host re-registers handlers under the new scope.
+        let mock = Arc::new(MockBridge::new());
+        let returned_draft = AgentBuildDraft {
+            model: None,
+            system_prompt: None,
+            additional_instructions: vec![],
+            labels: BTreeMap::new(),
+            app_context: None,
+            external_tools: vec![ExternalToolDef {
+                name: "my_tool".to_string(),
+                description: "A custom tool".to_string(),
+                input_schema: json!({"type": "object"}),
+            }],
+            local_external_tools: Default::default(),
+        };
+        mock.set_response(
+            "callback/agent_customizer/customize_build",
+            Ok(serde_json::to_value(&returned_draft).unwrap()),
+        )
+        .await;
+
+        let customizer = GatewayAgentCustomizer::new(mock.clone());
+        let id = AgentIdentity::parse("agent:alpha").unwrap();
+        let context = AgentBuildContext {
+            identity: id.clone(),
+            active_peers: vec![],
+            managed_edges: vec![],
+            runtime_services: Default::default(),
+        };
+        let spec = DurableAgentSpec {
+            identity: id,
+            profile: meerkat_mob::ProfileName::from("default"),
+            addressability: AgentAddressability::Addressable,
+            display_name: None,
+            labels: BTreeMap::new(),
+            context: None,
+            additional_instructions: vec![],
+            initial_message: None,
+            runtime_mode_override: None,
+            backend: None,
+            binding: None,
+        };
+
+        let mut scopes = Vec::new();
+        for _ in 0..2 {
+            let mut draft = AgentBuildDraft {
+                model: None,
+                system_prompt: None,
+                additional_instructions: vec![],
+                labels: BTreeMap::new(),
+                app_context: None,
+                external_tools: vec![],
+                local_external_tools: Default::default(),
+            };
+            customizer
+                .customize_build(&context, &spec, &mut draft)
+                .await
+                .unwrap();
+            let (_, params) = mock.last_call().await;
+            scopes.push(params["scope_id"].as_str().unwrap().to_string());
+        }
+        assert_ne!(scopes[0], scopes[1], "each build must get a fresh scope");
+        assert!(scopes[0].starts_with("customize-agent:alpha-"));
+        assert!(scopes[1].starts_with("customize-agent:alpha-"));
+    }
+
+    #[test]
+    fn callback_result_string_becomes_single_text_block() {
+        let blocks = callback_result_to_content(&json!({"content": "hello"}));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "hello");
+    }
+
+    #[test]
+    fn callback_result_content_blocks_preserves_image() {
+        // Opt-in rich content: a callback/bridge tool hands the model an image
+        // via `content_blocks` — the gateway must NOT flatten it to text.
+        let blocks = callback_result_to_content(&json!({"content_blocks": [
+            {"type": "text", "text": "see this"},
+            {"type": "image", "media_type": "image/png", "source": "inline", "data": "aGVsbG8="},
+        ]}));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 2);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "see this");
+        assert_eq!(v[1]["type"], "image");
+        assert_eq!(v[1]["media_type"], "image/png");
+        assert_eq!(v[1]["source"], "inline");
+        assert_eq!(v[1]["data"], "aGVsbG8=");
+    }
+
+    #[test]
+    fn callback_result_plain_content_array_is_not_reinterpreted_as_blocks() {
+        // REGRESSION GUARD: a tool that returns a JSON array of *data* under the
+        // legacy `content` key — even one whose elements look like content blocks
+        // — must be serialized to a single text block, exactly as before 0.7.10.
+        // Rich content is only honored via the explicit `content_blocks` field.
+        let blocks = callback_result_to_content(&json!({
+            "content": [{"type": "text", "text": "data"}]
+        }));
+        let v = serde_json::to_value(&blocks).unwrap();
+        // Stays a SINGLE text block (NOT unwrapped into content blocks).
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        // The data array survives as the serialized text (key order is
+        // serializer-defined, so round-trip rather than compare the raw string).
+        let reparsed: serde_json::Value =
+            serde_json::from_str(v[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(reparsed, json!([{"type": "text", "text": "data"}]));
+    }
+
+    #[test]
+    fn callback_result_non_block_array_under_content_is_text() {
+        let blocks = callback_result_to_content(&json!({"content": [1, 2, 3]}));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "[1,2,3]");
+    }
+
+    #[test]
+    fn callback_result_empty_content_blocks_falls_back_to_content() {
+        // An empty `content_blocks` list is not valid rich content; fall back to
+        // the legacy `content` text path.
+        let blocks =
+            callback_result_to_content(&json!({"content_blocks": [], "content": "fallback"}));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "fallback");
+    }
+
+    #[test]
+    fn callback_result_malformed_content_blocks_falls_back_to_content() {
+        // A `content_blocks` value that is not a valid block list warns and falls
+        // back to the `content` text path (never panics, never drops the result).
+        let blocks = callback_result_to_content(&json!({
+            "content_blocks": [{"type": "bogus_variant"}],
+            "content": "fallback text",
+        }));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "fallback text");
+    }
+
+    #[test]
+    fn callback_result_object_becomes_text_block() {
+        let blocks = callback_result_to_content(&json!({"content": {"k": "v"}}));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "{\"k\":\"v\"}");
+    }
+
+    #[test]
+    fn callback_result_missing_content_serializes_whole_result() {
+        let blocks = callback_result_to_content(&json!({"other": 1}));
+        let v = serde_json::to_value(&blocks).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "{\"other\":1}");
     }
 
     #[tokio::test]

--- a/sdk/python/meerkat_mobkit/__init__.py
+++ b/sdk/python/meerkat_mobkit/__init__.py
@@ -147,11 +147,26 @@ from .events import (
 # Config modules (importable as meerkat_mobkit.auth, etc.)
 from .config import auth, memory, session_store
 
+# Rich tool-result content blocks for callback tool handlers.
+from .tool_content import (
+    ToolResultContent,
+    image_block,
+    image_blob_block,
+    text_block,
+    tool_content,
+)
+
 __all__ = [
     # Builder + Runtime
     "MobKit",
     "MobKitBuilder",
     "MobKitRuntime",
+    # Tool-result content blocks
+    "text_block",
+    "image_block",
+    "image_blob_block",
+    "tool_content",
+    "ToolResultContent",
     # Data models
     "DiscoverySpec",
     "PreSpawnData",

--- a/sdk/python/meerkat_mobkit/agent_builder.py
+++ b/sdk/python/meerkat_mobkit/agent_builder.py
@@ -53,6 +53,10 @@ class CallbackDispatcher:
         self._tool_handlers: dict[tuple[str, str], Any] = {}
         # Track scope_ids so we can clean up handlers when a scope is released
         self._scope_tools: dict[str, list[str]] = {}
+        # customize_build is re-invoked with a fresh scope on every restore; track
+        # the latest scope per identity so we can release the previous one (the
+        # gateway has no scope-release signal — newest-wins is the semantics).
+        self._customizer_scope_by_identity: dict[str, str] = {}
         # Identity-first providers (REQ-45)
         self._continuity_store: Any | None = None
         self._lease_provider: Any | None = None
@@ -153,6 +157,13 @@ class CallbackDispatcher:
             result = handler(arguments)
             if asyncio.iscoroutine(result):
                 result = await result
+            # Rich content is opt-in: only an explicit ToolResultContent is
+            # delivered as content blocks (images / multi-block). Any other
+            # return keeps the legacy single-text-block behavior.
+            from .tool_content import ToolResultContent
+
+            if isinstance(result, ToolResultContent):
+                return {"content_blocks": result.blocks}
             return {"content": result}
 
         # ----- Identity-first provider routing (REQ-45) -----
@@ -295,10 +306,30 @@ class CallbackDispatcher:
         op = method.rsplit("/", 1)[-1]
 
         if op == "customize_build":
+            scope_id = params.get("scope_id")
             context = AgentBuildContext.from_dict(params["context"])
             spec = DurableAgentSpec.from_dict(params["spec"])
             draft = AgentBuildDraft.from_dict(params["draft"])
             await customizer.customize_build(context, spec, draft)
+            # Capture any tool handlers the customizer registered via
+            # draft.register_tool(), keyed by this build's scope — the same
+            # (scope_id, tool) map build_agent uses, so callback/call_tool
+            # dispatches to them. Guard on scope_id for forward/backward compat
+            # with a gateway that does not yet send it.
+            handlers = draft.tool_handlers
+            if scope_id and handlers:
+                # Release the previous scope for this identity before registering
+                # the new one — customize_build is re-invoked per restore and the
+                # gateway never signals scope release, so this bounds growth to one
+                # live scope per identity (newest wins).
+                prior = self._customizer_scope_by_identity.get(context.identity)
+                if prior and prior != scope_id:
+                    self.release_scope(prior)
+                self._customizer_scope_by_identity[context.identity] = scope_id
+                tool_names = self._scope_tools.setdefault(scope_id, [])
+                for name, handler in handlers.items():
+                    self._tool_handlers[(scope_id, name)] = handler
+                    tool_names.append(name)
             return draft.to_dict()
 
         if op == "after_create":

--- a/sdk/python/meerkat_mobkit/identity_first_models.py
+++ b/sdk/python/meerkat_mobkit/identity_first_models.py
@@ -289,6 +289,49 @@ class AgentBuildDraft:
     labels: dict[str, str] = field(default_factory=dict)
     app_context: Any | None = None
     external_tools: list[ExternalToolDef] = field(default_factory=list)
+    _tool_handlers: dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
+
+    def register_tool(
+        self,
+        name: str,
+        handler: Any,
+        *,
+        description: str = "",
+        input_schema: dict[str, Any] | None = None,
+    ) -> None:
+        """Register a callable external tool on this build.
+
+        Parity with :meth:`SessionBuildOptions.register_tool`, but available in
+        ``AgentCustomizer.customize_build`` — which runs on BOTH fresh create and
+        restore/reconcile. The handler is dispatched in-process when the agent
+        invokes the tool; it receives a dict of arguments and returns a
+        JSON-serializable result. Use this to reattach identity-scoped tools
+        (MCP, comms, etc.) so resumed agents keep them.
+
+        Args:
+            name: Tool name (string).
+            handler: Async or sync callable ``(args: dict) -> Any``.
+            description: Human-readable tool description.
+            input_schema: JSON Schema for the tool arguments
+                (defaults to ``{"type": "object"}``).
+        """
+        if not isinstance(name, str):
+            raise TypeError(f"tool name must be a string, got {type(name).__name__}: {name!r}")
+        if not callable(handler):
+            raise TypeError(f"handler must be callable, got {type(handler).__name__}: {handler!r}")
+        self.external_tools.append(
+            ExternalToolDef(
+                name=name,
+                description=description,
+                input_schema=input_schema if input_schema is not None else {"type": "object"},
+            )
+        )
+        self._tool_handlers[name] = handler
+
+    @property
+    def tool_handlers(self) -> dict[str, Any]:
+        """Handlers registered via :meth:`register_tool` (in-process only)."""
+        return dict(self._tool_handlers)
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {}

--- a/sdk/python/meerkat_mobkit/tool_content.py
+++ b/sdk/python/meerkat_mobkit/tool_content.py
@@ -1,0 +1,79 @@
+"""Rich content blocks for callback tool-handler results.
+
+A callback tool handler (registered via :meth:`SessionBuildOptions.register_tool`
+or :meth:`AgentBuildDraft.register_tool`) normally returns a JSON-serializable
+value, which the model sees as text. To hand the model an **image** or multiple
+content blocks, wrap them with :func:`tool_content` and return that — the gateway
+then delivers them as real content blocks instead of text::
+
+    def screenshot_tool(args):
+        png_b64 = capture()  # base64-encoded PNG bytes
+        return tool_content(
+            text_block("Here is the screenshot:"),
+            image_block("image/png", png_b64),
+        )
+
+Rich content is **opt-in**: only a :class:`ToolResultContent` (from
+:func:`tool_content`) is delivered as content blocks. A plain return value — a
+string, dict, or even a bare ``list`` — keeps the default text behavior, so a
+tool that returns ordinary list/dict data is never reinterpreted. The block
+shapes mirror the runtime's ``ContentBlock`` wire format (internally tagged by
+``type``); blocks are parsed strictly, so extra keys on a block are dropped.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "text_block",
+    "image_block",
+    "image_blob_block",
+    "tool_content",
+    "ToolResultContent",
+]
+
+
+def text_block(text: str) -> dict[str, Any]:
+    """A text content block."""
+    return {"type": "text", "text": text}
+
+
+def image_block(media_type: str, data: str) -> dict[str, Any]:
+    """An inline image content block.
+
+    Args:
+        media_type: MIME type, e.g. ``"image/png"`` or ``"image/jpeg"``.
+        data: Base64-encoded image bytes.
+    """
+    return {"type": "image", "media_type": media_type, "source": "inline", "data": data}
+
+
+def image_blob_block(media_type: str, blob_id: str) -> dict[str, Any]:
+    """An image content block referencing a durable blob by id.
+
+    Use when the image already lives in the runtime blob store; prefer
+    :func:`image_block` when the handler has the bytes in hand.
+    """
+    return {"type": "image", "media_type": media_type, "source": "blob", "blob_id": blob_id}
+
+
+@dataclass(frozen=True)
+class ToolResultContent:
+    """Explicit rich tool result: a list of content blocks for the model.
+
+    Return an instance (most easily via :func:`tool_content`) from a callback
+    tool handler to deliver images / multiple blocks. Returning anything else
+    keeps the default single-text-block behavior.
+    """
+
+    blocks: list[dict[str, Any]]
+
+
+def tool_content(*blocks: dict[str, Any]) -> ToolResultContent:
+    """Bundle content blocks into a rich tool result.
+
+    Build the blocks with :func:`text_block`, :func:`image_block`, or
+    :func:`image_blob_block`.
+    """
+    return ToolResultContent(list(blocks))

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.9"
+version = "0.7.10"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/python/tests/test_customizer_tools.py
+++ b/sdk/python/tests/test_customizer_tools.py
@@ -1,0 +1,164 @@
+"""Tests for AgentCustomizer external-tool handler registration.
+
+The identity-first ``AgentCustomizer.customize_build`` callback runs on BOTH
+fresh create and restore/reconcile (unlike ``build_agent``, whose options are
+empty on restore). A customizer can register callable tools via
+``draft.register_tool(...)``; those handlers ride the SAME (scope_id, tool)
+map + ``callback/call_tool`` dispatch that ``build_agent`` uses, so resumed
+agents keep their identity-scoped tools (MCP, comms, etc.).
+"""
+import pytest
+from meerkat_mobkit.agent_builder import CallbackDispatcher
+from meerkat_mobkit.identity_first_models import AgentBuildDraft
+
+_CONTEXT = {"identity": "agent:alpha", "active_peers": [], "managed_edges": []}
+_SPEC = {"identity": "agent:alpha", "profile": "default"}
+
+
+class _ToolCustomizer:
+    """Customizer that registers a sync and an async tool on the draft."""
+
+    async def customize_build(self, context, spec, draft) -> None:
+        draft.register_tool(
+            "sync_tool",
+            lambda args: {"echo": args.get("input", "")},
+            description="echoes input",
+            input_schema={"type": "object", "properties": {"input": {"type": "string"}}},
+        )
+
+        async def async_handler(args):
+            return {"async_echo": args.get("input", "")}
+
+        draft.register_tool("async_tool", async_handler)
+
+
+def _customize_params(scope_id, draft=None):
+    params = {"context": _CONTEXT, "spec": _SPEC, "draft": draft or {}}
+    if scope_id is not None:
+        params["scope_id"] = scope_id
+    return params
+
+
+class TestCustomizerToolDispatch:
+    @pytest.fixture
+    def dispatcher(self):
+        d = CallbackDispatcher()
+        d.register_agent_customizer(_ToolCustomizer())
+        return d
+
+    @pytest.mark.asyncio
+    async def test_customize_build_captures_handlers(self, dispatcher):
+        result = await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params("c1")
+        )
+        # The returned draft carries tool DEFS only — handlers stay in-process.
+        names = [t["name"] for t in result["external_tools"]]
+        assert names == ["sync_tool", "async_tool"]
+        for tool in result["external_tools"]:
+            assert "handler" not in tool
+        assert ("c1", "sync_tool") in dispatcher._tool_handlers
+        assert ("c1", "async_tool") in dispatcher._tool_handlers
+
+    @pytest.mark.asyncio
+    async def test_call_sync_tool(self, dispatcher):
+        await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params("c1")
+        )
+        result = await dispatcher.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "c1", "tool": "sync_tool", "arguments": {"input": "hello"}},
+        )
+        assert result == {"content": {"echo": "hello"}}
+
+    @pytest.mark.asyncio
+    async def test_call_async_tool(self, dispatcher):
+        await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params("c1")
+        )
+        result = await dispatcher.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "c1", "tool": "async_tool", "arguments": {"input": "world"}},
+        )
+        assert result == {"content": {"async_echo": "world"}}
+
+    @pytest.mark.asyncio
+    async def test_scope_isolation(self, dispatcher):
+        await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params("c1")
+        )
+        with pytest.raises(ValueError, match="no handler registered"):
+            await dispatcher.handle_callback(
+                "callback/call_tool",
+                {"scope_id": "c2", "tool": "sync_tool", "arguments": {}},
+            )
+
+    @pytest.mark.asyncio
+    async def test_restore_reregisters_under_new_scope(self, dispatcher):
+        """customize_build re-invoked on restore with a NEW scope: latest wins.
+
+        Models the gateway minting a fresh ``customize-<identity>-N`` scope on
+        every reconcile; the host re-registers handlers and the newest scope
+        dispatches. Releasing the stale scope leaves the latest working.
+        """
+        await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params("customize-agent:alpha-1")
+        )
+        await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params("customize-agent:alpha-2")
+        )
+        # Latest scope dispatches.
+        result = await dispatcher.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "customize-agent:alpha-2", "tool": "sync_tool", "arguments": {"input": "hi"}},
+        )
+        assert result == {"content": {"echo": "hi"}}
+        # Release the stale scope; the latest still dispatches.
+        dispatcher.release_scope("customize-agent:alpha-1")
+        assert ("customize-agent:alpha-1", "sync_tool") not in dispatcher._tool_handlers
+        result = await dispatcher.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "customize-agent:alpha-2", "tool": "sync_tool", "arguments": {"input": "yo"}},
+        )
+        assert result == {"content": {"echo": "yo"}}
+
+    @pytest.mark.asyncio
+    async def test_missing_scope_id_degrades_gracefully(self, dispatcher):
+        """A gateway that does not yet send scope_id: no crash, defs still returned.
+
+        Handlers simply aren't harvested (tools appear declared-only).
+        """
+        result = await dispatcher.handle_callback(
+            "callback/agent_customizer/customize_build", _customize_params(None)
+        )
+        names = [t["name"] for t in result["external_tools"]]
+        assert names == ["sync_tool", "async_tool"]
+        # No scope means no harvested handlers.
+        assert all(k[1] != "sync_tool" for k in dispatcher._tool_handlers)
+
+
+class TestAgentBuildDraftRegisterTool:
+    def test_register_tool_appends_def_and_stores_handler(self):
+        draft = AgentBuildDraft()
+        draft.register_tool("t", lambda args: args, description="d", input_schema={"type": "object"})
+        assert len(draft.external_tools) == 1
+        assert draft.external_tools[0].name == "t"
+        assert draft.external_tools[0].description == "d"
+        assert "t" in draft.tool_handlers
+
+    def test_register_tool_default_schema(self):
+        draft = AgentBuildDraft()
+        draft.register_tool("t", lambda args: args)
+        assert draft.external_tools[0].input_schema == {"type": "object"}
+
+    def test_to_dict_omits_handlers(self):
+        draft = AgentBuildDraft()
+        draft.register_tool("t", lambda args: args)
+        assert "tool_handlers" not in draft.to_dict()
+        assert draft.to_dict()["external_tools"] == [
+            {"name": "t", "description": "", "input_schema": {"type": "object"}}
+        ]
+
+    def test_non_callable_handler_raises(self):
+        draft = AgentBuildDraft()
+        with pytest.raises(TypeError, match="handler must be callable"):
+            draft.register_tool("bad", "not_a_function")

--- a/sdk/python/tests/test_tool_content.py
+++ b/sdk/python/tests/test_tool_content.py
@@ -1,0 +1,90 @@
+"""Tests for rich tool-result content blocks (callback tools returning images)."""
+import pytest
+from meerkat_mobkit import (
+    ToolResultContent,
+    image_block,
+    image_blob_block,
+    text_block,
+    tool_content,
+)
+from meerkat_mobkit.agent_builder import CallbackDispatcher
+from meerkat_mobkit.models import SessionBuildOptions
+
+
+class TestContentBlockHelpers:
+    def test_text_block(self):
+        assert text_block("hi") == {"type": "text", "text": "hi"}
+
+    def test_image_block_inline(self):
+        assert image_block("image/png", "aGVsbG8=") == {
+            "type": "image",
+            "media_type": "image/png",
+            "source": "inline",
+            "data": "aGVsbG8=",
+        }
+
+    def test_image_blob_block(self):
+        assert image_blob_block("image/jpeg", "blob-123") == {
+            "type": "image",
+            "media_type": "image/jpeg",
+            "source": "blob",
+            "blob_id": "blob-123",
+        }
+
+
+class TestToolContentWrapper:
+    def test_tool_content_builds_marker(self):
+        tc = tool_content(text_block("a"), image_block("image/png", "aGVsbG8="))
+        assert isinstance(tc, ToolResultContent)
+        assert tc.blocks == [
+            {"type": "text", "text": "a"},
+            {"type": "image", "media_type": "image/png", "source": "inline", "data": "aGVsbG8="},
+        ]
+
+
+class TestHandlerReturnsContentBlocks:
+    """An explicit tool_content(...) return is delivered as content_blocks; a
+    plain return keeps the legacy single-text/content path (opt-in)."""
+
+    @pytest.mark.asyncio
+    async def test_tool_content_becomes_content_blocks(self):
+        blocks = [text_block("see this:"), image_block("image/png", "aGVsbG8=")]
+
+        class _Builder:
+            async def build_agent(self, opts: SessionBuildOptions) -> None:
+                opts.register_tool("shot", lambda args: tool_content(*blocks))
+
+        d = CallbackDispatcher()
+        d.register_builder(_Builder())
+        await d.handle_callback("callback/build_agent", {"options": {"scope_id": "s1"}})
+        result = await d.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "s1", "tool": "shot", "arguments": {}},
+        )
+        assert result == {"content_blocks": blocks}
+        # The image block survives verbatim.
+        assert result["content_blocks"][1] == {
+            "type": "image",
+            "media_type": "image/png",
+            "source": "inline",
+            "data": "aGVsbG8=",
+        }
+
+    @pytest.mark.asyncio
+    async def test_plain_list_return_stays_content_not_content_blocks(self):
+        """A bare list return (no tool_content) must NOT be treated as blocks."""
+        data = [{"type": "text", "text": "this is data"}]
+
+        class _Builder:
+            async def build_agent(self, opts: SessionBuildOptions) -> None:
+                opts.register_tool("rows", lambda args: data)
+
+        d = CallbackDispatcher()
+        d.register_builder(_Builder())
+        await d.handle_callback("callback/build_agent", {"options": {"scope_id": "s1"}})
+        result = await d.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "s1", "tool": "rows", "arguments": {}},
+        )
+        assert result == {"content": data}
+        assert "content_blocks" not in result

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",

--- a/sdk/typescript/src/agent-builder.ts
+++ b/sdk/typescript/src/agent-builder.ts
@@ -6,6 +6,7 @@
  */
 
 import { SessionBuildOptions, type ToolHandler } from "./models.js";
+import { ToolResultContent } from "./tool-content.js";
 import {
   parseErrorEvent,
   parseContinuityRecord,
@@ -70,6 +71,9 @@ export class CallbackDispatcher {
   private _errorCallback: ErrorCallback | null = null;
   private readonly _toolHandlers = new Map<string, ToolHandler>();
   private readonly _scopeTools = new Map<string, string[]>();
+  // Latest customizer scope per identity, so a restore can release the prior
+  // scope (the gateway has no scope-release signal — newest-wins semantics).
+  private readonly _customizerScopeByIdentity = new Map<string, string>();
   private _continuityStore: ContinuityStore | null = null;
   private _leaseProvider: LeaseProvider | null = null;
   private _rosterProvider: RosterProvider | null = null;
@@ -222,6 +226,12 @@ export class CallbackDispatcher {
       }
 
       const result = await handler(args);
+      // Rich content is opt-in: only an explicit ToolResultContent is delivered
+      // as content blocks (images / multi-block). Any other return keeps the
+      // legacy single-text-block behavior.
+      if (result instanceof ToolResultContent) {
+        return { content_blocks: result.blocks };
+      }
       return { content: result };
     }
 
@@ -374,10 +384,32 @@ export class CallbackDispatcher {
       if (this._agentCustomizer === null) {
         throw new Error("no AgentCustomizer registered");
       }
+      const scopeId = String(params.scope_id ?? "");
       const context = parseAgentBuildContext(params.context);
       const spec = parseDurableAgentSpec(params.spec);
       const draft = parseAgentBuildDraft(params.draft);
       await this._agentCustomizer.customizeBuild(context, spec, draft);
+      // Capture any tool handlers the customizer registered via
+      // draft.registerTool(), keyed by this build's scope — the same
+      // (scope, tool) map build_agent uses, so callback/call_tool dispatches
+      // to them. Guard on scopeId for compat with a gateway not yet sending it.
+      if (scopeId && draft.toolHandlers.size > 0) {
+        // Release the previous scope for this identity before registering the
+        // new one — customize_build is re-invoked per restore and the gateway
+        // never signals scope release, so this bounds growth to one live scope
+        // per identity (newest wins).
+        const prior = this._customizerScopeByIdentity.get(context.identity);
+        if (prior && prior !== scopeId) {
+          this.releaseScope(prior);
+        }
+        this._customizerScopeByIdentity.set(context.identity, scopeId);
+        const toolNames: string[] = [];
+        for (const [name, handler] of draft.toolHandlers) {
+          this._toolHandlers.set(`${scopeId}:${name}`, handler);
+          toolNames.push(name);
+        }
+        this._scopeTools.set(scopeId, toolNames);
+      }
       return agentBuildDraftToDict(draft);
     }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -41,6 +41,10 @@ export type {
 
 // -- Data models ----------------------------------------------------------
 
+// Rich tool-result content blocks for callback tool handlers.
+export { textBlock, imageBlock, imageBlobBlock, toolContent, ToolResultContent } from "./tool-content.js";
+export type { ContentBlock } from "./tool-content.js";
+
 export { SessionBuildOptions } from "./models.js";
 export type {
   DiscoverySpec,

--- a/sdk/typescript/src/tool-content.ts
+++ b/sdk/typescript/src/tool-content.ts
@@ -1,0 +1,63 @@
+/**
+ * Rich content blocks for callback tool-handler results.
+ *
+ * A callback tool handler (registered via {@link SessionBuildOptions.registerTool}
+ * or {@link AgentBuildDraft.registerTool}) normally returns a JSON-serializable
+ * value, which the model sees as text. To hand the model an **image** or
+ * multiple content blocks, wrap them with {@link toolContent} and return that —
+ * the gateway then delivers them as real content blocks instead of text:
+ *
+ * ```ts
+ * draft.registerTool("screenshot", async () => {
+ *   const pngB64 = await capture();
+ *   return toolContent(textBlock("Here is the screenshot:"), imageBlock("image/png", pngB64));
+ * });
+ * ```
+ *
+ * Rich content is **opt-in**: only a {@link ToolResultContent} (from
+ * {@link toolContent}) is delivered as content blocks. A plain return value — a
+ * string, object, or even a bare array — keeps the default text behavior, so a
+ * tool that returns ordinary array/object data is never reinterpreted. The block
+ * shapes mirror the runtime's `ContentBlock` wire format (tagged by `type`);
+ * blocks are parsed strictly, so extra keys on a block are dropped.
+ */
+
+export type ContentBlock = Record<string, unknown>;
+
+/** A text content block. */
+export function textBlock(text: string): ContentBlock {
+  return { type: "text", text };
+}
+
+/**
+ * An inline image content block.
+ *
+ * @param mediaType MIME type, e.g. `"image/png"` or `"image/jpeg"`.
+ * @param data Base64-encoded image bytes.
+ */
+export function imageBlock(mediaType: string, data: string): ContentBlock {
+  return { type: "image", media_type: mediaType, source: "inline", data };
+}
+
+/**
+ * An image content block referencing a durable blob by id. Prefer
+ * {@link imageBlock} when the handler has the bytes in hand.
+ */
+export function imageBlobBlock(mediaType: string, blobId: string): ContentBlock {
+  return { type: "image", media_type: mediaType, source: "blob", blob_id: blobId };
+}
+
+/**
+ * Explicit rich tool result: a list of content blocks for the model. Return one
+ * (most easily via {@link toolContent}) from a callback tool handler to deliver
+ * images / multiple blocks. Returning anything else keeps the default
+ * single-text-block behavior.
+ */
+export class ToolResultContent {
+  constructor(public readonly blocks: ContentBlock[]) {}
+}
+
+/** Bundle content blocks into a rich tool result. */
+export function toolContent(...blocks: ContentBlock[]): ToolResultContent {
+  return new ToolResultContent(blocks);
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -5,6 +5,9 @@
  * convert from the wire protocol's snake_case representation.
  */
 
+// Type-only import (erased at runtime — no module cycle).
+import type { ToolHandler } from "./models.js";
+
 // -- Helpers (internal) ---------------------------------------------------
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -2049,19 +2052,67 @@ export interface AgentBuildDraft {
   labels: Record<string, string>;
   appContext: unknown | null;
   externalTools: ExternalToolDef[];
+  /**
+   * Register a callable external tool on this build. Parity with
+   * {@link SessionBuildOptions.registerTool}, but available inside
+   * {@link AgentCustomizer.customizeBuild} — which runs on BOTH fresh create
+   * and restore/reconcile — so resumed agents keep identity-scoped tools
+   * (MCP, comms, etc.). The handler is dispatched in-process when the agent
+   * invokes the tool.
+   *
+   * @example
+   * ```ts
+   * async customizeBuild(ctx, spec, draft) {
+   *   draft.registerTool("send_to_im", async (args) => sendIm(args), "Send an IM");
+   * }
+   * ```
+   */
+  registerTool(
+    name: string,
+    handler: ToolHandler,
+    description?: string,
+    inputSchema?: Record<string, unknown>,
+  ): void;
+  /** Handlers registered via {@link registerTool} (in-process only). */
+  readonly toolHandlers: ReadonlyMap<string, ToolHandler>;
 }
 
 export function parseAgentBuildDraft(raw: unknown): AgentBuildDraft {
   const d = asRecord(raw);
   const rawTools = Array.isArray(d.external_tools) ? d.external_tools : [];
-  return {
+  const externalTools = rawTools.map(parseExternalToolDef);
+  const toolHandlers = new Map<string, ToolHandler>();
+  const draft: AgentBuildDraft = {
     model: typeof d.model === "string" ? d.model : null,
     systemPrompt: typeof d.system_prompt === "string" ? d.system_prompt : null,
     additionalInstructions: asStringArray(d.additional_instructions),
     labels: asStringRecord(d.labels),
     appContext: d.app_context !== undefined && d.app_context !== null ? d.app_context : null,
-    externalTools: rawTools.map(parseExternalToolDef),
+    externalTools,
+    registerTool(
+      name: string,
+      handler: ToolHandler,
+      description = "",
+      inputSchema: Record<string, unknown> = { type: "object" },
+    ): void {
+      if (typeof name !== "string") {
+        throw new TypeError(
+          `tool name must be a string, got ${typeof name}: ${String(name)}`,
+        );
+      }
+      if (typeof handler !== "function") {
+        throw new TypeError(
+          `handler must be callable, got ${typeof handler}: ${String(handler)}`,
+        );
+      }
+      externalTools.push({ name, description, inputSchema });
+      toolHandlers.set(name, handler);
+    },
+    get toolHandlers(): ReadonlyMap<string, ToolHandler> {
+      return new Map(toolHandlers);
+    },
   };
+  return draft;
 }
 
 export function agentBuildDraftToDict(

--- a/sdk/typescript/tests/identity-first.test.ts
+++ b/sdk/typescript/tests/identity-first.test.ts
@@ -293,6 +293,208 @@ describe("AgentBuildContext + AgentBuildDraft (REQ-49a)", () => {
     assert.equal(wire.a, "lead:main");
     assert.equal(wire.b, "worker:1");
   });
+
+  it("AgentBuildDraft.registerTool appends a def and stores the handler in-process", async () => {
+    const { parseAgentBuildDraft, agentBuildDraftToDict } = await import("../src/types.js");
+    const draft = parseAgentBuildDraft({});
+    draft.registerTool("echo", async (args) => args, "echoes input", { type: "object" });
+    assert.equal(draft.externalTools.length, 1);
+    assert.equal(draft.externalTools[0].name, "echo");
+    assert.equal(draft.externalTools[0].description, "echoes input");
+    assert.equal(draft.toolHandlers.size, 1);
+
+    // The handler must NOT leak onto the wire — defs only.
+    const wire = agentBuildDraftToDict(draft);
+    const wireTools = wire.external_tools as Array<Record<string, unknown>>;
+    assert.equal(wireTools[0].name, "echo");
+    assert.equal(wireTools[0].handler, undefined);
+  });
+
+  it("AgentBuildDraft.registerTool defaults the schema", async () => {
+    const { parseAgentBuildDraft } = await import("../src/types.js");
+    const draft = parseAgentBuildDraft({});
+    draft.registerTool("t", async () => null);
+    assert.deepEqual(draft.externalTools[0].inputSchema, { type: "object" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentCustomizer external-tool handler registration (restore-path parity)
+// ---------------------------------------------------------------------------
+
+describe("AgentCustomizer customize_build handler registration", () => {
+  const CONTEXT = { identity: "agent:alpha", active_peers: [], managed_edges: [] };
+  const SPEC = { identity: "agent:alpha", profile: "default" };
+
+  async function makeDispatcher() {
+    const { CallbackDispatcher } = await import("../src/agent-builder.js");
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerAgentCustomizer({
+      async customizeBuild(_ctx, _spec, draft) {
+        draft.registerTool("echo", (args) => ({ echo: args.input }), "echoes input");
+      },
+    });
+    return dispatcher;
+  }
+
+  it("captures handlers registered in customizeBuild and dispatches call_tool", async () => {
+    const dispatcher = await makeDispatcher();
+    const result = (await dispatcher.handleCallback(
+      "callback/agent_customizer/customize_build",
+      { scope_id: "c1", context: CONTEXT, spec: SPEC, draft: {} },
+    )) as Record<string, unknown>;
+    const tools = result.external_tools as Array<Record<string, unknown>>;
+    assert.equal(tools[0].name, "echo");
+    assert.equal(tools[0].handler, undefined);
+
+    const called = await dispatcher.handleCallback("callback/call_tool", {
+      scope_id: "c1",
+      tool: "echo",
+      arguments: { input: "hi" },
+    });
+    assert.deepEqual(called, { content: { echo: "hi" } });
+  });
+
+  it("isolates handlers by scope", async () => {
+    const dispatcher = await makeDispatcher();
+    await dispatcher.handleCallback("callback/agent_customizer/customize_build", {
+      scope_id: "c1",
+      context: CONTEXT,
+      spec: SPEC,
+      draft: {},
+    });
+    await assert.rejects(
+      dispatcher.handleCallback("callback/call_tool", {
+        scope_id: "c2",
+        tool: "echo",
+        arguments: {},
+      }),
+      /no handler registered/,
+    );
+  });
+
+  it("re-registers under a fresh scope on restore; latest dispatches and stale releases cleanly", async () => {
+    const dispatcher = await makeDispatcher();
+    await dispatcher.handleCallback("callback/agent_customizer/customize_build", {
+      scope_id: "customize-agent:alpha-1",
+      context: CONTEXT,
+      spec: SPEC,
+      draft: {},
+    });
+    await dispatcher.handleCallback("callback/agent_customizer/customize_build", {
+      scope_id: "customize-agent:alpha-2",
+      context: CONTEXT,
+      spec: SPEC,
+      draft: {},
+    });
+    const r = await dispatcher.handleCallback("callback/call_tool", {
+      scope_id: "customize-agent:alpha-2",
+      tool: "echo",
+      arguments: { input: "yo" },
+    });
+    assert.deepEqual(r, { content: { echo: "yo" } });
+
+    dispatcher.releaseScope("customize-agent:alpha-1");
+    const r2 = await dispatcher.handleCallback("callback/call_tool", {
+      scope_id: "customize-agent:alpha-2",
+      tool: "echo",
+      arguments: { input: "ok" },
+    });
+    assert.deepEqual(r2, { content: { echo: "ok" } });
+  });
+
+  it("degrades gracefully when the gateway sends no scope_id", async () => {
+    const dispatcher = await makeDispatcher();
+    const result = (await dispatcher.handleCallback(
+      "callback/agent_customizer/customize_build",
+      { context: CONTEXT, spec: SPEC, draft: {} },
+    )) as Record<string, unknown>;
+    const tools = result.external_tools as Array<Record<string, unknown>>;
+    assert.equal(tools[0].name, "echo");
+  });
+
+  it("a customizer-registered tool returns image content via toolContent()", async () => {
+    const { CallbackDispatcher } = await import("../src/agent-builder.js");
+    const { textBlock, imageBlock, toolContent } = await import("../src/tool-content.js");
+    const blocks = [textBlock("see this:"), imageBlock("image/png", "aGVsbG8=")];
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerAgentCustomizer({
+      async customizeBuild(_ctx, _spec, draft) {
+        draft.registerTool("shot", () => toolContent(...blocks));
+      },
+    });
+    await dispatcher.handleCallback("callback/agent_customizer/customize_build", {
+      scope_id: "c1",
+      context: CONTEXT,
+      spec: SPEC,
+      draft: {},
+    });
+    const result = await dispatcher.handleCallback("callback/call_tool", {
+      scope_id: "c1",
+      tool: "shot",
+      arguments: {},
+    });
+    assert.deepEqual(result, { content_blocks: blocks });
+  });
+
+  it("a plain array return is NOT reinterpreted as content blocks", async () => {
+    const { CallbackDispatcher } = await import("../src/agent-builder.js");
+    const dispatcher = new CallbackDispatcher();
+    const data = [{ type: "text", text: "this is data" }];
+    dispatcher.registerAgentCustomizer({
+      async customizeBuild(_ctx, _spec, draft) {
+        draft.registerTool("rows", () => data);
+      },
+    });
+    await dispatcher.handleCallback("callback/agent_customizer/customize_build", {
+      scope_id: "c1",
+      context: CONTEXT,
+      spec: SPEC,
+      draft: {},
+    });
+    const result = (await dispatcher.handleCallback("callback/call_tool", {
+      scope_id: "c1",
+      tool: "rows",
+      arguments: {},
+    })) as Record<string, unknown>;
+    assert.deepEqual(result, { content: data });
+    assert.equal(result.content_blocks, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool-result content-block helpers
+// ---------------------------------------------------------------------------
+
+describe("tool-content helpers", () => {
+  it("textBlock / imageBlock / imageBlobBlock build the wire shapes", async () => {
+    const { textBlock, imageBlock, imageBlobBlock } = await import("../src/tool-content.js");
+    assert.deepEqual(textBlock("hi"), { type: "text", text: "hi" });
+    assert.deepEqual(imageBlock("image/png", "aGVsbG8="), {
+      type: "image",
+      media_type: "image/png",
+      source: "inline",
+      data: "aGVsbG8=",
+    });
+    assert.deepEqual(imageBlobBlock("image/jpeg", "blob-123"), {
+      type: "image",
+      media_type: "image/jpeg",
+      source: "blob",
+      blob_id: "blob-123",
+    });
+  });
+
+  it("toolContent wraps blocks into a ToolResultContent marker", async () => {
+    const { textBlock, imageBlock, toolContent, ToolResultContent } = await import(
+      "../src/tool-content.js"
+    );
+    const tc = toolContent(textBlock("a"), imageBlock("image/png", "aGVsbG8="));
+    assert.ok(tc instanceof ToolResultContent);
+    assert.deepEqual(tc.blocks, [
+      { type: "text", text: "a" },
+      { type: "image", media_type: "image/png", source: "inline", data: "aGVsbG8=" },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes to the callback/bridge tool path (release **0.7.10**, lockstep across crates.io / PyPI / npm / Bazel):

### 1. `AgentCustomizer` external-tool **handler** registration (restore-path fix)
`customize_build` runs on **both** fresh create and restore/reconcile, but could previously only declare handler-less `ExternalToolDef`s — so resumed agents silently lost their identity-scoped MCP/comms/etc. tools (the `build_agent` options bag is empty on restore; root cause of the empty bag is an upstream meerkat-mob defect, tracked separately).

- **Rust** `GatewayAgentCustomizer` mints a per-build scope `customize-{identity}-{n}`, ships it in the `customize_build` params, and keys the callback tool dispatcher by that scope instead of the bare identity (reusing the existing `callback/call_tool` plumbing verbatim).
- **Python** `AgentBuildDraft.register_tool(...)` / **TS** `AgentBuildDraft.registerTool(...)` register callable tools; the dispatcher harvests them into the same `(scope, tool)` handler map `build_agent` already uses.
- The SDK **releases the prior per-identity scope** on each restore (the gateway has no scope-release signal), bounding handler-map growth to one live scope per identity.
- `customize_build`/`customizeBuild` signatures are **unchanged** — scope is consumed inside the SDK — so existing customizers and handler-less external tools keep working.

### 2. Callback/bridge tool results can carry **images** / multi-block content
Both callback tool dispatchers shared a helper that always flattened results into a single text block, so a callback tool could never hand the model an image.

- Rich content is **opt-in**: a handler returns `tool_content(...)` / `ToolResultContent`, which the SDK sends as a distinct `content_blocks` field; the gateway deserializes it into runtime `ContentBlock`s.
- A plain return keeps the **exact** legacy `content` → single-text-block behavior, so a tool returning an ordinary JSON array of data is never silently reinterpreted (regression-guarded by test).
- SDK helpers: `text_block`/`image_block`/`image_blob_block` + `tool_content` (Python); `textBlock`/`imageBlock`/`imageBlobBlock` + `toolContent`/`ToolResultContent` (TS), emitting the internally-tagged `source:inline` wire shape.

## Testing
- Rust: new `gateway_bridges` tests (per-build scope, restore re-registration, `content_blocks` preservation, **regression guard** that plain `content` arrays stay text, empty/malformed `content_blocks` fallback).
- Python (67) + TS (493) SDK tests, incl. opt-in vs plain-return and per-identity scope release.
- Local `make ci` green except the documented co-scheduling load flakes (`list_runs` ×2, `routing_delivery::phase0_contract_009`), each verified passing in isolation.

## Review
Went through an adversarial multi-agent review (5 dimensions, per-finding verification); all 7 confirmed findings addressed in this branch — the headline one being the opt-in redesign that eliminates the array-reinterpretation regression on the existing `build_agent` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)