### PR TITLE
Fix reset fresh-spawn profile adoption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.7.17"
+version = "0.7.18"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -49,7 +49,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -89,7 +89,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -136,7 +136,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -173,7 +173,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -210,7 +210,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -247,7 +247,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -284,7 +284,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -321,7 +321,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -369,7 +369,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -427,7 +427,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -490,7 +490,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -549,7 +549,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -607,7 +607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -665,7 +665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -722,7 +722,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -780,7 +780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -840,7 +840,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -898,7 +898,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -956,7 +956,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1014,7 +1014,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1072,7 +1072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1130,7 +1130,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1188,7 +1188,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1249,7 +1249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1309,7 +1309,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1367,7 +1367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1425,7 +1425,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1485,7 +1485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1547,7 +1547,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1607,7 +1607,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1665,7 +1665,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1723,7 +1723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1781,7 +1781,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1839,7 +1839,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1897,7 +1897,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1955,7 +1955,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2012,7 +2012,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2073,7 +2073,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2134,7 +2134,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2192,7 +2192,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2250,7 +2250,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2308,7 +2308,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2366,7 +2366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2424,7 +2424,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2482,7 +2482,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2540,7 +2540,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2598,7 +2598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2656,7 +2656,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2718,7 +2718,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2776,7 +2776,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2834,7 +2834,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2892,7 +2892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2950,7 +2950,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3008,7 +3008,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3066,7 +3066,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3124,7 +3124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3182,7 +3182,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3243,7 +3243,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3304,7 +3304,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3420,7 +3420,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3478,7 +3478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3539,7 +3539,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3601,7 +3601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3659,7 +3659,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3717,7 +3717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3775,7 +3775,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3836,7 +3836,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3894,7 +3894,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3952,7 +3952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.7.17",
+        "CARGO_PKG_VERSION": "0.7.18",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -552,6 +552,71 @@ actions = ["agent.view"]
     }
 
     #[test]
