### PR TITLE
meerkat 0.7.14 upgrade + memory P3-outbound/P5 + carried-store fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcb9df5a55552886c149bda5015d1e83e422ae1373a954bc9b26a47906d7d3f"
+checksum = "d077a99d53bb7ec352423e86c724bd73c4560682234dceab79b674bbca97ca42"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279dcdba58d6a4b0f712655543b3680e7fbcadc54912254a6307dfc4e73a1da2"
+checksum = "8dd5490c887350b0f69913fb3a8de1db9dd21530926abff23c2572cd9c8701e4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f6eff969e1f1f3cffa50b7fc9941824ec9d63d7104bbd289d95af33d8e2a3"
+checksum = "ec205096ee17f56ba04471c62a464d78f92900debbb6b8fbfa755641e4220374"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50cb2a1bd0b1127d86fabdb3b79b563b4c1798dc3f563996f579d30095c2a1e"
+checksum = "cafa59983105c9ece4bffb30ee30cf2e8defd1afca9e5373f825e8a441218ceb"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23b6c4bbaa906b80175fc3ac3e6cc7d2bce133dd1424a400cf55f514e8d7cad"
+checksum = "32a2e4e7d0ce58b82af5942bcec3a98b1a4ba9d1124ab61059402cc6bbd2efc1"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1a87efab1e58f7a07a43921e91997d1a9762b483ef8378f16b726da7dd16f7"
+checksum = "9d48b72ef6c1cc5aa318152ec7121ae08fa8a24c07db344280471271c83ad1b5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced47d1411bf06180ac8db6654d5c7c0546a0bdab2e691067e5b488f6551e830"
+checksum = "e6c1f732d3df531fa6e67a1ee40b801c6b2b17a90902e799002e1e7bf404cfab"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21197e2f6c737c02adc79b9e2737b7b7b41c14c109f49c5d9d5ab13671fda20e"
+checksum = "a8446a6ea68096693e7019034c5919a58e0d162e51d239a0563446d7f01d0ddd"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa2f70bfffd50fbac7ae423bc30d557b30e032f2987293039a9e243528ef8ed"
+checksum = "9b5c54f82f4ed0c0d7508af73bb8aa16895f951d527b3ff795a1b843b8ce7729"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a2f43de33ffbd31948ab8f2fcc81fd1fa4b7364ca113e7a0d9d6766e5a805b"
+checksum = "6c70363228276febc71dcd2cfa9ddd863d64826c375650cb796abb8111805cbf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b2a698b0f488deff3e45a84e7b78e5c24cbaf643149b8a874be21fad79dd9d"
+checksum = "7f2c2c9f5aee098c2d8812a46b2c0459db5aff1b936b70214aba5a4b3a37f259"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaed1329a511f99b711ff61986c69024163716e230195eb51b5fc85bad888cc"
+checksum = "0fdd160f4e5de97c5a744c192578a20d5cb3bdcfba964034901074f3aa2dc937"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261a3275eeb10c34835ab57f106a7fcbcda069c1b606111913a7ab1dd71c125a"
+checksum = "d5f634620a2b84db77056b8fb840ebd21df36fe8b56912fe61c0d648721c3cf1"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da667f8fe1653f1a303b157341fa613a791972b113d2b455a48a0097ad48937f"
+checksum = "f992ba93ad17c962b08c378a7245efb397bc8d64e74d89a9ad48292adce3f311"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7315ba5a49b7d7c711d21d9e801e1bf4946f8327da94f0c9613c5655c73895"
+checksum = "cc7871a7aa64eae45f656d0ea111a8429cb1fe367d62c0207de82d5d96008bc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003af8107f98a87b2553068921af42520d1514e5fb748dad22505e724586bb4f"
+checksum = "524105877ce99fdc18abeb1b77a37eae3ed73709ee4f1f05fb22868ea5a182cc"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8969ee46a73bf1774c6b8aef09321f89269ae6c208e90b85d1ed4674eb1bbb"
+checksum = "c0571300b851e6b255ea7d25b8a54357c950cff7732d3739c9a019b7f6351816"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50d4b880850a0f3b64bb8614588f7eecb7d6816ca73a7e551e9a10c4c4e93b6"
+checksum = "8cce63a9a2655fab561eae1787da3a9a83cc5a88d94e1fc88c6281bc5a3b2663"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d562787b88f353fb8e74bd2c3a8d56342b112934fd469d1ad1fa406a84df23d6"
+checksum = "83a97a08ebf6d2355c7ab1b12d1e88adb512a97b770501a6cc16d40031d4d837"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f002b52fdcb7453c8659f23aa1f88e2ebf912bd938f9fe323360d65bf81a4c85"
+checksum = "9afd29adc96f1337f38eaa1b2b83efedfc31c5fe722676656e93a497015c284f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5259b0371967ffeddc2cc6ecaa59cff68025fc9706a8cca218094dd250bf8ab9"
+checksum = "134631c32a9d45fd4d392b18e359e80572e885ba6739a4ecb4adc7465966c4d0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29398783c88bcb295aa26a12911dc636978899659ddac53fb9235ad6debf42f"
+checksum = "d274415a3433fd67c776ebe4fcf3a985d3257cee1ab20556bc9bf5c5033647af"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd63baa7a75f81923fa0dfbe0a0ce6e05b03fa14fa04855c22dbc714c88d463"
+checksum = "ccec45806102d3444e8673478c9b900f569c7532af59ce2652d627e4fa540a46"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab43730c37daf12e4d7c39a175ce853671048e0896017bc469b38cc75eee7429"
+checksum = "e9dc2f7322c1144d3a6b7b57960ab7d6a68e48b6e8d39d0afea4ef4299fdbeb9"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab992bb31edb90adc597d791e760860b77c535bcc921613559ddae449b7048"
+checksum = "61b452b223baa0f1a1c4682ae77e3d8986f08fd5fc675d252da1807cc3e62f9a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed843473e24fcbe506a65d5289d80021dee0c9488684d8fca6f9e32510fc10c"
+checksum = "075747264811315dd166086b0ef0d3fe318ad45f43104cbcca937b7dc743781c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f4d4974d71f13dc4f9ac25d6c85b95e2a0c898d74d6bb471ca240c3ce93421"
+checksum = "0de6e983802388dcf853b6d6cce436310ecc9a68e0e75c3d8dc58e161d2dc30e"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717cd11e203852d87e6cb52a779e6b152bcd42c4472697431e39c88683fcff6e"
+checksum = "b2af2a9592e99da93d1be649e2f546b7848ecbca3578a421cc1da4c27fe56a61"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a456c8ed0eb0ca8c5464f454757d9429f43933b460303586f7bff89220ac61"
+checksum = "dc26fa65ecacb064c456e6238448ed3a470d318adbd50c895bae3fbcae1a5981"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1973c4b3bbfa4d2ecf1ff40c18430de17c0ab1c8fb01775b5d57945e23fc494f"
+checksum = "75670a92eeefa69ecce3143890c5deaf3d0fc8afecc16b9c2bafcbf04946025e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e78ddc0de36da998b7db50fa8ff1a3bedbd18d8f5ef35b08808eb98deddaa2e"
+checksum = "13387b6ff29ee518f4685a936566993360240f77c12128e90c89b462e74c6c2a"
 dependencies = [
  "async-trait",
  "chrono",

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -2387,6 +2387,69 @@ rust_test(
 )
 
 rust_test(
+    name = "identity_first_cold_restart_continuity_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "identity_first_cold_restart_continuity",
+    crate_root = "tests/identity_first_cold_restart_continuity.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/identity_first_cold_restart_continuity.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.20",
+        "CARGO_BIN_NAME": "identity_first_cold_restart_continuity",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "identity_first_contracts_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -4299,6 +4362,69 @@ rust_test(
 )
 
 rust_test(
+    name = "schedule_store_text_carry_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "schedule_store_text_carry",
+    crate_root = "tests/schedule_store_text_carry.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/schedule_store_text_carry.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.20",
+        "CARGO_BIN_NAME": "schedule_store_text_carry",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "sdk_parity_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -5040,6 +5166,7 @@ test_suite(
         ":identity_first_boundary_test",
         ":identity_first_builder_test",
         ":identity_first_choke_test",
+        ":identity_first_cold_restart_continuity_test",
         ":identity_first_contracts_test",
         ":identity_first_kitchen_sink_test",
         ":identity_first_ob3_smoke_test",
@@ -5069,6 +5196,7 @@ test_suite(
         ":rpc_builtins_test",
         ":runtime_bootstrap_test",
         ":schedule_dispatch_test",
+        ":schedule_store_text_carry_test",
         ":sdk_parity_test",
         ":sdk_productization_test",
         ":selector_eval_harness_test",

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -4156,6 +4156,40 @@ external_addressable = true
                         let memory_events = runtime.memory_event_sink();
                         store.set_event_sink(memory_events.clone());
                         tracker.set_event_sink(memory_events.clone());
+                        // §10.1 ask 5 (outbound half): make the member's comms
+                        // runtime the authenticated carrier of the host's taint
+                        // fact. When a session ingests untrusted content the
+                        // tracker stamps the member Tainted; peers then read the
+                        // sender's own signed declaration instead of
+                        // reconstructing taint from host-side joins, closing the
+                        // cross-process loop. Fire-and-forget: the member may not
+                        // be materialized (transient / definition-mob members
+                        // that never took a lease), so a miss is logged, not
+                        // fatal.
+                        let taint_mob_handle = runtime.mob_handle();
+                        tracker.set_outbound_taint_declarer(std::sync::Arc::new(
+                            move |identity: &str,
+                                  taint: Option<meerkat_core::comms::SenderContentTaint>| {
+                                let handle = taint_mob_handle.clone();
+                                let member =
+                                    meerkat_mobkit::member_comms_id::mob_member_id(identity);
+                                let identity_owned = identity.to_string();
+                                tokio::spawn(async move {
+                                    if let Err(err) = handle
+                                        .declare_member_outbound_taint(member, taint)
+                                        .await
+                                    {
+                                        tracing::debug!(
+                                            identity = %identity_owned,
+                                            ?taint,
+                                            error = %err,
+                                            "agent memory taint: outbound taint declaration \
+                                             failed (member may not be materialized)"
+                                        );
+                                    }
+                                });
+                            },
+                        ));
                         // §9.3 console Memory panel (P3b): a read handle on
                         // this realm store enables the read-only
                         // mobkit/memory/panel/* RPCs and the panel nav.

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -4368,10 +4368,17 @@ external_addressable = true
                             sinks.push(Arc::new(memory_steward::StewardTriggers::new(
                                 engine.clone(),
                             )));
-                            // The dream loop runs for the gateway process;
-                            // forgetting the handle keeps it alive (same
-                            // pattern as the member-event observer).
-                            std::mem::forget(engine.spawn_dream_loop());
+                            // Dream cadence (§ ask 7 / P5): when this gateway
+                            // runs a schedule host, the dream is driven as a
+                            // durable, misfire-aware host-runnable occurrence
+                            // (registered below at the schedule-host spawn).
+                            // Only gateways WITHOUT a schedule host keep the
+                            // in-process interval loop as a fallback. Forgetting
+                            // the handle keeps it alive (same pattern as the
+                            // member-event observer).
+                            if schedule_host_inputs.is_none() {
+                                std::mem::forget(engine.spawn_dream_loop());
+                            }
                             agent_memory_steward = Some(engine);
                             tracing::info!(
                                 model = %model,
@@ -4654,12 +4661,33 @@ external_addressable = true
                 );
             }
         }
+        // §8.5 / upstream ask 7 (P5): drive the memory steward's dream through
+        // the durable schedule host instead of a bare interval loop. Register
+        // the dream as a host runnable and find-or-create its cadence schedule
+        // (idempotent across boots via the persistent store). The in-process
+        // fallback loop is spawned only when there is no schedule host.
+        let runnable_host = meerkat_mobkit::schedule_wiring::steward_dream_runnable_host(
+            agent_memory_steward.clone(),
+        );
+        if let Some(steward) = agent_memory_steward.as_ref()
+            && let Err(error) = meerkat_mobkit::schedule_wiring::ensure_steward_dream_schedule(
+                &schedule_service,
+                steward.dream_cadence(),
+                chrono::Utc::now(),
+            )
+            .await
+        {
+            tracing::warn!(
+                error = %error,
+                "failed to ensure steward dream schedule; the steward will not dream on this gateway",
+            );
+        }
         meerkat_mobkit::schedule_wiring::spawn_schedule_host(
             service,
             adapter,
             schedule_service,
             mob_state,
-            None,
+            runnable_host,
             schedule_owner_id.clone(),
         )
     } else {

--- a/meerkat-mobkit/src/memory/steward.rs
+++ b/meerkat-mobkit/src/memory/steward.rs
@@ -993,15 +993,24 @@ impl StewardEngine {
         format!("dream-{}-{seq}", now_ms())
     }
 
-    /// The guarded interval loop (module docs: scheduling-subsystem
-    /// integration is a documented TODO; the cadence grammar is already
-    /// the subsystem's).
+    /// The configured dream cadence as a concrete interval. The durable
+    /// schedule host (§ ask 7 / P5) uses this to drive the dream runnable;
+    /// falls back to the same 6h default the in-process loop uses when the
+    /// cadence marker is malformed.
+    pub fn dream_cadence(&self) -> Duration {
+        self.config
+            .cadence_interval()
+            .unwrap_or(Duration::from_hours(6))
+    }
+
+    /// The guarded interval loop — the in-process fallback used only on
+    /// gateways with no schedule host. When a schedule host is present the
+    /// dream is driven as a durable, misfire-aware host-runnable occurrence
+    /// instead (see `schedule_wiring::steward_dream_runnable_host` /
+    /// `ensure_steward_dream_schedule`).
     pub fn spawn_dream_loop(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
         let engine = self.clone();
-        let interval = self
-            .config
-            .cadence_interval()
-            .unwrap_or(Duration::from_hours(6));
+        let interval = self.dream_cadence();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(interval).await;

--- a/meerkat-mobkit/src/memory/taint.rs
+++ b/meerkat-mobkit/src/memory/taint.rs
@@ -221,6 +221,16 @@ struct TaintInner {
     reset_boundaries: HashMap<String, u64>,
 }
 
+/// Host callback that stamps a member's OUTBOUND content-taint declaration
+/// (§10.1 ask 5, outbound half). Invoked with the member's public identity and
+/// the taint to declare — `Some(Tainted)` when the member's session ingests
+/// untrusted content, `None` when it rotates back to a clean session — so the
+/// member's peer sends carry the sender's signed declaration and receivers can
+/// propagate taint cross-process. The callback is fire-and-forget (the real
+/// declare is async on the mob runtime); it must not block.
+pub type OutboundTaintDeclarer =
+    Arc<dyn Fn(&str, Option<meerkat_core::comms::SenderContentTaint>) + Send + Sync>;
+
 /// Session-sticky taint tracker (§10.1, coarse P1). Cheap to clone; clones
 /// share state.
 #[derive(Clone, Default)]
@@ -229,6 +239,10 @@ pub struct SessionTaintTracker {
     inner: Arc<Mutex<TaintInner>>,
     /// §9.3 timeline sink for taint transitions; shared across clones.
     event_sink: Arc<Mutex<Option<Arc<dyn crate::memory::events::MemoryEventSink>>>>,
+    /// §10.1 ask 5 outbound half: declares a member's outbound content-taint
+    /// on the mob runtime so its peer sends carry the flag. Shared across
+    /// clones; `None` until the gateway wires the mob handle.
+    outbound_declarer: Arc<Mutex<Option<OutboundTaintDeclarer>>>,
 }
 
 impl SessionTaintTracker {
@@ -237,6 +251,34 @@ impl SessionTaintTracker {
             config: Arc::new(config),
             inner: Arc::new(Mutex::new(TaintInner::default())),
             event_sink: Arc::new(Mutex::new(None)),
+            outbound_declarer: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Wire the §10.1 outbound-taint declarer (bound to the mob handle at
+    /// gateway bootstrap). Shared across clones.
+    pub fn set_outbound_taint_declarer(&self, declarer: OutboundTaintDeclarer) {
+        *self
+            .outbound_declarer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(declarer);
+    }
+
+    /// Declare a member's outbound content-taint, if a declarer is wired.
+    /// Called on taint transitions (set/clear); must be invoked WITHOUT the
+    /// `inner` lock held (the callback may take time to hand off).
+    fn declare_outbound(
+        &self,
+        identity: &str,
+        taint: Option<meerkat_core::comms::SenderContentTaint>,
+    ) {
+        if let Some(declarer) = self
+            .outbound_declarer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+        {
+            declarer(identity, taint);
         }
     }
 
@@ -328,9 +370,9 @@ impl SessionTaintTracker {
         let previous = inner
             .current_session
             .insert(identity.to_string(), session_key.to_string());
-        if previous.as_deref() != Some(session_key)
-            && previous.is_some_and(|prior| inner.tainted.contains_key(&prior))
-        {
+        let rotated_away_from_tainted = previous.as_deref() != Some(session_key)
+            && previous.is_some_and(|prior| inner.tainted.contains_key(&prior));
+        if rotated_away_from_tainted {
             tracing::warn!(
                 identity,
                 session_key,
@@ -346,8 +388,17 @@ impl SessionTaintTracker {
                 },
             );
         }
+        // A held pre-attribution taint re-lands on the new session — it stays
+        // tainted, so do not clear the outbound declaration below.
+        let pending_reapplied = pending.is_some();
         if let Some(state) = pending {
             self.insert_taint(&mut inner, session_key.to_string(), state);
+        }
+        // §10.1 outbound half: on a clean rotation with no re-landed taint, the
+        // identity's live session is clean again — clear its outbound stamp.
+        if rotated_away_from_tainted && !pending_reapplied {
+            drop(inner);
+            self.declare_outbound(identity, None);
         }
     }
 
@@ -365,6 +416,10 @@ impl SessionTaintTracker {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         inner.pending_identity_taint.remove(identity);
         inner.current_session.remove(identity);
+        // §10.1 outbound half: reset is a fresh-context boundary — the identity
+        // no longer speaks for a tainted session, so clear its outbound stamp.
+        drop(inner);
+        self.declare_outbound(identity, None);
     }
 
     /// Mark a `reset()` boundary on the outgoing session (§8.4): every
@@ -551,6 +606,14 @@ impl SessionTaintTracker {
                 }
             }
         }
+        // §10.1 outbound half: the identity has ingested untrusted content, so
+        // stamp its peer sends Tainted (whether the taint landed on the current
+        // session or is held pending). Declare OUTSIDE the `inner` lock.
+        drop(inner);
+        self.declare_outbound(
+            identity,
+            Some(meerkat_core::comms::SenderContentTaint::Tainted),
+        );
     }
 
     fn insert_taint(&self, inner: &mut TaintInner, session: String, state: TaintState) {
@@ -1121,6 +1184,60 @@ mod tests {
                 .evidence_quarantine_reason(&session.to_string())
                 .is_some()
         );
+    }
+
+    #[test]
+    fn outbound_declarer_stamps_tainted_on_ingestion_and_clears_on_boundaries() {
+        use std::sync::{Arc, Mutex};
+        type Recorded = Vec<(String, Option<meerkat_core::comms::SenderContentTaint>)>;
+        let tracker = SessionTaintTracker::new(ContentTrustConfig::default());
+        let calls: Arc<Mutex<Recorded>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = calls.clone();
+        tracker.set_outbound_taint_declarer(Arc::new(move |identity, taint| {
+            sink.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push((identity.to_string(), taint));
+        }));
+
+        let session = SessionId::new();
+        tracker.observe_agent_event("identity:a", &run_started(&session));
+        // A benign tool makes no declaration.
+        tracker.observe_agent_event("identity:a", &tool_result("shell"));
+        assert!(calls.lock().unwrap().is_empty());
+
+        // Untrusted ingestion stamps the member Tainted for outbound peer sends.
+        tracker.observe_agent_event("identity:a", &tool_result("web_search"));
+        {
+            let recorded = calls.lock().unwrap();
+            assert_eq!(recorded.len(), 1, "one declaration expected: {recorded:?}");
+            assert_eq!(recorded[0].0, "identity:a");
+            assert_eq!(
+                recorded[0].1,
+                Some(meerkat_core::comms::SenderContentTaint::Tainted)
+            );
+        }
+
+        // Rotation to a fresh clean session clears the declaration (None, not
+        // Clean — an absent declaration, never coalesced into clean).
+        let fresh = SessionId::new();
+        tracker.note_current_session("identity:a", &fresh.to_string());
+        {
+            let recorded = calls.lock().unwrap();
+            assert_eq!(recorded.len(), 2, "rotation clears: {recorded:?}");
+            assert_eq!(recorded[1].1, None);
+        }
+
+        // Reset (the operator escape hatch) is also a fresh-context boundary.
+        tracker.observe_agent_event("identity:a", &tool_result("web_fetch"));
+        tracker.clear_identity("identity:a");
+        {
+            let recorded = calls.lock().unwrap();
+            assert_eq!(
+                recorded.last().expect("a clear declaration").1,
+                None,
+                "reset clears the outbound declaration: {recorded:?}"
+            );
+        }
     }
 
     #[test]

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -12,6 +12,11 @@
 //! actually fire: at due time it materializes a session and runs the prompt as
 //! a real agent turn). Both back onto a single durable [`ScheduleService`].
 //!
+//! [`steward_dream_runnable_host`] + [`ensure_steward_dream_schedule`] register
+//! the memory steward's dream as a host-runnable schedule target (§8.5 /
+//! upstream ask 7), so the dream fires as a durable, misfire-aware occurrence
+//! through the same host instead of a bare in-process interval loop.
+//!
 //! This is distinct from the static cron oracle (`MobKitBuilder::scheduling`),
 //! which drives module-dispatch ticks, not per-agent schedule tools.
 
@@ -19,6 +24,7 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use meerkat::surface::{
@@ -26,18 +32,170 @@ use meerkat::surface::{
     spawn_runtime_backed_schedule_host_with_mobs,
 };
 use meerkat::{
-    Config, FactoryAgentBuilder, MobTargetBinding, PersistentSessionService, ScheduleService,
-    ScheduleToolDispatcher, ScheduledMobAction, ScheduledSessionAction, SessionAgentBuilder,
-    SessionTargetBinding, SqliteScheduleStore, TargetBinding, UpdateScheduleRequest,
+    Config, CreateScheduleRequest, FactoryAgentBuilder, HostRunnable, HostRunnableError,
+    HostRunnableInvocation, HostRunnableName, HostRunnableOutcome, HostRunnableRegistry,
+    HostRunnableTargetBinding, IntervalTriggerSpec, MobTargetBinding, PersistentSessionService,
+    ScheduleRunnableHost, ScheduleService, ScheduleToolDispatcher, ScheduledMobAction,
+    ScheduledSessionAction, SessionAgentBuilder, SessionTargetBinding, SqliteScheduleStore,
+    TargetBinding, TriggerSpec, UpdateScheduleRequest,
 };
 use meerkat_core::service::SessionBuildOptions;
 use meerkat_mob_mcp::{MobMcpScheduleHost, MobMcpState};
 use meerkat_runtime::MeerkatMachine;
 use serde_json::{Map, Value};
 
+use crate::memory::steward::StewardEngine;
+
 /// File name for the durable schedule store, kept beside the runtime DB so a
 /// gateway and a library-mode runtime pointed at the same dir share state.
 pub const SCHEDULE_STORE_FILE: &str = "schedule.sqlite";
+
+/// Reserved host-runnable name for the memory steward's scheduled dream
+/// (§8.5 / upstream ask 7). Stable across boots: the find-or-create schedule
+/// keys idempotency on a target that names this runnable.
+pub const STEWARD_DREAM_RUNNABLE: &str = "mobkit.memory.steward.dream";
+
+/// Schedule name for the steward dream, used only for operator legibility in
+/// schedule listings — idempotency keys on the host-runnable target, not this.
+const STEWARD_DREAM_SCHEDULE_NAME: &str = "mobkit-memory-steward-dream";
+
+/// A [`HostRunnable`] that runs one guarded steward dream attempt. Registered
+/// with the schedule host so the dream fires as a durable, misfire-aware
+/// schedule occurrence instead of a bare in-process interval loop.
+struct StewardDreamRunnable {
+    engine: Arc<StewardEngine>,
+}
+
+#[async_trait]
+impl HostRunnable for StewardDreamRunnable {
+    async fn run(
+        &self,
+        _invocation: HostRunnableInvocation,
+    ) -> Result<HostRunnableOutcome, HostRunnableError> {
+        // `dream_now` is fully self-gating (enabled / min-signals / budget)
+        // and never returns an error — a skipped dream is a normal outcome,
+        // not an occurrence failure. Always report completion so the
+        // occurrence lands terminal-complete.
+        self.engine.dream_now().await;
+        Ok(HostRunnableOutcome::completed())
+    }
+}
+
+/// Build a host-runnable registry exposing the steward's dream, when a steward
+/// engine is present. Returned as `Arc<dyn ScheduleRunnableHost>` for
+/// [`spawn_schedule_host`]'s `runnable_host`; `None` when there is no steward
+/// to drive (the schedule host then serves session/mob targets only).
+#[must_use]
+// The runnable name is a non-empty const and registration into a fresh
+// registry cannot duplicate — both expects are structurally infallible.
+#[allow(clippy::expect_used)]
+pub fn steward_dream_runnable_host(
+    steward: Option<Arc<StewardEngine>>,
+) -> Option<Arc<dyn ScheduleRunnableHost>> {
+    let engine = steward?;
+    let mut registry = HostRunnableRegistry::new();
+    let name = HostRunnableName::parse(STEWARD_DREAM_RUNNABLE)
+        .expect("STEWARD_DREAM_RUNNABLE is a non-empty runnable name");
+    registry
+        .register(name, Arc::new(StewardDreamRunnable { engine }))
+        .expect("first registration into a fresh registry cannot duplicate");
+    Some(Arc::new(registry))
+}
+
+/// Find-or-create the durable schedule that drives the steward dream runnable
+/// at `cadence`. Idempotent across boots against the persistent schedule
+/// store: keyed on the reserved host-runnable target, so a restart reuses the
+/// existing schedule (and its planning cursor) rather than stacking duplicate
+/// dreams. When the configured cadence changed, the existing schedule's
+/// interval is updated in place; otherwise it is left untouched.
+// The runnable name is a non-empty const, so its parse is infallible.
+#[allow(clippy::expect_used)]
+pub async fn ensure_steward_dream_schedule(
+    service: &ScheduleService,
+    cadence: Duration,
+    now_utc: chrono::DateTime<chrono::Utc>,
+) -> Result<(), String> {
+    let every_seconds = cadence.as_secs().max(1);
+    let runnable = HostRunnableName::parse(STEWARD_DREAM_RUNNABLE)
+        .expect("STEWARD_DREAM_RUNNABLE is a non-empty runnable name");
+
+    let schedules = service
+        .list()
+        .await
+        .map_err(|error| format!("list schedules: {error}"))?;
+    let existing = schedules.into_iter().find(|schedule| {
+        matches!(
+            &schedule.target,
+            TargetBinding::HostRunnable(binding) if binding.runnable == runnable
+        )
+    });
+
+    // First occurrence one interval out (parity with the old loop's initial
+    // sleep-then-dream) so a fresh gateway does not dream immediately on boot.
+    let start_at_utc = now_utc + chrono::Duration::seconds(every_seconds as i64);
+    let trigger = TriggerSpec::Interval(IntervalTriggerSpec {
+        start_at_utc,
+        every_seconds,
+        end_at_utc: None,
+    });
+    let target = TargetBinding::host_runnable(HostRunnableTargetBinding {
+        runnable,
+        params: None,
+    });
+
+    match existing {
+        Some(schedule) => {
+            let cadence_unchanged = matches!(
+                &schedule.trigger,
+                TriggerSpec::Interval(spec) if spec.every_seconds == every_seconds
+            );
+            if cadence_unchanged {
+                return Ok(());
+            }
+            service
+                .update(
+                    &schedule.schedule_id,
+                    UpdateScheduleRequest {
+                        trigger: Some(trigger),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .map_err(|error| format!("update steward dream schedule cadence: {error}"))?;
+            tracing::info!(
+                schedule_id = %schedule.schedule_id,
+                every_seconds,
+                "updated steward dream schedule cadence"
+            );
+            Ok(())
+        }
+        None => {
+            let created = service
+                .create(CreateScheduleRequest {
+                    name: Some(STEWARD_DREAM_SCHEDULE_NAME.to_string()),
+                    description: Some(
+                        "MobKit memory steward dream (host-runnable target)".to_string(),
+                    ),
+                    trigger,
+                    target,
+                    misfire_policy: meerkat::MisfirePolicy::default(),
+                    overlap_policy: meerkat::OverlapPolicy::default(),
+                    missing_target_policy: meerkat::MissingTargetPolicy::default(),
+                    labels: std::collections::BTreeMap::new(),
+                    planning_horizon_days: None,
+                    planning_horizon_occurrences: None,
+                })
+                .await
+                .map_err(|error| format!("create steward dream schedule: {error}"))?;
+            tracing::info!(
+                schedule_id = %created.schedule_id,
+                every_seconds,
+                "created steward dream schedule (host-runnable target)"
+            );
+            Ok(())
+        }
+    }
+}
 
 #[derive(Clone, Default)]
 pub struct ScheduleMobTargetRegistry {
@@ -439,7 +597,7 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use meerkat::{
@@ -747,6 +905,74 @@ mod tests {
         let metadata = render_metadata.as_ref().expect("render metadata");
         let metadata = serde_json::to_value(metadata).expect("metadata value");
         assert_eq!(metadata["class"], expected_class);
+    }
+
+    #[test]
+    fn steward_dream_runnable_host_is_none_without_a_steward() {
+        assert!(steward_dream_runnable_host(None).is_none());
+    }
+
+    fn dream_target_count(schedules: &[meerkat::Schedule]) -> usize {
+        let runnable = HostRunnableName::parse(STEWARD_DREAM_RUNNABLE).expect("name");
+        schedules
+            .iter()
+            .filter(|schedule| {
+                matches!(
+                    &schedule.target,
+                    TargetBinding::HostRunnable(binding) if binding.runnable == runnable
+                )
+            })
+            .count()
+    }
+
+    fn dream_interval_seconds(schedule: &meerkat::Schedule) -> u64 {
+        match &schedule.trigger {
+            TriggerSpec::Interval(spec) => spec.every_seconds,
+            other => panic!("expected interval trigger, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_steward_dream_schedule_is_idempotent_and_updates_cadence() {
+        let service = ScheduleService::new(Arc::new(MemoryScheduleStore::default()));
+        let now: chrono::DateTime<chrono::Utc> = "2026-07-01T00:00:00Z".parse().expect("fixed now");
+
+        // First call creates exactly one host-runnable schedule.
+        ensure_steward_dream_schedule(&service, Duration::from_hours(6), now)
+            .await
+            .expect("create dream schedule");
+        let schedules = service.list().await.expect("list");
+        assert_eq!(
+            dream_target_count(&schedules),
+            1,
+            "one dream schedule created"
+        );
+        assert_eq!(dream_interval_seconds(&schedules[0]), 6 * 3600);
+
+        // Re-running with the same cadence is a no-op — no duplicate stacking
+        // across boots.
+        ensure_steward_dream_schedule(&service, Duration::from_hours(6), now)
+            .await
+            .expect("idempotent re-ensure");
+        let schedules = service.list().await.expect("list");
+        assert_eq!(
+            dream_target_count(&schedules),
+            1,
+            "still one dream schedule"
+        );
+
+        // A changed cadence updates the existing schedule in place, not a new
+        // one.
+        ensure_steward_dream_schedule(&service, Duration::from_mins(30), now)
+            .await
+            .expect("update cadence");
+        let schedules = service.list().await.expect("list");
+        assert_eq!(
+            dream_target_count(&schedules),
+            1,
+            "cadence change reuses schedule"
+        );
+        assert_eq!(dream_interval_seconds(&schedules[0]), 30 * 60);
     }
 
     #[tokio::test]

--- a/meerkat-mobkit/tests/identity_first_cold_restart_continuity.rs
+++ b/meerkat-mobkit/tests/identity_first_cold_restart_continuity.rs
@@ -1,0 +1,315 @@
+//! Upgrade-carry regression (Bug 1, HomeCore 0.7.20 report): a full process
+//! restart against the same on-disk store must RESUME each agent's transcript,
+//! not fresh-spawn it empty.
+//!
+//! On cold restart the identity runtime re-creates the member and calls
+//! `bridge.resume_session` (`MemberLaunchMode::Resume`). Before meerkat 0.7.14,
+//! the re-created runtime authority re-projected a transcript that only differed
+//! from the persisted row in bookkeeping (re-stamped run identity + timestamps),
+//! and the session-store append-only continuity guard rejected it as "not a
+//! continuation of persisted revision" — so `resume_session` fell into its
+//! `Err` arm and spawned a fresh, EMPTY member, silently dropping history on
+//! every restart. Every real deployment hit this; fresh-state tests never did.
+//!
+//! meerkat 0.7.14 (Ask B) makes the guard compare the shared prefix by content
+//! address, tolerating bookkeeping-only divergence, so resume succeeds. This
+//! test proves it end to end: boot, deliver a unique token, FULLY shut down,
+//! rebuild a fresh runtime against the SAME state dir, and assert the
+//! post-restart turn replays the token — impossible unless the transcript
+//! carried across the restart. The sibling respawn-continuity test covers the
+//! in-process recovery boundary; this one covers the cold restart.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use meerkat_client::{LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
+use meerkat_core::types::StopReason;
+use meerkat_mob::{MobDefinition, ProfileName};
+use meerkat_mobkit::UnifiedRuntimeBuilder;
+use meerkat_mobkit::identity_first::contracts::{AgentCustomizer, TopologyProvider};
+use meerkat_mobkit::identity_first::orchestrator::{RestoreOutcome, restore_flow};
+use meerkat_mobkit::identity_first::{
+    AgentAddressability, AgentBuildContext, AgentBuildDraft, AgentIdentity, ContinuityStore,
+    CustomizerError, DurabilityPolicy, DurableAgentSpec, IdentityRuntime, IdentityRuntimeConfig,
+    LocalContinuityStore, LocalLeaseProvider, ManagedPeerEdge, SessionBridge, TopologyContext,
+    TopologyError,
+};
+use meerkat_mobkit::mob_handle_runtime::SessionCreatedContext;
+use tokio::time::sleep;
+
+fn id(name: &str) -> AgentIdentity {
+    AgentIdentity::parse(name).unwrap()
+}
+
+fn spec(name: &str, addr: AgentAddressability, profile: &str) -> DurableAgentSpec {
+    DurableAgentSpec {
+        identity: id(name),
+        profile: ProfileName::from(profile),
+        addressability: addr,
+        display_name: None,
+        labels: BTreeMap::new(),
+        context: None,
+        additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
+        backend: None,
+        binding: None,
+    }
+}
+
+const MOB_TOML: &str = r#"
+[mob]
+id = "cold-restart-continuity"
+
+[profiles.personal]
+model = "gpt-5.5"
+external_addressable = true
+runtime_mode = "turn_driven"
+
+[profiles.personal.tools]
+comms = true
+"#;
+
+fn one_member_definition() -> MobDefinition {
+    MobDefinition::from_toml(MOB_TOML).expect("parse cold-restart mob definition")
+}
+
+struct EmptyTopology;
+#[async_trait]
+impl TopologyProvider for EmptyTopology {
+    async fn compute_edges(
+        &self,
+        _target_identities: &[AgentIdentity],
+        _context: &TopologyContext,
+    ) -> Result<Vec<ManagedPeerEdge>, TopologyError> {
+        Ok(vec![])
+    }
+}
+
+struct NoopCustomizer;
+#[async_trait]
+impl AgentCustomizer for NoopCustomizer {
+    async fn customize_build(
+        &self,
+        _context: &AgentBuildContext,
+        _spec: &DurableAgentSpec,
+        _draft: &mut AgentBuildDraft,
+    ) -> Result<(), CustomizerError> {
+        Ok(())
+    }
+    async fn after_create(
+        &self,
+        _identity: &AgentIdentity,
+        _session_id: &meerkat_core::types::SessionId,
+        _context: &SessionCreatedContext,
+    ) -> Result<(), CustomizerError> {
+        Ok(())
+    }
+}
+
+/// Records the serialized LLM request each turn and answers "ok" so turns
+/// complete without a real provider.
+#[derive(Clone, Default)]
+struct CaptureClient {
+    requests: Arc<std::sync::Mutex<Vec<String>>>,
+}
+impl CaptureClient {
+    fn count(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+    fn last(&self) -> Option<String> {
+        self.requests.lock().unwrap().last().cloned()
+    }
+}
+impl meerkat_client::LlmClient for CaptureClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+        Ok(messages.to_vec())
+    }
+    fn stream<'a>(
+        &'a self,
+        request: &'a LlmRequest,
+    ) -> Pin<Box<dyn futures::Stream<Item = Result<LlmEvent, LlmError>> + Send + 'a>> {
+        self.requests
+            .lock()
+            .unwrap()
+            .push(serde_json::to_string(request).unwrap_or_default());
+        Box::pin(async_stream::stream! {
+            yield Ok(LlmEvent::TextDelta { delta: "ok".to_string(), meta: None });
+            yield Ok(LlmEvent::Done {
+                outcome: LlmDoneOutcome::Success { stop_reason: StopReason::EndTurn },
+            });
+        })
+    }
+    fn provider(&self) -> meerkat::Provider {
+        meerkat::Provider::OpenAI
+    }
+    fn health_check<'life0, 'async_trait>(
+        &'life0 self,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), LlmError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+const RUNTIME_INSTANCE: &str = "cold-restart-continuity";
+
+/// Build a fresh runtime + identity runtime against `state_path`, capturing LLM
+/// requests into `capture`. Mirrors a process (re)start against a durable store.
+async fn boot(
+    state_path: &std::path::Path,
+    capture: CaptureClient,
+) -> (meerkat_mobkit::UnifiedRuntime, IdentityRuntime) {
+    let unified = UnifiedRuntimeBuilder::default()
+        .definition(one_member_definition())
+        .persistent_state(state_path)
+        .comms(true)
+        .default_llm_client(Arc::new(capture))
+        .build()
+        .await
+        .expect("build UnifiedRuntime");
+    let bridge: Arc<dyn SessionBridge> = unified
+        .session_bridge()
+        .expect("session_bridge should exist")
+        .clone();
+    let store = Arc::new(
+        LocalContinuityStore::open(state_path.join("continuity.db")).expect("continuity store"),
+    );
+    let identity_rt = IdentityRuntime::new(IdentityRuntimeConfig {
+        continuity_store: store as Arc<dyn ContinuityStore>,
+        lease_provider: Arc::new(LocalLeaseProvider::new()),
+        runtime_instance_id: RUNTIME_INSTANCE.to_string(),
+        has_runtime_store: true,
+        durability_policy: DurabilityPolicy::SyncWriteThrough,
+        bridge: Some(bridge),
+        default_timeout: None,
+    });
+    (unified, identity_rt)
+}
+
+// SCAFFOLD (not yet in CI): a faithful cold-restart harness needs the gateway's
+// exact continuity+session wiring. Here the boot-1 continuity record only
+// persists to the DB when a lease grant is present (orchestrator.rs upsert is
+// grant-gated), and a hand-assembled LocalContinuityStore + UnifiedRuntime does
+// not reload the persisted session the way rpc_gateway does — so boot 2 resolves
+// Uninitialized and re-Creates. The behavior this guards (Ask B: resume tolerates
+// bookkeeping-only re-projection divergence) is verified upstream in
+// meerkat-core 0.7.14 (`append_only_guard_accepts_rebookkept_prefix_identity_and_timestamps`)
+// and, for the mobkit recovery boundary, by identity_first_respawn_continuity.
+// Left as a runnable scaffold to finish against the gateway harness (or the
+// live deployment) rather than assert on a misconfigured setup.
+#[ignore = "needs gateway-faithful cold-restart harness; Ask B verified upstream + by respawn-continuity"]
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_first_cold_restart_preserves_transcript() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let state_path = temp.path().join("state");
+    let alice = id("personal:alice");
+    let roster = vec![spec(
+        "personal:alice",
+        AgentAddressability::Addressable,
+        "personal",
+    )];
+    const TOKEN: &str = "MARKER-BRAVO-9-YANKEE";
+
+    // --- Boot 1: create the member, deliver turn 1 with the token, shut down ---
+    {
+        let capture = CaptureClient::default();
+        let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
+
+        let result = restore_flow(
+            &identity_rt,
+            &roster,
+            Some(&EmptyTopology as &dyn TopologyProvider),
+            Some(&NoopCustomizer as &dyn AgentCustomizer),
+        )
+        .await
+        .expect("restore_flow (boot 1)");
+        match result.outcomes.get(&alice).expect("alice outcome") {
+            RestoreOutcome::Created { .. } => {}
+            other => panic!("expected Created on first boot, got {other:?}"),
+        }
+
+        identity_rt
+            .send(
+                &alice,
+                &meerkat_core::ContentInput::Text(format!("Please note this token: {TOKEN}")),
+            )
+            .await
+            .expect("send turn 1");
+
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while capture.count() < 1 {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for turn 1 to reach the LLM"
+            );
+            sleep(Duration::from_millis(100)).await;
+        }
+        // Let turn 1's assistant response commit to the persisted transcript
+        // before the shutdown flush.
+        sleep(Duration::from_millis(500)).await;
+        unified.shutdown().await;
+    }
+
+    // --- Boot 2: fresh runtime, SAME store. Resume must carry the transcript ---
+    {
+        let capture = CaptureClient::default(); // fresh: only boot-2 requests
+        let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
+
+        let result = restore_flow(
+            &identity_rt,
+            &roster,
+            Some(&EmptyTopology as &dyn TopologyProvider),
+            Some(&NoopCustomizer as &dyn AgentCustomizer),
+        )
+        .await
+        .expect("restore_flow (boot 2)");
+        // A cold restart with persisted history must recover the session, never
+        // re-Create it (a re-Create is the empty fresh-spawn regression).
+        match result.outcomes.get(&alice).expect("alice outcome") {
+            RestoreOutcome::Resumed { .. } | RestoreOutcome::Dormant { .. } => {}
+            other @ RestoreOutcome::Created { .. } => {
+                panic!("cold restart re-Created the member (history dropped): {other:?}")
+            }
+            other => panic!("unexpected restore outcome across cold restart: {other:?}"),
+        }
+
+        identity_rt
+            .send(
+                &alice,
+                &meerkat_core::ContentInput::Text("What token did I give you earlier?".to_string()),
+            )
+            .await
+            .expect("send turn 2");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while capture.count() < 1 {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for the post-restart turn to reach the LLM"
+            );
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        // The post-restart request must REPLAY turn 1's transcript. The token
+        // can only be present if resume loaded the persisted conversation
+        // instead of falling back to an empty fresh spawn (Bug 1 / Ask B).
+        let last_request = capture.last().expect("a post-restart request was captured");
+        assert!(
+            last_request.contains(TOKEN),
+            "post-restart LLM request must replay the persisted transcript (token {TOKEN}); \
+             cold-restart resume dropped the conversation history"
+        );
+
+        unified.shutdown().await;
+    }
+}

--- a/meerkat-mobkit/tests/schedule_store_text_carry.rs
+++ b/meerkat-mobkit/tests/schedule_store_text_carry.rs
@@ -1,0 +1,95 @@
+//! Upgrade-carry regression (Bug 2, HomeCore 0.7.20 report): a schedule store
+//! written with `schedule_json` as TEXT — the encoding pre-0.7.20 deployments
+//! carried — must still read after the upgrade.
+//!
+//! SQLite column affinity does not rewrite existing values, so a store authored
+//! before the BLOB rework holds the same UTF-8 JSON as TEXT. meerkat 0.7.14
+//! (Ask A) reads schedule JSON columns through a `Text|Blob`-tolerant boundary;
+//! before it, `list()` (and therefore mobkit's identity-target repair and the
+//! steward dream find-or-create) failed EVERY read with
+//! `Invalid column type Text at index: 0, name: schedule_json` on carried
+//! stores — invisible to fresh-state tests. This crosses that version boundary:
+//! author BLOB, rewrite to TEXT to simulate the carried store, reopen, and
+//! assert mobkit's schedule paths still work.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use meerkat::{ScheduleService, SqliteScheduleStore};
+use meerkat_mobkit::schedule_wiring::{SCHEDULE_STORE_FILE, ensure_steward_dream_schedule};
+
+fn typeof_schedule_json(path: &std::path::Path) -> String {
+    let conn = rusqlite::Connection::open(path).expect("raw open");
+    conn.query_row(
+        "SELECT typeof(schedule_json) FROM schedule_schedules LIMIT 1",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .expect("typeof schedule_json")
+}
+
+#[tokio::test]
+async fn carried_text_schedule_json_rows_read_after_upgrade() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(SCHEDULE_STORE_FILE);
+    let now = "2026-07-01T00:00:00Z".parse().expect("fixed now");
+
+    // 1. Author a schedule through the store today (writes schedule_json BLOB).
+    {
+        let store = SqliteScheduleStore::open(&path).expect("open store");
+        let service = ScheduleService::new(Arc::new(store));
+        ensure_steward_dream_schedule(&service, Duration::from_hours(6), now)
+            .await
+            .expect("create dream schedule");
+        assert_eq!(service.list().await.expect("list").len(), 1);
+    }
+    assert_eq!(
+        typeof_schedule_json(&path),
+        "blob",
+        "the store writes schedule_json as BLOB today"
+    );
+
+    // 2. Simulate a pre-0.7.20 carried store: rewrite the row to TEXT in place.
+    //    `CAST(blob AS TEXT)` reinterprets the identical UTF-8 JSON bytes with
+    //    TEXT affinity — exactly the legacy on-disk shape.
+    {
+        let conn = rusqlite::Connection::open(&path).expect("raw open");
+        conn.execute(
+            "UPDATE schedule_schedules SET schedule_json = CAST(schedule_json AS TEXT)",
+            [],
+        )
+        .expect("rewrite schedule_json to TEXT");
+    }
+    assert_eq!(
+        typeof_schedule_json(&path),
+        "text",
+        "row now carries the legacy TEXT encoding a carried store would hold"
+    );
+
+    // 3. Reopen on 0.7.14: list() must succeed over the TEXT row (Ask A's
+    //    Text|Blob boundary), and the idempotent ensure must reuse the carried
+    //    schedule rather than choke or duplicate it.
+    {
+        let store = SqliteScheduleStore::open(&path).expect("reopen store");
+        let service = ScheduleService::new(Arc::new(store));
+        let schedules = service
+            .list()
+            .await
+            .expect("list must not fail on carried TEXT schedule_json rows");
+        assert_eq!(
+            schedules.len(),
+            1,
+            "the carried schedule survives the upgrade and reads back"
+        );
+        let later = "2026-07-02T00:00:00Z".parse().expect("later now");
+        ensure_steward_dream_schedule(&service, Duration::from_hours(6), later)
+            .await
+            .expect("ensure_steward_dream_schedule over a carried TEXT store");
+        assert_eq!(
+            service.list().await.expect("list").len(),
+            1,
+            "idempotent ensure reuses the carried schedule (no duplicate)"
+        );
+    }
+}


### PR DESCRIPTION
Bundles the remaining pre-Elephant memory phases with the meerkat 0.7.14 upgrade that fixes the two HomeCore carried-store bugs. Targets a single **0.7.21** release. Builds on #215 (0.7.20).

## meerkat 0.7.13 → 0.7.14 upgrade

No mobkit API breaks. 0.7.14 lands the two carried-store fixes reported from the live HomeCore deployment (invisible to fresh-state tests; only upgraded/carried SQLite stores hit them):

- **Ask A — `meerkat-store`:** schedule/occurrence/receipt JSON columns now read through a `JsonColumnBytes` boundary that accepts both `ValueRef::Text` and `ValueRef::Blob`. A legacy TEXT `schedule_json` row on a carried store no longer fails every read (`Invalid column type Text at index: 0`), so the identity-target repair + steward-dream find-or-create run again.
- **Ask B — `meerkat-core`:** the append-only continuity guard now compares the shared transcript prefix by content address, tolerating bookkeeping-only divergence (re-stamped run identity + timestamps) from a re-created runtime authority on cold restart — genuine content divergence still fails. Fixes resume falling back to an empty fresh spawn (transcript-drop-on-restart).

## P3-outbound — declare member outbound content-taint (ask 5, outbound half)

Members now stamp their own signed content-taint on outbound peer envelopes (`MobHandle::declare_member_outbound_taint`): `Tainted` when a session ingests untrusted content, cleared to `None` on clean rotation / reset. Receivers read the sender's declaration instead of reconstructing taint from host-side joins — closes ask-5's cross-process loop. Inbound half shipped in #215.

## P5 — steward dream as a host-runnable schedule target (ask 7)

The steward dream now runs as a durable, misfire-aware schedule occurrence (idempotent find-or-create against the persistent store) instead of a bare interval loop; the in-process loop is kept only as the no-schedule-host fallback.

## Carry regression tests

- `schedule_store_text_carry` (green): author BLOB → rewrite `schedule_json` to TEXT to simulate a pre-0.7.20 store → reopen on 0.7.14 → assert `list()` + `ensure_steward_dream_schedule` succeed. Guards Ask A.
- `identity_first_cold_restart_continuity` (`#[ignore]` scaffold): full teardown + rebuild against the same on-disk store. Left ignored — a faithful cold-restart harness needs the gateway's continuity+session wiring; Ask B is verified upstream and by the in-process `identity_first_respawn_continuity` test.

## Tests

Full workspace suite green on 0.7.14 (1510 passed; the single flaky is the pre-existing `contract_009` load flake, passes on retry). Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)