### PR TITLE
chore: release v0.7.13 (meerkat 0.7.9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1658,9 +1658,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f2e5ec18d726581d3b20cbe360add5db13b34a8e37d7b27d8c53e4c5b7fcb3"
+checksum = "8609b876b947f2318e661130b6d77f898ee93e3d0e131a5a7cc39c37ab85ba05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1692,16 +1692,15 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
  "tokio_with_wasm",
  "tracing",
 ]
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee39acdd41a975ca3cde97bbaf8002114972260d511e16c670ef7a791a8f619f"
+checksum = "7489f6cea1fc8a10ba718b6c91729fd113d4d436f89ff5f8b2329fbb8a533bdc"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1723,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66e94993799fa7154585394ce0395e639d0612542fc299f42e851a071b63d3b"
+checksum = "93759c9010fba0f0f24a8981d71a8f85798657ef7354e4aeea4cc8337938f8f7"
 dependencies = [
  "async-trait",
  "axum",
@@ -1755,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a077128a6b66442b58bac45287add44d9407ea8fb79cbe334202862a4ce9a32"
+checksum = "cc0192ab8a6a3df8bb2912566586e3221ce99ea53586998214c7df5ca4aeebb0"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1768,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d243fa39b41fb392206098bf697f529f33a6f53d71b629533e083960f55b3e5"
+checksum = "ae42c2284dcf71d1984fa5080b6ff203381e458f0cb67eb782a0973bfdfcc395"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1781,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b84d6113b750725d1ecfc31556c49bc04ccaf00849c0a03df398ebcc25d326"
+checksum = "9485a7f759027fde629576a8557ed08d63ce9d4770f1e6b6661e81512de476d5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1817,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cfd6f16e492a2d5954c088bc099f8f7d7d31a65f72f0b8a692f9c0ed6fe024"
+checksum = "f914925d05a6744c59e2a8e7a1afae0915a4c656ceefa6e74c31c706cee16de9"
 dependencies = [
  "base64",
  "chrono",
@@ -1836,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997ef13feb24a41df53e371aaadd448881c84bdea8d3cdd9f23ec00599770efd"
+checksum = "75e78cc0ed00d31e278cf5008c58a15ec83918bf3b610e2edbe52125b0af2052"
 dependencies = [
  "async-trait",
  "base64",
@@ -1867,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea6e478b812735c74628132c40baff496d27f67a8839ab57cf18fb46dfdb360"
+checksum = "01def1ae8f78f9db1cd3c74d2bb6db631158887c130fe039ba1c4bc1313986ff"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1891,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13ac982ab18f8a852cd8c800b227765af01aaa7e23b1238b3e1654df04265eb"
+checksum = "566031cbb7108dcc4405e140709052a86fe3d6472cb3ea9380feb0ea752d0bff"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1914,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b0c1d1b42eeeaf240f0a77a37cafd6098928c10edba6c5870c1c2f2d16410a"
+checksum = "f240060a094730688092868ef7e6cc8d06beedf75ec6db03d1a11dfeb480c820"
 dependencies = [
  "async-trait",
  "axum",
@@ -1934,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940a66f3b4e876ea989965708045e8e8ca65193e6e12ed81287c5442d93d6d40"
+checksum = "55ebc897c72f91c09143a112178a1acaaadd91bbd4a18281a0bba86160f5b329"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1960,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777752fdf8d6457050b253d750b4954e31c4bbc4d7817c5a104859c902d5fb8e"
+checksum = "d40b4dddc5ec1d89562d38da92abc9f783a0531d1084c4b2f6e52f213a07094b"
 dependencies = [
  "quote",
  "syn",
@@ -1970,18 +1969,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd163e86221f83b8ce2695fe88a23d5761bf0c1125f475230a3bf9d7cd3be25"
+checksum = "21319a2fc7a0c3e480b2adc5dbfbe5ebea959e36b6ee074d86112ef9b3fc885f"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec241a63b3e5c570847c02b23114c71a5dffede376a484e586fb72258c86284"
+checksum = "c340678b2fc39d7fcf2af2c770e1b0e586e9ef7f12387a1aa079a5ef626ef2f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1990,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba16cff42aeecc0c3c37cb128e43116957d623f45c5c1a90e526ede222769c19"
+checksum = "8222ce2e078138e6a375ccb0c224b34cf7a90a5360e5b1847f600259821f1692"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2003,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264233f5ad0a0f8f8a5a7f2bc08f4bd97c6265b12848420bf916ec44920ca07b"
+checksum = "c773834b9d3b6b1bde2dd8b785f14aa88ac8152181af0f2146ce6371d233341b"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2016,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35dc2e1d5d262a39d8ea6973d2438c4d9cb4c9a82161c40cb28df8cb0c83de42"
+checksum = "d0cd89b2c6d8236cb4ae8012c2e96e2d52031deefd2f9bcbf2dc6a58c4d63b00"
 dependencies = [
  "async-trait",
  "futures",
@@ -2041,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4cb6048f4f45cf1e3f9456331e72ebb284a6b6a64277cca0b84880869481db"
+checksum = "dbdc3398c50db9d60978a21345b4a1e1750d09b2de7c8e33fa16aef9edcd4b4d"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2062,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30737ea41cb8a07eeb177394329d4244372980bd2ee8a9334cf1a8328513f6e"
+checksum = "de287f32402ea67c645ba96b68698247664512dcf8938fe853a0704b619b9013"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2100,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09394c27399888324f18e08b09b51ba23ea199240749659c3b9e0859e5622aa"
+checksum = "2ff2ada818778c0f981789561b6d0dbb852c3aec9d8e94e50aa2c12576969564"
 dependencies = [
  "async-trait",
  "futures",
@@ -2125,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2175,18 +2174,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86ad96a3d2fbf245cc0c76bbf8274289f546b048cd8dd8d03ea4a1177869fc8"
+checksum = "4f62b252b6e9cf798d8240c979a95cb78478e7e835811fe31ea40c36600d67f0"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad8a9adcdb77b668ee7098a64f35a626416b348185260e5545c2423ea2c2ddc"
+checksum = "27016a195832547780ec57c4a4bee73acbd1e1436e3244b050dcc293fd5bbc3e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2211,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc28fc27be2d418124d8bd0af3a544c912d113f640f6a94c7ba1aecab07f4ff"
+checksum = "ac0e53a93a937ac01e91ee2019375e69d030e60a5df4c01570013d325b20e84b"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2221,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148013ed28e9728b0f978c6119ee0ffc6166766e7a0cb274175fe11cceffd982"
+checksum = "0a42163965e4e89a282ae6176b3eafe13cff21b2aa53ec071f98134339279639"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2249,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d70f79efd8c8f42c9fe9b46c0a90caae24d40f9b266b7b619b76f6c03e501ef"
+checksum = "915634c897ca16d545d12e89abd7d9c1898b6b64bbc17206b0358db8fcb00169"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2275,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7951d7c8de95503b1d86c6b262f5eda2bf04c736e66755150559153e7577afd"
+checksum = "c2a68dce75bc06793658bde7e528d71f68af926981693578c1054f67229db01a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2301,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8be135b4893febf2f1f34b7c227ab07be7d59fa294e16368339adc90f86637"
+checksum = "1313201dc055a10200daf11537f3f086801695d94caa7b29ae9bed9767f5ca4d"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2324,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17d44b13a95aae1c421f615c39c29a77090b7ba733f7f990d0bf858f4d2e540"
+checksum = "1953d0e5554f98f7e03c3be20d6e40b6a50606c10c5f0f447c33baa9fd94635d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2341,15 +2340,16 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio_with_wasm",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e24d9a9673806f0df15559a8bdbf21f99c07f8a703668bb8833afbadfebb88"
+checksum = "cf83e713840377a3d8ba43fff575c6b8407137dca66054683728c44882f01faf"
 dependencies = [
  "async-trait",
  "base64",
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226da49479e28412ca052ced3f2c3cb48dfbdb258c37b003e6f64bf635265dd0"
+checksum = "e60486d7edf3e75bc7148d310d29867b296681a7f135bda9d86d1689850dd962"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3919,18 +3919,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -3938,7 +3926,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4175,23 +4163,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -4254,12 +4225,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.12"
+version = "0.7.13"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.12",
+        "CARGO_PKG_VERSION": "0.7.13",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/adaptive_layer_decision.schema.json
+++ b/meerkat-mobkit/src/adaptive_layer_decision.schema.json
@@ -16,6 +16,21 @@
         true
       ]
     },
+    "AnthropicCacheControlPolicy": {
+      "description": "Typed shape of Anthropic's prompt-cache breakpoint policy.",
+      "oneOf": [
+        {
+          "const": "disabled",
+          "description": "Do not request Anthropic prompt-cache breakpoints.",
+          "type": "string"
+        },
+        {
+          "const": "system_prefix",
+          "description": "Mark the stable top-level system prompt as an ephemeral cache prefix.",
+          "type": "string"
+        }
+      ]
+    },
     "AnthropicCompactionConfig": {
       "description": "Typed shape of Anthropic's automatic-compaction knob.",
       "oneOf": [
@@ -529,6 +544,21 @@
       "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
       "type": "string"
     },
+    "OpenAiPromptCacheRetention": {
+      "description": "Typed shape of OpenAI's prompt-cache retention hint.",
+      "oneOf": [
+        {
+          "const": "in_memory",
+          "description": "Retain only in memory.",
+          "type": "string"
+        },
+        {
+          "const": "24h",
+          "description": "Retain for 24 hours.",
+          "type": "string"
+        }
+      ]
+    },
     "OutputSchema": {
       "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
       "properties": {
@@ -786,6 +816,17 @@
           "additionalProperties": false,
           "description": "Per-turn Anthropic-specific knobs carried in `ProviderTag::Anthropic`.",
           "properties": {
+            "cache_control": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/AnthropicCacheControlPolicy"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Prompt-cache breakpoint policy."
+            },
             "compaction": {
               "anyOf": [
                 {
@@ -929,6 +970,24 @@
                 "null"
               ]
             },
+            "prompt_cache_key": {
+              "description": "OpenAI prompt-cache affinity routing key.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "prompt_cache_retention": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/OpenAiPromptCacheRetention"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "OpenAI prompt-cache retention hint."
+            },
             "provider": {
               "const": "open_ai",
               "type": "string"
@@ -960,6 +1019,13 @@
               "format": "int64",
               "type": [
                 "integer",
+                "null"
+              ]
+            },
+            "store": {
+              "description": "Responses API persistence override. Absent means the client sends\n`store: false` by default; callers may explicitly opt in with\n`Some(true)`.",
+              "type": [
+                "boolean",
                 "null"
               ]
             },
@@ -1020,6 +1086,13 @@
           "additionalProperties": false,
           "description": "Per-turn Gemini-specific knobs carried in `ProviderTag::Gemini`.",
           "properties": {
+            "cached_content_name": {
+              "description": "Gemini explicit context-cache resource name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "candidate_count": {
               "description": "Number of candidate completions (runtime/persistence knob, not\nread by the Gemini client today — preserved for V3 round-trip).",
               "format": "uint32",

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -5880,11 +5880,17 @@ async fn handle_console_runtime_rpc_with_visibility(
             }
         }
         "mobkit/wait_ready" => {
-            let timeout = request
-                .params
-                .get("timeout_ms")
-                .and_then(Value::as_u64)
-                .map(std::time::Duration::from_millis);
+            // Omit `timeout_ms` => mobkit's generous default ceiling (the SDK
+            // contract is "wait until ready"), not meerkat-mob 0.7.9's lowered
+            // 60s internal default that `None` would otherwise inherit.
+            let timeout = Some(
+                request
+                    .params
+                    .get("timeout_ms")
+                    .and_then(Value::as_u64)
+                    .map(std::time::Duration::from_millis)
+                    .unwrap_or(crate::unified_runtime::mob_ops::DEFAULT_WAIT_READY_TIMEOUT),
+            );
             match runtime.handle().wait_for_ready(timeout).await {
                 Ok(ready) => {
                     let entries: Vec<Value> = ready
@@ -5916,8 +5922,7 @@ async fn handle_console_runtime_rpc_with_visibility(
                     )
                 }
                 Err(err) => {
-                    let message = err.to_string();
-                    if message.to_lowercase().contains("timeout") {
+                    if crate::unified_runtime::mob_ops::is_ready_wait_timeout(&err) {
                         response_value(
                             response_id,
                             Some(serde_json::json!({
@@ -5927,7 +5932,7 @@ async fn handle_console_runtime_rpc_with_visibility(
                             None,
                         )
                     } else {
-                        internal_error(response_id, format!("wait_for_ready failed: {message}"))
+                        internal_error(response_id, format!("wait_for_ready failed: {err}"))
                     }
                 }
             }

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -2053,10 +2053,16 @@ pub(super) async fn handle_wait_ready(
     response_id: Value,
     params: &Value,
 ) -> JsonRpcResponse {
-    let timeout = params
-        .get("timeout_ms")
-        .and_then(Value::as_u64)
-        .map(std::time::Duration::from_millis);
+    // Omit `timeout_ms` => mobkit's generous default ceiling (the SDK contract
+    // is "wait until ready"), not meerkat-mob 0.7.9's lowered 60s internal
+    // default that `None` would otherwise inherit.
+    let timeout = Some(
+        params
+            .get("timeout_ms")
+            .and_then(Value::as_u64)
+            .map(std::time::Duration::from_millis)
+            .unwrap_or(crate::unified_runtime::mob_ops::DEFAULT_WAIT_READY_TIMEOUT),
+    );
     match runtime.mob_handle().wait_for_ready(timeout).await {
         Ok(ready) => {
             let entries: Vec<Value> = ready
@@ -2079,9 +2085,7 @@ pub(super) async fn handle_wait_ready(
             }
         }
         Err(err) => {
-            let message = err.to_string();
-            let timed_out = message.to_lowercase().contains("timeout");
-            if timed_out {
+            if crate::unified_runtime::mob_ops::is_ready_wait_timeout(&err) {
                 JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id,
@@ -2098,7 +2102,7 @@ pub(super) async fn handle_wait_ready(
                     result: None,
                     error: Some(JsonRpcError {
                         code: -32000,
-                        message: format!("wait_for_ready failed: {message}"),
+                        message: format!("wait_for_ready failed: {err}"),
                         data: None,
                     }),
                 }

--- a/meerkat-mobkit/src/unified_runtime/mob_ops.rs
+++ b/meerkat-mobkit/src/unified_runtime/mob_ops.rs
@@ -6,7 +6,7 @@
 //! operations — status, discover, reconcile, retire, helpers, etc. — are now
 //! on `MobHandle` directly; callers reach through `runtime.mob_handle()`.
 
-use meerkat_mob::{MobHandle, SpawnMemberSpec, SpawnResult};
+use meerkat_mob::{MobError, MobHandle, SpawnMemberSpec, SpawnResult};
 use std::future::Future;
 
 use crate::mob_handle_runtime::MobRuntimeError;
@@ -17,6 +17,32 @@ use super::UnifiedRuntime;
 // fail-fast enqueue in meerkat-mob 0.6.x. Keep bulk discovery bootstrap
 // serialized until the upstream signal path is backpressured.
 const MAX_CONCURRENT_SPAWN_MANY: usize = 1;
+
+/// Default ceiling for `mobkit/wait_ready` when the caller omits `timeout_ms`.
+///
+/// meerkat-mob 0.7.9 (#798, reactive-readiness redesign) lowered its own
+/// internal `DEFAULT_READY_WAIT_TIMEOUT` from 600s to 60s; that default is
+/// applied inside `MobHandle::wait_for_ready` whenever the caller passes
+/// `None`. mobkit's SDK contract for `wait_ready` is "wait until the mob is
+/// ready", so a caller that omits a timeout keeps the prior generous ceiling
+/// rather than silently inheriting meerkat's lowered 60s — the reactive wait
+/// still returns promptly when members converge, so this is only the safety
+/// wall for genuinely slow startups. Pass an explicit `timeout_ms` to override.
+pub(crate) const DEFAULT_WAIT_READY_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_mins(10);
+
+/// Whether a `MobHandle::wait_for_ready` error is a readiness-deadline timeout
+/// (which maps to the documented `{ ready: [], timeout: true }` envelope) as
+/// opposed to a genuine failure (which surfaces as an RPC error).
+///
+/// Matches the typed variant rather than the Display string: meerkat-mob's
+/// [`MobError::ReadyWaitTimedOut`] renders as `"member ready wait timed out"`,
+/// which does NOT contain the substring `"timeout"` (only `"timed out"`), so
+/// the previous `message.to_lowercase().contains("timeout")` check always fell
+/// through to the error branch and returned `-32000` instead of the envelope.
+pub(crate) fn is_ready_wait_timeout(err: &MobError) -> bool {
+    matches!(err, MobError::ReadyWaitTimedOut { .. })
+}
 
 impl UnifiedRuntime {
     pub fn mob_handle(&self) -> MobHandle {
@@ -118,11 +144,39 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use super::try_join_in_batches;
+    use super::{is_ready_wait_timeout, try_join_in_batches};
+    use meerkat_mob::MobError;
 
     #[tokio::test]
     async fn spawn_many_batch_size_stays_serial_until_upstream_backpressure_exists() {
         assert_eq!(super::MAX_CONCURRENT_SPAWN_MANY, 1);
+    }
+
+    #[test]
+    fn ready_wait_timeout_is_classified_as_envelope_not_error() {
+        // Regression (meerkat-mob 0.7.9 #798): the default ready-wait dropped
+        // 600s -> 60s, so `wait_for_ready` hits this timeout far more often.
+        // The prior `message.to_lowercase().contains("timeout")` never matched
+        // the Display "member ready wait timed out", so timeouts wrongly
+        // surfaced as a -32000 RPC error instead of `{ ready: [], timeout:true }`.
+        let timed_out = MobError::ReadyWaitTimedOut {
+            pending_member_ids: vec![],
+        };
+        assert!(is_ready_wait_timeout(&timed_out));
+
+        // Pin the exact failure mode that motivated the typed match.
+        let display = timed_out.to_string().to_lowercase();
+        assert!(
+            !display.contains("timeout"),
+            "old substring check would have missed this timeout"
+        );
+        assert!(display.contains("timed out"));
+
+        // Precision: a *kickoff* timeout also Displays "...timed out" but is not
+        // a readiness timeout — it must NOT be folded into the ready envelope.
+        assert!(!is_ready_wait_timeout(&MobError::KickoffWaitTimedOut {
+            pending_member_ids: vec![],
+        }));
     }
 
     #[tokio::test]

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -1889,7 +1889,10 @@ class MobHandle:
         ``timeout=True`` means partial readiness within the deadline; the
         ``ready`` list will be empty in that case.
 
-        :param timeout: optional seconds to wait. ``None`` blocks indefinitely.
+        :param timeout: optional seconds to wait. Omit/``None`` waits up to a
+            generous server-side default ceiling (~10 minutes); pass an explicit
+            value to override. The wait returns as soon as members converge — the
+            ceiling is only the wall before ``timeout=True`` is reported.
         """
         params: dict[str, Any] = {}
         if timeout is not None:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.12"
+version = "0.7.13"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -1254,7 +1254,8 @@ export class MobHandle {
    * Relays meerkat 0.6's `MobHandle::wait_for_ready`. Returns
    * `{ ready: [...], timeout: false }` on full convergence; on timeout
    * returns `{ ready: [], timeout: true }`. Pass `timeoutSeconds` to bound
-   * the wait, or omit it to block indefinitely.
+   * the wait, or omit it to wait up to a generous server-side default ceiling
+   * (~10 minutes); the wait returns as soon as members converge.
    */
   async waitReady(
     timeoutSeconds?: number,


### PR DESCRIPTION
Upgrades the meerkat family **0.7.8 → 0.7.9** and releases mobkit **0.7.13** (crates.io + PyPI + npm in lockstep).

The bump compiled clean, but `make ci` and the requested adversarial behavior-regression review surfaced **two real adaptations** a compile-only check would have missed:

### 1. Adaptive layer-decision schema drift (would break adaptive-pack deploys)
meerkat 0.7.9 added the `AnthropicCacheControlPolicy` and `OpenAiPromptCacheRetention` `$defs` to `LayerDecision`. mobkit bundles `adaptive_layer_decision.schema.json` pinned **Value-equal** to meerkat's canonical `layer_decision_schema()`; a mismatch fails any adaptive-pack deploy/validate with `StaleAdaptiveSchema`. Regenerated the bundled snapshot (purely additive, +73 lines). Guarded by `bundled_layer_decision_schema_matches_meerkat_canonical`.

### 2. `wait_ready` timeout contract regression (#798 fallout)
#798 lowered meerkat-mob's `DEFAULT_READY_WAIT_TIMEOUT` **600s → 60s** (applied whenever the caller passes `None`). mobkit's two `wait_ready` handlers:
- forwarded `None`, silently inheriting the new 60s where the SDK documents "wait until ready"; **and**
- detected the timeout via `message.to_lowercase().contains("timeout")`, which never matches the Display `"member ready wait timed out"` (only `"timed out"`) — so a ready-wait timeout returned RPC error `-32000` instead of the documented `{ ready: [], timeout: true }` envelope. The 10× shorter default made this latent bug far more reachable.

Fixes:
- mobkit supplies a generous **10-min** default ceiling when `timeout_ms` is omitted (meerkat's 60s only applies to its tool-callers, which get a detached-wait fallback mobkit's direct `MobHandle` path lacks);
- new typed classifier `mob_ops::is_ready_wait_timeout()` (matches `MobError::ReadyWaitTimedOut`) replaces the broken substring in both handlers — precise enough not to fold in a kickoff timeout;
- Python + TS docstrings corrected to stop promising "block indefinitely";
- regression test pins the Display-string mismatch + the classifier.

## Testing
- `make ci`: deterministic suite green (1158 pass); the only repeated failures are the documented rotating load-flakes (`list_runs_*`, `routing_delivery::phase0_contract_009`, `mob_events_streaming`, `mob_events_cursor_persistence` — all pass in isolation). Schema + wait_ready tests verified green via targeted runs.
- TS SDK: 493/493 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)