### PR TITLE
chore: upgrade meerkat family 0.7.14 → 0.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the meerkat family 0.7.14 → 0.7.15. Carries the upstream
+  transcript-restart-loss guard fix: on resume, a byte-identical re-sent base
+  prompt is preserved untouched and a changed prompt becomes an audited
+  transcript rewrite — both survive, composing with this release's
+  Inherit-on-resume default.
+
 ### Fixed
 
 - **A rejected resume no longer destroys the conversation.** The identity-first

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d077a99d53bb7ec352423e86c724bd73c4560682234dceab79b674bbca97ca42"
+checksum = "bc3967daeb3e04a2da1a381e263a4ea3e20029569a4b3284c98e01abbfaa14f6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5490c887350b0f69913fb3a8de1db9dd21530926abff23c2572cd9c8701e4"
+checksum = "1b7fc9e28abc2ed2f9c422ce94dabfdee2bcf86edf1866efa94b4f4665e71071"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec205096ee17f56ba04471c62a464d78f92900debbb6b8fbfa755641e4220374"
+checksum = "b2054af7bb6d308383638056d8e57567c2b31678aebc166daab3551718aefa22"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafa59983105c9ece4bffb30ee30cf2e8defd1afca9e5373f825e8a441218ceb"
+checksum = "f3994113d09267b4ded1eca0e814e9d727a162f8de3b135882a12c0dd3bc2ba2"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2e4e7d0ce58b82af5942bcec3a98b1a4ba9d1124ab61059402cc6bbd2efc1"
+checksum = "a60fb7bc2db43e6b141c0425927218e979c7fdc8a02405bc0c05ea71f2060d05"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d48b72ef6c1cc5aa318152ec7121ae08fa8a24c07db344280471271c83ad1b5"
+checksum = "2fffd469630d178a16a8531e967de1099be19b4d19d97e2e82feac021efdbe11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c1f732d3df531fa6e67a1ee40b801c6b2b17a90902e799002e1e7bf404cfab"
+checksum = "8cca12cebc8d047bf6c5eb84165d0806420196bba84e7d5b548c98e25a0ca948"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8446a6ea68096693e7019034c5919a58e0d162e51d239a0563446d7f01d0ddd"
+checksum = "1994b9e34a8f7dd05170904832b34723d5730530a693af18ab7b440f38d61cd9"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c54f82f4ed0c0d7508af73bb8aa16895f951d527b3ff795a1b843b8ce7729"
+checksum = "2645a2173ffc9b510f3093c3adcfe55dfbaf3c0b419b41593ebb9d287804ba4c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c70363228276febc71dcd2cfa9ddd863d64826c375650cb796abb8111805cbf"
+checksum = "07f6dcd982579238523ddd9504ae2f43925a2b6d1bbb476e4402c76e42af16ea"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c2c9f5aee098c2d8812a46b2c0459db5aff1b936b70214aba5a4b3a37f259"
+checksum = "28c6e6d7dcc3c6b58148d5b2c784498707735066f2e5755392d95eb15eaa1140"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdd160f4e5de97c5a744c192578a20d5cb3bdcfba964034901074f3aa2dc937"
+checksum = "449b62a9cf3d2cc9ab78cedc4bd4b54f0f2f32320383654c758c7302936d9dc9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f634620a2b84db77056b8fb840ebd21df36fe8b56912fe61c0d648721c3cf1"
+checksum = "4782173af2197e1eacef12a24d3d41d8e085265d7074690d8389ba6f89acedf6"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f992ba93ad17c962b08c378a7245efb397bc8d64e74d89a9ad48292adce3f311"
+checksum = "c1f1a881493093ac0a1b473831ae64da5bee639f9d1c6a04b818da28b9157ba9"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7871a7aa64eae45f656d0ea111a8429cb1fe367d62c0207de82d5d96008bc1"
+checksum = "f747271e768fce4c6079b054cbc61748d7559af3a4a3ce566b891181a3ef00f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524105877ce99fdc18abeb1b77a37eae3ed73709ee4f1f05fb22868ea5a182cc"
+checksum = "a1c76c3d7dee6b44d1de5e656f9af70d98070577e04957fcf27250351fb00788"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0571300b851e6b255ea7d25b8a54357c950cff7732d3739c9a019b7f6351816"
+checksum = "0c7d2f7e41351d18de9142b81a325dbef676cf05d7223bbc5f8c50da9fde2f10"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce63a9a2655fab561eae1787da3a9a83cc5a88d94e1fc88c6281bc5a3b2663"
+checksum = "8ace0bde6242e22ab90744ac4ab92545ed9384a417b570150be38680016e3d0f"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a97a08ebf6d2355c7ab1b12d1e88adb512a97b770501a6cc16d40031d4d837"
+checksum = "349b491478e749da44490e196acc85a320ccc1f95bf076f4a525b2590497d946"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afd29adc96f1337f38eaa1b2b83efedfc31c5fe722676656e93a497015c284f"
+checksum = "4daf6dd91ad8acc151b79ee2bf5e2fb857d619b360958bca3716dffb6ab30a32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134631c32a9d45fd4d392b18e359e80572e885ba6739a4ecb4adc7465966c4d0"
+checksum = "dbd39a641571edb496a653a8220262f6e2bfc6d2d0ea31ad41ad8f3a2809a12a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d274415a3433fd67c776ebe4fcf3a985d3257cee1ab20556bc9bf5c5033647af"
+checksum = "eeb5abe235a4ae038e237e0f66ff7e7e28a38834a4472ccba5a111ba443cf8a7"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccec45806102d3444e8673478c9b900f569c7532af59ce2652d627e4fa540a46"
+checksum = "b23ba6bdfaa1655a025b4c6a9226d376fab915205f926de36ff2dc50529d5002"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dc2f7322c1144d3a6b7b57960ab7d6a68e48b6e8d39d0afea4ef4299fdbeb9"
+checksum = "63b5db64aebb02243b3580aad937c6a5389f456c1e0501f96cfe8973df267b1a"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b452b223baa0f1a1c4682ae77e3d8986f08fd5fc675d252da1807cc3e62f9a"
+checksum = "db832a8b95e1bdb4189a6931566489eea1a034aca139bb015807e5c5d969fa40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075747264811315dd166086b0ef0d3fe318ad45f43104cbcca937b7dc743781c"
+checksum = "a8af0f3e4ac897e4d46506d42c379c85ed4e48b265f864239efa007616745ddd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de6e983802388dcf853b6d6cce436310ecc9a68e0e75c3d8dc58e161d2dc30e"
+checksum = "028ac7266ea38495b6850353b3a4908d14c5bacb135d7a4d7915db2bfd5d1999"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2af2a9592e99da93d1be649e2f546b7848ecbca3578a421cc1da4c27fe56a61"
+checksum = "2b570bbca84ec9a12354a57fff75d542be7e99295872118a6e0519ca74487d07"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc26fa65ecacb064c456e6238448ed3a470d318adbd50c895bae3fbcae1a5981"
+checksum = "09d34447609eade90f7b8618de45f513c73678156c687bd1494fa6789e436fa5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75670a92eeefa69ecce3143890c5deaf3d0fc8afecc16b9c2bafcbf04946025e"
+checksum = "b4a34efb98fd7c5fdc457113a1da07a573a209c46d8d6f84cd4fd6676f2eb710"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13387b6ff29ee518f4685a936566993360240f77c12128e90c89b462e74c6c2a"
+checksum = "88afb36d021af8d4d8155fca04aa58e8af6d2374f169ef154aaa236ace0bdf3b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -63,6 +63,11 @@ fn assert_bootstraps(persistent_sessions: bool) {
         // key-independent / CI-safe.
         .env("ANTHROPIC_API_KEY", "sk-ant-regression-test")
         .env("OPENAI_API_KEY", "sk-regression-test")
