### PR TITLE
feat: honor profile.tools.schedule — wire meerkat schedule tools + firing host

### DIFF
--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -26,10 +26,18 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 
 const FALLBACK_TEMPLATE_VERSION: &str = "tux-fallback-v2";
 
+/// Durable schedule service + the concrete persistent session service it shares
+/// with the firing host (the `dyn MobSessionService` returned for the spec can't
+/// drive the runtime-backed schedule host, which needs the concrete type).
+type ScheduleHostInputs = (
+    meerkat::ScheduleService,
+    Arc<PersistentSessionService<FactoryAgentBuilder>>,
+);
 type PersistentSessionServiceParts = (
     Arc<dyn meerkat_mob::MobSessionService>,
     Arc<meerkat_runtime::MeerkatMachine>,
     Arc<dyn BinaryBlobStore>,
+    Option<ScheduleHostInputs>,
 );
 
 #[derive(Debug, Deserialize)]
@@ -431,6 +439,15 @@ fn build_persistent_session_service(
     let config = Config::default();
     let mut builder = FactoryAgentBuilder::new(factory, config);
     builder.default_blob_store = Some(blob_store.clone());
+    // Attach meerkat's per-session schedule tools so members whose profile sets
+    // tools.schedule=true get the meerkat_schedule_* surface; the returned
+    // service backs the firing host spawned once the runtime has booted.
+    let schedule_service = meerkat_mobkit::schedule_wiring::attach_schedule_tools(
+        &builder,
+        runtime_db_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new(".")),
+    );
     let service = Arc::new(PersistentSessionService::new(
         builder,
         64,
@@ -438,7 +455,8 @@ fn build_persistent_session_service(
         Some(Arc::clone(&runtime_store)),
         blob_store,
     ));
-    Ok((service, adapter, binary_blob_store))
+    let schedule_host_inputs = schedule_service.map(|sched| (sched, Arc::clone(&service)));
+    Ok((service, adapter, binary_blob_store, schedule_host_inputs))
 }
 
 fn runtime_decision_state(
@@ -666,14 +684,19 @@ async fn run() -> anyhow::Result<()> {
     let runtime_id = definition.id.to_string();
     let image_generation = mob_definition_may_use_image_generation(&definition);
 
-    let session_spec = if persistent_sessions {
-        let (service, adapter, binary_blob_store) = build_persistent_session_service(
-            &store_path,
-            runtime_root.clone(),
-            project_root.clone(),
-            context_root.clone(),
-            image_generation,
-        )?;
+    let (session_spec, schedule_host_inputs) = if persistent_sessions {
+        let (service, adapter, binary_blob_store, schedule_host_inputs) =
+            build_persistent_session_service(
+                &store_path,
+                runtime_root.clone(),
+                project_root.clone(),
+                context_root.clone(),
+                image_generation,
+            )?;
+        // Pair the schedule wiring with a clone of the runtime adapter so the
+        // firing host can be spawned once the runtime has booted (below).
+        let schedule_host_inputs =
+            schedule_host_inputs.map(|(sched, svc)| (sched, svc, adapter.clone()));
         // The explicit runtime adapter must share the session service's runtime
         // persistence authority or meerkat 0.7 fails the bootstrap closed.
         // `with_session_runtime_adapter` wires the SAME adapter into the session
@@ -684,7 +707,7 @@ async fn run() -> anyhow::Result<()> {
             .with_session_runtime_adapter(adapter.clone());
         spec.runtime_adapter = Some(adapter);
         spec.binary_blob_store = Some(binary_blob_store);
-        spec
+        (spec, schedule_host_inputs)
     } else {
         // Build the ephemeral path manually to thread project/context roots
         // into AgentFactory (MobBootstrapSpec::ephemeral doesn't accept them).
@@ -726,7 +749,9 @@ async fn run() -> anyhow::Result<()> {
             .with_session_runtime_adapter(adapter.clone());
         spec.runtime_adapter = Some(adapter);
         spec.binary_blob_store = Some(binary_blob_store);
-        spec
+        // Ephemeral sessions have no persistent service; the runtime-backed
+        // schedule firing host (and thus schedule tools) is persistent-only.
+        (spec, None)
     };
     let mob_spec = session_spec.with_options(MobBootstrapOptions {
         allow_ephemeral_sessions: !persistent_sessions,
@@ -748,6 +773,21 @@ async fn run() -> anyhow::Result<()> {
     ))
     .await
     .context("failed to bootstrap local runtime")?;
+
+    // Run the schedule driver so members' authored schedules actually fire: at
+    // due time it materializes a session and runs the prompt as a real agent
+    // turn (session targets via the runtime-backed host, mob targets via the
+    // mob runtime). Held for the gateway's lifetime — dropping the handle shuts
+    // the host down. Persistent sessions only.
+    let _schedule_host = schedule_host_inputs.and_then(|(schedule_service, service, adapter)| {
+        meerkat_mobkit::schedule_wiring::spawn_schedule_host(
+            service,
+            adapter,
+            schedule_service,
+            runtime.mob_runtime().agent_mob_mcp_state(),
+            runtime_id.clone(),
+        )
+    });
 
     // Load contacts.toml if present. This enables mobkit/cross_mob/directory
     // (lookup of known mob addresses) without requiring peer mob handles.

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1885,6 +1885,15 @@ external_addressable = true
             session_store.clone(),
         )));
         inner_builder.default_blob_store = Some(blob_store.clone());
+        // Attach meerkat's per-session schedule tools so SDK-hosted members whose
+        // profile sets tools.schedule=true get the meerkat_schedule_* surface
+        // (the slot lives on the inner FactoryAgentBuilder and propagates through
+        // the callback wrapper). NOTE: the runtime-backed *firing* host is hard-
+        // typed to PersistentSessionService<FactoryAgentBuilder> and would bypass
+        // the SDK build callback (dropping identity tools, the 0.7.10 fix), so the
+        // SDK gateway authors schedules but does not yet fire them — that needs a
+        // meerkat host generic over the session builder.
+        let _ = meerkat_mobkit::schedule_wiring::attach_schedule_tools(&inner_builder, state_path);
         let callback_builder = StdioCallbackAgentBuilder {
             inner: inner_builder,
             bridge: bridge.clone(),

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -26,6 +26,7 @@ pub mod process;
 pub mod protocol;
 pub mod rpc;
 pub mod runtime;
+pub mod schedule_wiring;
 pub mod types;
 pub mod unified_runtime;
 

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -1,0 +1,138 @@
+//! Wire meerkat's per-session schedule tools + firing host into the gateways.
+//!
+//! A mob profile's `tools.schedule = true` maps (in `meerkat-mob`) to
+//! `override_schedule = Enable`, which already resolves on. But the schedule
+//! tools only compose if the agent factory's `default_schedule_tools` slot
+//! holds a dispatcher — and the mobkit gateways never populated it, so the
+//! `meerkat_schedule_*` surface was silently absent even when the capability
+//! was declared and allow-listed.
+//!
+//! [`attach_schedule_tools`] fills that slot (members can author schedules) and
+//! [`spawn_schedule_host`] runs the runtime-backed driver (authored schedules
+//! actually fire: at due time it materializes a session and runs the prompt as
+//! a real agent turn). Both back onto a single durable [`ScheduleService`].
+//!
+//! This is distinct from the static cron oracle (`MobKitBuilder::scheduling`),
+//! which drives module-dispatch ticks, not per-agent schedule tools.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use meerkat::surface::{
+    NoopScheduleMobHost, ScheduleHostHandle, SurfaceScheduleMobHost,
+    spawn_runtime_backed_schedule_host_with_mobs,
+};
+use meerkat::{
+    Config, FactoryAgentBuilder, PersistentSessionService, ScheduleService, ScheduleToolDispatcher,
+    SqliteScheduleStore,
+};
+use meerkat_core::service::SessionBuildOptions;
+use meerkat_mob_mcp::{MobMcpScheduleHost, MobMcpState};
+use meerkat_runtime::MeerkatMachine;
+
+/// File name for the durable schedule store, kept beside the runtime DB so a
+/// gateway and a library-mode runtime pointed at the same dir share state.
+pub const SCHEDULE_STORE_FILE: &str = "schedule.sqlite";
+
+/// Build a durable (Sqlite) [`ScheduleService`] under `state_dir` and attach its
+/// tool dispatcher to `builder`'s default schedule-tools slot.
+///
+/// After this, any member whose profile resolves schedule tools on
+/// (`tools.schedule = true` → `override_schedule = Enable`) is built with the
+/// `meerkat_schedule_{create,get,list,update,pause,resume,delete,occurrences}`
+/// surface. Returns the service so the same instance can back the firing host.
+///
+/// Call this on the `FactoryAgentBuilder` BEFORE it is consumed into a session
+/// service. Returns `None` (with a warning) if the store cannot be opened — the
+/// gateway then boots without schedule tools rather than failing closed.
+#[must_use]
+pub fn attach_schedule_tools(
+    builder: &FactoryAgentBuilder,
+    state_dir: &Path,
+) -> Option<ScheduleService> {
+    let path = state_dir.join(SCHEDULE_STORE_FILE);
+    let store = match SqliteScheduleStore::open(&path) {
+        Ok(store) => store,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %error,
+                "failed to open schedule store; schedule tools disabled for this gateway",
+            );
+            return None;
+        }
+    };
+    let service = ScheduleService::new(Arc::new(store));
+    meerkat::surface::set_default_schedule_tools(
+        builder,
+        Some(Arc::new(ScheduleToolDispatcher::new(service.clone()))),
+    );
+    Some(service)
+}
+
+/// Spawn the runtime-backed schedule host so authored schedules fire: at due
+/// time the driver materializes a session and runs the scheduled prompt as a
+/// real agent turn. Session targets are served by meerkat's runtime-backed
+/// host; mob targets by `meerkat-mob-mcp`'s host when a mob runtime is present.
+///
+/// Requires a persistent session service + the runtime adapter (the firing
+/// driver is not available for ephemeral sessions). The returned handle MUST be
+/// kept alive for the gateway's lifetime — dropping it shuts the host down.
+/// Returns `None` if the store kind cannot host.
+#[must_use]
+pub fn spawn_schedule_host(
+    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    adapter: Arc<MeerkatMachine>,
+    schedule_service: ScheduleService,
+    mob_state: Option<Arc<MobMcpState>>,
+    owner_id: impl Into<String>,
+) -> Option<ScheduleHostHandle> {
+    let mob_host: Arc<dyn SurfaceScheduleMobHost> = match mob_state {
+        Some(state) => Arc::new(MobMcpScheduleHost::new(state)),
+        None => Arc::new(NoopScheduleMobHost::new(
+            "scheduled mob targets are not supported: no mob runtime",
+        )),
+    };
+    spawn_runtime_backed_schedule_host_with_mobs(
+        service,
+        adapter,
+        Config::default(),
+        schedule_service,
+        SessionBuildOptions::default(),
+        mob_host,
+        owner_id,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use meerkat::AgentFactory;
+
+    #[test]
+    fn attach_schedule_tools_populates_the_builder_slot_and_opens_the_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let factory = AgentFactory::new(dir.path());
+        let builder = FactoryAgentBuilder::new(factory, Config::default());
+
+        // The default schedule-tools slot starts empty — this is exactly why
+        // `profile.tools.schedule = true` was inert before this wiring.
+        assert!(
+            builder.default_schedule_tools.read().unwrap().is_none(),
+            "slot should start empty"
+        );
+
+        let service = attach_schedule_tools(&builder, dir.path());
+
+        assert!(service.is_some(), "a durable schedule service is created");
+        assert!(
+            builder.default_schedule_tools.read().unwrap().is_some(),
+            "the dispatcher is installed so override_schedule=Enable members compose schedule tools",
+        );
+        assert!(
+            dir.path().join(SCHEDULE_STORE_FILE).exists(),
+            "the durable store file is created",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the upstream report: a mob profile with `[profiles.X.tools] schedule = true` parses and resolves to `override_schedule = Enable`, but the `meerkat_schedule_*` tools never appeared — meerkat's per-session schedule dispatcher slot was never populated by the gateways, so tool composition failed on the empty slot (factory gate: `effective_schedule && schedule_tools.is_some()`). The flag was recognized but inert.

Everything needed is already in **meerkat 0.7.5** (`meerkat-schedule`, `set_default_schedule_tools`, the runtime-backed host, `MobMcpScheduleHost`) — **no dep bump**.

## What changed

New lib module `schedule_wiring`:
- **`attach_schedule_tools(&builder, dir)`** — opens a durable Sqlite `ScheduleService` beside `runtime.sqlite` and installs `ScheduleToolDispatcher` into the builder's `default_schedule_tools` slot. Members whose profile resolves schedule tools on now compose `meerkat_schedule_{create,get,list,update,pause,resume,delete,occurrences}`.
- **`spawn_schedule_host(...)`** — runs meerkat's runtime-backed firing host (session targets) + `MobMcpScheduleHost` (mob targets), so authored schedules **fire**: at due time the driver materializes a session and runs the prompt as a real agent turn.

Gateways:
- **`mobkit_gateway`** (console, `PersistentSessionService<FactoryAgentBuilder>`): **tools + firing** — full author + execute.
- **`rpc_gateway`** (SDK / HomeCore): **tools** on the inner `FactoryAgentBuilder` (propagates through the `StdioCallbackAgentBuilder` wrapper) — fixes the reported absent-tools symptom.

## Known limitation (needs a small meerkat change)

Firing is **not** wired for the SDK gateway: `spawn_runtime_backed_schedule_host` is hard-typed to `PersistentSessionService<FactoryAgentBuilder>`, but the SDK gateway uses `<StdioCallbackAgentBuilder>` — and that host would bypass the SDK build callback (dropping identity tools, the 0.7.10 fix). The clean fix is to make the meerkat host generic over the session builder; SDK firing then becomes a one-line follow-up here. Tracked as a meerkat devs note.

## Testing
- Unit test: `attach_schedule_tools` populates the (initially empty) builder slot and opens the durable store.
- Both gateway bins compile; local `make ci` green except the documented `list_runs` co-scheduling load flakes (verified passing in isolation under settled load; A/B'd against clean `main` to rule out a regression).

Not a release — bundle with the next mobkit release per Luka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)