### PR TITLE
chore: release v0.7.14 (fix session-owned reset/delete archive-NotFound)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.13"
+version = "0.7.14"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.13",
+        "CARGO_PKG_VERSION": "0.7.14",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -15,8 +15,8 @@ use meerkat_mob::{
 
 use crate::mob_handle_runtime::{
     content_input_has_images, is_previous_member_cleanup_ambiguous_error,
-    is_recoverable_lifecycle_cleanup_error, model_capabilities_for_member,
-    topology_restore_failed_peer_ids,
+    is_recoverable_lifecycle_cleanup_error, is_recoverable_session_owned_retire_cleanup_error,
+    model_capabilities_for_member, topology_restore_failed_peer_ids,
 };
 
 use super::adapters::{ContinuitySessionStoreAdapter, SessionRuntimeState};
@@ -1031,7 +1031,19 @@ impl SessionBridge for MobSessionBridge {
                 self.forget_runtime_member(runtime_id).await;
                 Ok(())
             }
-            Err(err) if is_recoverable_lifecycle_cleanup_error(&err.to_string()) => Ok(()),
+            // All callers of `retire_member` are identity-first session-owned
+            // agents, so a mob-archive miss (NotFound for a registered runtime
+            // session) is the expected outcome of disposing one — not an
+            // orphan. Tolerate it so reset/delete_identity complete instead of
+            // bricking the identity until a process restart.
+            Err(err) if is_recoverable_session_owned_retire_cleanup_error(&err.to_string()) => {
+                // Disposal completed and the member left the roster, so the
+                // runtime-member mapping is stale — forget it (matching the
+                // success path) instead of leaking one entry per tolerated
+                // retire across the process lifetime.
+                self.forget_runtime_member(runtime_id).await;
+                Ok(())
+            }
             Err(err) => Err(BridgeError::Mob(err.to_string())),
         }
     }

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -65,6 +65,44 @@ pub(crate) fn is_recoverable_lifecycle_cleanup_error(error: &str) -> bool {
             ))
 }
 
+/// The mob lifecycle authority's `ArchiveSession` step legitimately found no
+/// session to archive because the retired member is a SESSION-OWNED
+/// identity-first agent (built via `Bridge::create_session` / a
+/// `SessionAgentBuilder` roster), not a spawned mob member tracked by that
+/// authority.
+///
+/// meerkat-mob disposes the member (succeeds), then runs `ArchiveSession`; the
+/// authority has no record for the session, and because the runtime adapter
+/// still holds it the archive helper escalates the miss to a fatal "disposal
+/// completed but ArchiveSession failed: ... NotFound for registered runtime
+/// session". For a session-owned identity that archive record never existed —
+/// disposal already completed — so the cleanup retire must not fail the
+/// lifecycle op (otherwise reset/delete_identity brick the identity until a
+/// process restart).
+///
+/// Requires the `disposal completed` prefix so an aborted disposal (the session
+/// genuinely never tore down) stays fail-closed.
+fn is_session_owned_archive_absent_cleanup_error(error: &str) -> bool {
+    error.contains("disposal completed but ArchiveSession failed")
+        && error.contains("NotFound for registered runtime session")
+}
+
+/// Retire-cleanup tolerance for the identity-first SESSION-OWNED bridge.
+///
+/// Every caller of [`Bridge::retire_member`](crate::identity_first) lives in
+/// `identity_first/`, where members are built session-owned (`create_session`),
+/// never spawned. So in addition to the shared recoverable-cleanup cases it
+/// also tolerates the session-owned archive-absent error above.
+///
+/// This is DELIBERATELY kept out of [`is_recoverable_lifecycle_cleanup_error`],
+/// which the mob-member reset/retire paths use (via `lifecycle_archive_cleanup_completed`)
+/// and which MUST keep rejecting archive-NotFound to surface genuinely orphaned
+/// spawned members.
+pub(crate) fn is_recoverable_session_owned_retire_cleanup_error(error: &str) -> bool {
+    is_recoverable_lifecycle_cleanup_error(error)
+        || is_session_owned_archive_absent_cleanup_error(error)
+}
+
 /// True when a session archive failed only at its final runtime-retire
 /// realization because the session machine sits in `Stopped`.
 ///
