### PR TITLE
Prepare v0.7.17 reset roster provider wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.16"
+version = "0.7.17"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.16",
+        "CARGO_PKG_VERSION": "0.7.17",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -2483,6 +2483,8 @@ external_addressable = true
         // Build provider bridges for callbacks to Python
         let roster: Arc<dyn meerkat_mobkit::identity_first::contracts::RosterProvider> =
             Arc::new(GatewayRosterProvider::new(bridge.clone()));
+        let mob_definition = runtime.mob_handle().definition().clone();
+        irt.set_reset_roster_provider_context(Some(roster.clone()), Some(mob_definition.clone()));
         let topology: Option<Arc<dyn meerkat_mobkit::identity_first::contracts::TopologyProvider>> =
             if has_topology_provider {
                 Some(Arc::new(GatewayTopologyProvider::new(bridge.clone())))
@@ -2542,7 +2544,7 @@ external_addressable = true
         // Call restore_flow to bootstrap identities from the roster provider
         let roster_specs = roster
             .roster(&RosterContext {
-                mob_definition: None,
+                mob_definition: Some(mob_definition.clone()),
                 previous_identities: Vec::new(),
             })
             .await
@@ -2580,6 +2582,7 @@ external_addressable = true
             topology_provider: topology,
             customizer,
             agent_memory_provider,
+            mob_definition: Some(mob_definition),
         })
     } else {
         None

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -300,7 +300,10 @@ impl IdentityFirstRuntimeContext {
         mob_definition: Option<meerkat_mob::MobDefinition>,
         lazy_materialization: bool,
     ) -> Self {
-        runtime.set_reset_roster_provider(Some(roster_provider.clone()));
+        runtime.set_reset_roster_provider_context(
+            Some(roster_provider.clone()),
+            mob_definition.clone(),
+        );
         Self {
             runtime,
             roster_provider,
@@ -353,7 +356,7 @@ pub struct IdentityRuntime {
     has_runtime_store: bool,
     durability_policy: DurabilityPolicy,
     bridge: Option<Arc<dyn SessionBridge>>,
-    reset_roster_provider: StdRwLock<Option<Arc<dyn RosterProvider>>>,
+    reset_roster_source: StdRwLock<Option<ResetRosterSource>>,
     runtime_services: AgentRuntimeServices,
     managed_peer_edges: RwLock<BTreeSet<(AgentIdentity, AgentIdentity)>>,
     managed_peer_reconcile_lock: Mutex<()>,
@@ -367,6 +370,12 @@ pub struct IdentityRuntime {
     default_timeout: Duration,
     materialization_failure_backoff: RwLock<BTreeMap<AgentIdentity, MaterializationFailureBackoff>>,
     error_hook: StdRwLock<Option<crate::unified_runtime::ErrorHook>>,
+}
+
+#[derive(Clone)]
+struct ResetRosterSource {
+    provider: Arc<dyn RosterProvider>,
+    mob_definition: Option<meerkat_mob::MobDefinition>,
 }
 
 #[derive(Debug, Clone)]
@@ -387,7 +396,7 @@ impl IdentityRuntime {
             has_runtime_store: config.has_runtime_store,
             durability_policy: config.durability_policy,
             bridge: config.bridge,
-            reset_roster_provider: StdRwLock::new(None),
+            reset_roster_source: StdRwLock::new(None),
             runtime_services: AgentRuntimeServices::empty(),
             managed_peer_edges: RwLock::new(BTreeSet::new()),
             managed_peer_reconcile_lock: Mutex::new(()),
@@ -406,6 +415,20 @@ impl IdentityRuntime {
 
     pub fn with_runtime_services(mut self, runtime_services: AgentRuntimeServices) -> Self {
         self.runtime_services = runtime_services;
+        self
+    }
+
+    pub fn with_reset_roster_provider(self, provider: Arc<dyn RosterProvider>) -> Self {
+        self.set_reset_roster_provider(Some(provider));
+        self
+    }
+
+    pub fn with_reset_roster_provider_context(
+        self,
+        provider: Arc<dyn RosterProvider>,
+        mob_definition: Option<meerkat_mob::MobDefinition>,
+    ) -> Self {
+        self.set_reset_roster_provider_context(Some(provider), mob_definition);
         self
     }
 
@@ -504,30 +527,48 @@ impl IdentityRuntime {
 
     /// Attach the roster provider reset should consult for current specs.
     pub fn set_reset_roster_provider(&self, provider: Option<Arc<dyn RosterProvider>>) {
-        match self.reset_roster_provider.write() {
-            Ok(mut stored_provider) => *stored_provider = provider,
+        self.set_reset_roster_provider_context(provider, None);
+    }
+
+    /// Attach the roster provider and context reset should consult for current specs.
+    pub fn set_reset_roster_provider_context(
+        &self,
+        provider: Option<Arc<dyn RosterProvider>>,
+        mob_definition: Option<meerkat_mob::MobDefinition>,
+    ) {
+        let source = provider.map(|provider| ResetRosterSource {
+            provider,
+            mob_definition,
+        });
+        match self.reset_roster_source.write() {
+            Ok(mut stored_source) => *stored_source = source,
             Err(err) => {
                 tracing::warn!(
                     error = %err,
-                    "identity runtime reset roster provider lock poisoned; dropping provider update"
+                    "identity runtime reset roster source lock poisoned; dropping provider update"
                 );
             }
         }
     }
 
     async fn adopt_current_roster_spec_for_reset(&self, identity: &AgentIdentity) {
-        let provider = match self.reset_roster_provider.read() {
-            Ok(stored_provider) => stored_provider.clone(),
+        let source = match self.reset_roster_source.read() {
+            Ok(stored_source) => stored_source.clone(),
             Err(err) => {
                 tracing::warn!(
                     error = %err,
-                    "reset: roster provider lock poisoned; rebuilding on stored spec"
+                    "reset: roster source lock poisoned; rebuilding on stored spec"
                 );
                 None
             }
         };
-        if let Some(provider) = provider {
-            self.adopt_roster_spec(&provider, identity).await;
+        if let Some(source) = source {
+            self.adopt_roster_spec_with_context(
+                &source.provider,
+                identity,
+                source.mob_definition.clone(),
+            )
+            .await;
         }
     }
 
@@ -1782,9 +1823,19 @@ impl IdentityRuntime {
         roster_provider: &Arc<dyn RosterProvider>,
         identity: &AgentIdentity,
     ) {
+        self.adopt_roster_spec_with_context(roster_provider, identity, None)
+            .await;
+    }
+
+    async fn adopt_roster_spec_with_context(
+        &self,
+        roster_provider: &Arc<dyn RosterProvider>,
+        identity: &AgentIdentity,
+        mob_definition: Option<meerkat_mob::MobDefinition>,
+    ) {
         match roster_provider
             .roster(&RosterContext {
-                mob_definition: None,
+                mob_definition,
                 previous_identities: Vec::new(),
             })
             .await
@@ -4002,7 +4053,60 @@ mod reset_reprofile_tests {
     }
 
     #[tokio::test]
-    async fn reset_reprofiles_session_from_current_roster_spec()
+    async fn reset_reprofiles_session_from_runtime_configured_roster_provider()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identity = AgentIdentity::parse("domain:security")?;
+        let roster = Arc::new(MutableRoster::new(vec![durable_spec(
+            identity.clone(),
+            "domain",
+        )]));
+        let bridge = Arc::new(RecordingBridge::default());
+        let runtime = Arc::new(
+            IdentityRuntime::new(IdentityRuntimeConfig {
+                continuity_store: Arc::new(LocalContinuityStore::in_memory()?),
+                lease_provider: Arc::new(LocalLeaseProvider::new()),
+                runtime_instance_id: "reset-reprofile-test".to_string(),
+                has_runtime_store: true,
+                durability_policy: DurabilityPolicy::SyncWriteThrough,
+                bridge: Some(bridge.clone()),
+                default_timeout: None,
+            })
+            .with_reset_roster_provider(roster.clone()),
+        );
+
+        super::super::orchestrator::restore_flow(
+            &runtime,
+            &roster
+                .roster(&RosterContext {
+                    mob_definition: None,
+                    previous_identities: Vec::new(),
+                })
+                .await?,
+            None,
+            None,
+        )
+        .await?;
+        roster
+            .set(vec![durable_spec(identity.clone(), "security")])
+            .await;
+
+        let record = runtime.reset(&identity).await?;
+
+        assert_eq!(record.generation.get(), 1);
+        assert_eq!(
+            bridge.create_profiles().await,
+            vec!["domain".to_string(), "security".to_string()]
+        );
+        let status = runtime.status(&identity).await?;
+        assert_eq!(
+            status.profile.map(|profile| profile.to_string()).as_deref(),
+            Some("security")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reset_reprofiles_session_from_identity_first_context_roster_provider()
     -> Result<(), Box<dyn std::error::Error>> {
         let identity = AgentIdentity::parse("domain:security")?;
         let roster = Arc::new(MutableRoster::new(vec![durable_spec(
@@ -4013,7 +4117,7 @@ mod reset_reprofile_tests {
         let runtime = Arc::new(IdentityRuntime::new(IdentityRuntimeConfig {
             continuity_store: Arc::new(LocalContinuityStore::in_memory()?),
             lease_provider: Arc::new(LocalLeaseProvider::new()),
-            runtime_instance_id: "reset-reprofile-test".to_string(),
+            runtime_instance_id: "reset-reprofile-context-test".to_string(),
             has_runtime_store: true,
             durability_policy: DurabilityPolicy::SyncWriteThrough,
             bridge: Some(bridge.clone()),

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -1207,6 +1207,7 @@ pub struct IdentityFirstContext {
     pub customizer: Option<std::sync::Arc<dyn crate::identity_first::contracts::AgentCustomizer>>,
     pub agent_memory_provider:
         Option<std::sync::Arc<dyn crate::identity_first::AgentMemoryProvider>>,
+    pub mob_definition: Option<meerkat_mob::MobDefinition>,
 }
 
 pub fn handle_unified_rpc_json<'a>(
@@ -3245,7 +3246,10 @@ async fn handle_unified_rpc_json_inner(
                     };
                 }
             };
-            identity_rt.set_reset_roster_provider(Some(identity_reset_ctx.roster_provider.clone()));
+            identity_rt.set_reset_roster_provider_context(
+                Some(identity_reset_ctx.roster_provider.clone()),
+                identity_reset_ctx.mob_definition.clone(),
+            );
             match identity_rt.reset(&identity).await {
                 Ok(record) => {
                     let cleanup_warning = if let Err(err) = retire_stale_rpc_members_for_identity(
@@ -3537,7 +3541,7 @@ async fn handle_unified_rpc_json_inner(
             let roster_specs = match ctx
                 .roster_provider
                 .roster(&crate::identity_first::RosterContext {
-                    mob_definition: None,
+                    mob_definition: ctx.mob_definition.clone(),
                     previous_identities: Vec::new(),
                 })
                 .await
@@ -4542,13 +4546,14 @@ mod tests {
         resolve_rpc_identity_control_target, rpc_live_identity_alias_visible,
         rpc_member_id_matches_durable_identity,
     };
-    use crate::identity_first::contracts::RosterProvider;
+    use crate::identity_first::contracts::{ContinuityStore, LeaseProvider, RosterProvider};
     use crate::identity_first::{
-        AgentAddressability, AgentIdentity, AgentRuntimeId, CheckpointVersion,
-        ContinuityGeneration, ContinuityRecord, DurabilityPolicy, DurableAgentSpec, FencingToken,
-        IdentityLifecycleState, IdentityRuntime, IdentityRuntimeConfig, LeaseGrant,
-        LocalContinuityStore, LocalLeaseProvider, MarkdownAgentMemoryStore, RosterContext,
-        RosterError,
+        AgentAddressability, AgentBuildDraft, AgentIdentity, AgentRuntimeId, BridgeError,
+        CheckpointVersion, ContinuityGeneration, ContinuityRecord, DurabilityPolicy,
+        DurableAgentSpec, FencingToken, IdentityLifecycleState, IdentityRuntime,
+        IdentityRuntimeConfig, LeaseAcquireResult, LeaseGrant, LocalContinuityStore,
+        LocalLeaseProvider, MarkdownAgentMemoryStore, ResumeSessionOutcome, RosterContext,
+        RosterError, SessionBridge, SessionSnapshot,
     };
     use crate::{
         DiscoverySpec, IdentityFirstContext, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig,
@@ -4573,6 +4578,135 @@ mod tests {
             _context: &RosterContext,
         ) -> Result<Vec<DurableAgentSpec>, RosterError> {
             Ok(Vec::new())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct ContextRequiredEmptyRosterProvider {
+        missing_definition_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ContextRequiredEmptyRosterProvider {
+        fn missing_definition_calls(&self) -> usize {
+            self.missing_definition_calls
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl RosterProvider for ContextRequiredEmptyRosterProvider {
+        async fn roster(
+            &self,
+            context: &RosterContext,
+        ) -> Result<Vec<DurableAgentSpec>, RosterError> {
+            if context.mob_definition.is_none() {
+                self.missing_definition_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                return Err(RosterError::ProviderUnavailable(
+                    "mob definition required".to_string(),
+                ));
+            }
+            Ok(Vec::new())
+        }
+    }
+
+    #[derive(Debug)]
+    struct ContextRequiredStaticRosterProvider {
+        specs: Vec<DurableAgentSpec>,
+        missing_definition_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ContextRequiredStaticRosterProvider {
+        fn new(specs: Vec<DurableAgentSpec>) -> Self {
+            Self {
+                specs,
+                missing_definition_calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn missing_definition_calls(&self) -> usize {
+            self.missing_definition_calls
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl RosterProvider for ContextRequiredStaticRosterProvider {
+        async fn roster(
+            &self,
+            context: &RosterContext,
+        ) -> Result<Vec<DurableAgentSpec>, RosterError> {
+            if context.mob_definition.is_none() {
+                self.missing_definition_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                return Err(RosterError::ProviderUnavailable(
+                    "mob definition required".to_string(),
+                ));
+            }
+            Ok(self.specs.clone())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RpcResetTestBridge {
+        create_calls: std::sync::atomic::AtomicUsize,
+        last_create_spec: tokio::sync::Mutex<Option<DurableAgentSpec>>,
+    }
+
+    impl RpcResetTestBridge {
+        async fn last_create_spec(&self) -> Option<DurableAgentSpec> {
+            self.last_create_spec.lock().await.clone()
+        }
+    }
+
+    #[async_trait]
+    impl SessionBridge for RpcResetTestBridge {
+        async fn create_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            session_id: &meerkat_core::types::SessionId,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            self.create_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            *self.last_create_spec.lock().await = Some(spec.clone());
+            Ok(session_id.clone())
+        }
+
+        async fn resume_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            session_id: &meerkat_core::types::SessionId,
+            _snapshot: &SessionSnapshot,
+        ) -> Result<ResumeSessionOutcome, BridgeError> {
+            Ok(ResumeSessionOutcome::Resumed {
+                session_id: session_id.clone(),
+            })
+        }
+
+        async fn deliver(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _content: &meerkat_core::ContentInput,
+        ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+            Ok(meerkat_core::types::SessionId::new())
+        }
+
+        async fn checkpoint_session(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _session_id: &meerkat_core::types::SessionId,
+        ) -> Result<SessionSnapshot, BridgeError> {
+            Ok(SessionSnapshot { data: Vec::new() })
+        }
+
+        async fn retire_member(&self, _runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
+            Ok(())
         }
     }
 
@@ -4619,6 +4753,60 @@ comms = true
                     default_llm_client: Some(Arc::new(TestClient::default())),
                 }),
         )
+    }
+
+    fn rpc_reprofile_mob_spec(
+        temp_dir: &tempfile::TempDir,
+    ) -> Result<MobBootstrapSpec, Box<dyn std::error::Error + Send + Sync>> {
+        let session_path = temp_dir.path().join("sessions");
+        std::fs::create_dir_all(&session_path)?;
+        let factory = AgentFactory::new(&session_path).comms(true);
+        let session_service = Arc::new(build_ephemeral_service(factory, Config::default(), 16));
+        let definition = MobDefinition::from_toml(
+            r#"
+[mob]
+id = "rpc-reset-reprofile-test"
+
+[profiles.domain]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.domain.tools]
+comms = true
+
+[profiles.security]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.security.tools]
+comms = true
+shell = true
+"#,
+        )?;
+        Ok(
+            MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
+                .with_options(MobBootstrapOptions {
+                    allow_ephemeral_sessions: true,
+                    notify_orchestrator_on_resume: true,
+                    default_llm_client: Some(Arc::new(TestClient::default())),
+                }),
+        )
+    }
+
+    fn rpc_durable_spec(identity: &str, profile: &str) -> DurableAgentSpec {
+        DurableAgentSpec {
+            identity: AgentIdentity::parse(identity).expect("valid identity"),
+            profile: meerkat_mob::ProfileName::from(profile),
+            addressability: AgentAddressability::Addressable,
+            display_name: None,
+            labels: BTreeMap::new(),
+            context: None,
+            additional_instructions: Vec::new(),
+            initial_message: None,
+            runtime_mode_override: None,
+            backend: None,
+            binding: None,
+        }
     }
 
     #[tokio::test]
@@ -4815,6 +5003,192 @@ comms = true
     }
 
     #[tokio::test]
+    async fn reconcile_identity_passes_mob_definition_to_roster_provider()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let temp_dir = tempfile::tempdir()?;
+        let runtime = Box::pin(
+            UnifiedRuntime::builder()
+                .mob_spec(rpc_test_mob_spec(&temp_dir)?)
+                .module_config(MobKitConfig {
+                    modules: Vec::new(),
+                    discovery: DiscoverySpec {
+                        namespace: "rpc-reconcile-roster-context-test".to_string(),
+                        modules: Vec::new(),
+                    },
+                    pre_spawn: Vec::new(),
+                })
+                .timeout(Duration::from_secs(1))
+                .build(),
+        )
+        .await?;
+        let identity_rt = Arc::new(IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(LocalContinuityStore::in_memory()?),
+            lease_provider: Arc::new(LocalLeaseProvider::new()),
+            runtime_instance_id: "rpc-reconcile-roster-context-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: None,
+            default_timeout: None,
+        }));
+        let roster_provider = Arc::new(ContextRequiredEmptyRosterProvider::default());
+        let identity_ctx = IdentityFirstContext {
+            runtime: identity_rt,
+            roster_provider: roster_provider.clone(),
+            topology_provider: None,
+            customizer: None,
+            agent_memory_provider: None,
+            mob_definition: Some(runtime.mob_handle().definition().clone()),
+        };
+
+        let response: Value = serde_json::from_str(
+            &handle_unified_rpc_json(
+                &runtime,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "mobkit/reconcile_identity",
+                    "params": {},
+                })
+                .to_string(),
+                Duration::from_secs(1),
+                None,
+                Some(&identity_ctx),
+            )
+            .await,
+        )?;
+
+        assert!(response["error"].is_null(), "{response:#?}");
+        assert_eq!(
+            roster_provider.missing_definition_calls(),
+            0,
+            "reconcile_identity must preserve mob_definition in roster context"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reset_identity_preserves_mob_definition_for_roster_reprofile()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let temp_dir = tempfile::tempdir()?;
+        let runtime = Box::pin(
+            UnifiedRuntime::builder()
+                .mob_spec(rpc_reprofile_mob_spec(&temp_dir)?)
+                .module_config(MobKitConfig {
+                    modules: Vec::new(),
+                    discovery: DiscoverySpec {
+                        namespace: "rpc-reset-roster-context-test".to_string(),
+                        modules: Vec::new(),
+                    },
+                    pre_spawn: Vec::new(),
+                })
+                .timeout(Duration::from_secs(1))
+                .build(),
+        )
+        .await?;
+
+        let continuity_store = Arc::new(LocalContinuityStore::in_memory()?);
+        let lease_provider = Arc::new(LocalLeaseProvider::new());
+        let bridge = Arc::new(RpcResetTestBridge::default());
+        let identity_rt = Arc::new(IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: continuity_store.clone(),
+            lease_provider: lease_provider.clone(),
+            runtime_instance_id: "rpc-reset-roster-context-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge.clone()),
+            default_timeout: None,
+        }));
+
+        let identity = AgentIdentity::parse("domain:security")?;
+        let initial_grants = lease_provider
+            .acquire_leases(
+                std::slice::from_ref(&identity),
+                "rpc-reset-roster-context-test",
+            )
+            .await?;
+        let initial_grant = match initial_grants.get(&identity) {
+            Some(LeaseAcquireResult::Acquired(grant)) => grant.clone(),
+            other => return Err(format!("expected acquired lease, got {other:?}").into()),
+        };
+        let initial_record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:domain:security:0")?,
+            session_id: meerkat_core::types::SessionId::new(),
+            generation: ContinuityGeneration::new(0),
+            checkpoint_version: CheckpointVersion::new(0),
+        };
+        continuity_store
+            .upsert_continuity_record(&initial_record, initial_grant.fencing_token)
+            .await?;
+        identity_rt
+            .register(
+                rpc_durable_spec(identity.as_str(), "domain"),
+                IdentityLifecycleState::Active,
+                Some(initial_record),
+                Some(initial_grant),
+            )
+            .await;
+
+        let roster_provider = Arc::new(ContextRequiredStaticRosterProvider::new(vec![
+            rpc_durable_spec(identity.as_str(), "security"),
+        ]));
+        let identity_ctx = IdentityFirstContext {
+            runtime: identity_rt.clone(),
+            roster_provider: roster_provider.clone(),
+            topology_provider: None,
+            customizer: None,
+            agent_memory_provider: None,
+            mob_definition: Some(runtime.mob_handle().definition().clone()),
+        };
+
+        let response: Value = serde_json::from_str(
+            &handle_unified_rpc_json(
+                &runtime,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "mobkit/reset",
+                    "params": { "identity": identity.as_str() },
+                })
+                .to_string(),
+                Duration::from_secs(1),
+                None,
+                Some(&identity_ctx),
+            )
+            .await,
+        )?;
+
+        assert!(response["error"].is_null(), "{response:#?}");
+        assert_eq!(
+            roster_provider.missing_definition_calls(),
+            0,
+            "mobkit/reset must preserve mob_definition when installing the reset roster provider"
+        );
+        assert_eq!(
+            bridge
+                .create_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "reset should rebuild through the bridge"
+        );
+        let created = bridge
+            .last_create_spec()
+            .await
+            .expect("reset should record created spec");
+        assert_eq!(created.profile.as_str(), "security");
+        assert_eq!(
+            identity_rt
+                .status(&identity)
+                .await?
+                .profile
+                .expect("identity should keep profile")
+                .as_str(),
+            "security"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn unified_rpc_agent_memory_remember_writes_identity_scoped_record()
     -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let temp_dir = tempfile::tempdir()?;
@@ -4881,6 +5255,7 @@ comms = true
             topology_provider: None,
             customizer: None,
             agent_memory_provider: Some(provider),
+            mob_definition: None,
         };
 
         let capabilities: Value = serde_json::from_str(
@@ -5142,6 +5517,7 @@ comms = true
             topology_provider: None,
             customizer: None,
             agent_memory_provider: Some(provider),
+            mob_definition: None,
         };
 
         let capabilities: Value = serde_json::from_str(
@@ -5815,6 +6191,7 @@ comms = true
             topology_provider: None,
             customizer: None,
             agent_memory_provider: None,
+            mob_definition: None,
         };
         for requested_identity in ["review:singleton", "rt:review:singleton:0"] {
             let response: Value = serde_json::from_str(
@@ -6062,6 +6439,7 @@ comms = true
             topology_provider: None,
             customizer: None,
             agent_memory_provider: None,
+            mob_definition: None,
         };
 
         let send = |id: u64, params: Value| {
@@ -6281,6 +6659,7 @@ comms = true
             topology_provider: None,
             customizer: None,
             agent_memory_provider: None,
+            mob_definition: None,
         };
         let raw = handle_unified_rpc_json(
             &runtime,
@@ -6394,6 +6773,7 @@ comms = true
             topology_provider: None,
             customizer: None,
             agent_memory_provider: None,
+            mob_definition: None,
         };
 
         // The raw roster member is part of the declared baseline ...

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -746,7 +746,11 @@ impl UnifiedRuntimeBuilder {
                     bridge,
                     default_timeout: None,
                 })
-                .with_runtime_services(AgentRuntimeServices::new(runtime.mob_runtime.handle())),
+                .with_runtime_services(AgentRuntimeServices::new(runtime.mob_runtime.handle()))
+                .with_reset_roster_provider_context(
+                    roster_provider.clone(),
+                    Some(runtime.mob_runtime.handle().definition().clone()),
+                ),
             );
             identity_runtime
                 .set_agent_customizer(agent_customizer.clone())

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -214,11 +214,51 @@ impl StubRosterProvider {
             specs: Arc::new(tokio::sync::Mutex::new(specs)),
         }
     }
+
+    async fn set(&self, specs: Vec<DurableAgentSpec>) {
+        *self.specs.lock().await = specs;
+    }
 }
 
 #[async_trait]
 impl RosterProvider for StubRosterProvider {
     async fn roster(&self, _context: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        Ok(self.specs.lock().await.clone())
+    }
+}
+
+#[derive(Clone)]
+struct MobDefinitionRequiredRosterProvider {
+    specs: Arc<tokio::sync::Mutex<Vec<DurableAgentSpec>>>,
+    missing_definition_calls: Arc<AtomicUsize>,
+}
+
+impl MobDefinitionRequiredRosterProvider {
+    fn new(specs: Vec<DurableAgentSpec>) -> Self {
+        Self {
+            specs: Arc::new(tokio::sync::Mutex::new(specs)),
+            missing_definition_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    async fn set(&self, specs: Vec<DurableAgentSpec>) {
+        *self.specs.lock().await = specs;
+    }
+
+    fn missing_definition_calls(&self) -> usize {
+        self.missing_definition_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl RosterProvider for MobDefinitionRequiredRosterProvider {
+    async fn roster(&self, context: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        if context.mob_definition.is_none() {
+            self.missing_definition_calls.fetch_add(1, Ordering::SeqCst);
+            return Err(RosterError::ProviderUnavailable(
+                "mob definition required".to_string(),
+            ));
+        }
         Ok(self.specs.lock().await.clone())
     }
 }
@@ -319,10 +359,39 @@ message = "run review cycle"
     .unwrap()
 }
 
+fn domain_security_definition() -> meerkat_mob::MobDefinition {
+    meerkat_mob::MobDefinition::from_toml(
+        r#"
+[mob]
+id = "identity-builder-reset-reprofile-test"
+
+[profiles.domain]
+model = "gpt-5.5"
+runtime_mode = "turn_driven"
+
+[profiles.domain.tools]
+comms = true
+
+[profiles.security]
+model = "gpt-5.5"
+runtime_mode = "turn_driven"
+
+[profiles.security.tools]
+comms = true
+shell = true
+"#,
+    )
+    .unwrap()
+}
+
 fn durable_spec(identity: &str) -> DurableAgentSpec {
+    durable_spec_with_profile(identity, "default")
+}
+
+fn durable_spec_with_profile(identity: &str, profile: &str) -> DurableAgentSpec {
     DurableAgentSpec {
         identity: AgentIdentity::parse(identity).unwrap(),
-        profile: meerkat_mob::ProfileName::from("default"),
+        profile: meerkat_mob::ProfileName::from(profile),
         addressability: AgentAddressability::Addressable,
         display_name: None,
         labels: BTreeMap::new(),
@@ -593,6 +662,131 @@ async fn identity_first_builder_persistent_state_accepts_roster_and_agent_memory
         .await
         .expect("runtime should expose empty reads after deleting bundled persistent memory");
     assert!(after_forget.is_empty());
+}
+
+#[tokio::test]
+async fn identity_first_builder_reset_reprofiles_from_current_roster_provider() {
+    let tmp = tempfile::tempdir().unwrap();
+    let identity = AgentIdentity::parse("domain:security").unwrap();
+    let roster = Arc::new(StubRosterProvider::new(vec![durable_spec_with_profile(
+        identity.as_str(),
+        "domain",
+    )]));
+
+    let runtime = Box::pin(
+        UnifiedRuntimeBuilder::default()
+            .definition(domain_security_definition())
+            .continuity_store(Arc::new(LocalContinuityStore::in_memory().unwrap()))
+            .lease_provider(Arc::new(
+                meerkat_mobkit::identity_first::LocalLeaseProvider::new(),
+            ))
+            .roster_provider(roster.clone())
+            .scratch_dir(tmp.path())
+            .identity_runtime_instance_id("builder-reset-reprofile-test")
+            .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+            .build(),
+    )
+    .await
+    .expect("builder should bootstrap identity-first runtime");
+
+    let identity_runtime = runtime
+        .identity_runtime()
+        .expect("identity runtime should be exposed");
+    let before = identity_runtime
+        .status(&identity)
+        .await
+        .expect("identity should start active");
+    assert_eq!(before.profile.unwrap().as_str(), "domain");
+
+    roster
+        .set(vec![durable_spec_with_profile(
+            identity.as_str(),
+            "security",
+        )])
+        .await;
+
+    let reset_record = identity_runtime
+        .reset(&identity)
+        .await
+        .expect("reset should use builder-installed roster provider");
+
+    assert_eq!(reset_record.generation.get(), 1);
+    let after = identity_runtime
+        .status(&identity)
+        .await
+        .expect("identity should remain active after reset");
+    assert_eq!(after.profile.unwrap().as_str(), "security");
+
+    let _ = runtime.mob_handle().stop().await;
+}
+
+#[tokio::test]
+async fn identity_first_builder_reset_reprofiles_with_roster_context() {
+    let tmp = tempfile::tempdir().unwrap();
+    let identity = AgentIdentity::parse("domain:security").unwrap();
+    let roster = Arc::new(MobDefinitionRequiredRosterProvider::new(vec![
+        durable_spec_with_profile(identity.as_str(), "domain"),
+    ]));
+
+    let runtime = Box::pin(
+        UnifiedRuntimeBuilder::default()
+            .definition(domain_security_definition())
+            .continuity_store(Arc::new(LocalContinuityStore::in_memory().unwrap()))
+            .lease_provider(Arc::new(
+                meerkat_mobkit::identity_first::LocalLeaseProvider::new(),
+            ))
+            .roster_provider(roster.clone())
+            .scratch_dir(tmp.path())
+            .identity_runtime_instance_id("builder-reset-reprofile-context-test")
+            .default_llm_client(Arc::new(meerkat_client::TestClient::default()))
+            .build(),
+    )
+    .await
+    .expect("builder should bootstrap with context-sensitive roster provider");
+
+    let identity_runtime = runtime
+        .identity_runtime()
+        .expect("identity runtime should be exposed");
+    assert_eq!(
+        identity_runtime
+            .status(&identity)
+            .await
+            .expect("identity should start active")
+            .profile
+            .unwrap()
+            .as_str(),
+        "domain"
+    );
+
+    roster
+        .set(vec![durable_spec_with_profile(
+            identity.as_str(),
+            "security",
+        )])
+        .await;
+
+    identity_runtime
+        .reset(&identity)
+        .await
+        .expect("reset should pass mob_definition to context-sensitive roster provider");
+
+    assert_eq!(
+        roster.missing_definition_calls(),
+        0,
+        "reset must preserve the builder/context mob_definition when reading the current roster"
+    );
+    assert_eq!(
+        identity_runtime
+            .status(&identity)
+            .await
+            .expect("identity should remain active after reset")
+            .profile
+            .unwrap()
+            .as_str(),
+        "security"
+    );
+
+    let _ = runtime.mob_handle().stop().await;
 }
 
 #[tokio::test]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.16"
+version = "0.7.17"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- wire the gateway-created `IdentityRuntime` with the live `GatewayRosterProvider` at construction time
- wire the same reset roster provider explicitly in `UnifiedRuntimeBuilder` so direct runtimes do not depend on a later context side effect
- add reset re-profile regressions for both direct runtime wiring and `IdentityFirstRuntimeContext` wiring
- bump package metadata to `0.7.17` for the next release, but do not tag or publish

## Why
`POST /dev/reset {domain:security}` reaches an HTTP/console reset path that only has `IdentityRuntime`. The runtime must already carry the roster provider so reset can re-read the current roster profile and rebuild from `profile=security` instead of the stored checkpoint `profile=domain`.

## Validation
- `make verify-version-parity`
- `cargo fmt --all && make fmt-check`
- `cargo test -p meerkat-mobkit reset_reprofiles_session_from -- --nocapture`
- `cargo test -p meerkat-mobkit --bin rpc_gateway -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat-mobkit --lib --bins --tests -- -D warnings`
- `cargo deny check` (passes with existing warnings about duplicate `getrandom`, unmatched license allowance, and ignored advisory not currently matched)
- `./scripts/repo-cargo publish -p meerkat-mobkit --locked --dry-run --allow-dirty`
- `npm install --ignore-scripts && npm run build && npm publish --access public --dry-run`
- `python3 -m build --wheel && python3 -m twine check dist/*0.7.17*` (passes with existing Python packaging metadata warnings)

## Release
Do not merge/tag/release until explicitly approved.
