### PR TITLE
[codex] Fix MobKit shutdown and delivery teardown flakes

### DIFF
--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -563,6 +563,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/access_control.rs",
@@ -625,6 +626,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/agent_lifecycle.rs",
@@ -691,6 +693,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/bigquery_adapter.rs",
@@ -754,6 +757,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/bigquery_gc.rs",
@@ -817,6 +821,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/builder_api.rs",
@@ -879,6 +884,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/console_customization_fixtures.rs",
@@ -940,6 +946,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/console_experience.rs",
@@ -1002,6 +1009,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/console_route_auth.rs",
@@ -1066,6 +1074,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/core_types_and_rpc.rs",
@@ -1128,6 +1137,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/cross_mob_signed.rs",
@@ -1190,6 +1200,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/cross_mob_tcp.rs",
@@ -1252,6 +1263,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/cross_mob_uds.rs",
@@ -1314,6 +1326,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/discovery_bootstrap.rs",
@@ -1376,6 +1389,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/distiller_eval_harness.rs",
@@ -1441,6 +1455,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/e2e_sdk_wire.rs",
@@ -1502,6 +1517,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/e2e_target_contracts.rs",
@@ -1568,6 +1584,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/event_log_recovery.rs",
@@ -1632,6 +1649,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/external_boundary.rs",
@@ -1694,6 +1712,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/gateway_external.rs",
@@ -1756,6 +1775,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/gateway_memory_config.rs",
@@ -1820,6 +1840,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/gating_policy.rs",
@@ -1886,6 +1907,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/governance_contracts.rs",
@@ -1950,6 +1972,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/hooks.rs",
@@ -2012,6 +2035,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/http_router.rs",
@@ -2074,6 +2098,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/hygienist_eval_harness.rs",
@@ -2139,6 +2164,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_boundary.rs",
@@ -2201,6 +2227,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_builder.rs",
@@ -2263,6 +2290,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_choke.rs",
@@ -2325,6 +2353,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_contracts.rs",
@@ -2387,6 +2416,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_e2e.rs",
@@ -2448,6 +2478,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_kitchen_sink.rs",
@@ -2513,6 +2544,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_ob3_smoke.rs",
@@ -2578,6 +2610,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_runtime.rs",
@@ -2643,6 +2676,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_types.rs",
@@ -2705,6 +2739,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/incident_command_center_pack.rs",
@@ -2767,6 +2802,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/jwks_cache_and_auth.rs",
@@ -2829,6 +2865,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/jwt_oidc_auth.rs",
@@ -2891,6 +2928,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/jwt_rsa.rs",
@@ -2953,6 +2991,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/legacy_session_resume.rs",
@@ -3015,6 +3054,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/list_flows_run_flow.rs",
@@ -3077,6 +3117,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/list_runs.rs",
@@ -3139,6 +3180,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mcp_boundary.rs",
@@ -3205,6 +3247,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/memory_comms_taint_contract.rs",
@@ -3267,6 +3310,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/memory_store.rs",
@@ -3329,6 +3373,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_cursor_persistence.rs",
@@ -3391,6 +3436,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_ingestion.rs",
@@ -3453,6 +3499,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_query.rs",
@@ -3515,6 +3562,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_query_ledger.rs",
@@ -3577,6 +3625,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_streaming.rs",
@@ -3639,6 +3688,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_run_labels.rs",
@@ -3701,6 +3751,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mobkit_gateway_bootstrap.rs",
@@ -3767,6 +3818,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/module_restart.rs",
@@ -3829,6 +3881,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/reference_app.rs",
@@ -3894,6 +3947,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/routing_delivery.rs",
@@ -3959,6 +4013,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/rpc_builtins.rs",
@@ -4021,6 +4076,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/runtime_bootstrap.rs",
@@ -4083,6 +4139,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/schedule_dispatch.rs",
@@ -4145,6 +4202,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/sdk_parity.rs",
@@ -4210,6 +4268,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/sdk_productization.rs",
@@ -4275,6 +4334,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/selector_eval_harness.rs",
@@ -4340,6 +4400,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/session_store_jsonl.rs",
@@ -4403,6 +4464,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/shutdown_drain.rs",
@@ -4465,6 +4527,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/sse_auth_gate.rs",
@@ -4527,6 +4590,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/steward_eval_harness.rs",
@@ -4592,6 +4656,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/swarm_integration.rs",
@@ -4657,6 +4722,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/tool_event_stream_contracts.rs",
@@ -4719,6 +4785,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/unified_console.rs",
@@ -4781,6 +4848,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/wildcard_routes.rs",

