### PR TITLE
chore: release v0.7.15 (re-profile session-owned identities on reset)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.14"
+version = "0.7.15"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.14",
+        "CARGO_PKG_VERSION": "0.7.15",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -1645,6 +1645,48 @@ impl IdentityRuntime {
         Ok(())
     }
 
+    /// Adopt the roster's CURRENT spec for `identity` into the in-memory entry,
+    /// so a subsequent [`reset`](Self::reset) rebuilds the regenerated session
+    /// on the current profile instead of carrying the stored one forward.
+    ///
+    /// Best-effort: logs and leaves the stored spec in place if the roster
+    /// can't be resolved or no longer lists the identity (reset's primary job —
+    /// the destructive continuity reset — must not fail because the roster
+    /// provider hiccuped). The runtime stays roster-agnostic; the provider is
+    /// supplied by the caller (the reset RPC handler), which owns it.
+    pub async fn adopt_roster_spec(
+        &self,
+        roster_provider: &Arc<dyn RosterProvider>,
+        identity: &AgentIdentity,
+    ) {
+        match roster_provider
+            .roster(&RosterContext {
+                mob_definition: None,
+                previous_identities: Vec::new(),
+            })
+            .await
+        {
+            Ok(specs) => {
+                if let Some(spec) = specs.into_iter().find(|s| &s.identity == identity)
+                    && let Err(err) = self.update_spec(spec).await
+                {
+                    tracing::warn!(
+                        identity = %identity,
+                        error = %err,
+                        "reset: failed to adopt current roster spec; rebuilding on stored spec",
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    identity = %identity,
+                    error = %err,
+                    "reset: roster provider failed; rebuilding on stored spec",
+                );
+            }
+        }
+    }
+
     /// Update the lease for an identity.
     pub async fn update_lease(
         &self,

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -2994,10 +2994,11 @@ async fn handle_unified_rpc_json_inner(
             }
         }
         "mobkit/reset" => {
-            let identity_rt = match identity_ctx {
-                Some(ctx) => &*ctx.runtime,
+            let identity_reset_ctx = match identity_ctx {
+                Some(ctx) => ctx,
                 None => return maybe_identity_not_configured(is_notification, response_id),
             };
+            let identity_rt = &*identity_reset_ctx.runtime;
             let identity_str = request
                 .params
                 .get("identity")
@@ -3090,6 +3091,13 @@ async fn handle_unified_rpc_json_inner(
                     };
                 }
             };
+            // Re-profile on reset: adopt the roster's CURRENT spec (e.g. a
+            // changed `profile`) for the regenerated session rather than
+            // carrying the stored spec forward. reset advances the generation,
+            // so the fresh member id never collides with the outgoing one.
+            identity_rt
+                .adopt_roster_spec(&identity_reset_ctx.roster_provider, &identity)
+                .await;
             match identity_rt.reset(&identity).await {
                 Ok(record) => {
                     let cleanup_warning = if let Err(err) = retire_stale_rpc_members_for_identity(

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -33,7 +33,8 @@ use meerkat_mobkit::identity_first::{
     DispatchIdempotencyKey, DispatchInput, DispatchOrigin, DurabilityPolicy, DurableAgentSpec,
     FencingToken, IdentityLifecycleState, IdentityRuntime, IdentityRuntimeConfig,
     IdentityRuntimeError, LeaseAcquireResult, LeaseError, LeaseGrant, LeaseRenewResult,
-    ManagedPeerEdge, SessionBridge, SessionSnapshot, TopologyContext, TopologyError,
+    ManagedPeerEdge, RosterContext, RosterError, RosterProvider, SessionBridge, SessionSnapshot,
+    TopologyContext, TopologyError,
 };
 use meerkat_mobkit::identity_first::{LocalContinuityStore, LocalLeaseProvider};
 use meerkat_mobkit::{ErrorEvent, ErrorHook};
@@ -852,6 +853,7 @@ struct CountingBridge {
     unregistered_session_ids: tokio::sync::Mutex<Vec<String>>,
     wires: tokio::sync::Mutex<Vec<(String, String)>>,
     current_wires: tokio::sync::Mutex<Vec<(String, String)>>,
+    last_create_spec: tokio::sync::Mutex<Option<DurableAgentSpec>>,
 }
 
 impl CountingBridge {
@@ -908,11 +910,12 @@ impl SessionBridge for CountingBridge {
         &self,
         _identity: &AgentIdentity,
         _runtime_id: &AgentRuntimeId,
-        _spec: &DurableAgentSpec,
+        spec: &DurableAgentSpec,
         _draft: &AgentBuildDraft,
         session_id: &meerkat_core::types::SessionId,
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         self.create_calls.fetch_add(1, Ordering::SeqCst);
+        *self.last_create_spec.lock().await = Some(spec.clone());
         if self.fail_create.load(Ordering::SeqCst) {
             return Err(BridgeError::Mob("create failed".to_string()));
         }
@@ -2526,6 +2529,144 @@ async fn identity_first_runtime_reset_register_failure_reports_cleanup_failure_a
         "cleanup ambiguity must not refresh a bridge-visible lease"
     );
     assert_old_token_snapshot_write_rejected(store.as_ref(), &id, &record, old_token).await;
+}
+
+/// Roster provider that returns a fixed set of specs (mirrors the operator's
+/// current roster definition).
+struct StaticRoster(Vec<DurableAgentSpec>);
+
+#[async_trait]
+impl RosterProvider for StaticRoster {
+    async fn roster(&self, _ctx: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        Ok(self.0.clone())
+    }
+}
+
+/// Roster provider that always fails (to exercise the best-effort fallback).
+struct FailingRoster;
+
+#[async_trait]
+impl RosterProvider for FailingRoster {
+    async fn roster(&self, _ctx: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        Err(RosterError::ProviderUnavailable(
+            "roster provider unavailable".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn identity_first_runtime_reset_adopts_updated_spec_profile() {
+    // Re-profile via reset (REQ-10 / HomeCore re-profile): the mobkit/reset RPC
+    // handler calls adopt_roster_spec(roster_provider, identity) before reset,
+    // so the generation-advancing rebuild creates the fresh session on the
+    // roster's CURRENT profile rather than the stored one. reset mints
+    // rt:{id}:{gen+1}, so the fresh member never collides with the outgoing
+    // gen-0 member. This drives the actual handler glue (roster -> find ->
+    // update_spec), so it FAILS on the pre-fix code where reset carried the
+    // stored profile forward.
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease_prov.clone(), bridge.clone());
+
+    let id = make_identity("domain:security");
+    let initial_grants = lease_prov
+        .acquire_leases(std::slice::from_ref(&id), "test-runtime")
+        .await
+        .unwrap();
+    let initial_grant = match initial_grants.get(&id).unwrap() {
+        LeaseAcquireResult::Acquired(g) => g.clone(),
+        _ => panic!("expected Acquired"),
+    };
+    let record = make_record("domain:security", 0, 1);
+    store
+        .upsert_continuity_record(&record, initial_grant.fencing_token)
+        .await
+        .unwrap();
+    runtime
+        .register(
+            make_spec("domain:security"), // stored profile = "default"
+            IdentityLifecycleState::Active,
+            Some(record),
+            Some(initial_grant),
+        )
+        .await;
+
+    // Operator flipped the roster profile to "security" (plus an unrelated
+    // identity, to prove adopt_roster_spec picks the matching one).
+    let mut reprofiled = make_spec("domain:security");
+    reprofiled.profile = meerkat_mob::ProfileName::from("security");
+    let roster: Arc<dyn RosterProvider> =
+        Arc::new(StaticRoster(vec![make_spec("other:agent"), reprofiled]));
+
+    // This is exactly what the reset RPC handler does before reset().
+    runtime.adopt_roster_spec(&roster, &id).await;
+
+    let new_record = runtime.reset(&id).await.unwrap();
+    assert_eq!(new_record.generation, ContinuityGeneration::new(1));
+    assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 1);
+
+    let created = bridge
+        .last_create_spec
+        .lock()
+        .await
+        .clone()
+        .expect("reset must create a fresh session via the bridge");
+    assert_eq!(
+        created.profile,
+        meerkat_mob::ProfileName::from("security"),
+        "reset must rebuild on the roster's current profile, not the stored 'default'",
+    );
+}
+
+#[tokio::test]
+async fn identity_first_runtime_reset_falls_back_to_stored_spec_when_roster_unavailable() {
+    // Best-effort: if the roster provider fails, adopt_roster_spec leaves the
+    // stored spec in place and reset still rebuilds (on the stored profile)
+    // rather than failing the destructive continuity reset.
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease_prov.clone(), bridge.clone());
+
+    let id = make_identity("domain:security");
+    let initial_grants = lease_prov
+        .acquire_leases(std::slice::from_ref(&id), "test-runtime")
+        .await
+        .unwrap();
+    let initial_grant = match initial_grants.get(&id).unwrap() {
+        LeaseAcquireResult::Acquired(g) => g.clone(),
+        _ => panic!("expected Acquired"),
+    };
+    let record = make_record("domain:security", 0, 1);
+    store
+        .upsert_continuity_record(&record, initial_grant.fencing_token)
+        .await
+        .unwrap();
+    runtime
+        .register(
+            make_spec("domain:security"), // stored profile = "default"
+            IdentityLifecycleState::Active,
+            Some(record),
+            Some(initial_grant),
+        )
+        .await;
+
+    let roster: Arc<dyn RosterProvider> = Arc::new(FailingRoster);
+    runtime.adopt_roster_spec(&roster, &id).await; // best-effort, must not panic
+
+    runtime.reset(&id).await.unwrap();
+    let created = bridge
+        .last_create_spec
+        .lock()
+        .await
+        .clone()
+        .expect("reset must still create a fresh session");
+    assert_eq!(
+        created.profile,
+        meerkat_mob::ProfileName::from("default"),
+        "roster failure must fall back to the stored profile, not brick reset",
+    );
 }
 
 #[tokio::test]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.14"
+version = "0.7.15"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Bug
`runtime.reset()` / SDK `reset()` could not **re-profile** a session-owned roster identity (HomeCore: `domain:security` stuck on `profile=domain`, shell never activated). reset regenerated the session from the **stored** in-memory entry spec and never re-read the roster provider's **current** spec, so the new generation rebuilt on the old profile. A restart also resumed the old profile (the gen+1 session was created on the stored profile).

A separate facet — a forced `delete_identity` + fresh-create over the still-Running gen-0 member failing with meerkat's `mob member already exists` / `invalid state transition: Running -> Running` — is a **meerkat defect** (it flattens a member-level retire rejection into a misleading mob-phase self-loop). The generation-advancing reset path sidesteps it for profile-backed identities and is the supported re-profile route. *(Note: the sidestep holds for profile-backed identities; externally-bound specs use a generation-independent member id — pre-existing, not changed here.)*

## Fix (mobkit-only, scoped to the `mobkit/reset` RPC path)
- **`IdentityRuntime::adopt_roster_spec(roster_provider, identity)`** — best-effort refresh of the in-memory entry spec from the roster's current spec. The runtime stays roster-agnostic (the provider is passed in by the handler, which owns it). On roster-provider error or identity-not-in-roster it logs and leaves the stored spec in place, so reset's destructive continuity reset never fails because the roster hiccuped.
- The **`mobkit/reset` handler** calls `adopt_roster_spec` before `reset()`, so the gen+1 rebuild's `create_session` uses the roster's current profile. reset mints `rt:{id}:{gen+1}`, so the fresh member never collides with the outgoing gen-0 member. A successful re-profile **persists across restart**: the gen+1 session's durable metadata is the new profile, which resume inherits.

## Scope / known limitations (documented)
- The **console** `reset`/`reset_all` handlers and **`reconcile_identity`** do NOT re-profile (`http_console` has no roster provider; reconcile resumes Ready continuity). Re-profiling is the SDK/RPC `reset` path HomeCore uses. Threading a roster provider into the console handlers is a possible follow-up.

## Testing
- `reset_adopts_updated_spec_profile`: drives `adopt_roster_spec` from a changed-profile roster → reset rebuilds on the new profile. **Fails on pre-fix code** (real regression guard).
- `reset_falls_back_to_stored_spec_when_roster_unavailable`: roster failure → reset still rebuilds on the stored profile (best-effort).
- Full reset suite (13 tests) green; Rust suite 1166/1166 locally (zero flakes); fmt/clippy/parity/python green. flow-editor validated on CI (local browser-probe is an env limitation).
- **Two adversarial Opus agents** (correctness/scoping; end-to-end/restart/test-validity) — no merge-blockers; their test-coverage finding is addressed by extracting + testing `adopt_roster_spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)