### PR TITLE
Agent memory: meerkat 0.7.13 upgrade + pre-Elephant phases + incident memory fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   TypeScript users, including bundled markdown persistence, contextual recall,
   explicit remember/recall/forget APIs, and next-turn injection for live
   identity sends.
+- Classic (roster-less) agent memory: the recorder `memory` tool and build-time
+  recall injection now attach to any mob member keyed on its `AgentIdentity`,
+  without requiring the roster/IdentityRuntime layer.
+- Ambient per-turn memory recall is delivered as a typed injected-context
+  message (excluded from compaction indexing) rather than fused into the user's
+  text, and is now **on by default** on the identity-first path — echo-safe by
+  construction (meerkat 0.7.12 upstream ask 1).
+- Compaction-discard harvest reads the exact session-memory range via
+  `enumerate_scoped`, and permanently-orphaned session scopes are reclaimed via
+  `drop_scope` at the identity-delete seam (asks 2 + 8).
+- Distilled memory records pin the transcript head revision their evidence was
+  read at, and Hygienist rewrites compare-and-swap on it (ask 4 refinement).
+- The taint tracker consumes the typed `AgentEvent::PeerContentIngested`
+  sender-taint declaration (canonical peer id, synchronous at ingestion),
+  superseding the projection-text join for declared taint (ask 5, inbound).
+
+### Changed
+
+- Upgraded the meerkat dependency family to 0.7.13.
+
+### Fixed
+
+- Host `SessionHook`/customizers that install `external_tools` or
+  `additional_instructions` on the session build now compose over the
+  agent-memory recorder instead of overwriting it — a plain assignment silently
+  dropped the `memory` tool and the build-time recall injection (fixed in the
+  incident-command-center example; the recorder is unaffected on paths that
+  compose).
 
 ## [0.6.39] - 2026-05-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6241d0316fd74b961c9a46a126d039e19bb23b6b46ab1be0937306ed7d533c"
+checksum = "8540b344695b58013b19a2605777ebb23169f15aaed80bbfef9937a7fd644fdd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc0c666af3a2853b6eaed4a162fbcb43d5b2086acede8524255a5fe74fd9b98"
+checksum = "dd5751635d1d6d72b90a28be74def8e44f6e79d2a43c9042174b56d3c419a894"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1721,7 +1721,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-llm-core",
  "meerkat-models",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e034a6e64de055ab4b1e711189d29f05e69c2dfc00fb9c3505243ea94ee03a46"
