### PR TITLE
identity-first: never abandon the durable session on a rejected resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the cold-restart transcript-loss class. Dynamic per-boot context belongs in
   runtime system-context appends, not the base prompt.
 
+### Added
+
+- The cold-restart continuity regression now runs in CI (previously an
+  ignored scaffold): boot → turn → full restart against the same on-disk
+  store → assert the identity resumes onto the same session id with the
+  transcript replayed, twice (second-restart variant). Its earlier "harness"
+  failure was in fact the outcome-reporting lie this release fixes.
+
 ## [0.7.21] - 2026-07-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A rejected resume no longer destroys the conversation.** The identity-first
+  session bridge used to catch *any* resume error and fall back to a fresh,
+  empty member spawn — permanently abandoning the durable transcript (the
+  HomeCore restart-loss bug). A resume failure now keeps the identity → session
+  binding intact, marks the identity **Broken** with the real error attached,
+  and the next reconcile retries the resume. A roster collision (in-process
+  restart) retires the stale member and retries the *resume*, never a fresh
+  spawn.
+- Reconcile outcome reporting is honest: a bridge resume that fresh-spawned
+  reports `created` (never `resumed`), and a successful resume without a
+  checkpoint snapshot reports `resumed` (the persisted mob session carried the
+  history). Resume errors are classified from meerkat's typed errors
+  (`MemberRestoreFailed`, transcript-continuity violations) instead of being
+  bucketed into one `runtime_identity_incompatible` reason.
+- Resume inherits the persisted System message instead of re-sending the
+  spec's explicit prompt. Re-sending made meerkat re-assemble the prompt,
+  which trips the session store's transcript-continuity guard on meerkat
+  ≤0.7.14 whenever the persisted prompt carries runtime context appends —
+  the cold-restart transcript-loss class. Dynamic per-boot context belongs in
+  runtime system-context appends, not the base prompt.
+
 ## [0.7.21] - 2026-07-04
 
 ### Changed

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -79,6 +79,16 @@ pub enum BridgeError {
     Mob(String),
     /// A required field was missing or invalid.
     InvalidInput(String),
+    /// Resume was rejected while a durable session row exists. The identity →
+    /// session binding MUST stay intact: callers mark the identity degraded
+    /// (Broken) with this error attached and retry on the next reconcile.
+    /// Never fresh-spawn on this error — the durable transcript is the only
+    /// copy of the conversation, and rebinding the identity to a fresh empty
+    /// session permanently abandons it (the HomeCore restart-loss regression).
+    ResumeRejected {
+        kind: ResumeRejectionKind,
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for BridgeError {
@@ -86,11 +96,75 @@ impl std::fmt::Display for BridgeError {
         match self {
             Self::Mob(msg) => write!(f, "session bridge mob error: {msg}"),
             Self::InvalidInput(msg) => write!(f, "session bridge invalid input: {msg}"),
+            Self::ResumeRejected { kind, detail } => write!(
+                f,
+                "session bridge resume rejected ({kind:?}): {detail}; durable session preserved, \
+                 identity degraded pending retry"
+            ),
         }
     }
 }
 
 impl std::error::Error for BridgeError {}
+
+/// Typed classification of a rejected resume, derived from meerkat's typed
+/// errors where available (report ask: don't bucket every resume error into
+/// one "runtime_identity_incompatible" reason).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumeRejectionKind {
+    /// meerkat's typed restore failure (`MobError::MemberRestoreFailed`): the
+    /// member is Broken-in-roster upstream with restore diagnostics preserved.
+    MemberRestoreFailed,
+    /// The session store rejected the resume as a transcript-continuity
+    /// violation ("incoming transcript is not a continuation of persisted
+    /// revision") — the meerkat ≤0.7.14 cold-restart re-projection class.
+    TranscriptContinuity,
+    /// Any other resume-time failure.
+    Other,
+}
+
+/// Log and construct the typed resume rejection for one failed resume step.
+/// Deliberately loud: a rejected resume degrades the identity until a
+/// reconcile retry succeeds, and the operator needs the real (classified)
+/// error — not a generic fallback reason.
+fn resume_rejected(
+    identity: &AgentIdentity,
+    session_id: &meerkat_core::types::SessionId,
+    error: &meerkat_mob::MobError,
+    step: &str,
+) -> BridgeError {
+    let kind = classify_resume_error(error);
+    tracing::error!(
+        identity = %identity,
+        session_id = %session_id,
+        kind = ?kind,
+        step,
+        error = %error,
+        "resume rejected; durable session preserved, identity degraded pending reconcile retry \
+         (refusing fresh-spawn fallback)"
+    );
+    BridgeError::ResumeRejected {
+        kind,
+        detail: format!("{step}: {error}"),
+    }
+}
+
+/// Classify a resume-spawn failure. Typed variants first; the string probe is
+/// belt-and-braces for continuity violations that reach us stringified through
+/// the provisioning path (`MobError::Internal`).
+fn classify_resume_error(error: &meerkat_mob::MobError) -> ResumeRejectionKind {
+    if matches!(error, meerkat_mob::MobError::MemberRestoreFailed { .. }) {
+        return ResumeRejectionKind::MemberRestoreFailed;
+    }
+    let text = error.to_string();
+    if text.contains("not a continuation of persisted revision")
+        || text.contains("TranscriptContinuityViolation")
+        || text.contains("continuity preflight")
+    {
+        return ResumeRejectionKind::TranscriptContinuity;
+    }
+    ResumeRejectionKind::Other
+}
 
 /// Typed reason a requested resume could not reuse the persisted runtime
 /// binding and had to fall back to a fresh member spawn.
@@ -610,34 +684,6 @@ impl MobSessionBridge {
                 .map(|_| ())
         }
     }