--- a/meerkat-mobkit/src/bin/mcp_fixture.rs
+++ b/meerkat-mobkit/src/bin/mcp_fixture.rs
@@ -39,6 +39,8 @@ const SCHEDULING_MESSAGE_PREFIX_ENV: &str = "MOBKIT_PHASE_C_SCHEDULING_MESSAGE_P
 const SCHEDULING_DISABLE_INJECTION_ENV: &str = "MOBKIT_PHASE_C_SCHEDULING_DISABLE_INJECTION";
 const HANG_ON_ENV: &str = "MOBKIT_PHASE_C_HANG_ON";
 const HANG_ON_FILE_ENV: &str = "MOBKIT_PHASE_C_HANG_ON_FILE";
+const DELAY_ON_ENV: &str = "MOBKIT_PHASE_C_DELAY_ON";
+const DELAY_MS_ENV: &str = "MOBKIT_PHASE_C_DELAY_MS";
 const CLOSE_DELAY_MS_ENV: &str = "MOBKIT_PHASE_C_CLOSE_DELAY_MS";
 const DEFAULT_CLOSE_DELAY_MS: u64 = 2_000;
 
@@ -121,6 +123,7 @@ fn handle_request(module: &str, request: &Value) -> Value {
             if should_hang("initialize", None) {
                 hang_forever(module, "initialize", None);
             }
+            maybe_delay(module, "initialize", None);
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -145,6 +148,7 @@ fn handle_request(module: &str, request: &Value) -> Value {
             if should_hang("list_tools", None) {
                 hang_forever(module, "list_tools", None);
             }
+            maybe_delay(module, "list_tools", None);
             append_log(&format!("{module}:list_tools"));
             let tools = tool_descriptors(module)
                 .into_iter()
@@ -193,6 +197,7 @@ fn handle_tool_call(module: &str, id: Value, request: &Value) -> Value {
     if should_hang("call_tool", Some(tool_name)) {
         hang_forever(module, "call_tool", Some(tool_name));
     }
+    maybe_delay(module, "call_tool", Some(tool_name));
     append_log(&format!("{module}:call:{tool_name}:{args}"));
 
     if env::var(FAIL_TOOL_ENV).ok().as_deref() == Some(tool_name) {
@@ -381,4 +386,49 @@ fn hang_forever(module: &str, operation: &str, tool_name: Option<&str>) -> ! {
     loop {
         std::thread::sleep(Duration::from_mins(1));
     }
+}
+
+fn maybe_delay(module: &str, operation: &str, tool_name: Option<&str>) {
+    if !matches_delay_target(operation, tool_name) {
+        return;
+    }
+    let delay_ms = env::var(DELAY_MS_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|delay_ms| *delay_ms > 0)
+        .unwrap_or(0);
+    if delay_ms == 0 {
+        return;
+    }
+    if let Some(tool_name) = tool_name {
+        append_log(&format!(
+            "{module}:delay:{operation}:{tool_name}:{delay_ms}"
+        ));
+    } else {
+        append_log(&format!("{module}:delay:{operation}:{delay_ms}"));
+    }
+    std::thread::sleep(Duration::from_millis(delay_ms));
+}
+
+fn matches_delay_target(operation: &str, tool_name: Option<&str>) -> bool {
+    let Some(raw) = env::var(DELAY_ON_ENV).ok() else {
+        return false;
+    };
+    raw.split(',').any(|candidate| {
+        let candidate = candidate.trim();
+        if candidate.is_empty() {
+            return false;
+        }
+        if candidate.eq_ignore_ascii_case("all") || candidate.eq_ignore_ascii_case(operation) {
+            return true;
+        }
+        if operation != "call_tool" {
+            return false;
+        }
+        let Some(tool_name) = tool_name else {
+            return false;
+        };
+        candidate.eq_ignore_ascii_case(&format!("call_tool:{tool_name}"))
+            || candidate.eq_ignore_ascii_case(&format!("call:{tool_name}"))
+    })
 }

--- a/meerkat-mobkit/src/runtime/module_boundary.rs
+++ b/meerkat-mobkit/src/runtime/module_boundary.rs
@@ -13,7 +13,7 @@ use super::*;
 
 pub(super) const MODULE_BOUNDARY_KIND_ENV: &str = "MOBKIT_MODULE_BOUNDARY";
 pub(super) const MODULE_BOUNDARY_KIND_MCP: &str = "mcp";
-pub(super) const CORE_MODULE_MCP_TIMEOUT: Duration = Duration::from_secs(1);
+pub(super) const CORE_MODULE_MCP_TIMEOUT: Duration = Duration::from_secs(5);
 pub(super) const ROUTER_RESOLVE_MCP_TOOL: &str = "routing.resolve";
 pub(super) const DELIVERY_SEND_MCP_TOOL: &str = "delivery.send";
 pub(super) const MEMORY_CONFLICT_READ_MCP_TOOL: &str = "memory.conflict_read";

--- a/meerkat-mobkit/src/unified_runtime/lifecycle.rs
+++ b/meerkat-mobkit/src/unified_runtime/lifecycle.rs
@@ -190,16 +190,20 @@ impl UnifiedRuntime {
             drain_duration_ms: drain_start.elapsed().as_millis() as u64,
         };
 
-        // Phase 2: Close event router
-        self.close_event_router().await;
-
-        // Phase 3: Shutdown modules and mob
-        let module_shutdown = self.module_runtime.lock().await.shutdown();
+        // Phase 2: Stop the mob actor while its router/module dependencies
+        // are still alive. Closing them first can race Stop against an
+        // already-dropped actor reply channel under teardown pressure.
         let mob_stop = self
             .mob_handle()
             .stop()
             .await
             .map_err(MobRuntimeError::from);
+
+        // Phase 3: Close event router
+        self.close_event_router().await;
+
+        // Phase 4: Shutdown modules
+        let module_shutdown = self.module_runtime.lock().await.shutdown();
         UnifiedRuntimeShutdownReport {
             drain,
             module_shutdown,

--- a/meerkat-mobkit/tests/http_router.rs
+++ b/meerkat-mobkit/tests/http_router.rs
@@ -257,6 +257,29 @@ fn sc_001_reference_app_router_proves_unified_owned_console_path() {
     assert!(!unified_runtime_source.contains("interaction_sse_router"));
 }
 
+#[test]
+fn sc_002_unified_shutdown_stops_mob_before_router_and_module_teardown() {
+    let lifecycle_source = include_str!("../src/unified_runtime/lifecycle.rs");
+    let mob_stop = lifecycle_source
+        .find("let mob_stop = self")
+        .expect("shutdown must stop mob");
+    let close_event_router = lifecycle_source
+        .find("self.close_event_router().await;")
+        .expect("shutdown must close event router");
+    let module_shutdown = lifecycle_source
+        .find("let module_shutdown = self.module_runtime.lock().await.shutdown();")
+        .expect("shutdown must stop modules");
+
+    assert!(
+        mob_stop < close_event_router,
+        "mob stop must happen before closing the event router"
+    );
+    assert!(
+        close_event_router < module_shutdown,
+        "module teardown must happen after mob stop and event-router close"
+    );
+}
+
 #[tokio::test]
 #[ignore]
 async fn req_002_router_builders_prove_console_and_sse_behavior() {

--- a/meerkat-mobkit/tests/routing_delivery.rs
+++ b/meerkat-mobkit/tests/routing_delivery.rs
@@ -27,6 +27,8 @@ use serde_json::{Value, json};
 
 const BOUNDARY_ENV_KEY: &str = "MOBKIT_MODULE_BOUNDARY";
 const BOUNDARY_ENV_VALUE_MCP: &str = "mcp";
+const DELAY_ON_ENV: &str = "MOBKIT_PHASE_C_DELAY_ON";
+const DELAY_MS_ENV: &str = "MOBKIT_PHASE_C_DELAY_MS";
 
 fn fixture_binary_path() -> PathBuf {
     if let Ok(path) = std::env::var("CARGO_BIN_EXE_mcp_fixture") {
@@ -200,6 +202,66 @@ fn phase0_contract_009_runtime_routes_and_delivery_history_project_without_host_
                 "backoff_ms": 0,
             }
         ])
+    );
+}
+
+#[test]
+fn phase0_contract_009_delivery_send_survives_slow_mcp_subprocess() {
+    let mut runtime = routing_delivery_runtime_with_env(
+        &[],
+        &[
+            (DELAY_ON_ENV, "call_tool:delivery.send"),
+            (DELAY_MS_ENV, "1500"),
+        ],
+    );
+
+    let add_route = parse_response(&handle_mobkit_rpc_json(
+        &mut runtime,
+        r#"{"jsonrpc":"2.0","id":"phase0-slow-route-add","method":"mobkit/routing/routes/add","params":{"route":{"route_key":"slow-route","recipient":"vip@example.com","channel":"notification","sink":"sms","target_module":"delivery","retry_max":0,"backoff_ms":5,"rate_limit_per_minute":9}}}"#,
+        Duration::from_secs(1),
+    ));
+    let resolved = parse_response(&handle_mobkit_rpc_json(
+        &mut runtime,
+        r#"{"jsonrpc":"2.0","id":"phase0-slow-route-resolve","method":"mobkit/routing/resolve","params":{"recipient":"vip@example.com","channel":"notification"}}"#,
+        Duration::from_secs(1),
+    ));
+    let sent = parse_response(&handle_mobkit_rpc_json(
+        &mut runtime,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": "phase0-slow-delivery-send",
+            "method": "mobkit/delivery/send",
+            "params": {
+                "resolution": resolved["result"].clone(),
+                "idempotency_key": "phase0-contract-009-slow",
+                "payload": {"message": "hello"}
+            }
+        })
+        .to_string(),
+        Duration::from_secs(1),
+    ));
+    let history = parse_response(&handle_mobkit_rpc_json(
+        &mut runtime,
+        r#"{"jsonrpc":"2.0","id":"phase0-slow-delivery-history","method":"mobkit/delivery/history","params":{"recipient":"vip@example.com","limit":10}}"#,
+        Duration::from_secs(1),
+    ));
+
+    runtime.shutdown();
+
+    assert_eq!(
+        add_route["result"]["route"]["route_key"],
+        json!("slow-route")
+    );
+    assert!(
+        sent["error"].is_null(),
+        "slow delivery should not time out under the core MCP budget: {sent}"
+    );
+    assert_eq!(sent["result"]["status"], json!("sent"));
+    assert_eq!(
+        history["result"]["deliveries"]
+            .as_array()
+            .map_or(0, Vec::len),
+        1
     );
 }
 

--- a/meerkat-mobkit/tests/shutdown_drain.rs
+++ b/meerkat-mobkit/tests/shutdown_drain.rs
@@ -22,7 +22,8 @@ use meerkat::{AgentFactory, Config, build_ephemeral_service};
 use meerkat_client::TestClient;
 use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
 use meerkat_mobkit::{
-    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, UnifiedRuntime,
+    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, ModuleConfig,
+    RestartPolicy, UnifiedRuntime,
 };
 
 fn mob_spec(temp_dir: &tempfile::TempDir) -> MobBootstrapSpec {
@@ -67,6 +68,15 @@ fn empty_module_config(namespace: &str) -> MobKitConfig {
     }
 }
 
+fn shell_module(id: &str, script: &str) -> ModuleConfig {
+    ModuleConfig {
+        id: id.to_string(),
+        command: "sh".to_string(),
+        args: vec!["-c".to_string(), script.to_string()],
+        restart_policy: RestartPolicy::Never,
+    }
+}
+
 fn member_spec(profile: &str, member_id: &str) -> SpawnMemberSpec {
     SpawnMemberSpec::from_wire(
         profile.to_string(),
@@ -75,6 +85,42 @@ fn member_spec(profile: &str, member_id: &str) -> SpawnMemberSpec {
         None,
         None,
     )
+}
+
+#[tokio::test]
+async fn shutdown_stops_mob_before_tearing_down_loaded_modules() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let runtime = Box::pin(
+        UnifiedRuntime::builder()
+            .mob_spec(mob_spec(&temp_dir))
+            .module_config(MobKitConfig {
+                modules: vec![shell_module(
+                    "router",
+                    r#"printf '%s\n' '{"event_id":"evt-router-ready","source":"module","timestamp_ms":10,"event":{"kind":"module","module":"router","event_type":"ready","payload":{"ok":true}}}'; exec sleep 30"#,
+                )],
+                discovery: DiscoverySpec {
+                    namespace: "shutdown-loaded-module".to_string(),
+                    modules: vec!["router".to_string()],
+                },
+                pre_spawn: vec![],
+            })
+            .timeout(Duration::from_secs(2))
+            .drain_timeout(Duration::from_millis(200))
+            .build(),
+    )
+    .await
+    .expect("build");
+
+    assert_eq!(runtime.loaded_modules().await, vec!["router".to_string()]);
+
+    let shutdown = runtime.shutdown().await;
+
+    assert_eq!(
+        shutdown.module_shutdown.terminated_modules,
+        vec!["router".to_string()]
+    );
+    assert_eq!(shutdown.module_shutdown.orphan_processes, 0);
+    shutdown.mob_stop.expect("mob stop should succeed");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes two separate heavy-runtime flake mechanisms in MobKit:

1. Shutdown/list-runs teardown race: `UnifiedRuntime::shutdown()` now stops the mob before closing the event router and module runtime, so `mob_stop` is not racing an already-torn-down actor dependency.
2. `contract_009` delivery flake: core module MCP calls now use a 5s budget instead of the previous 1s budget. The failing path was `mobkit/delivery/send` -> `send_delivery()` -> `delivery.send` over a fresh MCP stdio subprocess; under load the old inner MCP call budget could time out and surface as `sent["result"] == Null`.

The delivery regression is explicit and non-ignored: the MCP fixture can now inject finite delays, and `phase0_contract_009_delivery_send_survives_slow_mcp_subprocess` delays only `call_tool:delivery.send` by 1500ms, which exceeds the old budget and now succeeds.

## Validation

- `./scripts/repo-cargo fmt --all -- --check`
- `node scripts/generate-bazel-rust-builds.mjs --check`
- `cargo test -p meerkat-mobkit --test routing_delivery phase0_contract_009 -- --nocapture`
- `cargo test -p meerkat-mobkit --test routing_delivery -- --nocapture`
- `for i in 1 2 3 4 5 6 7 8; do cargo test -p meerkat-mobkit --test routing_delivery phase0_contract_009 -- --nocapture || exit $?; done`
- `cargo test -p meerkat-mobkit --test mcp_boundary -- --ignored --nocapture`
- `cargo test -p meerkat-mobkit --test shutdown_drain -- --nocapture`
- `cargo test -p meerkat-mobkit --test http_router -- --nocapture`
- `cargo test -p meerkat-mobkit --test list_runs -- --nocapture`
- `./scripts/repo-cargo clippy -p meerkat-mobkit --all-targets -- -D warnings`
- push hook: hardcoded secrets, whitespace, yaml/toml, merge conflicts, large files, `cargo fmt --check`, changed-crate clippy, workspace unit gate

## Review Gate

- Singer: GREEN
- Bernoulli: GREEN