+checksum = "1719b31ab220defebcef0d8289bc7f159d58b174a4af2def46eacfb3e6bf6b0d"
 dependencies = [
  "async-trait",
  "axum",
@@ -1749,7 +1749,7 @@ dependencies = [
  "meerkat-llm-core",
  "oauth2",
  "parking_lot",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9978edc0736dd24398c43560615d3a3523cbbb62ab19cb7734cffcb3ba60452e"
+checksum = "1a40d25e3fe655452df6e45b01262a53ce31fae73d4c1c7350a4e214c2824181"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38996bf17787136a18b4eb18ff4d7cd11e21ed080fd21a8f77164fbaf33d9938"
+checksum = "42f8fd0b6bd370c89f3258d9c3006dd7ea2a787dca5717ca0766f9eb44c35f94"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3aefe76bcc2c7ee2c49367700b2ba3c2a39f6dd5915eeb71dca1555b3f9e4da"
+checksum = "be4460338b9ce40ecd8423a1bf520d3a3e4b8e238a8e97e2c845dd0013267a12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18fc2bca29a6f65a9ee5ce8538e5a9107d527f6b4e6a55425f0011be4b0f600"
+checksum = "a1977ba7558e1ccc535afc49d5ce18514d53d0b52763d35d6fc91636e4933662"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a653ea7090331b8823a115de0946f1ec29917d2339ca2707a31750498294f5"
+checksum = "043fecd611f8e43824a663cbebd3449a85149b718fe0ab42ef4a885e7365dfb9"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd49030af4f957c71ecbfe0a7fa0dd9b33867d1141f341f672b5fc58b27a910c"
+checksum = "68b31609047bf1fbc1410de377c09d20d1b68a871a24d3688fa1d19c628c4046"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1890,7 +1890,7 @@ dependencies = [
  "meerkat-auth-core",
  "meerkat-core",
  "meerkat-llm-core",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60a2be2d4f7cf32d48c9a586534af7bf6adc6899fb0009b0bd100a80a75ef28"
+checksum = "c9c062371e289249d0426cc2e39d3ee42a1599f86f654c88bca4fe73e76ff9e5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1913,7 +1913,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-skills",
  "nix 0.29.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc2e7bb9ec09b73db53b5bfed9c32df30e8c72288f69341369c977a67e565a8"
+checksum = "8330d17189c84d74900a5f476de2137a96176bc3b44f92ecb0e53af622dd3e93"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38139954fae4da3572ffa3c954aba4616d6b7fb94740d07850c36ce98adc7518"
+checksum = "cb5d0c47532d483def8d29177a7e0da01e560942aedfb78bf6564a48aeba51d5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1957,7 +1957,7 @@ dependencies = [
  "meerkat-contracts",
  "meerkat-core",
  "parking_lot",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "slab",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfd37a670cd830a1091874ad670eeb43183e778cdd7c28d1e3af5565b8914b9"
+checksum = "0ede6fbb9c312594f8cfa214c727c68a626d43ee0b9de329f525f0c1c36adbc9"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c299d7942e4b45dcc861b85ba215327c1e9b909a878f48ae436f3351be666b"
+checksum = "c53c8812b2295775ba7727cd66675c6e73d2f580600d0bb89715e09522ca6ddd"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0cd5170b0332aefa2417dc3b7b2dd3153c18489b0712be5aa76ba211ee5fa5"
+checksum = "63ffb4ec81ea6e55f2e9ca648131c9fbd7fbf663c7d53e8ce70ba06d78783f6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009778653c66a67563455dc41e8d3f7f24153f61bb39191bf00acdddea227941"
+checksum = "bd93a181de443d44bf9ed86120bf9ba54399f909c55dc0eccaca1cd404f9a12c"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc723efbb2da0045ee587b3a9057dc495bf5257c0c223cb1fae1807dcb3431fc"
+checksum = "ffef0fdc15c291497c0d24ce84c9ba03f0be3446504b9a9ca15e59ae7b21b3af"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1295717f5a7e00a3e1c88f77e7153e28ea578242e1ebd4107c0cc8b6cd6ec8dc"
+checksum = "192e92669ba63aea6bea58c72e56535a88909329f45d88ac5b6c51318300c575"
 dependencies = [
  "async-trait",
  "futures",
@@ -2038,7 +2038,7 @@ dependencies = [
  "meerkat-contracts",
  "meerkat-core",
  "meerkat-skills",
- "reqwest",
+ "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3f615a3f1662d4a7ab569d2a6c03aff2387142a713e2c2eb5b81dc29fbca06"
+checksum = "1d82b1be74935e42eba9f496be9068acbb50470c4d1306eaf999924ee781c510"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79538d4d1bc536f41268e2b240350a454825a3545af0d79ef7af650d0f669d2e"
+checksum = "c395ed0e2a884170ba9e41b9c5dbde36240a7fe3f1565ef65101a3ede70a591c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f303c2b09363bccf069ffd7c3a083f235f880043088737133d3747f6d2e5565"
+checksum = "a425b59d10b52226eacf1ac744fdabaeadbb565b8be850c00b93f1d7d7ff2d1a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2168,7 +2168,7 @@ dependencies = [
  "meerkat-tools",
  "object_store",
  "rand_core 0.6.4",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rusqlite",
  "schemars",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a162cd55747d9fafe18da494da7639ed53204c0aadb0412f6502ff33937ed3"
+checksum = "0a144cedbc281d2e032fdef4fffb0f08c6556d5a28329d1b5fd49da5c40efca8"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7728f760f1a0fdfd872ed940c345e2992a5eee74bb12bf4539cbab1117f12"
+checksum = "afad6341a42904c507772772efa50e3f884310fefca53e93974d38dd1e9ea4fc"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2212,7 +2212,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-llm-core",
  "meerkat-models",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8f2e56020f37aface3b2a8482542b37a7b6b37b3c730d41452d45f3416c923"
+checksum = "b05172bb5d0cc269c436fab4917fe6f54a0e9e03c6f5d2c1b6877f79d9e24047"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1936580f62639582034b1bdb1335bbfdfb5ed3460a1d3ba077501f0334be0c"
+checksum = "78c54976a2b738aa37cb45e633aee2e1588d6dc2fd5d1ffe47b28f06c69bdcf3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ad2c6858397e5e782e7be1dde3852c037c301f4ae673c16d2ba7db9c207017"
+checksum = "1da3d49986b622d0d88233f25c4a0103a519ac62e34079f4f63f08a7d249f8e4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37500ff1856c0bca253e50ac67679176d7240e71cf8950859a8bf1ee4b005be"
+checksum = "35265271c33a86329e73fc7283f61d346bd74fc3055cfb569a47d7fcb5e218d5"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87afc05044afcb2849f837e86e7530be438725b53dfd7b754fe37e9015f0dd3"
+checksum = "e76318687e923bf0e6b4811c4fb0bb7aba9177e287c2a58b61d2b371976136b7"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2323,7 +2323,7 @@ dependencies = [
  "meerkat-capabilities",
  "meerkat-core",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d051edabb76e35565e8d57e72e1ff92386857025e8cbd75e82b509f35c805f92"
+checksum = "d9b9b5204cb76cc92331874f17ee5d1aa8bbfa9fd3b95b869968487f441bacf4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef6a65d4ed832775489584f0555a6e09c4eee2b8a1eb981d16e2e67062e57a4"
+checksum = "6030b9ae4a4fc33a83584cc59b01adea405dd9e4a17d7e2f34e09f3a8ce783f6"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8638525994b5c5ff7783e1c02e09a8c7e859a8cde6e7221e52f8134049d4d78a"
+checksum = "a1616616ab6717a4e02a0192930b350b528b18337f0627dc69bccc0127301f01"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2674,7 +2674,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3189,9 +3189,43 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -3210,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.14.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -3222,7 +3256,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "process-wrap",
- "reqwest",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -3237,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.14.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4424,6 +4458,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8540b344695b58013b19a2605777ebb23169f15aaed80bbfef9937a7fd644fdd"
+checksum = "3dcb9df5a55552886c149bda5015d1e83e422ae1373a954bc9b26a47906d7d3f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5751635d1d6d72b90a28be74def8e44f6e79d2a43c9042174b56d3c419a894"
+checksum = "279dcdba58d6a4b0f712655543b3680e7fbcadc54912254a6307dfc4e73a1da2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1719b31ab220defebcef0d8289bc7f159d58b174a4af2def46eacfb3e6bf6b0d"
+checksum = "610f6eff969e1f1f3cffa50b7fc9941824ec9d63d7104bbd289d95af33d8e2a3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a40d25e3fe655452df6e45b01262a53ce31fae73d4c1c7350a4e214c2824181"
+checksum = "c50cb2a1bd0b1127d86fabdb3b79b563b4c1798dc3f563996f579d30095c2a1e"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f8fd0b6bd370c89f3258d9c3006dd7ea2a787dca5717ca0766f9eb44c35f94"
+checksum = "f23b6c4bbaa906b80175fc3ac3e6cc7d2bce133dd1424a400cf55f514e8d7cad"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4460338b9ce40ecd8423a1bf520d3a3e4b8e238a8e97e2c845dd0013267a12"
+checksum = "9b1a87efab1e58f7a07a43921e91997d1a9762b483ef8378f16b726da7dd16f7"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1977ba7558e1ccc535afc49d5ce18514d53d0b52763d35d6fc91636e4933662"
+checksum = "ced47d1411bf06180ac8db6654d5c7c0546a0bdab2e691067e5b488f6551e830"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043fecd611f8e43824a663cbebd3449a85149b718fe0ab42ef4a885e7365dfb9"
+checksum = "21197e2f6c737c02adc79b9e2737b7b7b41c14c109f49c5d9d5ab13671fda20e"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b31609047bf1fbc1410de377c09d20d1b68a871a24d3688fa1d19c628c4046"
+checksum = "bfa2f70bfffd50fbac7ae423bc30d557b30e032f2987293039a9e243528ef8ed"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c062371e289249d0426cc2e39d3ee42a1599f86f654c88bca4fe73e76ff9e5"
+checksum = "15a2f43de33ffbd31948ab8f2fcc81fd1fa4b7364ca113e7a0d9d6766e5a805b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8330d17189c84d74900a5f476de2137a96176bc3b44f92ecb0e53af622dd3e93"
+checksum = "d0b2a698b0f488deff3e45a84e7b78e5c24cbaf643149b8a874be21fad79dd9d"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d0c47532d483def8d29177a7e0da01e560942aedfb78bf6564a48aeba51d5"
+checksum = "7aaed1329a511f99b711ff61986c69024163716e230195eb51b5fc85bad888cc"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede6fbb9c312594f8cfa214c727c68a626d43ee0b9de329f525f0c1c36adbc9"
+checksum = "261a3275eeb10c34835ab57f106a7fcbcda069c1b606111913a7ab1dd71c125a"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53c8812b2295775ba7727cd66675c6e73d2f580600d0bb89715e09522ca6ddd"
+checksum = "da667f8fe1653f1a303b157341fa613a791972b113d2b455a48a0097ad48937f"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ffb4ec81ea6e55f2e9ca648131c9fbd7fbf663c7d53e8ce70ba06d78783f6e"
+checksum = "0a7315ba5a49b7d7c711d21d9e801e1bf4946f8327da94f0c9613c5655c73895"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd93a181de443d44bf9ed86120bf9ba54399f909c55dc0eccaca1cd404f9a12c"
+checksum = "003af8107f98a87b2553068921af42520d1514e5fb748dad22505e724586bb4f"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffef0fdc15c291497c0d24ce84c9ba03f0be3446504b9a9ca15e59ae7b21b3af"
+checksum = "2f8969ee46a73bf1774c6b8aef09321f89269ae6c208e90b85d1ed4674eb1bbb"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192e92669ba63aea6bea58c72e56535a88909329f45d88ac5b6c51318300c575"
+checksum = "e50d4b880850a0f3b64bb8614588f7eecb7d6816ca73a7e551e9a10c4c4e93b6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d82b1be74935e42eba9f496be9068acbb50470c4d1306eaf999924ee781c510"
+checksum = "d562787b88f353fb8e74bd2c3a8d56342b112934fd469d1ad1fa406a84df23d6"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c395ed0e2a884170ba9e41b9c5dbde36240a7fe3f1565ef65101a3ede70a591c"
+checksum = "f002b52fdcb7453c8659f23aa1f88e2ebf912bd938f9fe323360d65bf81a4c85"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a425b59d10b52226eacf1ac744fdabaeadbb565b8be850c00b93f1d7d7ff2d1a"
+checksum = "5259b0371967ffeddc2cc6ecaa59cff68025fc9706a8cca218094dd250bf8ab9"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a144cedbc281d2e032fdef4fffb0f08c6556d5a28329d1b5fd49da5c40efca8"
+checksum = "b29398783c88bcb295aa26a12911dc636978899659ddac53fb9235ad6debf42f"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afad6341a42904c507772772efa50e3f884310fefca53e93974d38dd1e9ea4fc"
+checksum = "ccd63baa7a75f81923fa0dfbe0a0ce6e05b03fa14fa04855c22dbc714c88d463"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05172bb5d0cc269c436fab4917fe6f54a0e9e03c6f5d2c1b6877f79d9e24047"
+checksum = "ab43730c37daf12e4d7c39a175ce853671048e0896017bc469b38cc75eee7429"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c54976a2b738aa37cb45e633aee2e1588d6dc2fd5d1ffe47b28f06c69bdcf3"
+checksum = "d6ab992bb31edb90adc597d791e760860b77c535bcc921613559ddae449b7048"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da3d49986b622d0d88233f25c4a0103a519ac62e34079f4f63f08a7d249f8e4"
+checksum = "5ed843473e24fcbe506a65d5289d80021dee0c9488684d8fca6f9e32510fc10c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35265271c33a86329e73fc7283f61d346bd74fc3055cfb569a47d7fcb5e218d5"
+checksum = "54f4d4974d71f13dc4f9ac25d6c85b95e2a0c898d74d6bb471ca240c3ce93421"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76318687e923bf0e6b4811c4fb0bb7aba9177e287c2a58b61d2b371976136b7"
+checksum = "717cd11e203852d87e6cb52a779e6b152bcd42c4472697431e39c88683fcff6e"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b9b5204cb76cc92331874f17ee5d1aa8bbfa9fd3b95b869968487f441bacf4"
+checksum = "60a456c8ed0eb0ca8c5464f454757d9429f43933b460303586f7bff89220ac61"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6030b9ae4a4fc33a83584cc59b01adea405dd9e4a17d7e2f34e09f3a8ce783f6"
+checksum = "1973c4b3bbfa4d2ecf1ff40c18430de17c0ab1c8fb01775b5d57945e23fc494f"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1616616ab6717a4e02a0192930b350b528b18337f0627dc69bccc0127301f01"
+checksum = "1e78ddc0de36da998b7db50fa8ff1a3bedbd18d8f5ef35b08808eb98deddaa2e"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/design/agent-memory-architecture.md
+++ b/docs/design/agent-memory-architecture.md
@@ -834,6 +834,17 @@ thing being disabled is the weak lexical scorer, and the pull model (rich index 
 one cheap tool call) is exactly how Claude Code operates in its skip-index
 cohort.
 
+**Classic-mob (roster-less) scope.** The A2 decouple carries the two echo-safe
+surfaces — build-time injection and the Recorder tool — onto the classic mob
+path via meerkat-mob's per-spawn seam
+(`memory/spawn_customizer.rs::MemorySpawnCustomizer`), keyed on the member's
+`AgentIdentity` with no IdentityRuntime/roster requirement. Per-turn ambient
+injection is **deliberately not** carried over: it is off by default anyway
+(this section), and the classic send path has no injection hook. A classic-mob
+per-turn hook is a scoped follow-up gated on the same echo-safe delivery
+coupling above; until then `per_turn_injection = "budgeted"` only takes effect
+on identity-first members (the classic customizer warns at construction).
+
 Budget ladder (applies to build-time bodies and to `budgeted` per-turn mode):
 ≤2 KB/record (kept), ≤20 KB/assembly aggregate, ≤60 KB/session cumulative, then
 index-only until compaction — with the cumulative counter computed by transcript

--- a/examples/001-incident-command-center-pack/incident_command_center.rs
+++ b/examples/001-incident-command-center-pack/incident_command_center.rs
@@ -34,8 +34,9 @@ use meerkat_mobkit::runtime::{
 };
 use meerkat_mobkit::unified_runtime::{DesiredPeerEdge, EdgeDiscovery, UnifiedRuntime};
 use meerkat_mobkit::{
-    DiscoverySpec, MobKitConfig, ModuleConfig, PreSpawnData, RestartPolicy, RuntimeDecisionInputs,
-    RuntimeDecisionState, TrustedOidcRuntimeConfig, build_runtime_decision_state,
+    AgentMemoryConfig, DiscoverySpec, MobKitConfig, ModuleConfig, PreSpawnData, RestartPolicy,
+    RuntimeDecisionInputs, RuntimeDecisionState, SqliteAgentMemoryStore, TrustedOidcRuntimeConfig,
+    build_runtime_decision_state,
 };
 
 const BOUNDARY_ENV_KEY: &str = "MOBKIT_MODULE_BOUNDARY";
@@ -202,11 +203,30 @@ async fn build_runtime_bundle_with_client(
     default_llm_client: Option<Arc<dyn LlmClient>>,
 ) -> Result<IncidentRuntimeBundle> {
     let definition = incident_definition()?;
+    // Classic-mob agent memory (no roster / IdentityRuntime): the recorder
+    // `memory` tool + build-time injection attach per member via the spawn
+    // customizer, and the bundled SQLite store auto-wires the Memory panel.
+    // Records accrue organically as the incident agents record durable facts
+    // (see the memory guidance in the commander/scribe roles).
+    let memory_dir = std::env::var("INCIDENT_COMMAND_CENTER_MEMORY_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("incident-command-center-memory"));
+    std::fs::create_dir_all(&memory_dir).ok();
+    let memory_store =
+        SqliteAgentMemoryStore::open(&memory_dir).context("open incident agent-memory store")?;
+
     let mut builder = UnifiedRuntime::builder()
         .definition(definition)
         .session_hook(Arc::new(IncidentSessionHook))
         .module_config(example_module_config(scenario)?)
         .edge_discovery(ScenarioEdgeDiscovery::new(scenario.links.clone()))
+        .agent_memory(
+            Arc::new(memory_store),
+            AgentMemoryConfig {
+                recorder_tool: true,
+                ..AgentMemoryConfig::default()
+            },
+        )
         .timeout(Duration::from_mins(1));
     if let Some(client) = default_llm_client.or_else(default_incident_llm_client_from_env) {
         builder = builder.default_llm_client(client);
@@ -488,6 +508,8 @@ HOW TO OPERATE:
 - Your final operator answer should be concise, operationally useful, and mention which teammates you consulted.
 - Do not pretend a peer confirmed something if they have not replied.
 - When the operator explicitly asks you to generate an image, call `generate_image` directly without consulting peers first. Include `provider: "openai"` and the configured image model (`model: "{image_model}"`) in the image request so the example uses the selected image route instead of the provider default. If asked why a model was used, say it came from the example's image-model configuration, not from a fixed policy preference.
+- You have a `memory` tool for durable knowledge that should outlive this incident. When you establish or decide something durable — the affected service, the confirmed root cause, the chosen mitigation, an operator's stated preference — record it with `memory` (`action: "remember"`, a one-line `title`, a `description` of when it matters next time, the fact in `body`). If a durable fact you recorded is later corrected, `action: "update"` its `memory_id` so the new fact supersedes the old one. Record decisions and established facts only, not routine chatter.
+- IMPORTANT — `memory` vs `task_create`: an operator preference, instruction, or established fact is KNOWLEDGE and goes to `memory` (never `task_create`). `task_create` is only for actionable incident work items to be done. If the operator says "remember" or states how they want things done, that is always a `memory` write.
 """
 
 [skills.payments_sre_role]
@@ -554,6 +576,12 @@ JOB:
 - If you cannot identify the sender from the comms notice, say that explicitly; otherwise always send the reply.
 - When commander asks what is currently established, answer with the tightest fact pattern you have.
 - Do not invent operational actions; you summarize and confirm.
+
+DURABLE MEMORY:
+- You have a `memory` tool for durable, cross-incident knowledge. As the scribe you are the primary keeper of it.
+- When a fact becomes ESTABLISHED (the affected service, the confirmed root cause, the chosen mitigation, an operator preference on how updates are worded), call `memory` with `action: "remember"`: a one-line `title`, a `description` of when this fact matters for a future incident, and the fact itself in `body`. Set `epistemic: "operator_said"` when it came from the operator, otherwise `"observed"`.
+- If an established fact is later CORRECTED (e.g. the root cause is revised, or a mitigation is superseded by a safer one), call `memory` with `action: "update"` on the prior record's `memory_id` so the correction supersedes the stale fact rather than sitting beside it.
+- Record sparingly: durable established facts and decisions, never turn-by-turn chatter.
 """
 
 [skills.approval_gate_role]
@@ -912,7 +940,11 @@ impl SessionHook for IncidentSessionHook {
         let labels = req.labels.clone().unwrap_or_default();
         let is_commander = is_incident_commander_request(req, &labels);
         let build = req.build.get_or_insert_with(SessionBuildOptions::default);
-        build.external_tools = Some(Arc::new(IncidentToolDispatcher));
+        // COMPOSE over any existing external tools (the agent-memory recorder's
+        // `memory` tool) instead of replacing them — a plain assignment here
+        // silently dropped the recorder, so `memory` never reached the model.
+        let inner = build.external_tools.take();
+        build.external_tools = Some(Arc::new(IncidentToolDispatcher { inner }));
         if is_commander {
             build.override_mob = ToolCategoryOverride::Enable;
             build.resume_override_mask.override_mob = true;
@@ -959,7 +991,13 @@ impl SessionHook for IncidentSessionHook {
 }
 
 #[derive(Clone)]
-pub(crate) struct IncidentToolDispatcher;
+pub struct IncidentToolDispatcher {
+    /// Any external-tool dispatcher already installed on the build (e.g. the
+    /// agent-memory recorder's `memory` tool). We COMPOSE over it rather than
+    /// replace it — overwriting `build.external_tools` would silently drop the
+    /// recorder and the memory feature would never reach the model.
+    pub inner: Option<Arc<dyn AgentToolDispatcher>>,
+}
 
 fn incident_tool_provenance() -> ToolProvenance {
     ToolProvenance {
@@ -972,7 +1010,7 @@ fn incident_tool_provenance() -> ToolProvenance {
 impl AgentToolDispatcher for IncidentToolDispatcher {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
         let provenance = incident_tool_provenance();
-        vec![
+        let mut tools = vec![
             Arc::new(ToolDef {
                 name: "inspect_service".into(),
                 description: "Inspect the current health and saturation of a named service"
@@ -987,8 +1025,13 @@ impl AgentToolDispatcher for IncidentToolDispatcher {
                 input_schema: meerkat_tools::schema_for::<AnalyzeImpactArgs>(),
                 provenance: Some(provenance),
             }),
-        ]
-        .into()
+        ];
+        // Compose: surface the inner dispatcher's tools (the `memory` recorder)
+        // alongside ours so they all reach the model.
+        if let Some(inner) = self.inner.as_ref() {
+            tools.extend(inner.tools().iter().cloned());
+        }
+        tools.into()
     }
 
     async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
@@ -1036,7 +1079,12 @@ impl AgentToolDispatcher for IncidentToolDispatcher {
                 )
                 .into())
             }
-            _ => Err(ToolError::not_found(call.name)),
+            // Unknown to us: delegate to the composed inner dispatcher (the
+            // memory recorder), so its `memory` tool actually works.
+            other => match self.inner.as_ref() {
+                Some(inner) => inner.dispatch(call).await,
+                None => Err(ToolError::not_found(other)),
+            },
         }
     }
 }

--- a/examples/001-incident-command-center-pack/incident_command_center.rs
+++ b/examples/001-incident-command-center-pack/incident_command_center.rs
@@ -909,7 +909,7 @@ impl EdgeDiscovery for ScenarioEdgeDiscovery {
 }
 
 #[derive(Clone)]
-struct IncidentSessionHook;
+pub struct IncidentSessionHook;
 
 fn is_incident_commander(labels: &BTreeMap<String, String>) -> bool {
     labels
@@ -954,23 +954,33 @@ impl SessionHook for IncidentSessionHook {
             // runtime authority bridge mints the generated context.
             build.apply_generated_create_only_mob_operator_access(ToolCategoryOverride::Enable);
         }
-        if labels
+        // COMPOSE, don't overwrite: the agent-memory customizer already pushed
+        // the build-time memory-recall injection and the recorder protocol into
+        // `additional_instructions`. A plain assignment here dropped them, so a
+        // respawned/fresh member never recalled its stored memories (the
+        // operator saw a respawn "forget" the name it had just recorded).
+        // Preserve what's there, then append the incident framing.
+        let incident_instructions = if labels
             .get("addressable")
             .is_some_and(|value| value.eq_ignore_ascii_case("false"))
         {
-            build.additional_instructions = Some(vec![
+            vec![
                 "You are an internal-only control-plane identity. Refuse conversational requests and explain that the operator should use console controls instead.".to_string(),
                 "You may still collaborate with peers over the comms tools when they ask for approval, health, or internal control-plane help.".to_string(),
-            ]);
+            ]
         } else {
-            build.additional_instructions = Some(vec![
+            vec![
                 "You are part of a synthetic incident command center for a fictional payments outage. Stay within that scenario and never claim real-world access.".to_string(),
                 "Be concise and operator-focused. Use one short paragraph unless the operator explicitly asks for more.".to_string(),
                 "Use the stock comms tools for real collaboration: call peers first when you need teammate context, then send concise requests or updates.".to_string(),
                 "When the operator asks for a status sweep, you must run both available tools before answering: inspect_service with service=payments-api and analyze_customer_impact with cohort=enterprise-merchants.".to_string(),
                 "When the operator asks a short follow-up, answer directly from current context, but if the question depends on another specialist's knowledge you should consult that peer instead of guessing.".to_string(),
-            ]);
-        }
+            ]
+        };
+        build
+            .additional_instructions
+            .get_or_insert_with(Vec::new)
+            .extend(incident_instructions);
         Ok(())
     }
 

--- a/examples/004-mdm-console-pack/target.rs
+++ b/examples/004-mdm-console-pack/target.rs
@@ -171,6 +171,7 @@ impl CoreExecutor for TargetCoreExecutor {
         );
         let req = StartTurnRequest {
             prompt,
+            injected_context: Vec::new(),
             system_prompt: None,
             event_tx: None,
             // meerkat 0.7: render_metadata/skill_references live on the
@@ -448,6 +449,7 @@ async fn setup_session(
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
             build: Some(build_opts),
             labels: None,
+            injected_context: Vec::new(),
         })
         .await
         .map_err(|error| anyhow::anyhow!("create session: {error}"))?;

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -563,6 +563,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/access_control.rs",
@@ -625,6 +626,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/agent_lifecycle.rs",
@@ -691,6 +693,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/bigquery_adapter.rs",
@@ -754,6 +757,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/bigquery_gc.rs",
@@ -817,6 +821,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/builder_api.rs",
@@ -825,6 +830,69 @@ rust_test(
     rustc_env = {
         "CARGO_PKG_VERSION": "0.7.19",
         "CARGO_BIN_NAME": "builder_api",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
+    name = "classic_agent_memory_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "classic_agent_memory",
+    crate_root = "tests/classic_agent_memory.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/classic_agent_memory.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.19",
+        "CARGO_BIN_NAME": "classic_agent_memory",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -879,6 +947,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/console_customization_fixtures.rs",
@@ -940,6 +1009,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/console_experience.rs",
@@ -1002,6 +1072,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/console_route_auth.rs",
@@ -1066,6 +1137,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/core_types_and_rpc.rs",
@@ -1128,6 +1200,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/cross_mob_signed.rs",
@@ -1190,6 +1263,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/cross_mob_tcp.rs",
@@ -1252,6 +1326,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/cross_mob_uds.rs",
@@ -1314,6 +1389,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/discovery_bootstrap.rs",
@@ -1376,6 +1452,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/distiller_eval_harness.rs",
@@ -1441,6 +1518,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/e2e_sdk_wire.rs",
@@ -1502,6 +1580,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/e2e_target_contracts.rs",
@@ -1568,6 +1647,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/event_log_recovery.rs",
@@ -1632,6 +1712,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/external_boundary.rs",
@@ -1694,6 +1775,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/gateway_external.rs",
@@ -1756,6 +1838,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/gateway_memory_config.rs",
@@ -1820,6 +1903,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/gating_policy.rs",
@@ -1886,6 +1970,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/governance_contracts.rs",
@@ -1950,6 +2035,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/hooks.rs",
@@ -2012,6 +2098,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/http_router.rs",
@@ -2074,6 +2161,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/hygienist_eval_harness.rs",
@@ -2139,6 +2227,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_boundary.rs",
@@ -2201,6 +2290,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_builder.rs",
@@ -2263,6 +2353,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_choke.rs",
@@ -2325,6 +2416,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_contracts.rs",
@@ -2387,6 +2479,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_e2e.rs",
@@ -2448,6 +2541,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_kitchen_sink.rs",
@@ -2513,6 +2607,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_ob3_smoke.rs",
@@ -2531,6 +2626,69 @@ rust_test(
         ":package_runfiles",
         "//:repo_governance_files",
     ],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
+    name = "identity_first_respawn_continuity_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "identity_first_respawn_continuity",
+    crate_root = "tests/identity_first_respawn_continuity.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/identity_first_respawn_continuity.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.19",
+        "CARGO_BIN_NAME": "identity_first_respawn_continuity",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
     env = {
         "RUST_MIN_STACK": "16777216",
     },
@@ -2578,6 +2736,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_runtime.rs",
@@ -2643,6 +2802,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/identity_first_types.rs",
@@ -2705,6 +2865,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/incident_command_center_pack.rs",
@@ -2767,6 +2928,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/jwks_cache_and_auth.rs",
@@ -2829,6 +2991,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/jwt_oidc_auth.rs",
@@ -2891,6 +3054,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/jwt_rsa.rs",
@@ -2953,6 +3117,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/legacy_session_resume.rs",
@@ -3015,6 +3180,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/list_flows_run_flow.rs",
@@ -3077,6 +3243,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/list_runs.rs",
@@ -3139,6 +3306,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mcp_boundary.rs",
@@ -3205,6 +3373,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/memory_comms_taint_contract.rs",
@@ -3267,6 +3436,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/memory_store.rs",
@@ -3329,6 +3499,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_cursor_persistence.rs",
@@ -3391,6 +3562,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_ingestion.rs",
@@ -3453,6 +3625,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_query.rs",
@@ -3515,6 +3688,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_query_ledger.rs",
@@ -3577,6 +3751,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_events_streaming.rs",
@@ -3639,6 +3814,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mob_run_labels.rs",
@@ -3701,6 +3877,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/mobkit_gateway_bootstrap.rs",
@@ -3767,6 +3944,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/module_restart.rs",
@@ -3829,6 +4007,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/reference_app.rs",
@@ -3894,6 +4073,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/routing_delivery.rs",
@@ -3959,6 +4139,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/rpc_builtins.rs",
@@ -4021,6 +4202,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/runtime_bootstrap.rs",
@@ -4083,6 +4265,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/schedule_dispatch.rs",
@@ -4145,6 +4328,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/sdk_parity.rs",
@@ -4210,6 +4394,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/sdk_productization.rs",
@@ -4275,6 +4460,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/selector_eval_harness.rs",
@@ -4340,6 +4526,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/session_store_jsonl.rs",
@@ -4403,6 +4590,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/shutdown_drain.rs",
@@ -4465,6 +4653,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/sse_auth_gate.rs",
@@ -4527,6 +4716,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/steward_eval_harness.rs",
@@ -4592,6 +4782,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/swarm_integration.rs",
@@ -4657,6 +4848,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/tool_event_stream_contracts.rs",
@@ -4719,6 +4911,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/unified_console.rs",
@@ -4781,6 +4974,7 @@ rust_test(
         "src/memory/selector_prompt_v0.md",
         "src/memory/steward_prompt_v0.md",
         "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
     ],
     srcs = [
         "tests/wildcard_routes.rs",
@@ -4825,6 +5019,7 @@ test_suite(
         ":bigquery_adapter_test",
         ":bigquery_gc_test",
         ":builder_api_test",
+        ":classic_agent_memory_test",
         ":console_experience_test",
         ":console_route_auth_test",
         ":core_types_and_rpc_test",
@@ -4848,6 +5043,7 @@ test_suite(
         ":identity_first_contracts_test",
         ":identity_first_kitchen_sink_test",
         ":identity_first_ob3_smoke_test",
+        ":identity_first_respawn_continuity_test",
         ":identity_first_runtime_test",
         ":identity_first_types_test",
         ":incident_command_center_pack_test",

--- a/meerkat-mobkit/src/bin/distiller_eval.rs
+++ b/meerkat-mobkit/src/bin/distiller_eval.rs
@@ -220,6 +220,7 @@ async fn main() {
         session_key: "fixture-session".to_string(),
         start_index: 0,
         end_index: input.transcript.len() as u64,
+        head_revision: None,
         messages: input
             .transcript
             .iter()

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -817,6 +817,7 @@ async fn run() -> anyhow::Result<()> {
             adapter,
             schedule_service,
             mob_state,
+            None,
             runtime_id.clone(),
         )
     } else {

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -4625,6 +4625,7 @@ external_addressable = true
             adapter,
             schedule_service,
             mob_state,
+            None,
             schedule_owner_id.clone(),
         )
     } else {

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -617,6 +617,7 @@ actions = ["agent.view"]
             build: Some(build),
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
 
         let options = callback_build_agent_options(&req, "build-test");
@@ -652,6 +653,7 @@ actions = ["agent.view"]
             build: Some(build),
             labels: Some(request_labels),
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
 
         let options = callback_build_agent_options(&req, "build-test");
@@ -3045,6 +3047,7 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                 build: req.build.clone(),
                 labels: req.labels.clone(),
                 deferred_prompt_policy: req.deferred_prompt_policy,
+                injected_context: req.injected_context.clone(),
             };
             ensure_shell_tooling_build_substrate(&mut normalized_req);
             return self.inner.build_agent(&normalized_req, event_tx).await;
@@ -3078,6 +3081,7 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                     build: req.build.clone(),
                     labels: req.labels.clone(),
                     deferred_prompt_policy: req.deferred_prompt_policy,
+                    injected_context: req.injected_context.clone(),
                 };
                 // Apply additional_instructions as system prompt extension
                 if let Some(instructions) = result.get("additional_instructions") {

--- a/meerkat-mobkit/src/identity_first/adapters.rs
+++ b/meerkat-mobkit/src/identity_first/adapters.rs
@@ -704,6 +704,10 @@ impl AgentCustomizer for SessionHookCustomizerAdapter {
                 Some(draft.labels.clone())
             },
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            // Meerkat 0.7.12: typed per-request ambient injection (upstream
+            // ask #1). This synthetic request only carries build-draft state;
+            // memory injection rides its own path, so it stays empty here.
+            injected_context: Vec::new(),
         };
 
         // Snapshot "before" state for unsupported-mutation detection (REQ-30).

--- a/meerkat-mobkit/src/identity_first/agent_memory.rs
+++ b/meerkat-mobkit/src/identity_first/agent_memory.rs
@@ -425,6 +425,13 @@ pub trait AgentMemoryProvider: Send + Sync {
     fn supports_authored_writes(&self) -> bool {
         false
     }
+
+    /// Bundled-store downcast seam: the builder wires the console Memory
+    /// panel (§9.3) when — and only when — the configured provider is the
+    /// bundled SQLite store. External providers keep the default `None`.
+    fn as_sqlite_store(&self) -> Option<&crate::memory::sqlite_store::SqliteAgentMemoryStore> {
+        None
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -917,8 +924,9 @@ pub const MEMORY_TOOL_NAME: &str = "memory";
 
 /// Build-time behavioral protocol for members that carry the Recorder.
 /// Injected as an additional instruction alongside the memory index — the
-/// write-side counterpart of the coordinator's recall protocol.
-const RECORDER_PROTOCOL_INSTRUCTIONS: &str = "Memory recorder protocol: you have a `memory` tool \
+/// write-side counterpart of the coordinator's recall protocol. Shared with
+/// the classic-mob spawn customizer (`crate::memory::spawn_customizer`).
+pub(crate) const RECORDER_PROTOCOL_INSTRUCTIONS: &str = "Memory recorder protocol: you have a `memory` tool \
 for durable records that survive session resets and respawns.\n\
 - Check the memory index in your context before writing; if a record already covers the fact, \
 use action \"update\" on its id instead of creating a duplicate.\n\
@@ -1061,6 +1069,23 @@ pub(crate) struct MemoryRecorder {
 }
 
 impl MemoryRecorder {
+    /// Shared constructor for the two recorder hosts: the identity-first
+    /// `AgentMemoryCustomizer` and the classic-mob
+    /// `crate::memory::spawn_customizer::MemorySpawnCustomizer`.
+    pub(crate) fn new(
+        provider: Arc<dyn AgentMemoryProvider>,
+        config: AgentMemoryConfig,
+        identity: AgentIdentity,
+        mob: Option<String>,
+    ) -> Self {
+        Self {
+            provider,
+            config,
+            identity,
+            mob,
+        }
+    }
+
     fn identity_scope(&self) -> MemoryScope {
         MemoryScope::Identity {
             realm: self.config.realm.clone(),
@@ -1744,7 +1769,7 @@ fn build_query_text(context: &AgentBuildContext, spec: &DurableAgentSpec) -> Opt
     (!text.is_empty()).then_some(text)
 }
 
-fn insert_terms(terms: &mut BTreeSet<String>, value: &str) {
+pub(crate) fn insert_terms(terms: &mut BTreeSet<String>, value: &str) {
     for term in value
         .split(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '-')
         .map(str::trim)

--- a/meerkat-mobkit/src/identity_first/agent_memory.rs
+++ b/meerkat-mobkit/src/identity_first/agent_memory.rs
@@ -749,6 +749,23 @@ impl AgentMemoryRuntimeInjector {
         }
     }
 
+    /// Ask 2 GC: after distilling a permanently-orphaned session, reclaim its
+    /// meerkat semantic-memory rows (respawn/reset mint a fresh id; delete
+    /// discards it — the old scope is dead weight that every future build in
+    /// the realm re-embeds). Best-effort; no-op without a wired distiller.
+    /// MUST NOT be called for resumable retires.
+    pub async fn drop_orphaned_session_scope(
+        &self,
+        session_key: &str,
+        cause: crate::memory::distiller::DistillCause,
+    ) {
+        if let Some(distiller) = self.distiller.as_ref() {
+            distiller
+                .drop_orphaned_session_scope(session_key, cause)
+                .await;
+        }
+    }
+
     /// §8.5 exit interviews: record a retired/deleted identity in the
     /// pending-harvest queue so the NEXT dream harvests its store. One
     /// fast local write, best-effort — rotation never fails on it. No-op

--- a/meerkat-mobkit/src/identity_first/agent_memory.rs
+++ b/meerkat-mobkit/src/identity_first/agent_memory.rs
@@ -955,6 +955,10 @@ pub const MEMORY_TOOL_NAME: &str = "memory";
 /// the classic-mob spawn customizer (`crate::memory::spawn_customizer`).
 pub(crate) const RECORDER_PROTOCOL_INSTRUCTIONS: &str = "Memory recorder protocol: you have a `memory` tool \
 for durable records that survive session resets and respawns.\n\
+- Use `memory` for KNOWLEDGE — operator preferences and instructions, established facts, \
+decisions, gotchas, open loops. When the operator says \"remember\" or states a preference, \
+that goes to `memory`. Do NOT use a task/workflow tool (e.g. task_create) for this: task tools \
+track work to DO, `memory` stores what is TRUE or PREFERRED.\n\
 - Check the memory index in your context before writing; if a record already covers the fact, \
 use action \"update\" on its id instead of creating a duplicate.\n\
 - One fact per record. Write the `description` for your future self's retrieval — it is what \
@@ -971,7 +975,13 @@ steward dreams can close it.\n\
 write mob scope directly.";
 
 fn memory_tool_description() -> String {
-    "Durable identity-scoped memory: remember, update, forget, recall, and propose_to_mob. \
+    "Remember durable knowledge that must outlive this session — operator preferences and \
+     instructions, established facts, decisions, gotchas, and open loops. Use this whenever you \
+     learn something you should still know next time. This is NOT a task or workflow tool: \
+     `memory` stores what is TRUE or PREFERRED (knowledge); task/work tools track what must be \
+     DONE (action). When the operator says \"remember\" or states a preference, that is always \
+     `memory`, never a task. \
+     Durable identity-scoped memory: remember, update, forget, recall, and propose_to_mob. \
      Records persist across session resets and respawns and are injected into future builds. \
      Protocol: check your injected memory index first and prefer `update` on an existing \
      record id over writing a near-duplicate; keep one fact per record; write `description` \

--- a/meerkat-mobkit/src/identity_first/agent_memory.rs
+++ b/meerkat-mobkit/src/identity_first/agent_memory.rs
@@ -70,8 +70,14 @@ pub enum AgentMemoryRecallFailurePolicy {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentMemoryPerTurnInjection {
-    #[default]
     Off,
+    /// Ambient per-turn recall, budget-laddered and dedup'd, delivered as a
+    /// separate typed injected-context body (meerkat 0.7.12 ask 1). Now the
+    /// default: echo-safe by construction (excluded from compaction indexing)
+    /// and delivered on an authenticated channel rather than fused into user
+    /// text. Active on the identity-first path; the classic (roster-less) mob
+    /// path still injects at build time only (§9.1).
+    #[default]
     Budgeted,
 }
 
@@ -142,7 +148,7 @@ impl Default for AgentMemoryConfig {
             recall_timeout_ms: DEFAULT_RECALL_TIMEOUT_MS,
             recall_failure_policy: AgentMemoryRecallFailurePolicy::Skip,
             instruction_header: None,
-            per_turn_injection: AgentMemoryPerTurnInjection::Off,
+            per_turn_injection: AgentMemoryPerTurnInjection::Budgeted,
             defang_inbound: true,
             llm_writes: AgentMemoryLlmWrites::Observed,
             recorder_tool: true,
@@ -784,12 +790,16 @@ impl AgentMemoryRuntimeInjector {
 
     /// Ambient per-turn injection. `session_key` scopes the cross-turn dedup
     /// and cumulative byte budget; without it only the per-assembly cap holds.
+    /// Assemble the ambient per-turn recall as a separate `injected_context`
+    /// body (meerkat 0.7.12 ask 1). Returns the vector to deliver alongside
+    /// the user message; empty means inject nothing. See
+    /// [`RecallCoordinator::inject_for_turn`].
     pub async fn inject_for_turn(
         &self,
         identity: &AgentIdentity,
         session_key: Option<&str>,
         content: &meerkat_core::ContentInput,
-    ) -> Result<meerkat_core::ContentInput, AgentMemoryError> {
+    ) -> Result<Vec<meerkat_core::ContentInput>, AgentMemoryError> {
         self.coordinator
             .inject_for_turn(identity, session_key, content)
             .await
@@ -2041,6 +2051,24 @@ mod tests {
     use async_trait::async_trait;
     use meerkat_mob::ProfileName;
     use std::error::Error;
+
+    /// Ask 1: `inject_for_turn` now returns the recall as a SEPARATE
+    /// `Vec<ContentInput>` (typed injected-context bodies), not fused with the
+    /// user's text. This helper flattens the bodies to one string so
+    /// "injection contains X" assertions read unchanged; an empty vector
+    /// (nothing injected) flattens to the empty string — and, unlike the old
+    /// fused return, it no longer echoes the user's own message back.
+    trait InjectionText {
+        fn text_content(&self) -> String;
+    }
+    impl InjectionText for Vec<meerkat_core::ContentInput> {
+        fn text_content(&self) -> String {
+            self.iter()
+                .map(meerkat_core::ContentInput::text_content)
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    }
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Barrier, Mutex};
     use std::time::Duration;
@@ -2940,8 +2968,10 @@ mod tests {
         );
         let injected_text = injected.text_content();
         assert!(injected_text.contains("Passport location"));
-        assert!(injected_text.contains("Current user message"));
-        assert!(injected_text.contains("Where did I put my passport?"));
+        // Ask 1: the injection is a SEPARATE body — it must NOT echo the
+        // user's own message (that travels on the user channel).
+        assert!(!injected_text.contains("Current user message"));
+        assert!(!injected_text.contains("Where did I put my passport?"));
         Ok(())
     }
 
@@ -2960,7 +2990,7 @@ mod tests {
             .inject_for_turn(&identity()?, None, &content)
             .await?;
 
-        assert_eq!(injected.text_content(), "hello");
+        assert!(injected.is_empty());
         Ok(())
     }
 
@@ -3001,7 +3031,7 @@ mod tests {
             .inject_for_turn(&identity()?, None, &content)
             .await?;
 
-        assert_eq!(injected.text_content(), "hello");
+        assert!(injected.is_empty());
         Ok(())
     }
 
@@ -3049,7 +3079,7 @@ mod tests {
             Err(_) => return Err("locked markdown recall should respect timeout".into()),
         };
 
-        assert_eq!(injected.text_content(), "hello");
+        assert!(injected.is_empty());
         Ok(())
     }
 
@@ -3083,7 +3113,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn per_turn_injection_defaults_off() -> Result<(), Box<dyn Error>> {
+    async fn per_turn_injection_defaults_budgeted() -> Result<(), Box<dyn Error>> {
+        // Ask 1 flipped the platform default from Off to Budgeted (ambient
+        // injection is now echo-safe: delivered as a separate typed
+        // injected-context body, excluded from compaction indexing). Default
+        // config must now recall AND inject.
+        assert_eq!(
+            AgentMemoryConfig::default().per_turn_injection,
+            AgentMemoryPerTurnInjection::Budgeted,
+            "per-turn injection now defaults to budgeted"
+        );
         let provider = Arc::new(CapturingProvider {
             request: Mutex::new(None),
             records: vec![AgentMemoryRecord {
@@ -3103,13 +3142,16 @@ mod tests {
             .inject_for_turn(&identity()?, Some("session-1"), &content)
             .await?;
 
-        assert_eq!(injected.text_content(), content.text_content());
+        // Recall ran and the record was injected as its own body — and the
+        // user's message is NOT echoed back into it.
+        assert!(injected.text_content().contains("Fact"));
+        assert!(!injected.text_content().contains("where is the fact?"));
         let captured = provider
             .request
             .lock()
             .map_err(|err| format!("capture mutex poisoned: {err}"))?
             .clone();
-        assert!(captured.is_none(), "off mode must not recall at all");
+        assert!(captured.is_some(), "budgeted default must recall");
         Ok(())
     }
 
@@ -3144,9 +3186,8 @@ mod tests {
         let second = injector
             .inject_for_turn(&identity()?, Some("session-a"), &content)
             .await?;
-        assert_eq!(
-            second.text_content(),
-            "hello",
+        assert!(
+            second.is_empty(),
             "already-injected record must not re-inject in the same session"
         );
 
@@ -3183,7 +3224,7 @@ mod tests {
             blocks < 12,
             "assembly budget must exclude some of 12 x 2KB records (got {blocks})"
         );
-        let overhead = text.len() - content.text_content().len();
+        let overhead = text.len();
         assert!(overhead <= MAX_INJECTED_ASSEMBLY_BYTES + 64);
         Ok(())
     }
@@ -3209,7 +3250,7 @@ mod tests {
             let injected = injector
                 .inject_for_turn(&identity()?, Some("session-x"), &content)
                 .await?;
-            let overhead = injected.text_content().len() - content.text_content().len();
+            let overhead = injected.text_content().len();
             assert!(overhead <= MAX_INJECTED_ASSEMBLY_BYTES + 64);
             if overhead == 0 {
                 saw_passthrough_at = Some(turn);

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -137,6 +137,7 @@ async fn submit_internal_bridge_work(
     handle: &MobHandle,
     member_id: &MobAgentIdentity,
     content: &meerkat_core::ContentInput,
+    injected_context: &[meerkat_core::ContentInput],
     handling_mode: HandlingMode,
 ) -> Result<(), BridgeError> {
     let entry = handle
@@ -144,12 +145,20 @@ async fn submit_internal_bridge_work(
         .await
         .map_err(|err| BridgeError::Mob(err.to_string()))?
         .ok_or_else(|| BridgeError::Mob(format!("member not found: {member_id}")))?;
+    // Ask 1: attach ambient memory recall as a separate typed injected-context
+    // body rather than fusing it into the user's message text. WorkSpec carries
+    // it to the StartTurnRequest, where meerkat stamps each entry as the
+    // InjectedContext transcript role (excluded from compaction indexing).
+    let mut spec = WorkSpec::new(content.clone(), WorkOrigin::Internal);
+    if !injected_context.is_empty() {
+        spec = spec.with_injected_context(injected_context.to_vec());
+    }
     handle
         .submit_work_with_mode(
             entry.agent_runtime_id.clone(),
             entry.fence_token,
             WorkRef::new(),
-            WorkSpec::new(content.clone(), WorkOrigin::Internal),
+            spec,
             handling_mode,
         )
         .await
@@ -211,6 +220,22 @@ pub trait SessionBridge: Send + Sync {
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         let _ = handling_mode;
         self.deliver(runtime_id, content).await
+    }
+
+    /// Deliver content plus a separate `injected_context` body (meerkat
+    /// 0.7.12 ask 1: typed ambient injection alongside — not fused into —
+    /// the user's message). Bridges that do not carry injected context fall
+    /// back to plain delivery of the user content, dropping the injection.
+    async fn deliver_with_mode_and_context(
+        &self,
+        runtime_id: &AgentRuntimeId,
+        content: &meerkat_core::ContentInput,
+        injected_context: &[meerkat_core::ContentInput],
+        handling_mode: HandlingMode,
+    ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+        let _ = injected_context;
+        self.deliver_with_mode(runtime_id, content, handling_mode)
+            .await
     }
 
     /// Checkpoint the current session state for a mob member.
@@ -938,7 +963,9 @@ impl SessionBridge for MobSessionBridge {
         // complete. The identity layer owns addressability enforcement — the
         // bridge is an internal delivery mechanism regardless of whether the
         // identity is Addressable or InternalOnly.
-        match submit_internal_bridge_work(&self.handle, &mid, content, HandlingMode::Queue).await {
+        match submit_internal_bridge_work(&self.handle, &mid, content, &[], HandlingMode::Queue)
+            .await
+        {
             Ok(()) => {}
             Err(err) if is_repairable_bridge_delivery_error(&err.to_string()) => {
                 tracing::warn!(
@@ -952,7 +979,7 @@ impl SessionBridge for MobSessionBridge {
                     member_entry_before_delivery,
                 ))
                 .await?;
-                submit_internal_bridge_work(&self.handle, &mid, content, HandlingMode::Queue)
+                submit_internal_bridge_work(&self.handle, &mid, content, &[], HandlingMode::Queue)
                     .await?;
             }
             Err(err) => return Err(BridgeError::Mob(err.to_string())),
@@ -972,6 +999,17 @@ impl SessionBridge for MobSessionBridge {
         &self,
         runtime_id: &AgentRuntimeId,
         content: &meerkat_core::ContentInput,
+        handling_mode: HandlingMode,
+    ) -> Result<meerkat_core::types::SessionId, BridgeError> {
+        self.deliver_with_mode_and_context(runtime_id, content, &[], handling_mode)
+            .await
+    }
+
+    async fn deliver_with_mode_and_context(
+        &self,
+        runtime_id: &AgentRuntimeId,
+        content: &meerkat_core::ContentInput,
+        injected_context: &[meerkat_core::ContentInput],
         handling_mode: HandlingMode,
     ) -> Result<meerkat_core::types::SessionId, BridgeError> {
         let mid = self.member_id_for_runtime_id(runtime_id).await;
@@ -1006,7 +1044,15 @@ impl SessionBridge for MobSessionBridge {
             }
         }
 
-        match submit_internal_bridge_work(&self.handle, &mid, content, handling_mode).await {
+        match submit_internal_bridge_work(
+            &self.handle,
+            &mid,
+            content,
+            injected_context,
+            handling_mode,
+        )
+        .await
+        {
             Ok(()) => {}
             Err(err) if is_repairable_bridge_delivery_error(&err.to_string()) => {
                 tracing::warn!(
@@ -1020,7 +1066,14 @@ impl SessionBridge for MobSessionBridge {
                     member_entry_before_delivery,
                 ))
                 .await?;
-                submit_internal_bridge_work(&self.handle, &mid, content, handling_mode).await?;
+                submit_internal_bridge_work(
+                    &self.handle,
+                    &mid,
+                    content,
+                    injected_context,
+                    handling_mode,
+                )
+                .await?;
             }
             Err(err) => return Err(BridgeError::Mob(err.to_string())),
         }

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -3752,10 +3752,23 @@ impl IdentityRuntime {
         // Bounded; deletion proceeds at the pre-rotation timeout.
         if let Some(injector) = self.agent_memory.read().await.clone() {
             if let Some(session_id) = session_id.as_ref() {
+                let session_key = session_id.to_string();
                 injector
                     .distill_before_rotation(
                         identity,
-                        &session_id.to_string(),
+                        &session_key,
+                        crate::memory::distiller::DistillCause::Delete,
+                    )
+                    .await;
+                // Ask 2 GC: delete permanently abandons this session id, and
+                // its knowledge has just been distilled into the identity-keyed
+                // MobKit store (which the exit-interview harvest below reads —
+                // a DIFFERENT store from the meerkat session-memory scope). So
+                // reclaiming the orphaned meerkat scope here frees dead
+                // re-embed weight without starving any downstream read.
+                injector
+                    .drop_orphaned_session_scope(
+                        &session_key,
                         crate::memory::distiller::DistillCause::Delete,
                     )
                     .await;

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -2544,8 +2544,12 @@ impl IdentityRuntime {
         // is defanged first (§9.1 anti-spoofing — even with injection off,
         // forged memory envelopes are an inbound threat) and only then
         // considered for ambient injection.
-        let content_to_deliver = if handling_mode == HandlingMode::Steer {
-            content.clone()
+        // Ask 1: the user content and the ambient memory recall travel as
+        // SEPARATE bodies — `content_to_deliver` is the (defanged) user
+        // message, `injected_context` is the recall assembled as its own
+        // typed injected-context body. They are never fused into one text.
+        let (content_to_deliver, injected_context) = if handling_mode == HandlingMode::Steer {
+            (content.clone(), Vec::new())
         } else {
             match self.agent_memory.read().await.clone() {
                 Some(injector) => {
@@ -2560,21 +2564,27 @@ impl IdentityRuntime {
                         }
                     }
                     let defanged = injector.defang_inbound(identity, content);
-                    injector
+                    let injected_context = injector
                         .inject_for_turn(identity, memory_session_key.as_deref(), &defanged)
                         .await
                         .map_err(|err| {
                             IdentityRuntimeError::Internal(format!("agent memory recall: {err}"))
-                        })?
+                        })?;
+                    (defanged, injected_context)
                 }
-                None => content.clone(),
+                None => (content.clone(), Vec::new()),
             }
         };
 
         // Deliver through the session bridge when available.
         if let (Some(bridge), Some(rid)) = (&self.bridge, &runtime_id) {
             let delivered_session_id = bridge
-                .deliver_with_mode(rid, &content_to_deliver, handling_mode)
+                .deliver_with_mode_and_context(
+                    rid,
+                    &content_to_deliver,
+                    &injected_context,
+                    handling_mode,
+                )
                 .await
                 .map_err(|e| IdentityRuntimeError::Internal(format!("bridge deliver: {e}")))?;
             if let Some(rebound_token) = self

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -120,11 +120,12 @@ pub use memory::{
     CompactionResetSink, ContentTrustConfig, DistillCause, DistillerConfig, DistillerEngine,
     DreamOutcome, DreamRun, HygieneCause, HygieneOutcome, HygienistConfig, HygienistEngine,
     ManifestTier, MemberAgentEventSink, MemoryConflictBridge, MemoryEventSink, MemoryGatingBridge,
-    MemoryKind, MemoryRecord, MemoryScope, MemoryTimelineEvent, MobPurposeSource, NewMemoryRecord,
-    OperatorResolver, PromotionGateResolver, RecordMeta, SessionStoreEvidenceResolver,
-    SessionTaintTracker, SqliteAgentMemoryStore, StagedMemoryStore, StagedMutationBatch, StagedOp,
-    StewardConfig, StewardEngine, StewardTriggers, TaintLlmWriteGate, TaintObserverGuard,
-    TrustTier, spawn_member_event_observer, spawn_taint_observer,
+    MemoryKind, MemoryRecord, MemoryScope, MemorySpawnCustomizer, MemoryTimelineEvent,
+    MobPurposeSource, NewMemoryRecord, OperatorResolver, PromotionGateResolver, RecordMeta,
+    SessionStoreEvidenceResolver, SessionTaintTracker, SqliteAgentMemoryStore, StagedMemoryStore,
+    StagedMutationBatch, StagedOp, StewardConfig, StewardEngine, StewardTriggers,
+    TaintLlmWriteGate, TaintObserverGuard, TrustTier, spawn_member_event_observer,
+    spawn_taint_observer,
 };
 pub use mob_handle_runtime::{
     AfterCreateHook, CapabilityFlags, MobBootstrapOptions, MobBootstrapSpec, MobRuntime,

--- a/meerkat-mobkit/src/memory/coordinator.rs
+++ b/meerkat-mobkit/src/memory/coordinator.rs
@@ -432,21 +432,30 @@ impl RecallCoordinator {
 
     /// Ambient per-turn injection. `session_key` scopes the cross-turn dedup
     /// and cumulative byte budget; without it only the per-assembly cap holds.
+    /// Assemble the ambient per-turn memory recall as a SEPARATE typed
+    /// injected-context body (meerkat 0.7.12 ask 1): the return is the
+    /// `injected_context` vector to attach alongside the user's message, NOT
+    /// fused into its text. An empty vector means "inject nothing" (off,
+    /// empty query, exhausted budget, or no records) — the caller then
+    /// delivers the user content unchanged. Delivering as the typed class is
+    /// what makes injection echo-safe (excluded from compaction indexing) and
+    /// authenticated (a channel, not a text pattern) rather than the old
+    /// fused-into-user-text behavior.
     pub async fn inject_for_turn(
         &self,
         identity: &AgentIdentity,
         session_key: Option<&str>,
         content: &meerkat_core::ContentInput,
-    ) -> Result<meerkat_core::ContentInput, AgentMemoryError> {
+    ) -> Result<Vec<meerkat_core::ContentInput>, AgentMemoryError> {
         if self.config.per_turn_injection == AgentMemoryPerTurnInjection::Off {
-            return Ok(content.clone());
+            return Ok(Vec::new());
         }
         let query_text = compact_whitespace(&content.text_content());
         let query_terms = terms_from_value(&query_text)
             .into_iter()
             .collect::<Vec<_>>();
         if self.config.selection == AgentMemorySelection::Contextual && query_text.is_empty() {
-            return Ok(content.clone());
+            return Ok(Vec::new());
         }
         let (skip_ids, budget) = match session_key {
             Some(key) => {
@@ -466,7 +475,7 @@ impl RecallCoordinator {
             None => (None, MAX_INJECTED_ASSEMBLY_BYTES),
         };
         if budget < MIN_INJECTION_BUDGET_BYTES {
-            return Ok(content.clone());
+            return Ok(Vec::new());
         }
         let selected = self
             .selector_records(
@@ -499,7 +508,7 @@ impl RecallCoordinator {
             ),
         };
         if records.is_empty() {
-            return Ok(content.clone());
+            return Ok(Vec::new());
         }
         let nonce = self.nonce_for(identity, session_key);
         let Some(rendered) = render_injection_annotated(
@@ -511,7 +520,7 @@ impl RecallCoordinator {
             skip_ids.as_ref(),
             budget,
         ) else {
-            return Ok(content.clone());
+            return Ok(Vec::new());
         };
         if let Some(key) = session_key {
             let mut guard = self
@@ -548,7 +557,11 @@ impl RecallCoordinator {
             &rendered.included_ids,
         )
         .await;
-        Ok(prepend_memory_injection(content, rendered.text))
+        // Ask 1: deliver the recall as a separate injected-context body
+        // (meerkat stamps ContentInput in `injected_context` as the typed
+        // InjectedContext role → excluded from compaction indexing). The
+        // user's message text is never touched.
+        Ok(vec![meerkat_core::ContentInput::Text(rendered.text)])
     }
 
     // -----------------------------------------------------------------------
@@ -1279,25 +1292,6 @@ fn age_phrase(age_days: u64) -> String {
     }
 }
 
-pub(crate) fn prepend_memory_injection(
-    content: &meerkat_core::ContentInput,
-    injection: String,
-) -> meerkat_core::ContentInput {
-    match content {
-        meerkat_core::ContentInput::Text(text) => meerkat_core::ContentInput::Text(format!(
-            "{injection}\n\nCurrent user message:\n{text}"
-        )),
-        meerkat_core::ContentInput::Blocks(blocks) => {
-            let mut with_memory = Vec::with_capacity(blocks.len() + 1);
-            with_memory.push(meerkat_core::ContentBlock::Text {
-                text: format!("{injection}\n\nCurrent user message follows."),
-            });
-            with_memory.extend(blocks.iter().cloned());
-            meerkat_core::ContentInput::Blocks(with_memory)
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Defanging (pure)
 // ---------------------------------------------------------------------------
@@ -1443,6 +1437,24 @@ mod tests {
     use async_trait::async_trait;
     use std::error::Error;
     use std::sync::Mutex as StdMutex;
+
+    /// Ask 1 changed `inject_for_turn` to return the recall as a SEPARATE
+    /// `Vec<ContentInput>` (the typed injected-context bodies) instead of a
+    /// single ContentInput fused with the user's text. This test-only helper
+    /// flattens the returned bodies back to one string so the existing
+    /// "injection contains X" assertions read unchanged; an empty vector
+    /// (nothing injected) flattens to the empty string.
+    trait InjectionText {
+        fn text_content(&self) -> String;
+    }
+    impl InjectionText for Vec<meerkat_core::ContentInput> {
+        fn text_content(&self) -> String {
+            self.iter()
+                .map(meerkat_core::ContentInput::text_content)
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    }
 
     fn identity() -> Result<AgentIdentity, Box<dyn Error>> {
         AgentIdentity::parse("identity:luka").map_err(|err| {
@@ -2287,7 +2299,7 @@ mod tests {
         let second = coordinator
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(second.text_content(), "hello");
+        assert!(second.is_empty(), "deduped turn injects nothing new");
         assert_eq!(
             provider.captured_injections().len(),
             1,
@@ -2500,9 +2512,8 @@ mod tests {
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
 
-        assert_eq!(
-            injected.text_content(),
-            "hello",
+        assert!(
+            injected.is_empty(),
             "an empty selection is a verdict, not a fallback"
         );
         assert!(provider.captured_injections().is_empty());
@@ -2613,9 +2624,8 @@ mod tests {
         let first = coordinator
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(
-            first.text_content(),
-            "hello",
+        assert!(
+            first.is_empty(),
             "the escalating turn itself must not block on the sweep"
         );
 
@@ -2697,7 +2707,15 @@ mod tests {
         let provider = Arc::new(FakeProvider::bodies_only(vec![record(
             "mem-1", "Fact", "Body",
         )]));
-        let coordinator = RecallCoordinator::new(provider.clone(), AgentMemoryConfig::default());
+        // Ask 1 flipped the default to Budgeted, so this test must opt Off
+        // explicitly to exercise the off-mode short-circuit it is named for.
+        let coordinator = RecallCoordinator::new(
+            provider.clone(),
+            AgentMemoryConfig {
+                per_turn_injection: AgentMemoryPerTurnInjection::Off,
+                ..AgentMemoryConfig::default()
+            },
+        );
         let id = identity()?;
         let content = meerkat_core::ContentInput::Text("hello".to_string());
 
@@ -2705,7 +2723,7 @@ mod tests {
             .inject_for_turn(&id, Some("s"), &content)
             .await?;
 
-        assert_eq!(injected.text_content(), "hello");
+        assert!(injected.is_empty(), "nothing to inject this turn");
         assert!(provider.captured_injections().is_empty());
         assert!(provider.captured_usage().is_empty());
         Ok(())
@@ -2786,9 +2804,8 @@ mod tests {
         let injected = build(false)
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(
-            injected.text_content(),
-            "hello",
+        assert!(
+            injected.is_empty(),
             "no mob binding ⇒ mob scope stays out of composition"
         );
         Ok(())
@@ -2843,9 +2860,8 @@ mod tests {
         let first = coordinator
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(
-            first.text_content(),
-            "hello",
+        assert!(
+            first.is_empty(),
             "failed attempt falls back to (empty) lexical recall"
         );
         assert_eq!(
@@ -2911,7 +2927,7 @@ mod tests {
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
 
-        assert_eq!(injected.text_content(), "hello");
+        assert!(injected.is_empty(), "nothing to inject this turn");
         assert_eq!(
             ready_sweep_of(&coordinator, "session-a"),
             Some(vec!["mem-deep".to_string()]),
@@ -2979,11 +2995,7 @@ mod tests {
         let starved = coordinator
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(
-            starved.text_content(),
-            "hello",
-            "nothing fits the starved budget"
-        );
+        assert!(starved.is_empty(), "nothing fits the starved budget");
         assert_eq!(
             ready_sweep_of(&coordinator, "session-a"),
             Some(vec!["mem-deep".to_string()]),
@@ -3049,7 +3061,10 @@ mod tests {
         let deduped = coordinator
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(deduped.text_content(), "hello", "dedup before compaction");
+        assert!(
+            deduped.is_empty(),
+            "dedup before compaction injects nothing new"
+        );
         seed_ready_sweep(&coordinator, "session-a", &["mem-sweep"]);
 
         coordinator.on_session_compacted("session-a");
@@ -3093,7 +3108,10 @@ mod tests {
         let still_deduped = coordinator
             .inject_for_turn(&id, Some("session-b"), &content)
             .await?;
-        assert_eq!(still_deduped.text_content(), "hello");
+        assert!(
+            still_deduped.is_empty(),
+            "still deduped: nothing new to inject"
+        );
         Ok(())
     }
 
@@ -3195,9 +3213,8 @@ mod tests {
             .clone()
             .inject_for_turn(&id, Some("session-a"), &content)
             .await?;
-        assert_eq!(
-            second.text_content(),
-            "hello",
+        assert!(
+            second.is_empty(),
             "dedup must hold across coordinator clones"
         );
         assert_eq!(provider.captured_injections().len(), 1);
@@ -3236,7 +3253,7 @@ mod tests {
                 .clone()
                 .inject_for_turn(&id, Some("session-x"), &content)
                 .await?;
-            let overhead = injected.text_content().len() - content.text_content().len();
+            let overhead = injected.text_content().len();
             assert!(overhead <= MAX_INJECTED_ASSEMBLY_BYTES + 64);
             if overhead == 0 {
                 saw_passthrough_at = Some(turn);

--- a/meerkat-mobkit/src/memory/distiller.rs
+++ b/meerkat-mobkit/src/memory/distiller.rs
@@ -515,6 +515,11 @@ pub struct TranscriptSlice {
     pub start_index: u64,
     pub end_index: u64,
     pub messages: Vec<TranscriptMessage>,
+    /// Ask 4 refinement (0.7.12): the transcript head revision id at the
+    /// instant this slice was read, so distilled records can pin the exact
+    /// revision their evidence was extracted from (§7.1). `None` when the
+    /// source cannot report a revision.
+    pub head_revision: Option<String>,
 }
 
 /// How the engine reads persisted transcripts. The real implementation is
@@ -562,6 +567,11 @@ impl TranscriptSource for SessionStoreTranscriptSource {
         let Some(session) = session else {
             return Ok(None);
         };
+        // Ask 4 refinement: pin the head revision the extractor is about to
+        // read. `transcript_revision()` is fallible serialization; a failure
+        // degrades to None ("head at capture time") rather than blocking the
+        // distillation.
+        let head_revision = session.transcript_revision().ok();
         let all = session.messages();
         let end_index = all.len() as u64;
         let start_index = from_index.min(end_index);
@@ -585,6 +595,7 @@ impl TranscriptSource for SessionStoreTranscriptSource {
             start_index,
             end_index,
             messages,
+            head_revision,
         }))
     }
 }
@@ -1385,7 +1396,7 @@ impl DistillerEngine {
 
         // Evidence read comes before the budget gate: an empty window must
         // not burn a budgeted run.
-        let (evidence_text, evidence_range, window_end) = match cause {
+        let (evidence_text, evidence_range, window_end, head_revision) = match cause {
             DistillCause::Compaction => {
                 let Some(compaction) = self.compaction.as_ref() else {
                     return DistillOutcome::Skipped {
@@ -1415,7 +1426,9 @@ impl DistillerEngine {
                     };
                 }
                 let range = discard_evidence_range(&entries);
-                (render_discards(&entries), range, None)
+                // Discards predate the current transcript head (they were
+                // evicted at compaction), so there is no head revision to pin.
+                (render_discards(&entries), range, None, None)
             }
             _ => {
                 let slice = match self.transcripts.read(session_key, cursor).await {
@@ -1455,7 +1468,13 @@ impl DistillerEngine {
                     };
                 }
                 let range = Some((slice.start_index, slice.end_index.saturating_sub(1)));
-                (render_transcript(&slice), range, Some(slice.end_index))
+                let head_revision = slice.head_revision.clone();
+                (
+                    render_transcript(&slice),
+                    range,
+                    Some(slice.end_index),
+                    head_revision,
+                )
             }
         };
 
@@ -1579,7 +1598,13 @@ impl DistillerEngine {
                     continue;
                 }
             };
-            let record = self.build_record(&op, session_key, generation, evidence_range);
+            let record = self.build_record(
+                &op,
+                session_key,
+                generation,
+                evidence_range,
+                head_revision.as_deref(),
+            );
             let result = match &op.action {
                 ProposedAction::Remember => {
                     self.provider
@@ -1638,6 +1663,7 @@ impl DistillerEngine {
         session_key: &str,
         generation: u64,
         window_range: Option<(u64, u64)>,
+        revision: Option<&str>,
     ) -> NewMemoryRecord {
         let mut tags = op.tags.clone();
         if op.epistemic == Epistemic::OperatorSaid
@@ -1667,7 +1693,10 @@ impl DistillerEngine {
             evidence: vec![EvidenceRef {
                 session_id: session_key.to_string(),
                 generation,
-                revision: None,
+                // Ask 4 refinement: pin the transcript head revision the
+                // evidence was read at (None on the compaction path, whose
+                // discards predate the current head).
+                revision: revision.map(str::to_string),
                 range,
             }],
             verification: None,
@@ -2146,6 +2175,7 @@ mod tests {
                     text: text.to_string(),
                 })
                 .collect(),
+            head_revision: Some("rev-head".to_string()),
         }
     }
 
@@ -2347,7 +2377,9 @@ mod tests {
         let evidence = &record.evidence[0];
         assert_eq!(evidence.session_id, "sess-1");
         assert_eq!(evidence.generation, 3);
-        assert_eq!(evidence.revision, None);
+        // Ask 4 refinement: transcript-path evidence pins the head revision
+        // the slice was read at (the StaticTranscript reports "rev-head").
+        assert_eq!(evidence.revision.as_deref(), Some("rev-head"));
         assert_eq!(
             evidence.range,
             Some((1, 2)),

--- a/meerkat-mobkit/src/memory/distiller.rs
+++ b/meerkat-mobkit/src/memory/distiller.rs
@@ -47,9 +47,10 @@
 //! (c) **Compaction** — `AgentEvent::CompactionCompleted` is observable on
 //! the agent-event stream; the discarded content survives only in
 //! meerkat's session semantic memory, so the post-compaction run reads the
-//! discard range host-side via `MemoryStore::search` over that session's
-//! scope (read-only [`HnswDiscardSource`]; opened lazily, one query,
-//! dropped — D3's re-index cost is paid once per harvest, never held).
+//! discard range host-side via `MemoryStore::enumerate_scoped` over that
+//! session's scope (ask 8: exact, provenance-ordered, paged — read-only
+//! [`HnswDiscardSource`]; opened lazily, drained, dropped — D3's re-index
+//! cost is paid once per harvest, never held).
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -633,6 +634,20 @@ pub trait CompactionDiscardSource: Send + Sync {
         session_key: &str,
         limit: usize,
     ) -> Result<Vec<DiscardEntry>, DistillerError>;
+
+    /// Ask 2 (landed in meerkat 0.7.12): reclaim a permanently-orphaned
+    /// session's semantic-memory rows via `MemoryStore::drop_scope`. Session
+    /// ids rotate under respawn/reset and vanish under delete, stranding rows
+    /// that nothing will ever search yet that every future agent build in the
+    /// realm re-embeds (defect D3, storage half). Callers MUST run this only
+    /// AFTER distillation has preserved what mattered, and ONLY for causes
+    /// that permanently abandon the id. Returns the number of rows dropped
+    /// (0 when unsupported — the default is a no-op for stores/test doubles
+    /// without a drop facility).
+    async fn drop_scope(&self, session_key: &str) -> Result<usize, DistillerError> {
+        let _ = session_key;
+        Ok(0)
+    }
 }
 
 /// Reads meerkat's own session semantic memory store at
@@ -643,21 +658,21 @@ pub trait CompactionDiscardSource: Send + Sync {
 ///
 /// Cost note (D3): `HnswMemoryStore::open` rebuilds its in-RAM index from
 /// the SQLite rows on every open, so the store is opened lazily per
-/// harvest, queried once, and dropped. The default ranking policy is a
-/// local bag-of-words hash — no network calls. `MemoryStore::search` is the
-/// only read surface (no enumeration API), so the harvest is one scoped
-/// query with a generous limit: at per-session compaction-row counts this
-/// approximates enumeration, and the approximation is documented rather
-/// than hidden.
+/// harvest and dropped afterwards.
+///
+/// Ask 8 (landed in meerkat 0.7.12): the harvest now reads the discard range
+/// via `MemoryStore::enumerate_scoped` — exact, provenance-ordered (durable
+/// id), paged — instead of the old generous-limit `search` approximation.
+/// Enumeration is read-only and additive; it does not touch indexing/search
+/// semantics. The per-page `limit` is the total safety ceiling on rows read;
+/// if a scope exceeds it the harvest stops and logs (never silently), but at
+/// per-session compaction-row counts the full scope fits well within it.
 pub struct HnswDiscardSource {
     dir: PathBuf,
 }
 
-/// The single harvest query (see [`HnswDiscardSource`] docs on why a query
-/// exists at all): doctrine-shaped terms so bag-of-words ranking surfaces
-/// the durable-memory-relevant rows first when the limit truncates.
-const HARVEST_QUERY: &str =
-    "operator said corrected decided preference fact gotcha procedure open loop reference";
+/// Raw scope rows fetched per `enumerate_scoped` page.
+const HARVEST_PAGE_ROWS: usize = 256;
 
 impl HnswDiscardSource {
     pub fn new(dir: impl Into<PathBuf>) -> Self {
@@ -672,7 +687,7 @@ impl CompactionDiscardSource for HnswDiscardSource {
         session_key: &str,
         limit: usize,
     ) -> Result<Vec<DiscardEntry>, DistillerError> {
-        use meerkat_core::memory::{MemorySearchScope, MemoryStore};
+        use meerkat_core::memory::{MemoryEnumerationRequest, MemorySearchScope, MemoryStore};
 
         if !self.dir.is_dir() {
             // No session semantic memory in this deployment: nothing was
@@ -688,21 +703,76 @@ impl CompactionDiscardSource for HnswDiscardSource {
             .map_err(|err| DistillerError::Store(err.to_string()))?
             .map_err(|err| DistillerError::Store(err.to_string()))?;
         let scope = MemorySearchScope::for_session(session_id);
-        let results = store
-            .search(&scope, HARVEST_QUERY, limit)
+
+        // Ask 8: page the scope exactly, in durable-id order, until it is
+        // exhausted or the safety ceiling is hit — no relevance ranking, no
+        // silent truncation.
+        let mut entries = Vec::new();
+        let mut offset = 0usize;
+        loop {
+            let remaining = limit.saturating_sub(entries.len());
+            if remaining == 0 {
+                break;
+            }
+            let page = store
+                .enumerate_scoped(
+                    &scope,
+                    MemoryEnumerationRequest {
+                        limit: HARVEST_PAGE_ROWS.min(remaining),
+                        offset,
+                        source_overlap: None,
+                        indexed_after: None,
+                    },
+                )
+                .await
+                .map_err(|err| DistillerError::Store(err.to_string()))?;
+            for record in page.records {
+                entries.push(DiscardEntry {
+                    range: record
+                        .metadata
+                        .source
+                        .source_range()
+                        .map(|range| (range.start(), range.end())),
+                    content: record.content,
+                });
+            }
+            match page.next_offset {
+                Some(next) if entries.len() < limit => offset = next,
+                Some(_) => {
+                    tracing::warn!(
+                        session_key,
+                        limit,
+                        "compaction discard harvest hit its row ceiling; \
+                         scope has more rows than were read"
+                    );
+                    break;
+                }
+                None => break,
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn drop_scope(&self, session_key: &str) -> Result<usize, DistillerError> {
+        use meerkat_core::memory::{MemoryOwner, MemoryStore};
+
+        if !self.dir.is_dir() {
+            // No session semantic memory in this deployment: nothing to reap.
+            return Ok(0);
+        }
+        let session_id = meerkat_core::types::SessionId::parse(session_key).map_err(|err| {
+            DistillerError::Transcript(format!("invalid session key '{session_key}': {err}"))
+        })?;
+        let dir = self.dir.clone();
+        let store = tokio::task::spawn_blocking(move || meerkat_memory::HnswMemoryStore::open(dir))
+            .await
+            .map_err(|err| DistillerError::Store(err.to_string()))?
+            .map_err(|err| DistillerError::Store(err.to_string()))?;
+        let receipt = store
+            .drop_scope(&MemoryOwner::canonical_session(session_id))
             .await
             .map_err(|err| DistillerError::Store(err.to_string()))?;
-        Ok(results
-            .into_iter()
-            .map(|result| DiscardEntry {
-                range: result
-                    .metadata
-                    .source
-                    .source_range()
-                    .map(|range| (range.start(), range.end())),
-                content: result.content,
-            })
-            .collect())
+        Ok(receipt.dropped_entries)
     }
 }
 
@@ -1642,6 +1712,38 @@ impl DistillerEngine {
         }
     }
 
+    /// Ask 2 GC: reclaim a permanently-orphaned session's semantic-memory
+    /// rows after its knowledge has been distilled. Best-effort and bounded —
+    /// a rotation must never fail on cleanup. Caller MUST have already run
+    /// `distill_before_rotation` for this session and MUST only invoke this
+    /// for causes that permanently abandon the session id (respawn/reset mint
+    /// a fresh id; delete discards it) — never for resumable retires.
+    pub async fn drop_orphaned_session_scope(
+        self: &Arc<Self>,
+        session_key: &str,
+        cause: DistillCause,
+    ) {
+        let Some(compaction) = self.compaction.as_ref() else {
+            return;
+        };
+        match compaction.drop_scope(session_key).await {
+            Ok(0) => {}
+            Ok(dropped) => tracing::debug!(
+                session_key,
+                cause = cause.as_str(),
+                dropped,
+                "agent memory GC: reclaimed orphaned session semantic-memory rows"
+            ),
+            Err(err) => tracing::warn!(
+                session_key,
+                cause = cause.as_str(),
+                error = %err,
+                "agent memory GC: dropping orphaned session scope failed; \
+                 rows remain (re-embed tax persists), rotation proceeds"
+            ),
+        }
+    }
+
     /// Detached distillation (reset / resume-fallback / compaction): never
     /// on any critical path. The session store outlives the session, so the
     /// read stays valid after teardown.
@@ -1759,6 +1861,70 @@ mod tests {
     use crate::memory::records::RecordStatus;
     use futures::stream;
     use std::sync::Mutex as StdMutex;
+
+    // Ask 2+8 (meerkat 0.7.12): the compaction-discard harvest reads its
+    // session's semantic-memory scope EXACTLY via `enumerate_scoped`, and a
+    // permanently-orphaned scope is reclaimed via `drop_scope`. This exercises
+    // both against a real `HnswMemoryStore` seeded with compaction-discard
+    // rows (proving the source_range mapping and the round-trip drop).
+    #[tokio::test]
+    async fn hnsw_discard_source_enumerates_then_drops_scope()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use meerkat_core::memory::{
+            MemoryIndexRequest, MemoryIndexScope, MemoryMetadata, MemorySource, MemoryStore,
+            MessageRange,
+        };
+        use meerkat_core::types::{MemoryIndexableContent, SessionId};
+
+        let dir = tempfile::tempdir()?;
+        let session = SessionId::new();
+
+        // Seed two discarded ranges into meerkat's session semantic memory.
+        {
+            let store = meerkat_memory::HnswMemoryStore::open(dir.path())?;
+            let scope = MemoryIndexScope::for_session(session.clone());
+            for (start, end, text) in [
+                (0u64, 2u64, "operator prefers terse status updates"),
+                (2u64, 5u64, "root cause was an expired upstream TLS cert"),
+            ] {
+                let request = MemoryIndexRequest::new(
+                    scope.clone(),
+                    MemoryIndexableContent::Indexable(text.to_string()),
+                    MemoryMetadata {
+                        session_id: session.clone(),
+                        source: MemorySource::Compaction {
+                            source_range: MessageRange::new(start, end)?,
+                        },
+                        indexed_at: meerkat_core::time_compat::SystemTime::now(),
+                    },
+                )?;
+                store.index_scoped(request).await?;
+            }
+        }
+
+        let source = HnswDiscardSource::new(dir.path());
+
+        // Exact enumeration: both rows, with their source ranges intact.
+        let discards = source
+            .read_discards(&session.to_string(), COMPACTION_HARVEST_LIMIT)
+            .await?;
+        assert_eq!(discards.len(), 2, "enumeration must return every scope row");
+        assert!(discards.iter().any(|d| d.range == Some((0, 2))));
+        assert!(
+            discards
+                .iter()
+                .any(|d| d.content.contains("expired upstream TLS cert"))
+        );
+
+        // GC: dropping the scope reclaims exactly those rows; a re-read is empty.
+        let dropped = source.drop_scope(&session.to_string()).await?;
+        assert_eq!(dropped, 2, "drop_scope must reclaim every seeded row");
+        let after = source
+            .read_discards(&session.to_string(), COMPACTION_HARVEST_LIMIT)
+            .await?;
+        assert!(after.is_empty(), "dropped scope must enumerate empty");
+        Ok(())
+    }
 
     // -- scripted LLM -------------------------------------------------------
 

--- a/meerkat-mobkit/src/memory/hygienist.rs
+++ b/meerkat-mobkit/src/memory/hygienist.rs
@@ -369,13 +369,23 @@ pub struct AppliedRevision {
 /// extension, so the gateway threads a typed handle to here at bootstrap.
 #[async_trait]
 pub trait TranscriptRevisionSeam: Send + Sync {
-    /// The session's current transcript (full message list, revision head).
+    /// The session's current transcript together with its head revision id at
+    /// read time (ask 4 refinement: `list_transcript_revisions` now exposes
+    /// the head, so the caller can pin what it read and compare-and-swap on
+    /// the rewrite). The head is `None` when the source cannot report one.
     /// `Ok(None)` when the session does not exist.
-    async fn read_messages(&self, session_key: &str) -> Result<Option<Vec<Message>>, String>;
+    async fn read_messages(
+        &self,
+        session_key: &str,
+    ) -> Result<Option<(Vec<Message>, Option<String>)>, String>;
 
     /// Commit one audited rewrite replacing `[start, end)` with
     /// `replacement`. Implementations must refuse mid-turn sessions
     /// (meerkat's `TranscriptEditRunningBehavior::Reject` default).
+    /// `expected_parent_revision` (the head observed by the matching
+    /// `read_messages`) is a compare-and-swap guard: the rewrite is rejected
+    /// if the head advanced since, so hygiene never commits against a
+    /// transcript that changed under it.
     async fn rewrite(
         &self,
         session_key: &str,
@@ -383,6 +393,7 @@ pub trait TranscriptRevisionSeam: Send + Sync {
         end: usize,
         replacement: Vec<Message>,
         note: &str,
+        expected_parent_revision: Option<String>,
     ) -> Result<AppliedRevision, String>;
 }
 
@@ -418,10 +429,13 @@ impl SessionServiceRevisionSeam {
 
 #[async_trait]
 impl TranscriptRevisionSeam for SessionServiceRevisionSeam {
-    async fn read_messages(&self, session_key: &str) -> Result<Option<Vec<Message>>, String> {
+    async fn read_messages(
+        &self,
+        session_key: &str,
+    ) -> Result<Option<(Vec<Message>, Option<String>)>, String> {
         let session_id = meerkat_core::types::SessionId::parse(session_key)
             .map_err(|err| format!("invalid session key '{session_key}': {err}"))?;
-        match self
+        let messages = match self
             .service
             .read_history(
                 &session_id,
@@ -432,10 +446,30 @@ impl TranscriptRevisionSeam for SessionServiceRevisionSeam {
             )
             .await
         {
-            Ok(page) => Ok(Some(page.messages)),
-            Err(meerkat_core::SessionError::NotFound { .. }) => Ok(None),
-            Err(err) => Err(err.to_string()),
-        }
+            Ok(page) => page.messages,
+            Err(meerkat_core::SessionError::NotFound { .. }) => return Ok(None),
+            Err(err) => return Err(err.to_string()),
+        };
+        // Ask 4 refinement: capture the head revision for the rewrite CAS.
+        // `limit: Some(0)` fetches the head without the commit log. A store
+        // that does not support revision listing degrades to `None` (no CAS,
+        // same as before) rather than failing the hygiene read.
+        let head_revision = match self
+            .service
+            .list_transcript_revisions(
+                &session_id,
+                meerkat_core::service::SessionTranscriptRevisionListQuery {
+                    limit: Some(0),
+                    offset: None,
+                },
+            )
+            .await
+        {
+            Ok(list) => Some(list.head_revision),
+            Err(meerkat_core::SessionError::Unsupported(_)) => None,
+            Err(err) => return Err(err.to_string()),
+        };
+        Ok(Some((messages, head_revision)))
     }
 
     async fn rewrite(
@@ -445,6 +479,7 @@ impl TranscriptRevisionSeam for SessionServiceRevisionSeam {
         end: usize,
         replacement: Vec<Message>,
         note: &str,
+        expected_parent_revision: Option<String>,
     ) -> Result<AppliedRevision, String> {
         let session_id = meerkat_core::types::SessionId::parse(session_key)
             .map_err(|err| format!("invalid session key '{session_key}': {err}"))?;
@@ -462,12 +497,12 @@ impl TranscriptRevisionSeam for SessionServiceRevisionSeam {
                     replacement,
                     reason,
                     actor: Some("mobkit-hygienist".to_string()),
-                    // No head-read API exists on SessionService, so there is
-                    // no revision id to compare-and-swap against; the
-                    // mutation guard + running-behavior Reject are the
-                    // concurrency protection (documented upstream ask
-                    // refinement).
-                    expected_parent_revision: None,
+                    // Ask 4 refinement: compare-and-swap against the head the
+                    // matching read observed (via list_transcript_revisions).
+                    // If the head advanced since, meerkat rejects the rewrite,
+                    // so hygiene never commits against a changed transcript.
+                    // Belt-and-braces with the mutation guard + Reject default.
+                    expected_parent_revision,
                     running_behavior: meerkat_core::TranscriptEditRunningBehavior::default(),
                 },
             )
@@ -1244,8 +1279,8 @@ impl HygienistEngine {
     ) -> HygieneOutcome {
         // Reads come before the budget gate: an empty transcript must not
         // burn a budgeted run.
-        let messages = match self.seam.read_messages(session_key).await {
-            Ok(Some(messages)) => messages,
+        let (messages, head_revision) = match self.seam.read_messages(session_key).await {
+            Ok(Some(read)) => read,
             Ok(None) => {
                 return HygieneOutcome::Skipped {
                     reason: "session not found".to_string(),
@@ -1370,7 +1405,14 @@ impl HygienistEngine {
         let note = truncate_utf8_boundary(&format!("{run_id}: {rationales}"), 512);
         match self
             .seam
-            .rewrite(session_key, hull_start, hull_end, replacement, &note)
+            .rewrite(
+                session_key,
+                hull_start,
+                hull_end,
+                replacement,
+                &note,
+                head_revision,
+            )
             .await
         {
             Ok(revision) => HygieneOutcome::Applied {
@@ -1872,12 +1914,27 @@ mod tests {
         messages: Vec<Message>,
         rewrites: StdMutex<Vec<(usize, usize, usize)>>,
         refuse: bool,
+        /// CAS value the engine forwarded from read_messages to rewrite. The
+        /// outer `Option` records whether rewrite was called at all; the inner
+        /// is the forwarded `expected_parent_revision` — two distinct facts.
+        #[allow(clippy::option_option)]
+        last_expected_parent: StdMutex<Option<Option<String>>>,
     }
+
+    // The head this scripted seam reports at read time — the CAS value the
+    // engine must forward verbatim to the rewrite.
+    const SCRIPTED_HEAD_REVISION: &str = "rev-head-at-read";
 
     #[async_trait]
     impl TranscriptRevisionSeam for ScriptedSeam {
-        async fn read_messages(&self, _session_key: &str) -> Result<Option<Vec<Message>>, String> {
-            Ok(Some(self.messages.clone()))
+        async fn read_messages(
+            &self,
+            _session_key: &str,
+        ) -> Result<Option<(Vec<Message>, Option<String>)>, String> {
+            Ok(Some((
+                self.messages.clone(),
+                Some(SCRIPTED_HEAD_REVISION.to_string()),
+            )))
         }
 
         async fn rewrite(
@@ -1887,7 +1944,13 @@ mod tests {
             end: usize,
             replacement: Vec<Message>,
             _note: &str,
+            expected_parent_revision: Option<String>,
         ) -> Result<AppliedRevision, String> {
+            *self
+                .last_expected_parent
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                Some(expected_parent_revision);
             if self.refuse {
                 return Err("session is running".to_string());
             }
@@ -1996,6 +2059,7 @@ mod tests {
             messages: transcript(),
             rewrites: StdMutex::new(Vec::new()),
             refuse: false,
+            last_expected_parent: StdMutex::new(None),
         })
     }
 
@@ -2025,6 +2089,17 @@ mod tests {
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .as_slice(),
             &[(2, 3, 1)]
+        );
+        // Ask 4 refinement: the head observed at read time is forwarded to the
+        // rewrite as the compare-and-swap parent (no longer None).
+        assert_eq!(
+            scripted
+                .last_expected_parent
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+            Some(Some(SCRIPTED_HEAD_REVISION.to_string())),
+            "hygiene must CAS against the head it read"
         );
         assert_eq!(
             sink.types(),
@@ -2115,6 +2190,7 @@ mod tests {
             messages: transcript(),
             rewrites: StdMutex::new(Vec::new()),
             refuse: true,
+            last_expected_parent: StdMutex::new(None),
         });
         let engine = engine_with(PRUNE_REPLY, scripted, Vec::new(), None, 2);
         let outcome = engine

--- a/meerkat-mobkit/src/memory/mod.rs
+++ b/meerkat-mobkit/src/memory/mod.rs
@@ -14,6 +14,7 @@ pub mod hygienist;
 pub mod records;
 pub mod secrets;
 pub mod selector;
+pub mod spawn_customizer;
 pub mod sqlite_store;
 pub mod staged;
 pub mod steward;
@@ -50,6 +51,7 @@ pub use selector::{
     SelectedRecordFetch, Selection, SelectorError, SelectorHandle, SelectorProfile,
     SelectorRuntime, SelectorSpec, SelectorStage, select,
 };
+pub use spawn_customizer::MemorySpawnCustomizer;
 pub use sqlite_store::{
     EvidenceRefResolver, PendingHarvest, PendingPromotion, PendingProposal, ScopeOverview,
     SqliteAgentMemoryStore,

--- a/meerkat-mobkit/src/memory/spawn_customizer.rs
+++ b/meerkat-mobkit/src/memory/spawn_customizer.rs
@@ -1,0 +1,418 @@
+//! Classic-mob agent memory (docs/design/agent-memory-architecture.md §8.2,
+//! §9.1) without the identity-first orchestration layer.
+//!
+//! Memory is keyed by [`AgentIdentity`], which every mob member already has —
+//! it does not require the continuity/roster machinery. This module carries
+//! the BASIC memory surface onto the classic mob path through meerkat-mob's
+//! pre-build seam ([`meerkat_mob::SpawnMemberCustomizer`], applied to every
+//! member spawn including resume restores): the Recorder `memory` tool and
+//! the echo-safe build-time injection block. The ADVANCED lifecycle features
+//! (distill-on-respawn/reset/retire, exit interviews, per-turn ambient
+//! injection) stay bound to `IdentityRuntime`.
+//!
+//! Per-turn injection on the classic path is a deliberate no-op: the P0.1
+//! echo-safety default is `AgentMemoryPerTurnInjection::Off`, and the classic
+//! send path has no injection hook yet. A classic-mob per-turn hook is a
+//! scoped follow-up (see the design doc §9.1); until then `budgeted` only
+//! takes effect on identity-first members.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use meerkat_mob::{
+    MobError, SpawnCustomizationContext, SpawnMemberCustomizer, SpawnMemberSpec, ids::MobId,
+};
+
+use crate::identity_first::AgentIdentity;
+use crate::identity_first::agent_memory::{
+    AgentMemoryConfig, AgentMemoryError, AgentMemoryPerTurnInjection, AgentMemoryProvider,
+    MemoryRecorder, RECORDER_PROTOCOL_INSTRUCTIONS, RecorderToolDispatcher, compact_whitespace,
+    insert_terms,
+};
+use crate::memory::coordinator::RecallCoordinator;
+
+/// Per-spawn memory customizer for classic (roster-less) mobs. One instance
+/// serves the whole mob runtime; recorder dispatchers are re-created per
+/// spawn, so the tool surface stays restore-safe exactly like the
+/// identity-first `customize_build` path.
+pub struct MemorySpawnCustomizer {
+    coordinator: RecallCoordinator,
+}
+
+impl MemorySpawnCustomizer {
+    pub fn new(provider: Arc<dyn AgentMemoryProvider>, config: AgentMemoryConfig) -> Self {
+        if config.per_turn_injection == AgentMemoryPerTurnInjection::Budgeted {
+            tracing::warn!(
+                "agent_memory.per_turn_injection = budgeted has no effect on the classic mob \
+                 path; ambient per-turn injection is identity-first-only for now (build-time \
+                 injection and the recorder tool are unaffected)"
+            );
+        }
+        Self {
+            coordinator: RecallCoordinator::new(provider, config),
+        }
+    }
+
+    /// The customizer body, factored off the trait so tests can drive it:
+    /// `SpawnCustomizationContext` is `#[non_exhaustive]` and only meerkat-mob
+    /// constructs it.
+    fn apply(
+        &self,
+        mob_id: &MobId,
+        spawner_identity: Option<&meerkat_mob::ids::AgentIdentity>,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        // Memory scope keys pin to the PUBLIC member alias — the identity
+        // space the console, panel filters, and persisted records speak —
+        // not the comms-safe roster encoding meerkat-mob spawns with
+        // (`agent:mem` arrives here as `mk--agent_cmem`). A member alias
+        // that fails validation gets no memory surface — loudly, never
+        // silently — instead of blocking the spawn.
+        let alias = crate::member_comms_id::runtime_alias_str(spec.identity.as_str());
+        let identity = match AgentIdentity::parse(alias.as_ref()) {
+            Ok(identity) => identity,
+            Err(err) => {
+                tracing::warn!(
+                    identity = %spec.identity,
+                    error = %err,
+                    "agent memory skipped for member: identity fails memory-scope validation"
+                );
+                return Ok(());
+            }
+        };
+
+        let injection = block_on_build_injection(
+            &self.coordinator,
+            &identity,
+            spawn_query_text(mob_id, &identity, spec),
+            spawn_query_terms(mob_id, &identity, spawner_identity, spec),
+        )
+        .map_err(|err| {
+            MobError::Internal(format!(
+                "agent memory build injection failed for '{}': {err}",
+                identity.as_str()
+            ))
+        })?;
+        if let Some(injection) = injection
+            && !injection.is_empty()
+        {
+            spec.additional_instructions
+                .get_or_insert_with(Vec::new)
+                .push(injection);
+        }
+
+        // §8.2 Recorder: same capability gate as the identity-first path.
+        // The dispatcher composes over any per-spawn external-tool overlay
+        // already on the spec; meerkat-mob then composes the result with
+        // profile bundles and mob-wide defaults (profile tools win name
+        // collisions).
+        let config = self.coordinator.config();
+        let provider = self.coordinator.provider();
+        if config.recorder_tool && provider.supports_authored_writes() {
+            let recorder =
+                MemoryRecorder::new(provider, config, identity, Some(mob_id.to_string()));
+            let inner = spec.external_tools.take();
+            spec.external_tools = Some(Arc::new(RecorderToolDispatcher::new(inner, recorder)));
+            spec.additional_instructions
+                .get_or_insert_with(Vec::new)
+                .push(RECORDER_PROTOCOL_INSTRUCTIONS.to_string());
+        }
+        Ok(())
+    }
+}
+
+impl SpawnMemberCustomizer for MemorySpawnCustomizer {
+    fn customize_spawn(
+        &self,
+        ctx: &SpawnCustomizationContext,
+        spec: &mut SpawnMemberSpec,
+    ) -> Result<(), MobError> {
+        self.apply(&ctx.mob_id, ctx.spawner_identity.as_ref(), spec)
+    }
+}
+
+/// Run the async build-injection assembly from meerkat-mob's synchronous
+/// `customize_spawn` seam. A dedicated thread with its own current-thread
+/// runtime keeps this correct on any caller runtime flavor (no
+/// `block_in_place` panic on current-thread runtimes, and the coordinator's
+/// internal `tokio::time::timeout`s get a live timer driver). Bounded by the
+/// coordinator's own recall budget (2× `recall_timeout_ms` for the selector
+/// stage), so a spawn never hangs on memory.
+fn block_on_build_injection(
+    coordinator: &RecallCoordinator,
+    identity: &AgentIdentity,
+    query_text: Option<String>,
+    query_terms: Vec<String>,
+) -> Result<Option<String>, AgentMemoryError> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|err| {
+                        AgentMemoryError::Io(format!(
+                            "memory recall runtime failed to start: {err}"
+                        ))
+                    })?;
+                runtime.block_on(coordinator.assemble_build_injection(
+                    identity,
+                    query_text,
+                    query_terms,
+                ))
+            })
+            .join()
+            .unwrap_or_else(|_| {
+                Err(AgentMemoryError::Io(
+                    "memory build-injection assembly panicked".to_string(),
+                ))
+            })
+    })
+}
+
+/// Classic-path counterpart of the identity-first `build_query_text`: the
+/// spawn spec has no continuity context (no active peers or managed edges),
+/// so the query composes identity + profile + labels + mob.
+fn spawn_query_text(
+    mob_id: &MobId,
+    identity: &AgentIdentity,
+    spec: &SpawnMemberSpec,
+) -> Option<String> {
+    let mut parts = vec![
+        format!("identity {}", identity.as_str()),
+        format!("profile {}", spec.role_name),
+        format!("mob {mob_id}"),
+    ];
+    if let Some(labels) = spec.labels.as_ref() {
+        for (key, value) in labels {
+            parts.push(format!("label {key} {value}"));
+        }
+    }
+    let text = compact_whitespace(&parts.join(" "));
+    (!text.is_empty()).then_some(text)
+}
+
+fn spawn_query_terms(
+    mob_id: &MobId,
+    identity: &AgentIdentity,
+    spawner_identity: Option<&meerkat_mob::ids::AgentIdentity>,
+    spec: &SpawnMemberSpec,
+) -> Vec<String> {
+    let mut terms = BTreeSet::new();
+    insert_terms(&mut terms, identity.as_str());
+    insert_terms(&mut terms, spec.role_name.as_str());
+    insert_terms(&mut terms, mob_id.as_str());
+    if let Some(spawner) = spawner_identity {
+        insert_terms(&mut terms, spawner.as_str());
+    }
+    if let Some(labels) = spec.labels.as_ref() {
+        for (key, value) in labels {
+            insert_terms(&mut terms, key);
+            insert_terms(&mut terms, value);
+        }
+    }
+    terms.into_iter().collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::memory::records::MemoryAuthor;
+    use crate::memory::sqlite_store::SqliteAgentMemoryStore;
+    use meerkat_core::agent::AgentToolDispatcher;
+    use meerkat_mob::ProfileName;
+    use meerkat_mob::ids::AgentIdentity as MobIdentity;
+
+    fn sqlite_store(dir: &std::path::Path) -> Arc<SqliteAgentMemoryStore> {
+        Arc::new(SqliteAgentMemoryStore::open(dir).expect("open sqlite store"))
+    }
+
+    fn spec_for(identity: &str) -> SpawnMemberSpec {
+        SpawnMemberSpec::new(ProfileName::from("worker"), MobIdentity::from(identity))
+    }
+
+    async fn seed_record(store: &SqliteAgentMemoryStore, identity: &str, title: &str, body: &str) {
+        let scope = crate::memory::records::MemoryScope::Identity {
+            realm: "default".to_string(),
+            identity: identity.to_string(),
+        };
+        store
+            .remember_authored(
+                &scope,
+                crate::memory::records::NewMemoryRecord {
+                    kind: crate::memory::records::MemoryKind::Fact,
+                    title: title.to_string(),
+                    description: title.to_string(),
+                    body: body.to_string(),
+                    tags: vec![],
+                    evidence: vec![],
+                    verification: None,
+                },
+                MemoryAuthor::Operator,
+            )
+            .await
+            .expect("seed memory record");
+    }
+
+    #[test]
+    fn registers_recorder_tool_and_protocol_on_spawn_spec() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = sqlite_store(dir.path());
+        let customizer = MemorySpawnCustomizer::new(store, AgentMemoryConfig::default());
+
+        let mut spec = spec_for("agent:mem");
+        customizer
+            .apply(&MobId::from("test-mob"), None, &mut spec)
+            .expect("apply succeeds");
+
+        let tools = spec.external_tools.as_ref().expect("recorder registered");
+        assert!(
+            tools
+                .tools()
+                .iter()
+                .any(|tool| tool.name.as_ref() == crate::identity_first::MEMORY_TOOL_NAME),
+            "memory tool must be registered on the spawn spec"
+        );
+        let instructions = spec.additional_instructions.as_ref().expect("instructions");
+        assert!(
+            instructions
+                .iter()
+                .any(|section| section.contains("Memory recorder protocol")),
+            "recorder protocol instructions must be injected: {instructions:#?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn injects_build_time_memory_block_for_seeded_identity() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = sqlite_store(dir.path());
+        seed_record(
+            &store,
+            "agent:mem",
+            "Deploy window",
+            "Deploys are frozen on Fridays.",
+        )
+        .await;
+        let customizer = MemorySpawnCustomizer::new(
+            store.clone(),
+            AgentMemoryConfig {
+                selection: crate::identity_first::AgentMemorySelection::Always,
+                ..AgentMemoryConfig::default()
+            },
+        );
+
+        // Spawn specs arrive with the comms-safe roster encoding; memory
+        // must key on the decoded public alias (`agent:mem`).
+        let mut spec = spec_for(crate::member_comms_id::mob_member_id_str("agent:mem").as_ref());
+        assert_eq!(spec.identity.as_str(), "mk--agent_cmem");
+        customizer
+            .apply(&MobId::from("test-mob"), None, &mut spec)
+            .expect("apply succeeds");
+
+        let instructions = spec.additional_instructions.as_ref().expect("instructions");
+        assert!(
+            instructions
+                .iter()
+                .any(|section| section.contains("Deploys are frozen on Fridays.")),
+            "build-time injection must carry the seeded record body: {instructions:#?}"
+        );
+    }
+
+    #[test]
+    fn recorder_composes_over_existing_per_spawn_overlay() {
+        struct EchoDispatcher;
+        #[async_trait::async_trait]
+        impl AgentToolDispatcher for EchoDispatcher {
+            fn tools(&self) -> Arc<[Arc<meerkat_core::ToolDef>]> {
+                vec![Arc::new(meerkat_core::ToolDef {
+                    name: "echo".into(),
+                    description: "echo".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    provenance: None,
+                })]
+                .into()
+            }
+            async fn dispatch(
+                &self,
+                call: meerkat_core::types::ToolCallView<'_>,
+            ) -> Result<meerkat_core::ops::ToolDispatchOutcome, meerkat_core::error::ToolError>
+            {
+                Ok(meerkat_core::ToolResult {
+                    tool_use_id: call.id.to_string(),
+                    content: vec![],
+                    is_error: false,
+                }
+                .into())
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = sqlite_store(dir.path());
+        let customizer = MemorySpawnCustomizer::new(store, AgentMemoryConfig::default());
+
+        let mut spec = spec_for("agent:mem");
+        spec.external_tools = Some(Arc::new(EchoDispatcher));
+        customizer
+            .apply(&MobId::from("test-mob"), None, &mut spec)
+            .expect("apply succeeds");
+
+        let tools = spec.external_tools.as_ref().expect("dispatcher present");
+        let names: Vec<String> = tools
+            .tools()
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+        assert!(names.contains(&"echo".to_string()), "{names:?}");
+        assert!(names.contains(&"memory".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn recorder_skipped_when_disabled_or_provider_read_only() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = sqlite_store(dir.path());
+        let customizer = MemorySpawnCustomizer::new(
+            store,
+            AgentMemoryConfig {
+                recorder_tool: false,
+                ..AgentMemoryConfig::default()
+            },
+        );
+        let mut spec = spec_for("agent:mem");
+        customizer
+            .apply(&MobId::from("test-mob"), None, &mut spec)
+            .expect("apply succeeds");
+        assert!(spec.external_tools.is_none(), "recorder_tool=false");
+
+        // Markdown store: no authored-write support, so injection-only.
+        let md_dir = tempfile::tempdir().expect("temp dir");
+        let markdown = Arc::new(
+            crate::identity_first::MarkdownAgentMemoryStore::open(md_dir.path())
+                .expect("markdown store"),
+        );
+        let customizer = MemorySpawnCustomizer::new(markdown, AgentMemoryConfig::default());
+        let mut spec = spec_for("agent:mem");
+        customizer
+            .apply(&MobId::from("test-mob"), None, &mut spec)
+            .expect("apply succeeds");
+        assert!(
+            spec.external_tools.is_none(),
+            "read-only provider must not register the recorder"
+        );
+    }
+
+    #[test]
+    fn invalid_memory_identity_skips_without_failing_spawn() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = sqlite_store(dir.path());
+        let customizer = MemorySpawnCustomizer::new(store, AgentMemoryConfig::default());
+
+        // Whitespace fails the memory-scope identity validation.
+        let mut spec = spec_for("agent with spaces");
+        customizer
+            .apply(&MobId::from("test-mob"), None, &mut spec)
+            .expect("apply must not fail the spawn");
+        assert!(spec.external_tools.is_none());
+        assert!(spec.additional_instructions.is_none());
+    }
+}

--- a/meerkat-mobkit/src/memory/spawn_customizer.rs
+++ b/meerkat-mobkit/src/memory/spawn_customizer.rs
@@ -42,10 +42,15 @@ pub struct MemorySpawnCustomizer {
 impl MemorySpawnCustomizer {
     pub fn new(provider: Arc<dyn AgentMemoryProvider>, config: AgentMemoryConfig) -> Self {
         if config.per_turn_injection == AgentMemoryPerTurnInjection::Budgeted {
-            tracing::warn!(
-                "agent_memory.per_turn_injection = budgeted has no effect on the classic mob \
-                 path; ambient per-turn injection is identity-first-only for now (build-time \
-                 injection and the recorder tool are unaffected)"
+            // `Budgeted` is now the platform default (ask 1 made ambient
+            // injection echo-safe), so this is no longer a user misconfig —
+            // it is an as-designed limitation of the classic path, which
+            // still injects at build time only (§9.1). Debug, not warn, to
+            // avoid spamming every roster-less mob that just takes defaults.
+            tracing::debug!(
+                "agent_memory.per_turn_injection = budgeted: ambient per-turn injection is \
+                 identity-first-only for now; the classic mob path injects at build time only \
+                 (the recorder tool and build-time injection are unaffected)"
             );
         }
         Self {

--- a/meerkat-mobkit/src/memory/sqlite_store.rs
+++ b/meerkat-mobkit/src/memory/sqlite_store.rs
@@ -225,6 +225,22 @@ impl SqliteAgentMemoryStore {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(gate);
     }
 
+    /// Install the §10.1 gate only when none is present. The classic-mob
+    /// builder path uses this so it never clobbers a taint-tracking gate an
+    /// embedder (or the gateway) installed before handing the store over.
+    /// Returns whether this call installed the gate.
+    pub fn set_llm_write_gate_if_absent(&self, gate: Arc<dyn LlmWriteGate>) -> bool {
+        let mut guard = self
+            .llm_write_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if guard.is_some() {
+            return false;
+        }
+        *guard = Some(gate);
+        true
+    }
+
     /// Install the §10.2 evidence-ref resolver. The steward wiring installs
     /// it at startup; from then on every staged retier to `agent_verified`
     /// must cite evidence that resolves against the session store.
@@ -241,6 +257,24 @@ impl SqliteAgentMemoryStore {
             .event_sink
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(sink);
+    }
+
+    /// Wire the §9.3 sink only when none is present — the classic-mob
+    /// builder path uses this so an embedder-installed sink survives.
+    /// Returns whether this call installed the sink.
+    pub fn set_event_sink_if_absent(
+        &self,
+        sink: Arc<dyn crate::memory::events::MemoryEventSink>,
+    ) -> bool {
+        let mut guard = self
+            .event_sink
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if guard.is_some() {
+            return false;
+        }
+        *guard = Some(sink);
+        true
     }
 
     fn gate(&self) -> Option<Arc<dyn LlmWriteGate>> {
@@ -1300,6 +1334,10 @@ impl AgentMemoryProvider for SqliteAgentMemoryStore {
 
     fn supports_authored_writes(&self) -> bool {
         true
+    }
+
+    fn as_sqlite_store(&self) -> Option<&SqliteAgentMemoryStore> {
+        Some(self)
     }
 }
 

--- a/meerkat-mobkit/src/memory/steward.rs
+++ b/meerkat-mobkit/src/memory/steward.rs
@@ -3722,6 +3722,7 @@ mod tests {
                 session_key: session_key.to_string(),
                 start_index: start,
                 end_index: end,
+                head_revision: None,
                 messages: messages[start as usize..]
                     .iter()
                     .enumerate()

--- a/meerkat-mobkit/src/memory/taint.rs
+++ b/meerkat-mobkit/src/memory/taint.rs
@@ -267,10 +267,32 @@ impl SessionTaintTracker {
             AgentEvent::RunStarted { session_id, input } => {
                 let session_key = session_id.to_string();
                 self.note_current_session(identity, &session_key);
-                // §10.1 comms taint join: peer-delivered content arrives as
-                // the run's injected input, not as a typed event.
+                // §10.1 comms taint join (legacy, belt-and-braces): before
+                // meerkat 0.7.13 the only inbound signal was projection text.
+                // It stays as a fallback for same-process senders whose taint
+                // this host tracks but who make no envelope declaration.
                 if let Some(text) = input.prompt_text() {
                     self.observe_inbound_peer_content(identity, &session_key, &text);
+                }
+            }
+            // §10.1 ask 5 (0.7.13): consume the sender's SIGNED content-taint
+            // declaration from the typed peer-ingestion event — canonical peer
+            // identity, emitted synchronously as the block commits — instead of
+            // parsing rendered projection text. Only an affirmative `Tainted`
+            // taints the receiving session; `None` ("no declaration") and
+            // `Clean` do not, and `None` is never coalesced into `Clean`.
+            AgentEvent::PeerContentIngested {
+                peer, sender_taint, ..
+            } => {
+                if *sender_taint == Some(meerkat_core::comms::SenderContentTaint::Tainted) {
+                    let sender = peer
+                        .as_ref()
+                        .and_then(|peer| peer.display_name.clone())
+                        .unwrap_or_else(|| "peer".to_string());
+                    self.mark_identity_tainted(
+                        identity,
+                        format!("peer content declared tainted by sender '{sender}'"),
+                    );
                 }
             }
             // Taint on result *ingestion*: these are the events whose content
@@ -878,6 +900,49 @@ mod tests {
             }],
             is_error: false,
         }
+    }
+
+    fn peer_ingested(taint: Option<meerkat_core::comms::SenderContentTaint>) -> AgentEvent {
+        AgentEvent::PeerContentIngested {
+            kind: meerkat_core::types::CommsNoticeKind::Message,
+            peer: None,
+            request_id: None,
+            sender_taint: taint,
+        }
+    }
+
+    // Ask 5 (0.7.13): the receiver taints on a sender's SIGNED `Tainted`
+    // declaration, from the typed event — but `None` ("no declaration") and
+    // `Clean` must never taint, and `None` is never coalesced into `Clean`.
+    #[test]
+    fn declared_peer_taint_taints_receiver_but_none_or_clean_does_not() {
+        use meerkat_core::comms::SenderContentTaint;
+        let tracker = SessionTaintTracker::new(ContentTrustConfig::default());
+        tracker.note_current_session("identity:b", "sess-b");
+
+        tracker.observe_agent_event("identity:b", &peer_ingested(None));
+        assert!(
+            tracker.session_taint("sess-b").is_none(),
+            "no declaration must not taint"
+        );
+
+        tracker.observe_agent_event(
+            "identity:b",
+            &peer_ingested(Some(SenderContentTaint::Clean)),
+        );
+        assert!(
+            tracker.session_taint("sess-b").is_none(),
+            "an affirmative Clean declaration must not taint"
+        );
+
+        tracker.observe_agent_event(
+            "identity:b",
+            &peer_ingested(Some(SenderContentTaint::Tainted)),
+        );
+        assert!(
+            tracker.session_taint("sess-b").is_some(),
+            "a declared-tainted peer delivery taints the receiving session"
+        );
     }
 
     #[test]

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -2255,6 +2255,10 @@ pub struct MobBootstrapSpec {
     /// service's `runtime_store` can stay `None` (keeping the checkpointer
     /// enabled). See meerkat-session#checkpointer-enabled-flag.
     pub runtime_adapter: Option<Arc<meerkat_runtime::MeerkatMachine>>,
+    /// Pre-build customizer applied to every mob member spawn (classic-path
+    /// agent memory rides here — see `crate::memory::spawn_customizer`).
+    /// Forwarded to `MobBuilder::with_spawn_member_customizer`.
+    pub(crate) spawn_member_customizer: Option<Arc<dyn meerkat_mob::SpawnMemberCustomizer>>,
     /// Holds the ephemeral temp directory alive for the lifetime of the spec.
     /// Only populated when the builder creates an ephemeral runtime.
     pub(crate) _ephemeral_dir: Option<Arc<tempfile::TempDir>>,
@@ -2287,6 +2291,7 @@ impl MobBootstrapSpec {
                 default_llm_client: None,
             },
             runtime_adapter: None,
+            spawn_member_customizer: None,
             _ephemeral_dir: None,
         }
     }
@@ -2915,6 +2920,10 @@ impl MobRuntime {
             .with_session_service(session_service.clone())
             .allow_ephemeral_sessions(spec.options.allow_ephemeral_sessions)
             .notify_orchestrator_on_resume(spec.options.notify_orchestrator_on_resume);
+
+        if let Some(customizer) = spec.spawn_member_customizer.clone() {
+            builder = builder.with_spawn_member_customizer(customizer);
+        }
 
         if let Some(client) = default_llm_client {
             builder = builder.with_default_llm_client(client);

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -3901,6 +3901,7 @@ shell = true
             }),
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
 
         ensure_shell_tooling_build_substrate(&mut req);
@@ -3949,6 +3950,7 @@ shell = true
             }),
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
 
         ensure_shell_tooling_build_substrate(&mut req);
@@ -4509,6 +4511,7 @@ realm_profile = "worker-v2"
             build: None,
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
 
         // create_session will fail (no LLM) but the hook runs first.
@@ -4569,6 +4572,7 @@ realm_profile = "worker-v2"
             build: None,
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::Discard,
+            injected_context: Vec::new(),
         };
 
         let (event_tx, _event_rx) = tokio::sync::mpsc::channel(8);
@@ -5221,6 +5225,7 @@ image_generation = true
     fn normalize_runtime_turn_request_strips_runtime_owned_semantics() {
         let req = meerkat_core::service::StartTurnRequest {
             prompt: meerkat_core::ContentInput::Text("checkpoint".to_string()),
+            injected_context: Vec::new(),
             system_prompt: Some("system".to_string()),
             event_tx: None,
             runtime: meerkat_core::service::StartTurnRuntimeSemantics {
@@ -5298,6 +5303,7 @@ image_generation = true
             build: None,
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
         // before_create must succeed with default impl.
         hook.before_create(&mut req).await.unwrap();
@@ -5336,6 +5342,7 @@ image_generation = true
             build: None,
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
         let result = hook.before_create(&mut req).await;
         assert!(result.is_err());
@@ -5369,6 +5376,7 @@ image_generation = true
             build: None,
             labels: None,
             deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
         };
         hook.before_create(&mut req).await.unwrap();
         assert_eq!(req.model, "hook-overridden");

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -414,6 +414,7 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
     adapter: Arc<MeerkatMachine>,
     schedule_service: ScheduleService,
     mob_state: Option<Arc<MobMcpState>>,
+    runnable_host: Option<Arc<dyn meerkat::ScheduleRunnableHost>>,
     owner_id: impl Into<String>,
 ) -> Option<ScheduleHostHandle> {
     let mob_host: Arc<dyn SurfaceScheduleMobHost> = match mob_state {
@@ -422,6 +423,9 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
             "scheduled mob targets are not supported: no mob runtime",
         )),
     };
+    // meerkat 0.7.13 (upstream ask 10): thread a host-runnable registry so
+    // host-registered runnables (e.g. the memory steward's dream) can be
+    // driven as schedule occurrences. `None` keeps mob/session targets only.
     spawn_runtime_backed_schedule_host_with_mobs(
         service,
         adapter,
@@ -429,6 +433,7 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
         schedule_service,
         SessionBuildOptions::default(),
         mob_host,
+        runnable_host,
         owner_id,
     )
 }

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -450,9 +450,15 @@ impl UnifiedRuntimeBuilder {
         let has_lease_provider = self.lease_provider.is_some();
         let has_roster_provider = self.roster_provider.is_some();
         let has_topology_provider = self.topology_provider.is_some();
-        let has_agent_memory =
-            self.agent_memory_provider.is_some() || self.agent_memory_from_persistent_state;
-        let has_agent_customizer = self.agent_customizer.is_some() || has_agent_memory;
+        // A2 decouple: agent memory is keyed by AgentIdentity, which every
+        // mob member already has, so enabling it must NOT pull in the
+        // identity-first orchestration layer (roster/continuity/leases).
+        // Without a roster the BASIC memory surface (recorder tool +
+        // build-time injection + panel store) rides the classic path via a
+        // `MemorySpawnCustomizer`; with a roster, memory composes into the
+        // IdentityRuntime customizer exactly as before (advanced lifecycle
+        // features included).
+        let has_agent_customizer = self.agent_customizer.is_some();
         let has_identity_runtime_instance_id = self.identity_runtime_instance_id.is_some();
         let has_scratch_dir = self.scratch_dir.is_some();
         let has_external_identity_storage =
@@ -531,7 +537,7 @@ impl UnifiedRuntimeBuilder {
 
         // Legacy mob_spec path takes precedence — must be consumed before
         // resolve_mob_spec (which borrows &self for the definition path).
-        let mob_spec = match self.mob_spec.take() {
+        let mut mob_spec = match self.mob_spec.take() {
             Some(spec) => {
                 // Legacy path: require module_config and timeout as before.
                 if self.module_config.is_none() {
@@ -596,6 +602,25 @@ impl UnifiedRuntimeBuilder {
             )
         });
         let agent_customizer = self.composed_agent_customizer(agent_memory_provider.clone());
+
+        // Classic (roster-less) agent memory: register the per-spawn memory
+        // customizer on the mob runtime itself, so every member spawn —
+        // consumer, agent-tool, policy, respawn, resume — gets the recorder
+        // tool and the build-time injection keyed on its AgentIdentity. The
+        // identity-first path keeps its AgentCustomizer instead (composing
+        // both would double-inject on identity-first materializations).
+        let classic_agent_memory = if wants_identity_first {
+            None
+        } else {
+            agent_memory_provider.clone()
+        };
+        if let Some(provider) = classic_agent_memory.as_ref() {
+            mob_spec.spawn_member_customizer =
+                Some(Arc::new(crate::memory::MemorySpawnCustomizer::new(
+                    provider.clone(),
+                    self.agent_memory_config.clone().unwrap_or_default(),
+                )));
+        }
 
         // The structural-events subscription cursor lives in the
         // persistent metadata adapter. For ephemeral builds this can be
@@ -880,6 +905,27 @@ impl UnifiedRuntimeBuilder {
             console_log_store,
             ..runtime
         };
+
+        // Classic-path bundled-store wiring: the console Memory panel (§9.3),
+        // the §10.1 posture write gate (only when the embedder did not
+        // install a taint-tracking gate already), and the §9.3 timeline sink
+        // for quarantined writes. Providers other than the bundled SQLite
+        // store keep injection + recorder without a panel.
+        if let Some(store) = classic_agent_memory
+            .as_ref()
+            .and_then(|provider| provider.as_sqlite_store())
+        {
+            let llm_writes = self
+                .agent_memory_config
+                .as_ref()
+                .map(|config| config.llm_writes)
+                .unwrap_or_default();
+            store.set_llm_write_gate_if_absent(Arc::new(
+                crate::memory::taint::TaintLlmWriteGate::new(None, llm_writes),
+            ));
+            store.set_event_sink_if_absent(runtime.memory_event_sink());
+            runtime.set_memory_panel_store(store.clone());
+        }
 
         let pre_spawn_context = if let Some(hook) = self.pre_spawn_hook {
             hook().await.map_err(|err| {

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -1140,6 +1140,7 @@ mod tests {
             deferred_prompt_policy: DeferredPromptPolicy::Discard,
             build: Some(build),
             labels: None,
+            injected_context: Vec::new(),
         }
     }
 

--- a/meerkat-mobkit/src/unified_runtime/lifecycle.rs
+++ b/meerkat-mobkit/src/unified_runtime/lifecycle.rs
@@ -190,16 +190,20 @@ impl UnifiedRuntime {
             drain_duration_ms: drain_start.elapsed().as_millis() as u64,
         };
 
-        // Phase 2: Close event router
-        self.close_event_router().await;
-
-        // Phase 3: Shutdown modules and mob
-        let module_shutdown = self.module_runtime.lock().await.shutdown();
+        // Phase 2: Stop the mob actor while its router/module dependencies
+        // are still alive. Closing them first can race Stop against an
+        // already-dropped actor reply channel under teardown pressure.
         let mob_stop = self
             .mob_handle()
             .stop()
             .await
             .map_err(MobRuntimeError::from);
+
+        // Phase 3: Close event router
+        self.close_event_router().await;
+
+        // Phase 4: Shutdown modules
+        let module_shutdown = self.module_runtime.lock().await.shutdown();
         UnifiedRuntimeShutdownReport {
             drain,
             module_shutdown,

--- a/meerkat-mobkit/tests/classic_agent_memory.rs
+++ b/meerkat-mobkit/tests/classic_agent_memory.rs
@@ -1,0 +1,572 @@
+//! A2 decouple: the BASIC agent-memory surface (recorder `memory` tool +
+//! build-time injection + Memory panel store) works on the classic mob path
+//! for any member keyed on its meerkat `AgentIdentity`, WITHOUT a roster
+//! provider or an `IdentityRuntime`. The identity-first path (roster present)
+//! is untouched — its own suites cover it.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode, header};
+use meerkat_client::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
+use meerkat_core::types::StopReason;
+use meerkat_mob::{MobDefinition, SpawnMemberSpec};
+use meerkat_mobkit::memory::MemoryAuthor;
+use meerkat_mobkit::{
+    AgentMemoryConfig, AgentMemoryPerTurnInjection, AgentMemoryProvider, AgentMemorySelection,
+    AuthPolicy, BigQueryNaming, ConsolePolicy, MemoryKind, MemoryScope, NewMemoryRecord,
+    RuntimeDecisionInputs, RuntimeOpsPolicy, SqliteAgentMemoryStore, TrustedOidcRuntimeConfig,
+    UnifiedRuntime, build_runtime_decision_state,
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+const CLASSIC_MOB_TOML: &str = r#"
+[mob]
+id = "classic-memory-mob"
+
+[profiles.worker]
+model = "gpt-5.5"
+runtime_mode = "autonomous_host"
+external_addressable = true
+
+[profiles.worker.tools]
+comms = true
+"#;
+
+fn test_definition() -> MobDefinition {
+    MobDefinition::from_toml(CLASSIC_MOB_TOML).expect("parse test mob definition")
+}
+
+/// LLM stub that records every request (tool names + full JSON) so tests can
+/// assert on the member's build surface: registered tools and the system
+/// instructions the memory customizer injected.
+#[derive(Clone, Default)]
+struct CaptureClient {
+    requests: Arc<std::sync::Mutex<Vec<CapturedRequest>>>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+#[derive(Clone)]
+struct CapturedRequest {
+    tool_names: Vec<String>,
+    request_json: String,
+}
+
+impl CaptureClient {
+    fn captured(&self) -> Vec<CapturedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    async fn wait_for_request(&self, minimum: usize) -> Vec<CapturedRequest> {
+        tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                let captured = self.captured();
+                if captured.len() >= minimum {
+                    return captured;
+                }
+                self.notify.notified().await;
+            }
+        })
+        .await
+        .expect("member turn should reach the LLM client")
+    }
+}
+
+impl LlmClient for CaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+        Ok(messages.to_vec())
+    }
+
+    fn stream<'a>(
+        &'a self,
+        request: &'a LlmRequest,
+    ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+        let captured = CapturedRequest {
+            tool_names: request
+                .tools
+                .iter()
+                .map(|tool| tool.name.to_string())
+                .collect(),
+            request_json: serde_json::to_string(request).unwrap_or_default(),
+        };
+        self.requests.lock().unwrap().push(captured);
+        self.notify.notify_waiters();
+        Box::pin(async_stream::stream! {
+            yield Ok(LlmEvent::TextDelta {
+                delta: "ok".to_string(),
+                meta: None,
+            });
+            yield Ok(LlmEvent::Done {
+                outcome: LlmDoneOutcome::Success {
+                    stop_reason: StopReason::EndTurn,
+                },
+            });
+        })
+    }
+
+    fn provider(&self) -> meerkat::Provider {
+        meerkat::Provider::OpenAI
+    }
+
+    fn health_check<'life0, 'async_trait>(
+        &'life0 self,
+    ) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+async fn seed_identity_record(
+    store: &SqliteAgentMemoryStore,
+    identity: &str,
+    title: &str,
+    body: &str,
+) {
+    store
+        .remember_authored(
+            &MemoryScope::Identity {
+                realm: "default".to_string(),
+                identity: identity.to_string(),
+            },
+            NewMemoryRecord {
+                kind: MemoryKind::Fact,
+                title: title.to_string(),
+                description: title.to_string(),
+                body: body.to_string(),
+                tags: vec![],
+                evidence: vec![],
+                verification: None,
+            },
+            MemoryAuthor::Operator,
+        )
+        .await
+        .expect("seed memory record");
+}
+
+async fn build_classic_runtime(
+    store: SqliteAgentMemoryStore,
+    config: AgentMemoryConfig,
+    client: CaptureClient,
+) -> UnifiedRuntime {
+    Box::pin(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .agent_memory(Arc::new(store), config)
+            .default_llm_client(Arc::new(client))
+            .build(),
+    )
+    .await
+    .expect("classic runtime with agent memory and NO roster must build")
+}
+
+// ---------------------------------------------------------------------------
+// Build succeeds without a roster; no IdentityRuntime is constructed; the
+// panel store is auto-wired.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_agent_memory_builds_without_roster_and_without_identity_runtime() {
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+
+    let runtime = build_classic_runtime(
+        store,
+        AgentMemoryConfig::default(),
+        CaptureClient::default(),
+    )
+    .await;
+
+    assert!(
+        runtime.identity_runtime().is_none(),
+        "classic memory must not construct an IdentityRuntime"
+    );
+    assert!(
+        runtime.identity_first_context().is_none(),
+        "classic memory must not construct an identity-first context"
+    );
+    assert!(
+        runtime.memory_panel_store().is_some(),
+        "bundled sqlite provider must auto-wire the Memory panel store"
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// ---------------------------------------------------------------------------
+// Member builds get the recorder tool + the build-time memory injection.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_member_build_registers_recorder_and_injects_memory() {
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+    seed_identity_record(
+        &store,
+        "helper",
+        "Deploy window",
+        "Deploys are frozen on Fridays.",
+    )
+    .await;
+
+    let client = CaptureClient::default();
+    let runtime = build_classic_runtime(
+        store,
+        AgentMemoryConfig {
+            selection: AgentMemorySelection::Always,
+            ..AgentMemoryConfig::default()
+        },
+        client.clone(),
+    )
+    .await;
+
+    runtime
+        .spawn_many(vec![SpawnMemberSpec::from_wire(
+            "worker".to_string(),
+            "helper".to_string(),
+            None,
+            None,
+            None,
+        )])
+        .await
+        .expect("spawn member on the classic path");
+    meerkat_mobkit::send_message_on_mob(&runtime.mob_handle(), "helper", "hello".to_string())
+        .await
+        .expect("send message");
+
+    let captured = client.wait_for_request(1).await;
+    let first = &captured[0];
+    assert!(
+        first.tool_names.iter().any(|name| name == "memory"),
+        "recorder tool must be registered on the member build: {:?}",
+        first.tool_names
+    );
+    assert!(
+        first
+            .request_json
+            .contains("Deploys are frozen on Fridays."),
+        "build-time injection must carry the seeded record body"
+    );
+    assert!(
+        first.request_json.contains("Memory recorder protocol"),
+        "recorder protocol instructions must be injected"
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// ---------------------------------------------------------------------------
+// Per-turn ambient injection is Off/no-op on the classic path: even the
+// explicit `budgeted` opt-in must not prepend memory into delivered turns
+// (there is no classic send-path hook yet — documented follow-up).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_per_turn_injection_is_a_noop_even_when_budgeted() {
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+    seed_identity_record(
+        &store,
+        "helper",
+        "Deploy window",
+        "Deploys are frozen on Fridays.",
+    )
+    .await;
+
+    let client = CaptureClient::default();
+    let runtime = build_classic_runtime(
+        store,
+        AgentMemoryConfig {
+            per_turn_injection: AgentMemoryPerTurnInjection::Budgeted,
+            ..AgentMemoryConfig::default()
+        },
+        client.clone(),
+    )
+    .await;
+
+    runtime
+        .spawn_many(vec![SpawnMemberSpec::from_wire(
+            "worker".to_string(),
+            "helper".to_string(),
+            None,
+            None,
+            None,
+        )])
+        .await
+        .expect("spawn member");
+    meerkat_mobkit::send_message_on_mob(
+        &runtime.mob_handle(),
+        "helper",
+        "what changed?".to_string(),
+    )
+    .await
+    .expect("send message");
+
+    let captured = client.wait_for_request(1).await;
+    let latest = captured.last().expect("delivered turn");
+    assert!(
+        !latest.request_json.contains("<mobkit_memory_observation"),
+        "per-turn memory envelope must not appear in classic-path turns"
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// ---------------------------------------------------------------------------
+// The console Memory panel RPC is serviceable on the classic path (the
+// builder auto-wires the panel store; experience.memory follows from it).
+// ---------------------------------------------------------------------------
+
+fn decision_state() -> meerkat_mobkit::RuntimeDecisionState {
+    build_runtime_decision_state(RuntimeDecisionInputs {
+        bigquery: BigQueryNaming {
+            dataset: "classic_memory_dataset".to_string(),
+            table: "classic_memory_table".to_string(),
+        },
+        trusted_mobkit_toml: r#"
+[[modules]]
+id = "router"
+command = "router-bin"
+args = []
+restart_policy = "always"
+"#
+        .to_string(),
+        auth: AuthPolicy {
+            default_provider: meerkat_mobkit::AuthProvider::GoogleOAuth,
+            email_allowlist: vec!["root@example.test".to_string()],
+        },
+        trusted_oidc: TrustedOidcRuntimeConfig {
+            discovery_json:
+                r#"{"issuer":"https://trusted.mobkit.local","jwks_uri":"https://trusted.mobkit.local/.well-known/jwks.json"}"#
+                    .to_string(),
+            jwks_json: r#"{"keys":[{"kid":"kid-current","kty":"oct","alg":"HS256","k":"cGhhc2U3LXRydXN0ZWQtY3VycmVudC1zZWNyZXQ"}]}"#
+                .to_string(),
+            audience: "meerkat-console".to_string(),
+        },
+        console: ConsolePolicy {
+            require_app_auth: false,
+            ..ConsolePolicy::default()
+        },
+        ops: RuntimeOpsPolicy::default(),
+        release_metadata_json: include_str!("../assets/release-targets.json").to_string(),
+    })
+    .expect("decision state builds")
+}
+
+async fn rpc(app: &axum::Router, method: &str, params: Value) -> Value {
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "id": "test",
+        "method": method,
+        "params": params,
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/console/rpc")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload.to_string()))
+                .expect("rpc request"),
+        )
+        .await
+        .expect("rpc response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("rpc body");
+    serde_json::from_slice(&body).expect("rpc json")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_memory_panel_records_rpc_is_serviceable() {
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+    seed_identity_record(&store, "helper", "Panel fact", "Visible from the panel.").await;
+
+    let runtime = build_classic_runtime(
+        store,
+        AgentMemoryConfig::default(),
+        CaptureClient::default(),
+    )
+    .await;
+    let app = runtime.build_reference_app_router(decision_state());
+
+    let records = rpc(&app, "mobkit/memory/panel/records", json!({})).await;
+    assert_eq!(records["error"], Value::Null, "{records:#?}");
+    let rows = records["result"]["records"].as_array().expect("records");
+    assert!(
+        rows.iter().any(|row| row["title"] == json!("Panel fact")),
+        "seeded record must be readable through the panel RPC: {rows:#?}"
+    );
+
+    // experience.memory affordance follows the wired panel store.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/console/experience")
+                .body(Body::empty())
+                .expect("experience request"),
+        )
+        .await
+        .expect("experience response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("experience body");
+    let experience: Value = serde_json::from_slice(&body).expect("experience json");
+    assert_eq!(
+        experience["memory"]["available"],
+        json!(true),
+        "experience.memory must be available on the classic path: {experience:#?}"
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// Control experiment: turn reaches LLM without memory configured.
+#[tokio::test(flavor = "multi_thread")]
+async fn control_member_turn_reaches_llm_without_memory() {
+    let client = CaptureClient::default();
+    let runtime = Box::pin(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .default_llm_client(Arc::new(client.clone()))
+            .build(),
+    )
+    .await
+    .expect("classic runtime without memory");
+    runtime
+        .spawn_many(vec![SpawnMemberSpec::from_wire(
+            "worker".to_string(),
+            "helper".to_string(),
+            None,
+            None,
+            None,
+        )])
+        .await
+        .expect("spawn member");
+    meerkat_mobkit::send_message_on_mob(&runtime.mob_handle(), "helper", "hello".to_string())
+        .await
+        .expect("send message");
+    client.wait_for_request(1).await;
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// ---------------------------------------------------------------------------
+// Gate: genuinely-invalid combinations still error.
+// ---------------------------------------------------------------------------
+
+async fn build_err(builder: meerkat_mobkit::UnifiedRuntimeBuilder) -> String {
+    match Box::pin(builder.build()).await {
+        Ok(_) => panic!("build should have failed"),
+        Err(err) => err.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn gate_still_rejects_invalid_memory_combinations() {
+    // agent_memory() and persistent_agent_memory() are mutually exclusive.
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+    let err = build_err(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .persistent_state(memory_dir.path().join("state"))
+            .agent_memory(Arc::new(store), AgentMemoryConfig::default())
+            .persistent_agent_memory(AgentMemoryConfig::default()),
+    )
+    .await;
+    assert!(err.contains("mutually exclusive"), "{err}");
+
+    // persistent_agent_memory() still requires persistent_state().
+    let err = build_err(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .persistent_agent_memory(AgentMemoryConfig::default()),
+    )
+    .await;
+    assert!(err.contains("requires persistent_state"), "{err}");
+
+    // Identity-first inputs (a custom AgentCustomizer) still require the
+    // roster even when memory is configured.
+    struct NoopCustomizer;
+    #[async_trait::async_trait]
+    impl meerkat_mobkit::identity_first::contracts::AgentCustomizer for NoopCustomizer {
+        async fn customize_build(
+            &self,
+            _context: &meerkat_mobkit::identity_first::AgentBuildContext,
+            _spec: &meerkat_mobkit::identity_first::DurableAgentSpec,
+            _draft: &mut meerkat_mobkit::identity_first::AgentBuildDraft,
+        ) -> Result<(), meerkat_mobkit::identity_first::CustomizerError> {
+            Ok(())
+        }
+    }
+    let memory_dir2 = tempfile::tempdir().expect("memory dir");
+    let store2 = SqliteAgentMemoryStore::open(memory_dir2.path()).expect("sqlite store");
+    let err = build_err(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .agent_customizer(Arc::new(NoopCustomizer))
+            .agent_memory(Arc::new(store2), AgentMemoryConfig::default()),
+    )
+    .await;
+    assert!(err.contains("roster_provider"), "{err}");
+}
+
+// ---------------------------------------------------------------------------
+// persistent_agent_memory (markdown store) still behaves: classic build is
+// injection-only — no recorder tool (read-only provider), no panel store.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_persistent_agent_memory_markdown_is_injection_only() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let client = CaptureClient::default();
+    let runtime = Box::pin(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .persistent_state(state_dir.path().join("state"))
+            .persistent_agent_memory(AgentMemoryConfig::default())
+            .default_llm_client(Arc::new(client.clone()))
+            .build(),
+    )
+    .await
+    .expect("classic markdown memory must build without a roster");
+
+    assert!(runtime.identity_runtime().is_none());
+    assert!(
+        runtime.memory_panel_store().is_none(),
+        "markdown provider has no panel store"
+    );
+
+    runtime
+        .spawn_many(vec![SpawnMemberSpec::from_wire(
+            "worker".to_string(),
+            "helper".to_string(),
+            None,
+            None,
+            None,
+        )])
+        .await
+        .expect("spawn member");
+    meerkat_mobkit::send_message_on_mob(&runtime.mob_handle(), "helper", "hello".to_string())
+        .await
+        .expect("send message");
+    let captured = client.wait_for_request(1).await;
+    assert!(
+        !captured[0].tool_names.iter().any(|name| name == "memory"),
+        "read-only markdown provider must not register the recorder tool: {:?}",
+        captured[0].tool_names
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}

--- a/meerkat-mobkit/tests/classic_agent_memory.rs
+++ b/meerkat-mobkit/tests/classic_agent_memory.rs
@@ -42,6 +42,32 @@ fn test_definition() -> MobDefinition {
     MobDefinition::from_toml(CLASSIC_MOB_TOML).expect("parse test mob definition")
 }
 
+// A commander-like profile that ALSO enables meerkat's built-in tool
+// categories (builtins/mob/mob_tasks) — the incident-pack commander shape.
+// Guards that the recorder `memory` external tool still registers when those
+// categories are on (they compose, they do not suppress it). Diagnoses the
+// live finding that the commander reached for `task_create` (a mob_tasks tool)
+// instead of `memory`: that is tool *competition*, not a missing recorder.
+const COMMANDER_LIKE_MOB_TOML: &str = r#"
+[mob]
+id = "classic-memory-mob"
+
+[profiles.worker]
+model = "gpt-5.5"
+runtime_mode = "autonomous_host"
+external_addressable = true
+
+[profiles.worker.tools]
+builtins = true
+comms = true
+mob = true
+mob_tasks = true
+"#;
+
+fn commander_like_definition() -> MobDefinition {
+    MobDefinition::from_toml(COMMANDER_LIKE_MOB_TOML).expect("parse commander-like definition")
+}
+
 /// LLM stub that records every request (tool names + full JSON) so tests can
 /// assert on the member's build surface: registered tools and the system
 /// instructions the memory customizer injected.
@@ -259,6 +285,138 @@ async fn classic_member_build_registers_recorder_and_injects_memory() {
     assert!(
         first.request_json.contains("Memory recorder protocol"),
         "recorder protocol instructions must be injected"
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile-spawned members ALSO get the recorder tool. The incident-command
+// pack (and every roster-less console example) populates its roster via
+// `reconcile`, not `spawn_many`; this guards that the customizer fires on the
+// reconcile spawn path too (regression: the panel stayed empty because the
+// memory tool never reached reconcile-spawned members).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_reconcile_spawned_member_registers_recorder() {
+    use meerkat_mob::runtime::reconcile::ReconcileOptions;
+
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+    seed_identity_record(
+        &store,
+        "helper",
+        "Deploy window",
+        "Deploys are frozen on Fridays.",
+    )
+    .await;
+
+    let client = CaptureClient::default();
+    let runtime = build_classic_runtime(
+        store,
+        AgentMemoryConfig {
+            selection: AgentMemorySelection::Always,
+            ..AgentMemoryConfig::default()
+        },
+        client.clone(),
+    )
+    .await;
+
+    runtime
+        .mob_handle()
+        .reconcile(
+            vec![SpawnMemberSpec::from_wire(
+                "worker".to_string(),
+                "helper".to_string(),
+                None,
+                None,
+                None,
+            )],
+            ReconcileOptions { retire_stale: true },
+        )
+        .await
+        .expect("reconcile roster on the classic path");
+    meerkat_mobkit::send_message_on_mob(&runtime.mob_handle(), "helper", "hello".to_string())
+        .await
+        .expect("send message");
+
+    let captured = client.wait_for_request(1).await;
+    let first = &captured[0];
+    assert!(
+        first.tool_names.iter().any(|name| name == "memory"),
+        "recorder tool must be registered on the reconcile-spawned member: {:?}",
+        first.tool_names
+    );
+    assert!(
+        first
+            .request_json
+            .contains("Deploys are frozen on Fridays."),
+        "build-time injection must carry the seeded record body on reconcile"
+    );
+    runtime.mob_handle().stop().await.expect("stop");
+}
+
+// ---------------------------------------------------------------------------
+// The recorder `memory` tool survives on a member whose profile also enables
+// meerkat's built-in tool categories (builtins/mob/mob_tasks) — the incident
+// commander shape. Diagnoses the live finding that the commander called
+// `task_create` (a mob_tasks tool) when asked to "remember": the recorder is
+// present, so that is tool *competition* in the model's selection, not a
+// missing/suppressed recorder.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn classic_recorder_survives_alongside_mob_tool_categories() {
+    use meerkat_mob::runtime::reconcile::ReconcileOptions;
+
+    let memory_dir = tempfile::tempdir().expect("memory dir");
+    let store = SqliteAgentMemoryStore::open(memory_dir.path()).expect("sqlite store");
+
+    let client = CaptureClient::default();
+    let runtime = Box::pin(
+        UnifiedRuntime::builder()
+            .definition(commander_like_definition())
+            .agent_memory(Arc::new(store), AgentMemoryConfig::default())
+            .default_llm_client(Arc::new(client.clone()))
+            .build(),
+    )
+    .await
+    .expect("commander-like classic runtime with agent memory must build");
+
+    runtime
+        .mob_handle()
+        .reconcile(
+            vec![SpawnMemberSpec::from_wire(
+                "worker".to_string(),
+                "helper".to_string(),
+                None,
+                None,
+                None,
+            )],
+            ReconcileOptions { retire_stale: true },
+        )
+        .await
+        .expect("reconcile commander-like member");
+    meerkat_mobkit::send_message_on_mob(&runtime.mob_handle(), "helper", "hello".to_string())
+        .await
+        .expect("send message");
+
+    let captured = client.wait_for_request(1).await;
+    let first = &captured[0];
+    // Both tools are present in the same (large) surface: the recorder is NOT
+    // suppressed by the mob categories — the live "commander used task_create
+    // to remember" behavior is model mis-selection among the competing tools,
+    // not a missing recorder. Guarding both documents that root cause.
+    assert!(
+        first.tool_names.iter().any(|name| name == "memory"),
+        "recorder `memory` tool must register even when builtins/mob/mob_tasks are enabled: {:?}",
+        first.tool_names
+    );
+    assert!(
+        first.tool_names.iter().any(|name| name == "task_create"),
+        "the mob_tasks `task_create` tool must also be present (it is what the recorder competes \
+         with for \"remember\" instructions): {:?}",
+        first.tool_names
     );
     runtime.mob_handle().stop().await.expect("stop");
 }

--- a/meerkat-mobkit/tests/http_router.rs
+++ b/meerkat-mobkit/tests/http_router.rs
@@ -257,6 +257,29 @@ fn sc_001_reference_app_router_proves_unified_owned_console_path() {
     assert!(!unified_runtime_source.contains("interaction_sse_router"));
 }
 
+#[test]
+fn sc_002_unified_shutdown_stops_mob_before_router_and_module_teardown() {
+    let lifecycle_source = include_str!("../src/unified_runtime/lifecycle.rs");
+    let mob_stop = lifecycle_source
+        .find("let mob_stop = self")
+        .expect("shutdown must stop mob");
+    let close_event_router = lifecycle_source
+        .find("self.close_event_router().await;")
+        .expect("shutdown must close event router");
+    let module_shutdown = lifecycle_source
+        .find("let module_shutdown = self.module_runtime.lock().await.shutdown();")
+        .expect("shutdown must stop modules");
+
+    assert!(
+        mob_stop < close_event_router,
+        "mob stop must happen before closing the event router"
+    );
+    assert!(
+        close_event_router < module_shutdown,
+        "module teardown must happen after mob stop and event-router close"
+    );
+}
+
 #[tokio::test]
 #[ignore]
 async fn req_002_router_builders_prove_console_and_sse_behavior() {

--- a/meerkat-mobkit/tests/identity_first_respawn_continuity.rs
+++ b/meerkat-mobkit/tests/identity_first_respawn_continuity.rs
@@ -1,0 +1,262 @@
+//! Deterministic guard for identity-first respawn transcript continuity.
+//!
+//! `IdentityRuntime::respawn` is a *recovery boundary*: it re-fences the live
+//! member and keeps its SessionId (`refresh_existing_session_runtime_state`),
+//! so the conversation must survive across a respawn. The live OB3 smoke test
+//! proves this via a model's verbal recall but is feature-gated and never runs
+//! in CI. This scripted version proves the same invariant every build: a
+//! `CaptureClient` records the exact messages sent to the LLM. We deliver turn 1
+//! carrying a unique token, respawn the identity, deliver turn 2, and assert
+//! turn 2's request REPLAYS turn 1's transcript. If respawn had torn the member
+//! down and started fresh, the token would be gone — exactly the "respawn
+//! forgets the conversation" regression (the identity-first analogue of the
+//! reported HomeCore behavior).
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use meerkat_client::{LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
+use meerkat_core::types::StopReason;
+use meerkat_mob::{MobDefinition, ProfileName};
+use meerkat_mobkit::UnifiedRuntimeBuilder;
+use meerkat_mobkit::identity_first::contracts::{AgentCustomizer, TopologyProvider};
+use meerkat_mobkit::identity_first::orchestrator::{RestoreOutcome, restore_flow};
+use meerkat_mobkit::identity_first::{
+    AgentAddressability, AgentBuildContext, AgentBuildDraft, AgentIdentity, ContinuityStore,
+    CustomizerError, DurabilityPolicy, DurableAgentSpec, IdentityRuntime, IdentityRuntimeConfig,
+    LocalContinuityStore, LocalLeaseProvider, ManagedPeerEdge, SessionBridge, TopologyContext,
+    TopologyError,
+};
+use meerkat_mobkit::mob_handle_runtime::SessionCreatedContext;
+use tokio::time::sleep;
+
+fn id(name: &str) -> AgentIdentity {
+    AgentIdentity::parse(name).unwrap()
+}
+
+fn spec(name: &str, addr: AgentAddressability, profile: &str) -> DurableAgentSpec {
+    DurableAgentSpec {
+        identity: id(name),
+        profile: ProfileName::from(profile),
+        addressability: addr,
+        display_name: None,
+        labels: BTreeMap::new(),
+        context: None,
+        additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
+        backend: None,
+        binding: None,
+    }
+}
+
+const MOB_TOML: &str = r#"
+[mob]
+id = "respawn-continuity"
+
+[profiles.personal]
+model = "gpt-5.5"
+external_addressable = true
+runtime_mode = "turn_driven"
+
+[profiles.personal.tools]
+comms = true
+"#;
+
+fn one_member_definition() -> MobDefinition {
+    MobDefinition::from_toml(MOB_TOML).expect("parse respawn-continuity mob definition")
+}
+
+struct EmptyTopology;
+#[async_trait]
+impl TopologyProvider for EmptyTopology {
+    async fn compute_edges(
+        &self,
+        _target_identities: &[AgentIdentity],
+        _context: &TopologyContext,
+    ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+        Ok(vec![])
+    }
+}
+
+struct NoopCustomizer;
+#[async_trait]
+impl AgentCustomizer for NoopCustomizer {
+    async fn customize_build(
+        &self,
+        _context: &AgentBuildContext,
+        _spec: &DurableAgentSpec,
+        _draft: &mut AgentBuildDraft,
+    ) -> Result<(), CustomizerError> {
+        Ok(())
+    }
+    async fn after_create(
+        &self,
+        _identity: &AgentIdentity,
+        _session_id: &meerkat_core::types::SessionId,
+        _context: &SessionCreatedContext,
+    ) -> Result<(), CustomizerError> {
+        Ok(())
+    }
+}
+
+/// Records the serialized LLM request each turn and answers "ok" so turns
+/// complete without a real provider.
+#[derive(Clone, Default)]
+struct CaptureClient {
+    requests: Arc<std::sync::Mutex<Vec<String>>>,
+}
+impl CaptureClient {
+    fn count(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+    fn last(&self) -> Option<String> {
+        self.requests.lock().unwrap().last().cloned()
+    }
+}
+impl meerkat_client::LlmClient for CaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+        Ok(messages.to_vec())
+    }
+    fn stream<'a>(
+        &'a self,
+        request: &'a LlmRequest,
+    ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+        self.requests
+            .lock()
+            .unwrap()
+            .push(serde_json::to_string(request).unwrap_or_default());
+        Box::pin(async_stream::stream! {
+            yield Ok(LlmEvent::TextDelta { delta: "ok".to_string(), meta: None });
+            yield Ok(LlmEvent::Done {
+                outcome: LlmDoneOutcome::Success { stop_reason: StopReason::EndTurn },
+            });
+        })
+    }
+    fn provider(&self) -> meerkat::Provider {
+        meerkat::Provider::OpenAI
+    }
+    fn health_check<'life0, 'async_trait>(
+        &'life0 self,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), LlmError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_first_respawn_preserves_transcript() {
+    let capture = CaptureClient::default();
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let state_path = temp.path().join("state");
+
+    let unified = UnifiedRuntimeBuilder::default()
+        .definition(one_member_definition())
+        .persistent_state(&state_path)
+        .comms(true)
+        .default_llm_client(Arc::new(capture.clone()))
+        .build()
+        .await
+        .expect("build UnifiedRuntime");
+
+    let bridge: Arc<dyn SessionBridge> = unified
+        .session_bridge()
+        .expect("session_bridge should exist")
+        .clone();
+    let store = Arc::new(
+        LocalContinuityStore::open(state_path.join("continuity.db")).expect("continuity store"),
+    );
+    let identity_rt = IdentityRuntime::new(IdentityRuntimeConfig {
+        continuity_store: store.clone() as Arc<dyn ContinuityStore>,
+        lease_provider: Arc::new(LocalLeaseProvider::new()),
+        runtime_instance_id: "respawn-continuity".to_string(),
+        has_runtime_store: true,
+        durability_policy: DurabilityPolicy::SyncWriteThrough,
+        bridge: Some(bridge),
+        default_timeout: None,
+    });
+
+    let alice = id("personal:alice");
+    let roster = vec![spec(
+        "personal:alice",
+        AgentAddressability::Addressable,
+        "personal",
+    )];
+    let result = restore_flow(
+        &identity_rt,
+        &roster,
+        Some(&EmptyTopology as &dyn TopologyProvider),
+        Some(&NoopCustomizer as &dyn AgentCustomizer),
+    )
+    .await
+    .expect("restore_flow");
+    match result.outcomes.get(&alice).expect("alice outcome") {
+        RestoreOutcome::Created { .. } => {}
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // --- Turn 1: deliver a unique token; wait for the turn to complete ---
+    const TOKEN: &str = "MARKER-ALPHA-7-ZEBRA";
+    identity_rt
+        .send(
+            &alice,
+            &meerkat_core::ContentInput::Text(format!("Please note this token: {TOKEN}")),
+        )
+        .await
+        .expect("send turn 1");
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while capture.count() < 1 {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for turn 1 to reach the LLM (capture.count={})",
+            capture.count()
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+    // Let turn 1's assistant response commit to the transcript before respawn.
+    sleep(Duration::from_millis(500)).await;
+    let captures_after_turn1 = capture.count();
+
+    // --- Respawn (recovery boundary: SessionId does not rotate) ---
+    identity_rt.respawn(&alice).await.expect("respawn");
+
+    // --- Turn 2: after respawn, refer back to the earlier token ---
+    identity_rt
+        .send(
+            &alice,
+            &meerkat_core::ContentInput::Text("What token did I give you earlier?".to_string()),
+        )
+        .await
+        .expect("send turn 2");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while capture.count() <= captures_after_turn1 {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for the post-respawn turn to reach the LLM"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    // The post-respawn request must REPLAY turn 1's transcript — the token can
+    // only be present if the respawned member kept/resumed the conversation.
+    let last_request = capture.last().expect("a post-respawn request was captured");
+    assert!(
+        last_request.contains(TOKEN),
+        "post-respawn LLM request must replay the prior transcript (token {TOKEN}); \
+         respawn dropped the conversation history"
+    );
+
+    unified.shutdown().await;
+}

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -7458,6 +7458,7 @@ impl meerkat_mobkit::memory::distiller::TranscriptSource for OrderWitnessTranscr
             session_key: session_key.to_string(),
             start_index: from_index,
             end_index: from_index + 1,
+            head_revision: None,
             messages: vec![meerkat_mobkit::memory::distiller::TranscriptMessage {
                 index: from_index,
                 role: "user",
@@ -7637,6 +7638,7 @@ impl meerkat_mobkit::memory::distiller::TranscriptSource for GatedTranscripts {
             session_key: session_key.to_string(),
             start_index: from_index,
             end_index: from_index + 1,
+            head_revision: None,
             messages: vec![meerkat_mobkit::memory::distiller::TranscriptMessage {
                 index: from_index,
                 role: "user",

--- a/meerkat-mobkit/tests/incident_command_center_pack.rs
+++ b/meerkat-mobkit/tests/incident_command_center_pack.rs
@@ -84,7 +84,7 @@ fn incident_local_tools_are_witnessed_for_delegate_inheritance() {
     // meerkat 0.7 made meerkat_mob::snapshot private; the same provenance
     // contract is asserted through the public meerkat_core::tool_scope
     // witness derivation the snapshot used internally.
-    let tools = IncidentToolDispatcher.tools();
+    let tools = IncidentToolDispatcher { inner: None }.tools();
     let defs: Vec<meerkat_core::types::ToolDef> =
         tools.iter().map(|tool| (**tool).clone()).collect();
     let filter = meerkat_core::tool_scope::ToolFilter::Allow(
@@ -100,6 +100,72 @@ fn incident_local_tools_are_witnessed_for_delegate_inheritance() {
         witnesses.contains_key("analyze_customer_impact"),
         "analyze_customer_impact must carry provenance so delegate can inherit it"
     );
+}
+
+// Regression: the incident tool dispatcher must COMPOSE over any external
+// tools already installed on the build (the agent-memory recorder's `memory`
+// tool), not replace them. The original hook overwrote build.external_tools,
+// silently dropping the recorder so `memory` never reached the model and the
+// Memory panel stayed empty.
+#[tokio::test]
+async fn incident_dispatcher_composes_inner_external_tools() {
+    use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
+    use meerkat_core::{ToolDispatchOutcome, ToolError};
+
+    struct FakeInner;
+    #[async_trait::async_trait]
+    impl AgentToolDispatcher for FakeInner {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            vec![Arc::new(ToolDef {
+                name: "memory".into(),
+                description: "stand-in recorder".to_string(),
+                input_schema: json!({"type": "object"}),
+                provenance: None,
+            })]
+            .into()
+        }
+        async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+            Ok(ToolResult::new(call.id.to_string(), "recorded".to_string(), false).into())
+        }
+    }
+
+    let dispatcher = IncidentToolDispatcher {
+        inner: Some(Arc::new(FakeInner)),
+    };
+    let names: Vec<String> = dispatcher
+        .tools()
+        .iter()
+        .map(|t| t.name.to_string())
+        .collect();
+    assert!(names.iter().any(|n| n == "inspect_service"));
+    assert!(names.iter().any(|n| n == "analyze_customer_impact"));
+    assert!(
+        names.iter().any(|n| n == "memory"),
+        "composed inner tool (memory recorder) must surface alongside incident tools: {names:?}"
+    );
+
+    // And an unknown-to-us call must delegate to the inner dispatcher (rather
+    // than NotFound) — proving the recorder's tool is actually callable.
+    let empty_args = serde_json::value::RawValue::from_string("{}".to_string()).unwrap();
+    dispatcher
+        .dispatch(ToolCallView {
+            id: "call-1",
+            name: "memory",
+            args: &empty_args,
+        })
+        .await
+        .expect("unknown tool must route to the inner recorder, not NotFound");
+
+    // With no inner, an unknown tool is genuinely absent.
+    let bare = IncidentToolDispatcher { inner: None };
+    let miss = bare
+        .dispatch(ToolCallView {
+            id: "call-2",
+            name: "memory",
+            args: &empty_args,
+        })
+        .await;
+    assert!(matches!(miss, Err(ToolError::NotFound { .. })));
 }
 
 #[tokio::test]

--- a/meerkat-mobkit/tests/incident_command_center_pack.rs
+++ b/meerkat-mobkit/tests/incident_command_center_pack.rs
@@ -31,7 +31,8 @@ use tower::ServiceExt;
 mod incident_command_center;
 
 use incident_command_center::{
-    IncidentToolDispatcher, build_runtime_bundle_with_default_client, scenario_path,
+    IncidentSessionHook, IncidentToolDispatcher, build_runtime_bundle_with_default_client,
+    scenario_path,
 };
 
 struct IncidentPackTestClient;
@@ -166,6 +167,93 @@ async fn incident_dispatcher_composes_inner_external_tools() {
         })
         .await;
     assert!(matches!(miss, Err(ToolError::NotFound { .. })));
+}
+
+// Regression: before_create must COMPOSE both external_tools AND
+// additional_instructions over what the agent-memory customizer already
+// installed on the build. Overwriting additional_instructions dropped the
+// build-time memory-recall injection, so a respawned/fresh member never
+// recalled its stored memories (the "respawn forgets my name" report).
+#[tokio::test]
+async fn incident_hook_composes_memory_injection_and_tools() {
+    use meerkat_core::config::SystemPromptOverride;
+    use meerkat_core::service::{CreateSessionRequest, InitialTurnPolicy, SessionBuildOptions};
+    use meerkat_mobkit::SessionHook;
+
+    // Stand in for the agent-memory customizer's pre-installed build state:
+    // a recalled-memory injection line + a recorder external-tool dispatcher.
+    let mut build = SessionBuildOptions::default();
+    build.additional_instructions = Some(vec!["MEMORY-RECALL: operator name is Luka.".to_string()]);
+    build.external_tools = Some(Arc::new(RecorderMarkerDispatcher));
+
+    let mut req = CreateSessionRequest {
+        model: "gpt-5.5".to_string(),
+        prompt: meerkat_core::ContentInput::Text(String::new()),
+        system_prompt: SystemPromptOverride::Inherit,
+        max_tokens: None,
+        event_tx: None,
+        initial_turn: InitialTurnPolicy::Defer,
+        build: Some(build),
+        labels: None,
+        deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+        injected_context: Vec::new(),
+    };
+
+    IncidentSessionHook
+        .before_create(&mut req)
+        .await
+        .expect("before_create");
+
+    let build = req.build.expect("build present");
+    let instructions = build.additional_instructions.expect("instructions present");
+    assert!(
+        instructions
+            .iter()
+            .any(|line| line.contains("operator name is Luka")),
+        "the pre-installed memory-recall injection must survive (composed, not overwritten): {instructions:?}"
+    );
+    assert!(
+        instructions
+            .iter()
+            .any(|line| line.contains("incident command center")),
+        "the incident framing must also be present"
+    );
+    let tool_names: Vec<String> = build
+        .external_tools
+        .expect("external tools present")
+        .tools()
+        .iter()
+        .map(|t| t.name.to_string())
+        .collect();
+    assert!(
+        tool_names.iter().any(|n| n == "memory-marker"),
+        "the pre-installed recorder tool must survive alongside incident tools: {tool_names:?}"
+    );
+    assert!(tool_names.iter().any(|n| n == "inspect_service"));
+}
+
+struct RecorderMarkerDispatcher;
+
+#[async_trait::async_trait]
+impl AgentToolDispatcher for RecorderMarkerDispatcher {
+    fn tools(&self) -> Arc<[Arc<meerkat_core::types::ToolDef>]> {
+        vec![Arc::new(meerkat_core::types::ToolDef {
+            name: "memory-marker".into(),
+            description: "stand-in recorder".to_string(),
+            input_schema: json!({"type": "object"}),
+            provenance: None,
+        })]
+        .into()
+    }
+    async fn dispatch(
+        &self,
+        call: meerkat_core::types::ToolCallView<'_>,
+    ) -> Result<meerkat_core::ToolDispatchOutcome, meerkat_core::ToolError> {
+        Ok(
+            meerkat_core::types::ToolResult::new(call.id.to_string(), "ok".to_string(), false)
+                .into(),
+        )
+    }
 }
 
 #[tokio::test]

--- a/meerkat-mobkit/tests/incident_command_center_pack.rs
+++ b/meerkat-mobkit/tests/incident_command_center_pack.rs
@@ -182,9 +182,11 @@ async fn incident_hook_composes_memory_injection_and_tools() {
 
     // Stand in for the agent-memory customizer's pre-installed build state:
     // a recalled-memory injection line + a recorder external-tool dispatcher.
-    let mut build = SessionBuildOptions::default();
-    build.additional_instructions = Some(vec!["MEMORY-RECALL: operator name is Luka.".to_string()]);
-    build.external_tools = Some(Arc::new(RecorderMarkerDispatcher));
+    let build = SessionBuildOptions {
+        additional_instructions: Some(vec!["MEMORY-RECALL: operator name is Luka.".to_string()]),
+        external_tools: Some(Arc::new(RecorderMarkerDispatcher)),
+        ..SessionBuildOptions::default()
+    };
 
     let mut req = CreateSessionRequest {
         model: "gpt-5.5".to_string(),

--- a/meerkat-mobkit/tests/shutdown_drain.rs
+++ b/meerkat-mobkit/tests/shutdown_drain.rs
@@ -22,7 +22,8 @@ use meerkat::{AgentFactory, Config, build_ephemeral_service};
 use meerkat_client::TestClient;
 use meerkat_mob::{MobDefinition, MobStorage, SpawnMemberSpec};
 use meerkat_mobkit::{
-    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, UnifiedRuntime,
+    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, ModuleConfig,
+    RestartPolicy, UnifiedRuntime,
 };
 
 fn mob_spec(temp_dir: &tempfile::TempDir) -> MobBootstrapSpec {
@@ -67,6 +68,15 @@ fn empty_module_config(namespace: &str) -> MobKitConfig {
     }
 }
 
+fn shell_module(id: &str, script: &str) -> ModuleConfig {
+    ModuleConfig {
+        id: id.to_string(),
+        command: "sh".to_string(),
+        args: vec!["-c".to_string(), script.to_string()],
+        restart_policy: RestartPolicy::Never,
+    }
+}
+
 fn member_spec(profile: &str, member_id: &str) -> SpawnMemberSpec {
     SpawnMemberSpec::from_wire(
         profile.to_string(),
@@ -75,6 +85,42 @@ fn member_spec(profile: &str, member_id: &str) -> SpawnMemberSpec {
         None,
         None,
     )
+}
+
+#[tokio::test]
+async fn shutdown_stops_mob_before_tearing_down_loaded_modules() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let runtime = Box::pin(
+        UnifiedRuntime::builder()
+            .mob_spec(mob_spec(&temp_dir))
+            .module_config(MobKitConfig {
+                modules: vec![shell_module(
+                    "router",
+                    r#"printf '%s\n' '{"event_id":"evt-router-ready","source":"module","timestamp_ms":10,"event":{"kind":"module","module":"router","event_type":"ready","payload":{"ok":true}}}'; exec sleep 30"#,
+                )],
+                discovery: DiscoverySpec {
+                    namespace: "shutdown-loaded-module".to_string(),
+                    modules: vec!["router".to_string()],
+                },
+                pre_spawn: vec![],
+            })
+            .timeout(Duration::from_secs(2))
+            .drain_timeout(Duration::from_millis(200))
+            .build(),
+    )
+    .await
+    .expect("build");
+
+    assert_eq!(runtime.loaded_modules().await, vec!["router".to_string()]);
+
+    let shutdown = runtime.shutdown().await;
+
+    assert_eq!(
+        shutdown.module_shutdown.terminated_modules,
+        vec!["router".to_string()]
+    );
+    assert_eq!(shutdown.module_shutdown.orphan_processes, 0);
+    shutdown.mob_stop.expect("mob stop should succeed");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Upgrades the meerkat family to **0.7.13** and lands the pre-Elephant memory phases it unblocks, plus two production fixes found by exercising the incident-command-center example live.

All commits are green: **1506 tests pass** (contract_009 is the known load-flake, passes on retry), **clippy `-D warnings` clean**, cargo/Python/TS version parity OK, `cargo publish --dry-run` succeeds.

## What's here

**Upgrade**
- meerkat 0.7.11 → 0.7.12 → 0.7.13 (adapts the new `injected_context` request field; picks up upstream asks 1–10).

**Memory phases (pre-Elephant)**
- **P1 (asks 1+3):** ambient per-turn recall delivered as a typed injected-context message (excluded from compaction indexing), not fused into user text; per-turn injection flipped **on by default** on the identity-first path — echo-safe by construction.
- **P2 (asks 2+8):** compaction-discard harvest uses exact `enumerate_scoped`; orphaned session scopes reclaimed via `drop_scope` at the delete seam.
- **P6 (ask 4 refinement):** distilled records pin the transcript head revision; Hygienist rewrites compare-and-swap on it.
- **P3 inbound (ask 5):** taint tracker consumes the typed `AgentEvent::PeerContentIngested` sender-taint (canonical peer id, synchronous), keeping the projection-text join as belt-and-braces.

**Fixes (incident example)**
- Host `SessionHook`s that set `external_tools` / `additional_instructions` now **compose** over the agent-memory recorder instead of overwriting it. A plain assignment silently dropped the `memory` tool (the panel never populated; the model reached for `task_create`) and the build-time recall injection (respawn "forgot" the operator). Both proven fixed live (record → survives respawn → recalled), with regression tests.

**Investigation (no code change needed)**
- Deterministic guard added proving **identity-first respawn preserves the transcript** (`identity_first_respawn_continuity.rs`). The incident's respawn "amnesia" is the **classic** path (meerkat-mob respawn = fresh replacement + ephemeral sessions), which is expected; cross-process loss would be the `resume_session` → fresh-spawn fallback (grep logs for `falling back to fresh spawn`).

## Not in this PR (follow-ups)
- **P3 outbound:** wire the tracker → `MobHandle::declare_member_outbound_taint` so members stamp taint on sends (seam identified).
- **P5 (ask 7):** register the steward dream as a host-runnable schedule target (0.7.13 threads `runnable_host`; wrapper plumbed, registration TODO).
- **P4 (ask 6):** fork-based distiller — large, optimization-only; recommended deferred.
- The feature-gated `identity_first_ob3_smoke.rs` (live tests) has pre-existing 0.7.13 `Profile` drift; not in default CI.

## Release
Prepared for the next version (CHANGELOG `[Unreleased]` updated). Proposed **0.7.20** (patch, repo cadence) — holding the `cargo release` tag/publish for confirmation on version + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)