### PR TITLE
ci(release): bound cargo parallelism on binary legs (OOM fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,13 @@ jobs:
         shell: bash
         env:
           CARGO_TARGET_DIR: target
+          # Bound rustc parallelism: the meerkat mega-crates (meerkat-mob,
+          # meerkat-runtime, meerkat-mobkit lib) each drive LLVM into multiple
+          # GB; at default -j on 16 GB hosted runners the Windows leg dies
+          # with "rustc-LLVM ERROR: out of memory" and the Linux legs get
+          # OOM-killed (surfacing as "runner received a shutdown signal",
+          # exit 143) — v0.7.22's first matrix run lost 3/5 legs to this.
+          CARGO_BUILD_JOBS: "2"
         run: |
           set -euo pipefail
           # Build BOTH gateways for this target with plain cargo. (The repo-cargo


### PR DESCRIPTION
v0.7.22's first binary-matrix run lost 3/5 legs to memory: Windows hit `rustc-LLVM ERROR: out of memory`; both Linux legs were OOM-killed (surfacing as runner 'shutdown signal', exit 143). `CARGO_BUILD_JOBS=2` bounds peak rustc/LLVM memory on the 16 GB hosted runners. After merge: re-dispatch `release.yml -f release_tag=v0.7.22` to attach the full asset set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)