### PR TITLE
chore: release v0.7.12 (meerkat 0.7.8 + SDK schedule firing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,9 +1658,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baba5145104663f4338a549e1a189bc19514801c8e7456f79c90f6a6e7954f2d"
+checksum = "a4f2e5ec18d726581d3b20cbe360add5db13b34a8e37d7b27d8c53e4c5b7fcb3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1699,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5646d194af1bca4ed93d161f1229211562a6a397090c8efa27e6ba3afb1ee64"
+checksum = "ee39acdd41a975ca3cde97bbaf8002114972260d511e16c670ef7a791a8f619f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1723,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f823ee9a24a2f6522f53865aba049f174b7fb004e55db99276acce6bd07eb8"
+checksum = "a66e94993799fa7154585394ce0395e639d0612542fc299f42e851a071b63d3b"
 dependencies = [
  "async-trait",
  "axum",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf96c89e992bbd122bff9e457b05984443c23a1bc3c0c7b52d40ebf6d3a5394"
+checksum = "8a077128a6b66442b58bac45287add44d9407ea8fb79cbe334202862a4ce9a32"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90b87ca850dc784b9f1edfededa73684e228fd688ba27fade13326b74bc2fa9"
+checksum = "5d243fa39b41fb392206098bf697f529f33a6f53d71b629533e083960f55b3e5"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb75539b5ae18bf2db7751251e3e4400a6a5750ef556cbe5e50f07c37dd4c7f"
+checksum = "70b84d6113b750725d1ecfc31556c49bc04ccaf00849c0a03df398ebcc25d326"
 dependencies = [
  "async-trait",
  "base64",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0852653792f564bf4f6ddbc6fe81772cba56c36ea954c3b22033f63484f40bed"
+checksum = "01cfd6f16e492a2d5954c088bc099f8f7d7d31a65f72f0b8a692f9c0ed6fe024"
 dependencies = [
  "base64",
  "chrono",
@@ -1836,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18db32c7a38ac4cd978f1b611070c7c62c36fb6b71727da5c1982990f4701d5e"
+checksum = "997ef13feb24a41df53e371aaadd448881c84bdea8d3cdd9f23ec00599770efd"
 dependencies = [
  "async-trait",
  "base64",
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acb8ae59009f979900e6d55b3599e92928e06ed801b35aaf1d63f4dddcc8c4"
+checksum = "0ea6e478b812735c74628132c40baff496d27f67a8839ab57cf18fb46dfdb360"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4824b5aae3a520c7f2056f53a370108f67144e57f8282e0e5d9e2212cb20467"
+checksum = "e13ac982ab18f8a852cd8c800b227765af01aaa7e23b1238b3e1654df04265eb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb05bedad8348b767e671bc1f959a8e9ce5259ae172b16da8bf590414008f2f"
+checksum = "c6b0c1d1b42eeeaf240f0a77a37cafd6098928c10edba6c5870c1c2f2d16410a"
 dependencies = [
  "async-trait",
  "axum",
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a210066d4f245f8697de174e5011f33fc54e2e8986f7abeb4f6277eb6a96621"
+checksum = "940a66f3b4e876ea989965708045e8e8ca65193e6e12ed81287c5442d93d6d40"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aabd391416d1a32e14afe5c2942edab3ccaa2dcb39b458ab44929201330dfb0"
+checksum = "777752fdf8d6457050b253d750b4954e31c4bbc4d7817c5a104859c902d5fb8e"
 dependencies = [
  "quote",
  "syn",
@@ -1970,18 +1970,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ef378b2afcf278d1413df7bf719ec27acc5ca77c3e9c0c82f53a011d004cb4"
+checksum = "2cd163e86221f83b8ce2695fe88a23d5761bf0c1125f475230a3bf9d7cd3be25"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f71b94543d5c72f7cb334fd08c95547f9c789428dee24ae5df41e39693db0"
+checksum = "2ec241a63b3e5c570847c02b23114c71a5dffede376a484e586fb72258c86284"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1990,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d84b9bd93a651b69a63640249de2fb0f43e225bdfaf5acbde15ceffaf95a9dc"
+checksum = "ba16cff42aeecc0c3c37cb128e43116957d623f45c5c1a90e526ede222769c19"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3484274e35a1c354997e8f991bfee60de11fe0a36d92f3bfea7bb9cc63980d33"
+checksum = "264233f5ad0a0f8f8a5a7f2bc08f4bd97c6265b12848420bf916ec44920ca07b"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dcbadd33262b702a23dfd0d9f2bb59f909a44a33dea5287235b552f016750e1"
+checksum = "35dc2e1d5d262a39d8ea6973d2438c4d9cb4c9a82161c40cb28df8cb0c83de42"
 dependencies = [
  "async-trait",
  "futures",
@@ -2041,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eec19f8a26384047434587ff5fde162df80c1af8510c07a35cfbbb9f6fc19f5"
+checksum = "1e4cb6048f4f45cf1e3f9456331e72ebb284a6b6a64277cca0b84880869481db"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a2554fc076fd16863c8426167c37d3b30a97dea623ef2bf2bb29a619bd3756"
+checksum = "b30737ea41cb8a07eeb177394329d4244372980bd2ee8a9334cf1a8328513f6e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02820f720b3318b3bf6f9817d7787d1826db7a3c5ede96359e5262155e3c4e04"
+checksum = "b09394c27399888324f18e08b09b51ba23ea199240749659c3b9e0859e5622aa"
 dependencies = [
  "async-trait",
  "futures",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2175,18 +2175,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c7ff6398a640b3f6d79c061638bbf10116ab2fca4abfd00d94af2f49afab29"
+checksum = "c86ad96a3d2fbf245cc0c76bbf8274289f546b048cd8dd8d03ea4a1177869fc8"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a6b9f91022b527ced52af9b05f1ce7e919842ebabd55a06f87728f9cb9f5fd"
+checksum = "0ad8a9adcdb77b668ee7098a64f35a626416b348185260e5545c2423ea2c2ddc"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2211,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0962a26c576306a865e23659eba4d50c5943e699a57d25fcff825ab9f778947a"
+checksum = "7cc28fc27be2d418124d8bd0af3a544c912d113f640f6a94c7ba1aecab07f4ff"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231792358c45ce8154d985b8e97c36d53204ea9034088f59dde00559c9bce1cc"
+checksum = "148013ed28e9728b0f978c6119ee0ffc6166766e7a0cb274175fe11cceffd982"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2249,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa0ebfa9ad80447432e184d752fecde5af860c0998b0dfdca5084688b4743a3"
+checksum = "2d70f79efd8c8f42c9fe9b46c0a90caae24d40f9b266b7b619b76f6c03e501ef"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2275,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9ded32a2e2f7fa528d103021420e14f50493ed64a36cde1b52dbeb885b17ca"
+checksum = "e7951d7c8de95503b1d86c6b262f5eda2bf04c736e66755150559153e7577afd"
 dependencies = [
  "async-trait",
  "futures",
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a7bca0556168f5930425d13205046bcf5ac7df5e8959ebc83275d0e2f4ba10"
+checksum = "4e8be135b4893febf2f1f34b7c227ab07be7d59fa294e16368339adc90f86637"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2324,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d843c465e211fb9cc9b42d3cfae2d3ad307d9ed4f08f1553f603455be3e9a8f3"
+checksum = "f17d44b13a95aae1c421f615c39c29a77090b7ba733f7f990d0bf858f4d2e540"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2347,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f21faadcadbdb887f3ebf86291961d01522ac3788054a5f9cebe1ae3701db2"
+checksum = "53e24d9a9673806f0df15559a8bdbf21f99c07f8a703668bb8833afbadfebb88"
 dependencies = [
  "async-trait",
  "base64",
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881c27b0a5b98735e9e04822349fd969b7b6b9c837add88dfc0c5eb820242fe9"
+checksum = "226da49479e28412ca052ced3f2c3cb48dfbdb258c37b003e6f64bf635265dd0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.11",
+        "CARGO_PKG_VERSION": "0.7.12",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1817,7 +1817,11 @@ external_addressable = true
     });
 
     // 5. Build session service with callback bridge.
-    let (mob_spec, _temp_dir) = if let Some(ref state_path) = persistent_state {
+    // Stable owner id for the schedule driver, captured before `definition` is
+    // moved into the bootstrap spec.
+    let schedule_owner_id = definition.id.to_string();
+    let (mob_spec, _temp_dir, schedule_host_inputs) = if let Some(ref state_path) = persistent_state
+    {
         if let Err(e) = std::fs::create_dir_all(state_path) {
             fail_init(
                 &request_id,
@@ -1886,28 +1890,33 @@ external_addressable = true
         )));
         inner_builder.default_blob_store = Some(blob_store.clone());
         // Attach meerkat's per-session schedule tools so SDK-hosted members whose
-        // profile sets tools.schedule=true get the meerkat_schedule_* surface
-        // (the slot lives on the inner FactoryAgentBuilder and propagates through
-        // the callback wrapper). NOTE: the runtime-backed *firing* host is hard-
-        // typed to PersistentSessionService<FactoryAgentBuilder> and would bypass
-        // the SDK build callback (dropping identity tools, the 0.7.10 fix), so the
-        // SDK gateway authors schedules but does not yet fire them — that needs a
-        // meerkat host generic over the session builder.
-        let _ = meerkat_mobkit::schedule_wiring::attach_schedule_tools(&inner_builder, state_path);
+        // profile sets tools.schedule=true get the meerkat_schedule_* surface (the
+        // slot lives on the inner FactoryAgentBuilder and propagates through the
+        // callback wrapper). The returned service backs the firing host spawned
+        // after the runtime boots — meerkat's runtime-backed host is now generic
+        // over the session builder, so scheduled sessions materialize through the
+        // SDK build callback and keep their identity-scoped tools.
+        let schedule_service =
+            meerkat_mobkit::schedule_wiring::attach_schedule_tools(&inner_builder, state_path);
         let callback_builder = StdioCallbackAgentBuilder {
             inner: inner_builder,
             bridge: bridge.clone(),
             has_session_builder,
             session_store: Some(session_store.clone()),
         };
-        let session_service: Arc<dyn meerkat_mob::MobSessionService> =
-            Arc::new(meerkat_session::PersistentSessionService::new(
-                callback_builder,
-                gateway_options.max_sessions,
-                session_store,
-                Some(Arc::clone(&runtime_store)),
-                blob_store,
-            ));
+        // Keep the CONCRETE typed service for the firing host (the runtime-backed
+        // host needs PersistentSessionService<StdioCallbackAgentBuilder>, not the
+        // erased Arc<dyn MobSessionService> the spec consumes).
+        let concrete_service = Arc::new(meerkat_session::PersistentSessionService::new(
+            callback_builder,
+            gateway_options.max_sessions,
+            session_store,
+            Some(Arc::clone(&runtime_store)),
+            blob_store,
+        ));
+        let schedule_host_inputs =
+            schedule_service.map(|sched| (sched, Arc::clone(&concrete_service), adapter.clone()));
+        let session_service: Arc<dyn meerkat_mob::MobSessionService> = concrete_service;
         let mut spec = MobBootstrapSpec::new(definition, mob_storage, session_service)
             .with_session_runtime_adapter(adapter.clone())
             .with_options(MobBootstrapOptions {
@@ -1917,7 +1926,7 @@ external_addressable = true
             });
         spec.runtime_adapter = Some(adapter);
         spec.binary_blob_store = Some(binary_blob_store);
-        (spec, None)
+        (spec, None, schedule_host_inputs)
     } else {
         // Ephemeral mode (original behavior).
         // Use MemoryStore to avoid JSONL writes — the gateway uses EphemeralSessionService
@@ -2007,7 +2016,8 @@ external_addressable = true
             });
         spec.runtime_adapter = Some(adapter);
         spec.binary_blob_store = Some(binary_blob_store);
-        (spec, temp_dir)
+        // Ephemeral sessions have no persistent service; firing is persistent-only.
+        (spec, temp_dir, None)
     };
 
     // Wire callback/after_create — notify Python/TS SDK after each session creation.
@@ -2076,6 +2086,22 @@ external_addressable = true
         let _ = stdout.flush();
         std::process::exit(1);
     });
+
+    // Run the schedule driver so SDK-hosted members' authored schedules fire: at
+    // due time the runtime-backed host materializes a session through the SDK
+    // build callback (keeping identity-scoped tools) and runs the prompt as a
+    // real agent turn. Held for the gateway's lifetime — dropping the handle
+    // shuts the host down. Persistent sessions only.
+    let _schedule_host = schedule_host_inputs.and_then(|(schedule_service, service, adapter)| {
+        meerkat_mobkit::schedule_wiring::spawn_schedule_host(
+            service,
+            adapter,
+            schedule_service,
+            runtime.mob_runtime().agent_mob_mcp_state(),
+            schedule_owner_id.clone(),
+        )
+    });
+
     if let Some(state_path) = persistent_state.as_ref() {
         let console_log_path = state_path.join("mobkit_console.sqlite");
         let console_log_store = Arc::new(

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -24,7 +24,7 @@ use meerkat::surface::{
 };
 use meerkat::{
     Config, FactoryAgentBuilder, PersistentSessionService, ScheduleService, ScheduleToolDispatcher,
-    SqliteScheduleStore,
+    SessionAgentBuilder, SqliteScheduleStore,
 };
 use meerkat_core::service::SessionBuildOptions;
 use meerkat_mob_mcp::{MobMcpScheduleHost, MobMcpState};
@@ -79,9 +79,14 @@ pub fn attach_schedule_tools(
 /// driver is not available for ephemeral sessions). The returned handle MUST be
 /// kept alive for the gateway's lifetime — dropping it shuts the host down.
 /// Returns `None` if the store kind cannot host.
+///
+/// Generic over the session builder `B` so both gateways can drive firing: the
+/// console gateway with `FactoryAgentBuilder`, and the SDK gateway with its
+/// `StdioCallbackAgentBuilder` (so scheduled sessions are materialized through
+/// the SDK build callback and keep their identity-scoped tools).
 #[must_use]
-pub fn spawn_schedule_host(
-    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
+    service: Arc<PersistentSessionService<B>>,
     adapter: Arc<MeerkatMachine>,
     schedule_service: ScheduleService,
     mob_state: Option<Arc<MobMcpState>>,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.11"
+version = "0.7.12"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release **v0.7.12**: bump meerkat 0.7.7 → **0.7.8** and mobkit → 0.7.12 (lockstep crates.io / PyPI / npm / Bazel).

### What this unblocks
meerkat 0.7.8 makes the runtime-backed schedule host **generic over the session builder** (`spawn_runtime_backed_schedule_host[_with_mobs]<B: SessionAgentBuilder + 'static>`). That lets the **SDK gateway fire** schedules — previously it could only *author* them (the host was hard-typed to `PersistentSessionService<FactoryAgentBuilder>` while the SDK gateway uses `<StdioCallbackAgentBuilder>`).

### mobkit changes
- `schedule_wiring::spawn_schedule_host` is now generic over `<B: SessionAgentBuilder + 'static>` — both gateways drive firing.
- **`rpc_gateway`** (SDK / HomeCore) wires the firing host on its persistent path: keeps the `ScheduleService` from `attach_schedule_tools`, captures the concrete `PersistentSessionService<StdioCallbackAgentBuilder>`, and spawns the runtime-backed host post-bootstrap (mirrors the `mobkit_gateway` pattern). Scheduled sessions materialize **through the SDK build callback**, so they keep their identity-scoped tools.

**Result:** SDK / HomeCore members can now **fire** schedules (materialize a session + run the prompt at due time), not just author them. The console gateway already fired.

## Testing
- **Gate A:** confirmed meerkat 0.7.8 shipped the generic host.
- **Gate B:** the 4 retire/archive tests pass on 0.7.8 (the #790 fix holds).
- Both gateway bins compile (the generic accepts `StdioCallbackAgentBuilder`; `mobkit_gateway` still infers `FactoryAgentBuilder`).
- `make ci` green except the documented `routing_delivery::phase0_contract_009` load flake (verified passing in isolation).
- TS SDK: 493 pass, clean build. Version parity green across Cargo / PyPI / npm / Bazel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)