+    fn callback_build_agent_options_include_profile_name_from_spawn_labels() {
+        let build = meerkat_core::service::SessionBuildOptions {
+            peer_meta: Some(
+                meerkat_core::PeerMeta::default()
+                    .with_label("role", "security")
+                    .with_label("agent_identity", "domain:security"),
+            ),
+            ..Default::default()
+        };
+        let req = CreateSessionRequest {
+            model: "security-model".to_string(),
+            prompt: meerkat_core::ContentInput::Text("noop".to_string()),
+            system_prompt: meerkat_core::config::SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            build: Some(build),
+            labels: None,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+        };
+
+        let options = callback_build_agent_options(&req, "build-test");
+
+        assert_eq!(options["scope_id"], "build-test");
+        assert_eq!(
+            options["profile_name"], "security",
+            "SDK build_agent must see the adopted roster profile instead of \
+             falling back to checkpoint-local defaults"
+        );
+        assert_eq!(options["labels"]["agent_identity"], "domain:security");
+    }
+
+    #[test]
+    fn callback_build_agent_options_merge_request_and_spawn_labels() {
+        let build = meerkat_core::service::SessionBuildOptions {
+            peer_meta: Some(
+                meerkat_core::PeerMeta::default()
+                    .with_label("role", "security")
+                    .with_label("agent_identity", "domain:security"),
+            ),
+            ..Default::default()
+        };
+        let mut request_labels = BTreeMap::new();
+        request_labels.insert("session_id".to_string(), "session-123".to_string());
+        let req = CreateSessionRequest {
+            model: "security-model".to_string(),
+            prompt: meerkat_core::ContentInput::Text("noop".to_string()),
+            system_prompt: meerkat_core::config::SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            build: Some(build),
+            labels: Some(request_labels),
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+        };
+
+        let options = callback_build_agent_options(&req, "build-test");
+
+        assert_eq!(options["profile_name"], "security");
+        assert_eq!(options["session_id"], "session-123");
+        assert_eq!(options["labels"]["session_id"], "session-123");
+        assert_eq!(options["labels"]["agent_identity"], "domain:security");
+    }
+
+    #[test]
     fn gateway_runtime_options_parse_agent_memory_defaults() {
         let tmp = tempfile::tempdir().expect("temp dir");
         let params = json!({
@@ -1516,6 +1581,47 @@ struct StdioCallbackAgentBuilder {
     session_store: Option<Arc<dyn meerkat::SessionStore>>,
 }
 
+fn callback_build_agent_options(req: &CreateSessionRequest, scope_id: &str) -> Value {
+    let request_labels = req.labels.as_ref();
+    let build_labels = req
+        .build
+        .as_ref()
+        .and_then(|build| build.peer_meta.as_ref())
+        .map(|meta| &meta.labels);
+    let mut labels = BTreeMap::new();
+    if let Some(build_labels) = build_labels {
+        labels.extend(
+            build_labels
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+    }
+    if let Some(request_labels) = request_labels {
+        labels.extend(
+            request_labels
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+    }
+    let labels = (!labels.is_empty()).then_some(labels);
+    let profile_name = build_labels
+        .and_then(|labels| labels.get("profile_name").or_else(|| labels.get("role")))
+        .or_else(|| {
+            request_labels
+                .and_then(|labels| labels.get("profile_name").or_else(|| labels.get("role")))
+        });
+    json!({
+        "scope_id": scope_id,
+        "session_id": labels.as_ref().and_then(|l| l.get("session_id")),
+        "profile_name": profile_name,
+        "model": &req.model,
+        "prompt": &req.prompt,
+        "labels": &labels,
+        "app_context": req.build.as_ref()
+            .and_then(|b| b.app_context.as_ref()),
+    })
+}
+
 #[async_trait]
 impl SessionAgentBuilder for StdioCallbackAgentBuilder {
     type Agent = FactoryAgent;
@@ -1540,15 +1646,7 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
 
         // Send callback to Python with full session context.
         // app_context flows from SpawnMemberSpec.context → build.app_context.
-        let options = json!({
-            "scope_id": scope_id,
-            "session_id": req.labels.as_ref().and_then(|l| l.get("session_id")),
-            "model": &req.model,
-            "prompt": &req.prompt,
-            "labels": &req.labels,
-            "app_context": req.build.as_ref()
-                .and_then(|b| b.app_context.as_ref()),
-        });
+        let options = callback_build_agent_options(req, &scope_id);
         let params = json!({ "options": options });
         let callback_result = self.bridge.call("callback/build_agent", params).await;
 

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -45,6 +45,10 @@ fn is_recoverable_bridge_respawn_cleanup_error(error: &str) -> bool {
     is_recoverable_lifecycle_cleanup_error(error)
 }
 
+fn is_member_already_exists_error(error: &meerkat_mob::MobError) -> bool {
+    matches!(error, meerkat_mob::MobError::MemberAlreadyExists(_))
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum MemberRepairRespawnFailure {
     DegradedTopologyRestore { failed_peer_ids: Vec<String> },
@@ -581,6 +585,34 @@ impl MobSessionBridge {
                 .map(|_| ())
         }
     }
+
+    async fn spawn_member_spec_replacing_collision(
+        &self,
+        runtime_id: &AgentRuntimeId,
+        member_id: &MobAgentIdentity,
+        spawn_spec: SpawnMemberSpec,
+    ) -> Result<(), meerkat_mob::MobError> {
+        match self.spawn_member_spec(spawn_spec.clone()).await {
+            Ok(()) => Ok(()),
+            Err(error) if is_member_already_exists_error(&error) => {
+                tracing::warn!(
+                    runtime_id = %runtime_id,
+                    member_id = %member_id,
+                    error = %error,
+                    "fresh-spawn fallback collided with an existing member; retiring and retrying with adopted spec"
+                );
+                match self.handle.retire(member_id.clone()).await {
+                    Ok(()) => {}
+                    Err(err)
+                        if is_recoverable_session_owned_retire_cleanup_error(&err.to_string()) => {}
+                    Err(err) => return Err(err),
+                }
+                self.forget_runtime_member(runtime_id).await;
+                self.spawn_member_spec(spawn_spec).await
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 /// Project meerkat 0.7's tri-state peer connectivity into an inspect-level
@@ -674,6 +706,10 @@ pub(crate) fn build_spawn_spec(
     labels.insert(
         "agent_identity".to_string(),
         spec.identity.as_str().to_string(),
+    );
+    labels.insert(
+        "profile_name".to_string(),
+        spec.profile.as_str().to_string(),
     );
     if !labels.is_empty() {
         spawn_spec = spawn_spec.with_labels(labels);
@@ -838,7 +874,7 @@ impl SessionBridge for MobSessionBridge {
                     draft,
                     self.base_profile_for_spec(spec).as_ref(),
                 );
-                self.spawn_member_spec(fresh_spec)
+                self.spawn_member_spec_replacing_collision(runtime_id, &mid, fresh_spec)
                     .await
                     .map_err(|e2| BridgeError::Mob(e2.to_string()))?;
 
@@ -1358,6 +1394,33 @@ mod tests {
                 .and_then(|labels| labels.get("agent_identity"))
                 .map(String::as_str),
             Some("agent:alpha")
+        );
+        assert_eq!(
+            spawn
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get("profile_name"))
+                .map(String::as_str),
+            Some("worker"),
+            "identity-first spawn labels must carry the adopted profile so the \
+             SDK build callback sees the roster profile, not a checkpoint default"
+        );
+        assert_eq!(
+            spawn.role_name.as_str(),
+            "worker",
+            "SpawnMemberSpec role remains the authoritative mob profile"
+        );
+    }
+
+    #[test]
+    fn fresh_fallback_collision_classifier_matches_member_already_exists() {
+        let error = meerkat_mob::MobError::MemberAlreadyExists(meerkat_mob::AgentIdentity::from(
+            "rt-agent-alpha-0",
+        ));
+
+        assert!(
+            is_member_already_exists_error(&error),
+            "fresh fallback must retry recreate-over-running-member collisions"
         );
     }
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.7.17"
+version = "0.7.18"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.7.17",
+      "version": "0.7.18",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- preserve adopted roster profile through reset fresh-spawn fallback by carrying `profile_name` in mob spawn labels
- retry fresh-spawn fallback over a colliding running member using the adopted `SpawnMemberSpec`
- pass gateway callback `profile_name` from mob build peer labels into SDK `build_agent` options, with merged request/build labels
- bump MobKit and SDK surfaces to 0.7.18

## Verification
- two subagent review gates: green
- rebase on `origin/main`: up to date
- `cargo fmt --check`
- `make verify-version-parity`
- `git diff --check HEAD~1..HEAD`
- `CARGO_INCREMENTAL=0 cargo test -p meerkat-mobkit --bin rpc_gateway -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p meerkat-mobkit --lib -- --nocapture`
- `CARGO_INCREMENTAL=0 ./scripts/repo-cargo clippy -p meerkat-mobkit --lib --bins --tests -- -D warnings`
- `cargo deny check`
- pre-push hooks: hardcoded secrets, whitespace, TOML, merge conflicts, large files, fmt, changed-crate clippy, workspace unit gate