-
-    async fn spawn_member_spec_replacing_collision(
-        &self,
-        runtime_id: &AgentRuntimeId,
-        member_id: &MobAgentIdentity,
-        spawn_spec: SpawnMemberSpec,
-    ) -> Result<(), meerkat_mob::MobError> {
-        match self.spawn_member_spec(spawn_spec.clone()).await {
-            Ok(()) => Ok(()),
-            Err(error) if is_member_already_exists_error(&error) => {
-                tracing::warn!(
-                    runtime_id = %runtime_id,
-                    member_id = %member_id,
-                    error = %error,
-                    "fresh-spawn fallback collided with an existing member; retiring and retrying with adopted spec"
-                );
-                match self.handle.retire(member_id.clone()).await {
-                    Ok(()) => {}
-                    Err(err)
-                        if is_recoverable_session_owned_retire_cleanup_error(&err.to_string()) => {}
-                    Err(err) => return Err(err),
-                }
-                self.forget_runtime_member(runtime_id).await;
-                self.spawn_member_spec(spawn_spec).await
-            }
-            Err(error) => Err(error),
-        }
-    }
 }
 
 /// Project meerkat 0.7's tri-state peer connectivity into an inspect-level
@@ -779,6 +825,33 @@ pub(crate) fn build_spawn_spec(
     spawn_spec
 }
 