+        // Isolate the gateway's state dir (peer keys) into this test's temp
+        // workspace: the default ~/.local/state/meerkat-mobkit is shared
+        // across concurrent test processes on CI runners and intermittently
+        // fails the peer-key load/mint (a recurring CI flake).
+        .env("XDG_STATE_HOME", workspace.path().join("xdg-state"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -174,6 +179,9 @@ fn mobkit_gateway_rejects_post_init_stdin_rpc_loudly() {
         .current_dir(workspace.path())
         .env("ANTHROPIC_API_KEY", "sk-ant-regression-test")
         .env("OPENAI_API_KEY", "sk-regression-test")
+        // Isolated state dir (peer keys) — see the sibling spawn above; the
+        // shared ~/.local/state default is a recurring CI peer-key flake.
+        .env("XDG_STATE_HOME", workspace.path().join("xdg-state"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())


### PR DESCRIPTION
Carries the upstream transcript-restart-loss guard fix (resume re-projection compared by content address; byte-identical re-sent prompts preserved, changed prompts become audited transcript rewrites). Composes with the mobkit-side resume hardening from #218. No API breaks; full workspace suite green (1516 passed; lone flaky is the pre-existing contract_009 load flake).

Together with #218 this completes the carried-store restart-loss story for the 0.7.22 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)