@@ -5228,6 +5266,76 @@ image_generation = true
         ));
         assert!(!is_recoverable_lifecycle_cleanup_error(
             "disposal aborted at ArchiveSession: continuity save: stale fencing token"
+        ));
+    }
+
+    /// Regression: `reset()` / `delete_identity()` for a SESSION-OWNED roster
+    /// identity failed because meerkat-mob escalates the archive miss to a fatal
+    /// "disposal completed but ArchiveSession failed: ... NotFound for
+    /// registered runtime session". The exact production strings (from the
+    /// field report) must classify as recoverable for the identity-first bridge
+    /// retire path.
+    #[test]
+    fn session_owned_retire_cleanup_accepts_archive_not_found_for_registered_runtime_session() {
+        // Exact shape the classifier receives at the bridge layer:
+        // `handle.retire(..).err().to_string()` (the `MobError` Display chain),
+        // WITHOUT any later `session bridge mob error:` wrapping.
+        let reset_error = "internal error: disposal completed but ArchiveSession failed: \
+            session error: agent error: Internal error: mob archive authority returned \
+            NotFound for registered runtime session 019ee136-33bc-7bc3-80f9-2aac38736291";
+        let delete_error = "internal error: disposal completed but ArchiveSession failed: \
+            session error: agent error: Internal error: mob archive authority returned \
+            NotFound for registered runtime session 019ee136-340d-7203-a089-c3357835c824";
+
+        assert!(is_recoverable_session_owned_retire_cleanup_error(
+            reset_error
+        ));
+        assert!(is_recoverable_session_owned_retire_cleanup_error(
+            delete_error
+        ));
+    }
+
+    /// The mob-MEMBER orphan gate must stay fail-closed on the same string — a
+    /// spawned member whose archive authority lost its record is a real orphan.
+    /// This is the deliberate separation: only the identity-first session-owned
+    /// retire path tolerates it.
+    #[test]
+    fn mob_member_lifecycle_gate_still_rejects_archive_not_found() {
+        let error = "internal error: disposal completed but ArchiveSession failed: \
+            session error: agent error: Internal error: mob archive authority returned \
+            NotFound for registered runtime session 019ee136-33bc-7bc3-80f9-2aac38736291";
+
+        assert!(!is_recoverable_lifecycle_cleanup_error(error));
+        // Belt-and-suspenders: the helper isolates the new arm.
+        assert!(is_session_owned_archive_absent_cleanup_error(error));
+    }
+
+    /// The session-owned gate is a strict superset of the shared one.
+    #[test]
+    fn session_owned_retire_cleanup_still_accepts_shared_recoverable_cases() {
+        let cancel_race = "internal error: disposal completed but ArchiveSession failed: \
+            session error: agent error: Internal error: runtime cancel-before-retire failed \
+            for 019e3c52-0f1b-73d3-a5c7-4b21c2bbf131: Runtime not ready: running";
+
+        assert!(is_recoverable_session_owned_retire_cleanup_error(
+            cancel_race
+        ));
+    }
+
+    /// Stay scoped to COMPLETED disposals: an aborted disposal (session never
+    /// tore down) or a bare NotFound without the disposal prefix is a real error.
+    #[test]
+    fn session_owned_retire_cleanup_requires_completed_disposal() {
+        assert!(!is_recoverable_session_owned_retire_cleanup_error(
+            "disposal aborted at ArchiveSession: mob archive authority returned NotFound \
+             for registered runtime session 019ee136-33bc-7bc3-80f9-2aac38736291"
+        ));
+        assert!(!is_recoverable_session_owned_retire_cleanup_error(
+            "mob archive authority returned NotFound for registered runtime session \
+             019ee136-33bc-7bc3-80f9-2aac38736291"
+        ));
+        assert!(!is_recoverable_session_owned_retire_cleanup_error(
+            "model provider returned rate limit"
         ));
     }
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.13"
+version = "0.7.14"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Bug
`runtime.reset()` and `runtime.delete_identity()` failed for **session-owned roster identities** (built via a `SessionAgentBuilder` / `bridge.create_session`, not spawned mob members) with:

```
disposal completed but ArchiveSession failed: ... mob archive authority
returned NotFound for registered runtime session <id>
```

meerkat-mob disposes the member (succeeds), then its `ArchiveSession` step escalates the mob-lifecycle-authority archive miss to a fatal error because the runtime adapter still holds the session (an orphan guard, `provisioner.rs:888`). For a session-owned identity that archive record **never existed** — it's a registered runtime session, not a spawned mob member — so the miss is expected, not an orphan. mobkit's `bridge.retire_member` surfaced it as a hard error, **bricking reset/delete until a process restart** and leaving a dangling `identity→rt:…` binding (reported by HomeCore; blocks re-profiling an agent via reset).

## Fix (scoped to the identity-first session-owned retire path only)
- **`is_recoverable_session_owned_retire_cleanup_error`** (`mob_handle_runtime.rs`): the shared recoverable-cleanup cases **plus** the session-owned archive-absent case (`"disposal completed but ArchiveSession failed"` + `"NotFound for registered runtime session"`), gated on the `disposal completed` prefix so an *aborted* disposal stays fail-closed.
- **`bridge.retire_member`** — the single chokepoint; every caller lives in `identity_first/`, all session-owned via `create_session`, never spawned — uses it, and now also calls `forget_runtime_member` on the tolerated branch to match the success path. Tolerating the miss lets reset/delete complete → identity ends **Active + rebound to the new generation** (reset) or **cleanly removed** (delete), resolving the dangling-binding/restart symptom.
- The shared **`is_recoverable_lifecycle_cleanup_error`** used by the mob-**member** reset/retire paths (`rpc`, `http_console`, `console_aggregator`, `mob_methods`) is **unchanged** and still rejects archive-NotFound, so genuinely orphaned spawned members are still surfaced.

## Why mobkit and not meerkat
meerkat cannot distinguish a legitimate session-owned identity from a real orphaned mob member (both look like "session in the adapter, no archivable record"); making its guard non-fatal would blunt orphan detection. mobkit is the only layer that knows the identity was built session-owned, and it already owns the recoverable-vs-fatal policy — so the scoped tolerance belongs here.

## Testing
- New regression tests use the **exact production error string** (the `MobError` Display chain that reaches the bridge) and assert the mob-member gate still rejects it (orphan detection intact).
- `make ci` green except the documented `routing_delivery::phase0_contract_009` load-flake (passes 1/1 in isolation). Classifier tests + fmt + clippy + the full suite otherwise green.
- **Two adversarial Opus review agents** (string-match fidelity, scoping/correctness, completeness, atomicity) found **no merge-blockers**; their two low-severity suggestions (forget stale mapping; test the exact un-wrapped string shape) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)