+/// Build the spawn spec for a RESUME of `session_id`.
+///
+/// Differs from a fresh spawn in two deliberate ways:
+/// - `launch_mode = Resume`, so meerkat loads the persisted session
+///   (conversation history intact) instead of creating a new one.
+/// - `system_prompt_override` is cleared (Inherit): the persisted System
+///   message is authoritative on resume. Re-sending the draft's explicit
+///   prompt makes meerkat re-assemble the prompt, and on meerkat ≤0.7.14 that
+///   trips the session store's transcript-continuity guard whenever the
+///   persisted prompt carries runtime context appends — the exact cold-restart
+///   transcript-loss class (HomeCore). Dynamic per-boot context belongs in
+///   runtime system-context appends, never the base prompt.
+pub(crate) fn build_resume_spawn_spec(
+    runtime_id: &AgentRuntimeId,
+    spec: &DurableAgentSpec,
+    draft: &AgentBuildDraft,
+    base_profile: Option<&meerkat_mob::Profile>,
+    session_id: &meerkat_core::types::SessionId,
+) -> SpawnMemberSpec {
+    let mut spawn_spec = build_spawn_spec(runtime_id, spec, draft, base_profile);
+    spawn_spec.launch_mode = MemberLaunchMode::Resume {
+        bridge_session_id: session_id.clone(),
+    };
+    spawn_spec.system_prompt_override = None;
+    spawn_spec
+}
+
 fn runtime_binding_from_wire(
     binding: meerkat_contracts::WireRuntimeBinding,
 ) -> Option<meerkat_mob::RuntimeBinding> {
@@ -832,7 +905,7 @@ impl SessionBridge for MobSessionBridge {
 
     async fn resume_session(
         &self,
-        _identity: &AgentIdentity,
+        identity: &AgentIdentity,
         runtime_id: &AgentRuntimeId,
         spec: &DurableAgentSpec,
         draft: &AgentBuildDraft,
@@ -840,19 +913,17 @@ impl SessionBridge for MobSessionBridge {
         _snapshot: &SessionSnapshot,
     ) -> Result<ResumeSessionOutcome, BridgeError> {
         if spec_uses_external_binding(spec) {
-            let mut spawn_spec = build_spawn_spec(
+            let spawn_spec = build_resume_spawn_spec(
                 runtime_id,
                 spec,
                 draft,
                 self.base_profile_for_spec(spec).as_ref(),
+                session_id,
             );
-            spawn_spec.launch_mode = MemberLaunchMode::Resume {
-                bridge_session_id: session_id.clone(),
-            };
             let mid = member_id_for_spawn_spec(runtime_id, spec);
-            self.spawn_member_spec(spawn_spec)
-                .await
-                .map_err(|e| BridgeError::Mob(e.to_string()))?;
+            self.spawn_member_spec(spawn_spec).await.map_err(|error| {
+                resume_rejected(identity, session_id, &error, "external-binding resume")
+            })?;
             self.remember_runtime_member(runtime_id, &mid).await;
             self.remember_runtime_session(runtime_id, session_id).await;
             return Ok(ResumeSessionOutcome::Resumed {
@@ -860,21 +931,19 @@ impl SessionBridge for MobSessionBridge {
             });
         }
 
-        // Try MemberLaunchMode::Resume first — this loads the existing session
-        // from the session store (conversation history intact).
-        let mut spawn_spec = build_spawn_spec(
+        // MemberLaunchMode::Resume loads the existing session from the session
+        // store (conversation history intact).
+        let spawn_spec = build_resume_spawn_spec(
             runtime_id,
             spec,
             draft,
             self.base_profile_for_spec(spec).as_ref(),
+            session_id,
         );
-        spawn_spec.launch_mode = MemberLaunchMode::Resume {
-            bridge_session_id: session_id.clone(),
-        };
 
         let mid = member_id_for_spawn_spec(runtime_id, spec);
 
-        match self.spawn_member_spec(spawn_spec).await {
+        match self.spawn_member_spec(spawn_spec.clone()).await {
             Ok(()) => {
                 self.remember_runtime_member(runtime_id, &mid).await;
                 self.remember_runtime_session(runtime_id, session_id).await;
@@ -882,42 +951,53 @@ impl SessionBridge for MobSessionBridge {
                     session_id: session_id.clone(),
                 })
             }
-            Err(e) => {
-                // Resume can fail if the old session's comms identity is still
-                // claimed (e.g., in-process restart where the previous mob actor
-                // hasn't fully terminated). Fall back to a fresh spawn.
+            Err(error) if is_member_already_exists_error(&error) => {
+                // Genuine roster collision: an in-process restart where the
+                // previous member actor hasn't fully terminated, or a Broken
+                // roster entry left by an earlier rejected resume. Retire the
+                // collision and retry the RESUME — never a fresh spawn; the
+                // durable session must stay bound to the identity.
                 tracing::warn!(
-                    identity = %_identity,
+                    identity = %identity,
                     session_id = %session_id,
-                    error = %e,
-                    reason = "runtime_identity_incompatible",
-                    "resume_session incompatible with current runtime binding, falling back to fresh spawn"
+                    error = %error,
+                    "resume_session hit a roster collision; retiring the stale member and retrying resume"
                 );
-                let fresh_spec = build_spawn_spec(
-                    runtime_id,
-                    spec,
-                    draft,
-                    self.base_profile_for_spec(spec).as_ref(),
-                );
-                self.spawn_member_spec_replacing_collision(runtime_id, &mid, fresh_spec)
-                    .await
-                    .map_err(|e2| BridgeError::Mob(e2.to_string()))?;
-
+                match self.handle.retire(mid.clone()).await {
+                    Ok(()) => {}
+                    Err(err)
+                        if is_recoverable_session_owned_retire_cleanup_error(&err.to_string()) => {}
+                    Err(err) => {
+                        return Err(resume_rejected(
+                            identity,
+                            session_id,
+                            &err,
+                            "collision retire before resume retry",
+                        ));
+                    }
+                }
+                self.forget_runtime_member(runtime_id).await;
+                self.spawn_member_spec(spawn_spec).await.map_err(|error| {
+                    resume_rejected(identity, session_id, &error, "resume retry after collision")
+                })?;
                 self.remember_runtime_member(runtime_id, &mid).await;
-                let session_id = self
-                    .resolve_runtime_session_id(
-                        runtime_id,
-                        &mid,
-                        "member spawned (fresh fallback) but has no session ID",
-                    )
-                    .await?;
-                Ok(ResumeSessionOutcome::FreshSpawned {
-                    session_id,
-                    reason: ResumeFallbackReason::RuntimeIdentityIncompatible {
-                        detail: e.to_string(),
-                    },
+                self.remember_runtime_session(runtime_id, session_id).await;
+                Ok(ResumeSessionOutcome::Resumed {
+                    session_id: session_id.clone(),
                 })
             }
+            // Any other resume failure: REFUSE to fall back to a fresh spawn.
+            // The durable session row exists and is the only copy of the
+            // conversation; rebinding the identity to a fresh empty session
+            // would permanently abandon it (the HomeCore restart-loss bug).
+            // Surface a typed rejection so the caller marks the identity
+            // degraded and the next reconcile retries the resume.
+            Err(error) => Err(resume_rejected(
+                identity,
+                session_id,
+                &error,
+                "resume spawn",
+            )),
         }
     }
 
@@ -1311,7 +1391,7 @@ impl SessionBridge for MobSessionBridge {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
+#[allow(clippy::expect_used, clippy::panic)]
 mod tests {
     use std::sync::Arc;
 
@@ -1636,5 +1716,64 @@ mod tests {
             ),
             "ordinary respawn failures must still fail bridge repair"
         );
+    }
+
+    /// The persisted System message is authoritative on resume: even when the
+    /// draft carries an explicit customizer prompt, the resume spawn spec must
+    /// NOT re-send it (meerkat ≤0.7.14 re-assembles the prompt and trips the
+    /// transcript-continuity guard — the HomeCore cold-restart loss class).
+    #[test]
+    fn resume_spawn_spec_inherits_persisted_system_prompt() {
+        let runtime_id = AgentRuntimeId::parse("rt:agent:alpha:0").expect("runtime id");
+        let draft = AgentBuildDraft {
+            model: None,
+            system_prompt: Some("explicit customizer prompt".to_string()),
+            additional_instructions: Vec::new(),
+            labels: std::collections::BTreeMap::new(),
+            app_context: None,
+            external_tools: Vec::new(),
+            local_external_tools: Default::default(),
+        };
+        let session_id = meerkat_core::types::SessionId::new();
+
+        let spawn =
+            build_resume_spawn_spec(&runtime_id, &durable_spec(), &draft, None, &session_id);
+
+        assert_eq!(
+            spawn.system_prompt_override, None,
+            "resume must inherit the persisted System message, never re-send the base prompt"
+        );
+        match &spawn.launch_mode {
+            MemberLaunchMode::Resume { bridge_session_id } => {
+                assert_eq!(bridge_session_id, &session_id);
+            }
+            other => panic!("expected Resume launch mode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resume_error_classification_is_typed_first() {
+        let restore_failed = meerkat_mob::MobError::MemberRestoreFailed {
+            member_id: meerkat_mob::ids::AgentIdentity::from("agent-alpha"),
+            session_id: None,
+            reason: "durable snapshot missing".to_string(),
+        };
+        assert_eq!(
+            classify_resume_error(&restore_failed),
+            ResumeRejectionKind::MemberRestoreFailed
+        );
+
+        let continuity = meerkat_mob::MobError::Internal(
+            "session save rejected: incoming transcript is not a continuation of persisted \
+             revision sha256:d57e07"
+                .to_string(),
+        );
+        assert_eq!(
+            classify_resume_error(&continuity),
+            ResumeRejectionKind::TranscriptContinuity
+        );
+
+        let other = meerkat_mob::MobError::WiringError("unrelated".to_string());
+        assert_eq!(classify_resume_error(&other), ResumeRejectionKind::Other);
     }
 }

--- a/meerkat-mobkit/src/identity_first/mod.rs
+++ b/meerkat-mobkit/src/identity_first/mod.rs
@@ -23,8 +23,8 @@ pub use agent_memory::{
     MEMORY_TOOL_NAME, MarkdownAgentMemoryStore, NewAgentMemory,
 };
 pub use bridge::{
-    BridgeError, MemberInspection, MobSessionBridge, ResumeFallbackReason, ResumeSessionOutcome,
-    SessionBridge,
+    BridgeError, MemberInspection, MobSessionBridge, ResumeFallbackReason, ResumeRejectionKind,
+    ResumeSessionOutcome, SessionBridge,
 };
 pub use contracts::*;
 pub use gateway_bridges::{

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -701,6 +701,12 @@ pub async fn restore_flow(
                     }
                 };
                 let mut abandoned_session_registration = None;
+                // The bridge's authoritative resume verdict, when a bridge ran:
+                // `Some(true)` = the persisted session was resumed, `Some(false)`
+                // = the bridge fresh-spawned (typed fallback). Reporting keys on
+                // THIS, not on snapshot presence — reconcile must never report
+                // `resumed` for a fresh-spawned member (the HomeCore lie).
+                let mut bridge_resumed: Option<bool> = None;
 
                 // Bridge: resume or create the real mob member when available.
                 // Skip if the identity is already active (mob member exists).
@@ -755,100 +761,76 @@ pub async fn restore_flow(
                         }
                     }
                     let registered_session_id = record.session_id.clone();
-                    let resumed_session_id = match &snapshot {
-                        Some(snap) => match bridge
-                            .resume_session(
-                                identity,
-                                &record.agent_runtime_id,
-                                spec,
-                                &draft,
-                                &record.session_id,
-                                snap,
-                            )
-                            .await
-                        {
-                            Ok(outcome) => outcome.session_id().clone(),
-                            Err(err) => {
-                                let unregister_error = bridge
-                                    .unregister_session_runtime_state(&registered_session_id)
-                                    .await
-                                    .err();
-                                let cleanup_error =
-                                    bridge.retire_member(&record.agent_runtime_id).await.err();
-                                let lease_cleanup_error = release_unactivated_restore_grants(
-                                    runtime,
-                                    &grants,
-                                    &activated_identities,
-                                )
-                                .await;
-                                return Err(IdentityRuntimeError::Internal(append_cleanup_error(
-                                    format!(
-                                        "bridge resume_session: {err}{}{}",
-                                        unregister_error
-                                            .as_ref()
-                                            .map(|e| format!("; unregister session failed: {e}"))
-                                            .unwrap_or_default(),
-                                        cleanup_error
-                                            .as_ref()
-                                            .map(|e| format!("; cleanup retire failed: {e}"))
-                                            .unwrap_or_default(),
-                                    ),
-                                    lease_cleanup_error,
-                                )));
-                            }
-                        },
-                        None => {
-                            // No snapshot but record exists — resume from session
-                            // store using the session_id from the continuity record.
-                            // The session data lives in the mob's session store,
-                            // not the continuity store's snapshot.
-                            match bridge
-                                .resume_session(
-                                    identity,
-                                    &record.agent_runtime_id,
-                                    spec,
-                                    &draft,
-                                    &record.session_id,
-                                    &SessionSnapshot { data: Vec::new() },
-                                )
+                    // When no checkpoint snapshot exists the session data still
+                    // lives in the mob's session store; resume passes an empty
+                    // snapshot and the bridge loads the persisted session by id.
+                    let resume_snapshot = snapshot
+                        .clone()
+                        .unwrap_or(SessionSnapshot { data: Vec::new() });
+                    let resumed_session_id = match bridge
+                        .resume_session(
+                            identity,
+                            &record.agent_runtime_id,
+                            spec,
+                            &draft,
+                            &record.session_id,
+                            &resume_snapshot,
+                        )
+                        .await
+                    {
+                        Ok(outcome) => {
+                            bridge_resumed = Some(outcome.fallback_reason().is_none());
+                            outcome.session_id().clone()
+                        }
+                        Err(err) => {
+                            // A rejected resume must not fail the whole restore
+                            // flow, and must NEVER abandon the durable session —
+                            // the transcript is the only copy. Keep the
+                            // identity → session binding intact, surface the
+                            // identity as Broken with the error attached, and
+                            // let the next reconcile retry the resume. Cleanup
+                            // is bookkeeping only: unregister the session
+                            // runtime state registered above (retried next
+                            // reconcile); do NOT retire the member (meerkat
+                            // keeps Broken-in-roster restore diagnostics) and
+                            // do NOT touch the continuity record.
+                            tracing::error!(
+                                %identity,
+                                session_id = %registered_session_id,
+                                error = %err,
+                                "restore resume rejected; marking identity Broken and preserving \
+                                 the durable session for reconcile retry"
+                            );
+                            if let Err(unregister_err) = bridge
+                                .unregister_session_runtime_state(&registered_session_id)
                                 .await
                             {
-                                Ok(outcome) => outcome.session_id().clone(),
-                                Err(err) => {
-                                    let unregister_error = bridge
-                                        .unregister_session_runtime_state(&registered_session_id)
-                                        .await
-                                        .err();
-                                    let cleanup_error =
-                                        bridge.retire_member(&record.agent_runtime_id).await.err();
-                                    let lease_cleanup_error = release_unactivated_restore_grants(
-                                        runtime,
-                                        &grants,
-                                        &activated_identities,
-                                    )
-                                    .await;
-                                    return Err(IdentityRuntimeError::Internal(
-                                        append_cleanup_error(
-                                            format!(
-                                                "bridge resume_session (no snapshot): {err}{}{}",
-                                                unregister_error
-                                                    .as_ref()
-                                                    .map(|e| format!(
-                                                        "; unregister session failed: {e}"
-                                                    ))
-                                                    .unwrap_or_default(),
-                                                cleanup_error
-                                                    .as_ref()
-                                                    .map(|e| format!(
-                                                        "; cleanup retire failed: {e}"
-                                                    ))
-                                                    .unwrap_or_default(),
-                                            ),
-                                            lease_cleanup_error,
-                                        ),
-                                    ));
-                                }
+                                tracing::warn!(
+                                    %identity,
+                                    error = %unregister_err,
+                                    "failed to unregister session runtime state after rejected resume"
+                                );
                             }
+                            runtime
+                                .register(
+                                    spec.clone(),
+                                    IdentityLifecycleState::Broken,
+                                    Some(record.clone()),
+                                    None,
+                                )
+                                .await;
+                            outcomes.insert(
+                                identity.clone(),
+                                RestoreOutcome::Broken(ContinuityFailure {
+                                    identity: identity.clone(),
+                                    kind: ContinuityFailureKind::ResumeRejected,
+                                    record: Some(record.clone()),
+                                    detail: err.to_string(),
+                                }),
+                            );
+                            // Not added to activated_identities: the final
+                            // cleanup releases this identity's lease grant.
+                            continue;
                         }
                     };
                     record.session_id = resumed_session_id;
@@ -1066,28 +1048,34 @@ pub async fn restore_flow(
                     .await;
                 activated_identities.insert(identity.clone());
 
-                match snapshot {
-                    Some(snap) => {
-                        outcomes.insert(
-                            identity.clone(),
-                            RestoreOutcome::Resumed {
-                                record: record.clone(),
-                                snapshot: snap,
-                                draft,
-                            },
-                        );
-                    }
-                    None => {
-                        // Record exists but no snapshot — treat as fresh create
-                        // with existing record (first checkpoint hasn't happened yet)
-                        outcomes.insert(
-                            identity.clone(),
-                            RestoreOutcome::Created {
-                                record: record.clone(),
-                                draft,
-                            },
-                        );
-                    }
+                // Outcome honesty: when a bridge ran, ITS verdict decides. A
+                // typed fresh-spawn fallback reports `Created` — never
+                // `Resumed` — regardless of snapshot presence; a successful
+                // bridge resume reports `Resumed` even without a checkpoint
+                // snapshot (the persisted mob session carried the history).
+                // Without a bridge (metadata-only restore) the checkpoint
+                // snapshot remains the only signal, as before.
+                let resumed = match bridge_resumed {
+                    Some(resumed) => resumed,
+                    None => snapshot.is_some(),
+                };
+                if resumed {
+                    outcomes.insert(
+                        identity.clone(),
+                        RestoreOutcome::Resumed {
+                            record: record.clone(),
+                            snapshot: snapshot.unwrap_or(SessionSnapshot { data: Vec::new() }),
+                            draft,
+                        },
+                    );
+                } else {
+                    outcomes.insert(
+                        identity.clone(),
+                        RestoreOutcome::Created {
+                            record: record.clone(),
+                            draft,
+                        },
+                    );
                 }
             }
 

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -1337,24 +1337,49 @@ impl IdentityRuntime {
                 let outcome = match outcome {
                     Ok(outcome) => outcome,
                     Err(err) => {
+                        // A rejected resume must NEVER abandon the durable
+                        // session (the transcript is the only copy). Keep the
+                        // identity → session binding intact — no retire, no
+                        // continuity rebind — mark the identity Broken with
+                        // the error attached so this send fails loudly, and
+                        // let the next reconcile retry the resume. Unregister
+                        // only the session-runtime-state bookkeeping (it is
+                        // re-registered on retry).
+                        tracing::error!(
+                            %identity,
+                            session_id = %registered_session_id,
+                            error = %err,
+                            "materialize resume rejected; marking identity Broken and preserving \
+                             the durable session for reconcile retry"
+                        );
                         let unregister_error = Self::unregister_bridge_session_runtime_states(
                             bridge.as_ref(),
                             std::slice::from_ref(&registered_session_id),
                         )
                         .await;
-                        let cleanup_error =
-                            bridge.retire_member(&record.agent_runtime_id).await.err();
                         let lease_cleanup_error =
                             self.release_uninstalled_materialize_lease(&grant).await;
+                        {
+                            let mut entries = self.entries.write().await;
+                            if let Some(entry) = entries.get_mut(identity) {
+                                entry.state = IdentityLifecycleState::Broken;
+                                entry.lease = None;
+                            }
+                        }
+                        self.emit_event(
+                            identity,
+                            IdentityEvent::StateChanged {
+                                identity: identity.clone(),
+                                new_state: IdentityLifecycleState::Broken,
+                            },
+                        )
+                        .await;
                         let detail = format!(
-                            "bridge resume_session: {err}{}{}{}",
+                            "bridge resume_session rejected (identity degraded, durable session \
+                             preserved for reconcile retry): {err}{}{}",
                             unregister_error
                                 .as_ref()
                                 .map(|e| format!("; unregister session failed: {e}"))
-                                .unwrap_or_default(),
-                            cleanup_error
-                                .as_ref()
-                                .map(|e| format!("; cleanup retire failed: {e}"))
                                 .unwrap_or_default(),
                             lease_cleanup_error
                                 .as_ref()

--- a/meerkat-mobkit/src/identity_first/types.rs
+++ b/meerkat-mobkit/src/identity_first/types.rs
@@ -288,6 +288,10 @@ pub enum ContinuityFailureKind {
     SnapshotCorrupted,
     GenerationMismatch,
     StoreUnavailable,
+    /// The bridge refused a resume while the durable session row exists (e.g.
+    /// a transcript-continuity rejection). The identity → session binding is
+    /// intact; the identity is degraded until a reconcile retry succeeds.
+    ResumeRejected,
 }
 
 /// A typed failure payload for broken continuity.

--- a/meerkat-mobkit/tests/identity_first_cold_restart_continuity.rs
+++ b/meerkat-mobkit/tests/identity_first_cold_restart_continuity.rs
@@ -196,18 +196,14 @@ async fn boot(
     (unified, identity_rt)
 }
 
-// SCAFFOLD (not yet in CI): a faithful cold-restart harness needs the gateway's
-// exact continuity+session wiring. Here the boot-1 continuity record only
-// persists to the DB when a lease grant is present (orchestrator.rs upsert is
-// grant-gated), and a hand-assembled LocalContinuityStore + UnifiedRuntime does
-// not reload the persisted session the way rpc_gateway does — so boot 2 resolves
-// Uninitialized and re-Creates. The behavior this guards (Ask B: resume tolerates
-// bookkeeping-only re-projection divergence) is verified upstream in
-// meerkat-core 0.7.14 (`append_only_guard_accepts_rebookkept_prefix_identity_and_timestamps`)
-// and, for the mobkit recovery boundary, by identity_first_respawn_continuity.
-// Left as a runnable scaffold to finish against the gateway harness (or the
-// live deployment) rather than assert on a misconfigured setup.
-#[ignore = "needs gateway-faithful cold-restart harness; Ask B verified upstream + by respawn-continuity"]
+// History: this test was first landed `#[ignore]`d as "harness can't reach
+// resume" — boot 2 appeared to re-Create. That diagnosis was wrong: the bridge
+// resumed fine, but the orchestrator reported the outcome by checkpoint-
+// snapshot presence and labeled a genuine resume `Created` — the exact
+// outcome-reporting lie from the HomeCore report. With outcomes keyed on the
+// bridge verdict (and resume inheriting the persisted System message), the
+// full cold-restart path passes deterministically and this is now a live
+// regression guard for both bugs.
 #[tokio::test(flavor = "multi_thread")]
 async fn identity_first_cold_restart_preserves_transcript() {
     let temp = tempfile::TempDir::new().expect("temp dir");
@@ -221,6 +217,7 @@ async fn identity_first_cold_restart_preserves_transcript() {
     const TOKEN: &str = "MARKER-BRAVO-9-YANKEE";
 
     // --- Boot 1: create the member, deliver turn 1 with the token, shut down ---
+    let original_session_id;
     {
         let capture = CaptureClient::default();
         let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
@@ -234,7 +231,9 @@ async fn identity_first_cold_restart_preserves_transcript() {
         .await
         .expect("restore_flow (boot 1)");
         match result.outcomes.get(&alice).expect("alice outcome") {
-            RestoreOutcome::Created { .. } => {}
+            RestoreOutcome::Created { record, .. } => {
+                original_session_id = record.session_id.clone();
+            }
             other => panic!("expected Created on first boot, got {other:?}"),
         }
 
@@ -273,14 +272,17 @@ async fn identity_first_cold_restart_preserves_transcript() {
         )
         .await
         .expect("restore_flow (boot 2)");
-        // A cold restart with persisted history must recover the session, never
-        // re-Create it (a re-Create is the empty fresh-spawn regression).
+        // A cold restart with persisted history must RESUME onto the same
+        // durable session — never re-Create (the empty fresh-spawn
+        // regression) and never report a resume as anything else.
         match result.outcomes.get(&alice).expect("alice outcome") {
-            RestoreOutcome::Resumed { .. } | RestoreOutcome::Dormant { .. } => {}
-            other @ RestoreOutcome::Created { .. } => {
-                panic!("cold restart re-Created the member (history dropped): {other:?}")
+            RestoreOutcome::Resumed { record, .. } => {
+                assert_eq!(
+                    record.session_id, original_session_id,
+                    "cold restart must resume the SAME durable session"
+                );
             }
-            other => panic!("unexpected restore outcome across cold restart: {other:?}"),
+            other => panic!("cold restart must report Resumed, got: {other:?}"),
         }
 
         identity_rt
@@ -308,6 +310,61 @@ async fn identity_first_cold_restart_preserves_transcript() {
             last_request.contains(TOKEN),
             "post-restart LLM request must replay the persisted transcript (token {TOKEN}); \
              cold-restart resume dropped the conversation history"
+        );
+
+        // Let turn 2 commit before the second restart.
+        sleep(Duration::from_millis(500)).await;
+        unified.shutdown().await;
+    }
+
+    // --- Boot 3 (second-restart variant): the resumed-then-extended session
+    // must survive ANOTHER restart. The HomeCore report hit the loss on every
+    // restart; the second one exercises resume over a transcript that itself
+    // grew after a resume. ---
+    {
+        let capture = CaptureClient::default(); // fresh: only boot-3 requests
+        let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
+
+        let result = restore_flow(
+            &identity_rt,
+            &roster,
+            Some(&EmptyTopology as &dyn TopologyProvider),
+            Some(&NoopCustomizer as &dyn AgentCustomizer),
+        )
+        .await
+        .expect("restore_flow (boot 3)");
+        match result.outcomes.get(&alice).expect("alice outcome") {
+            RestoreOutcome::Resumed { record, .. } => {
+                assert_eq!(
+                    record.session_id, original_session_id,
+                    "second restart must still resume the SAME durable session"
+                );
+            }
+            other => panic!("second restart must report Resumed, got: {other:?}"),
+        }
+
+        identity_rt
+            .send(
+                &alice,
+                &meerkat_core::ContentInput::Text("And once more: which token?".to_string()),
+            )
+            .await
+            .expect("send turn 3");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while capture.count() < 1 {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for the second post-restart turn to reach the LLM"
+            );
+            sleep(Duration::from_millis(100)).await;
+        }
+        let last_request = capture
+            .last()
+            .expect("a second post-restart request was captured");
+        assert!(
+            last_request.contains(TOKEN),
+            "the transcript must survive a SECOND restart (token {TOKEN} missing)"
         );
 
         unified.shutdown().await;

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -846,6 +846,7 @@ struct CountingBridge {
     fail_current_wires: AtomicBool,
     fail_retire: AtomicBool,
     force_resume_fallback: AtomicBool,
+    reject_resume_times: AtomicUsize,
     resume_delay: tokio::sync::Mutex<Option<Duration>>,
     resume_barrier: tokio::sync::Mutex<Option<Arc<tokio::sync::Barrier>>>,
     create_session_id: tokio::sync::Mutex<Option<meerkat_core::types::SessionId>>,
@@ -871,6 +872,13 @@ impl CountingBridge {
     async fn set_force_resume_fallback(&self, session_id: meerkat_core::types::SessionId) {
         self.force_resume_fallback.store(true, Ordering::SeqCst);
         *self.fallback_session_id.lock().await = Some(session_id);
+    }
+
+    /// Reject the next `times` resume attempts with the typed
+    /// `BridgeError::ResumeRejected` (the transcript-continuity class), then
+    /// succeed — models a resume that heals on a later reconcile retry.
+    fn reject_resume_times(&self, times: usize) {
+        self.reject_resume_times.store(times, Ordering::SeqCst);
     }
 
     async fn set_create_session_id(&self, session_id: meerkat_core::types::SessionId) {
@@ -949,6 +957,19 @@ impl SessionBridge for CountingBridge {
         let barrier = self.resume_barrier.lock().await.clone();
         if let Some(barrier) = barrier {
             barrier.wait().await;
+        }
+        if self
+            .reject_resume_times
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(BridgeError::ResumeRejected {
+                kind: meerkat_mobkit::identity_first::ResumeRejectionKind::TranscriptContinuity,
+                detail: "scripted: incoming transcript is not a continuation of persisted revision"
+                    .to_string(),
+            });
         }
         if self.force_resume_fallback.load(Ordering::SeqCst) {
             let fallback_session_id = self
@@ -4731,6 +4752,150 @@ async fn identity_first_runtime_restore_flow_resumes_ready() {
             assert_eq!(snapshot.data, b"snapshot data");
         }
         other => panic!("expected Resumed, got: {other:?}"),
+    }
+}
+
+/// Regression for the HomeCore restart transcript loss: a rejected resume must
+/// keep the identity → session binding intact (the durable transcript is the
+/// only copy), degrade the identity to Broken with the error attached, and let
+/// the next reconcile retry the resume — never fresh-spawn, never retire, and
+/// never fail the whole restore flow.
+#[tokio::test]
+async fn identity_first_runtime_restore_flow_rejected_resume_marks_broken_then_retries() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    bridge.reject_resume_times(1);
+    let runtime = make_runtime_with_bridge(store.clone(), lease_prov, bridge.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 0);
+    let original_session_id = record.session_id.clone();
+    store
+        .upsert_continuity_record(&record, FencingToken::new(0))
+        .await
+        .unwrap();
+    store
+        .save_session_snapshot(
+            &id,
+            &record.session_id,
+            record.generation,
+            CheckpointVersion::new(1),
+            FencingToken::new(0),
+            &SessionSnapshot {
+                data: b"snapshot data".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let roster = vec![make_spec("triage:main")];
+
+    // Flow 1: resume rejected. The flow itself succeeds; the identity comes
+    // back Broken with the typed failure attached.
+    let result = restore_flow(&runtime, &roster, None, None).await.unwrap();
+    match result.outcomes.get(&id).unwrap() {
+        RestoreOutcome::Broken(failure) => {
+            assert_eq!(
+                failure.kind,
+                meerkat_mobkit::identity_first::ContinuityFailureKind::ResumeRejected
+            );
+            assert!(
+                failure.detail.contains("not a continuation"),
+                "the real error must be attached, got: {}",
+                failure.detail
+            );
+            assert_eq!(
+                failure.record.as_ref().map(|r| r.session_id.clone()),
+                Some(original_session_id.clone()),
+                "the failure must still reference the durable session"
+            );
+        }
+        other => panic!("expected Broken, got: {other:?}"),
+    }
+    let status = runtime.status(&id).await.unwrap();
+    assert_eq!(status.state, IdentityLifecycleState::Broken);
+
+    // Destruction must not have happened: no fresh spawn, no retire, and the
+    // continuity binding still points at the original durable session.
+    assert_eq!(
+        bridge.create_calls.load(Ordering::SeqCst),
+        0,
+        "a rejected resume must never fresh-spawn"
+    );
+    assert_eq!(
+        bridge.retire_calls.load(Ordering::SeqCst),
+        0,
+        "a rejected resume must not retire the member"
+    );
+    let resolved = store.resolve_many(std::slice::from_ref(&id)).await.unwrap();
+    let ContinuityResolveState::Ready { record: bound } = resolved.get(&id).unwrap() else {
+        panic!("continuity record must survive a rejected resume");
+    };
+    assert_eq!(
+        bound.session_id, original_session_id,
+        "identity → session binding must stay intact"
+    );
+
+    // Flow 2 (the reconcile retry): resume now succeeds onto the SAME durable
+    // session — history intact, reported honestly as resumed.
+    let result = restore_flow(&runtime, &roster, None, None).await.unwrap();
+    match result.outcomes.get(&id).unwrap() {
+        RestoreOutcome::Resumed { record, .. } => {
+            assert_eq!(record.session_id, original_session_id);
+        }
+        other => panic!("expected Resumed on retry, got: {other:?}"),
+    }
+    let status = runtime.status(&id).await.unwrap();
+    assert_eq!(status.state, IdentityLifecycleState::Active);
+    assert_eq!(bridge.resume_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 0);
+}
+
+/// Regression for the reconcile-outcome lie: a bridge resume that fell back to
+/// a fresh spawn (typed `FreshSpawned`) must be reported as `created`, never
+/// `resumed` — reporting keyed on snapshot presence hid the HomeCore loss.
+#[tokio::test]
+async fn identity_first_runtime_restore_flow_reports_fresh_spawned_resume_as_created() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let fallback_session_id = meerkat_core::types::SessionId::new();
+    bridge
+        .set_force_resume_fallback(fallback_session_id.clone())
+        .await;
+    let runtime = make_runtime_with_bridge(store.clone(), lease_prov, bridge.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 0);
+    store
+        .upsert_continuity_record(&record, FencingToken::new(0))
+        .await
+        .unwrap();
+    store
+        .save_session_snapshot(
+            &id,
+            &record.session_id,
+            record.generation,
+            CheckpointVersion::new(1),
+            FencingToken::new(0),
+            &SessionSnapshot {
+                data: b"snapshot data".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let roster = vec![make_spec("triage:main")];
+    let result = restore_flow(&runtime, &roster, None, None).await.unwrap();
+    match result.outcomes.get(&id).unwrap() {
+        RestoreOutcome::Created { record, .. } => {
+            assert_eq!(
+                record.session_id, fallback_session_id,
+                "the fresh-spawned session id must be reported"
+            );
+        }
+        other => panic!("a fresh-spawned resume must report Created, got: {other:?}"),
     }
 }
 

--- a/meerkat-mobkit/tests/identity_first_types.rs
+++ b/meerkat-mobkit/tests/identity_first_types.rs
@@ -246,6 +246,7 @@ fn identity_first_types_failure_kind_all_variants() {
         ContinuityFailureKind::SnapshotCorrupted,
         ContinuityFailureKind::GenerationMismatch,
         ContinuityFailureKind::StoreUnavailable,
+        ContinuityFailureKind::ResumeRejected,
     ];
     for kind in &kinds {
         let json = serde_json::to_string(kind).expect("serialize");


### PR DESCRIPTION
The mobkit-side follow-through on the HomeCore restart transcript loss, per the meerkat root-causer's checklist. Works on unpatched meerkat 0.7.14; the meerkat-side guard fix (`claude/meerkat-transcript-restart-loss-1oahe3`) composes on the next dep bump.

## 1. Destructive fallback removed (ask #2 of the report)
`MobSessionBridge::resume_session` used to catch **any** resume error and fresh-spawn a replacement — rebinding the identity to an empty session and permanently abandoning the durable transcript. Now:
- A roster collision (in-process restart, or a Broken roster entry from an earlier rejected resume) retires the stale member and **retries the resume** — never a fresh spawn.
- Any other failure returns the typed `BridgeError::ResumeRejected` with the durable binding intact. The orchestrator marks the identity **Broken** (`ContinuityFailureKind::ResumeRejected`, real error attached) *without* failing the whole restore flow; the next reconcile retries the resume (Broken ≠ Active, so the Ready arm re-attempts). The lazy materialize path gets the same treatment: no retire, no rebind, send fails loudly.
- No retire on rejection: meerkat keeps its Broken-in-roster restore diagnostics (`MemberRestoreFailed` contract); leftovers self-heal through the collision→retry-resume path.

Since old rows were never deleted, identities that already lost history to the fallback can be re-bound to their pre-loss session ids (from logs) and recovered.

## 2. Honest outcome reporting + typed attribution
- Restore outcomes now key on the **bridge verdict**, not checkpoint-snapshot presence: a fresh-spawned member reports `created` (never `resumed`), and a successful resume without a snapshot reports `resumed` (the persisted mob session carried the history).
- Resume errors are classified from meerkat's typed errors (`MobError::MemberRestoreFailed`; transcript-continuity string probe as belt-and-braces for the stringified provisioning path) instead of one `runtime_identity_incompatible` bucket. The stale "old comms identity still claimed" comment is gone.

## 3. Resume inherits the persisted System message (works today on 0.7.14)
`build_resume_spawn_spec` clears `system_prompt_override` on the resume path. Re-sending the spec's explicit prompt made meerkat re-assemble it, tripping the transcript-continuity guard whenever the persisted prompt carried runtime context appends — precisely why meerkat-mob's own resume never hit the bug. Also the right semantics with the fix: dynamic per-boot context belongs in runtime system-context appends, never the base prompt (and with Inherit, a host that bakes per-boot data into its base prompt can no longer trip the guard through mobkit's resume).

## 4. Cold-restart regression now LIVE in CI (ask #5)
The previously-`#[ignore]`d scaffold passes deterministically — its "harness failure" was in fact the outcome-reporting lie (boot 2's resume succeeded; the old orchestrator labeled it `Created` for lack of a checkpoint snapshot). Hardened: strict `Resumed` + same-session-id pinning across restarts, transcript-token replay after each restart, and the second-restart variant. 3/3 stable locally.

New unit/flow regressions: rejected-resume → Broken + binding intact + no fresh spawn/retire + retry resumes the SAME session; fresh-spawned-reports-created; resume-spec Inherit guard; typed classification.

Full workspace suite green (1516 passed; lone flaky is the pre-existing contract_009 load flake). Clippy `--lib --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)