### PR TITLE
memory: operator-scope recall via console principal + single-embodiment guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Operator-scope memory recall is live in stock deployments (provisional
+  OperatorId keying: the console auth principal). With
+  `agent_memory.operator_scope = "provisional"`, the gateway now installs a
+  console-principal resolver: when an authenticated principal sends to an
+  identity from the console, that principal becomes the identity's active
+  operator and operator-scope records compose into recall — the durable
+  replacement for live-behavior-correction broadcast hacks. Unauthenticated
+  consoles keep the scope inert (activation requires config AND resolver AND
+  a real principal). Keying stays swappable behind the OperatorResolver seam.
 - Durable dream verdict sheets: every steward dream run persists to a new
   `dream_runs` table (partition label, timings, ops, and the full
   phases/verdicts/skips detail), and dead-weight usage-audit verdicts land in
@@ -16,9 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   "memories you might want to correct" list, resolvable per record. Two new
   read-only console RPCs serve them: `mobkit/memory/panel/dream_runs` and
   `mobkit/memory/panel/audit_verdicts` (same read grant as `panel/dreams`).
-
-### Added
-
 - Per-mob steward dreams (§8.5): with `agent_memory.steward.per_mob = true` on
   a multi-mob host, each dream attempt runs one partition per mob — that mob's
   scope plus its members' identity scopes, consolidated against that mob's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The single-embodiment guard fails loudly: restoring or materializing an
+  identity whose durable lease another live runtime instance holds now
+  returns the typed `AlreadyEmbodied { identity, holder }` error naming the
+  holding instance, instead of collapsing into a generic missing-lease
+  error. This is a policy point, not a structural assumption — future
+  multi-bind/forked-session semantics relax exactly this arm.
 - Delivery repair no longer rotates a wedged member onto a fresh, empty
   session. The identity bridge's deliver-time repair used to blind-respawn
   (`MobHandle::respawn` = retire + fresh spawn), abandoning the durable

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -4498,9 +4498,26 @@ external_addressable = true
         // installed, `operator_scope = "provisional"` composes nothing
         // (inert by design) while steward routing (proposal-keyed) is
         // already active.
+        // §16 Q1 provisional keying (decided 2026-07-04): OperatorId = the
+        // console auth principal. When the scope is provisional, install the
+        // console-principal resolver and share it with the runtime so the
+        // console send path can note authenticated interactions; recall
+        // composition activates for identities an authenticated principal
+        // has addressed (config AND resolver AND a real principal).
         let agent_memory_operator_resolver: Option<
             Arc<dyn meerkat_mobkit::memory::coordinator::OperatorResolver>,
-        > = None;
+        > = if gateway_options.agent_memory.as_ref().is_some_and(|memory| {
+            memory.config.operator_scope == meerkat_mobkit::AgentMemoryOperatorScope::Provisional
+        }) {
+            let resolver = Arc::new(meerkat_mobkit::ConsolePrincipalOperatorResolver::new());
+            runtime.set_console_operator_resolver(resolver.clone());
+            tracing::info!(
+                "agent memory operator scope active (provisional keying: console auth principal)"
+            );
+            Some(resolver)
+        } else {
+            None
+        };
         // Degrade LOUD, not silent: recall composition of the Operator scope
         // needs BOTH the knob and a resolver (coordinator.rs scope_set), so a
         // resolver-less provisional deployment gets steward proposal-routing
@@ -4513,9 +4530,7 @@ external_addressable = true
                 "agent_memory.operator_scope=\"provisional\" is configured but this gateway \
                  installs no operator resolver: operator-scope recall composition is INERT \
                  (records routed to the operator scope will not be recalled or injected); \
-                 steward routing of operator-scope proposals remains active; the provisional \
-                 console-auth-principal keying requires session-to-principal plumbing that \
-                 has not landed"
+                 steward routing of operator-scope proposals remains active"
             );
         }
         // §7.2 mob-scope binding: every identity this gateway hosts runs

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -99,6 +99,12 @@ pub struct ConsoleJsonState {
     /// read-only `mobkit/memory/panel/*` RPCs (§9.3). `None` (markdown
     /// store, no memory configured) leaves those methods unadvertised.
     pub(crate) memory_panel: Option<crate::memory::sqlite_store::SqliteAgentMemoryStore>,
+    /// §16 Q1 provisional operator keying: the console send path notes
+    /// "authenticated principal P addressed identity I" through this
+    /// resolver; the memory coordinator reads it for operator-scope recall.
+    /// `None` when the operator scope is off (or memory is unconfigured).
+    pub(crate) operator_resolver:
+        Option<Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>>,
 }
 
 #[derive(Debug, Clone)]
@@ -242,6 +248,7 @@ pub fn console_json_router(decisions: RuntimeDecisionState) -> Router {
         snapshot_read_model: ConsoleSnapshotReadModel::default(),
         access: None,
         memory_panel: None,
+        operator_resolver: None,
     })
 }
 
@@ -273,6 +280,7 @@ pub fn console_json_router_with_aggregator_and_access(
         snapshot_read_model: ConsoleSnapshotReadModel::default(),
         access,
         memory_panel: None,
+        operator_resolver: None,
     })
 }
 
@@ -326,6 +334,7 @@ pub(crate) fn console_json_router_with_runtime_and_events(
         Arc::new(HideImplicitDelegateMembersConsoleVisibilityPolicy),
         None,
         None,
+        None,
     )
 }
 
@@ -345,6 +354,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
     visibility_policy: Arc<dyn ConsoleVisibilityPolicy>,
     access: Option<AccessController>,
     memory_panel: Option<crate::memory::sqlite_store::SqliteAgentMemoryStore>,
+    operator_resolver: Option<Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>>,
 ) -> Router {
     let console_aggregator = console_events.clone().map(|events| {
         if let Some(store) = console_log_store {
@@ -389,6 +399,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
         snapshot_read_model,
         access,
         memory_panel,
+        operator_resolver,
     })
 }
 
@@ -745,6 +756,18 @@ async fn console_send_handler(
             "access_denied",
             "you are not allowed to send to this agent",
         );
+    }
+    // §16 Q1 provisional operator keying: an authenticated principal
+    // addressing this identity IS the active operator for its turns.
+    // Unauthenticated consoles (no subject) note nothing — operator-scope
+    // recall stays inert without a real principal.
+    if let Some(resolver) = state.operator_resolver.as_ref()
+        && let Some(subject) = auth_context
+            .access_view
+            .as_ref()
+            .and_then(|view| view.subject())
+    {
+        resolver.note_interaction(request.identity.as_str(), subject);
     }
     let Some(aggregator) = &state.console_aggregator else {
         return console_json_error(

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -229,7 +229,30 @@ pub async fn restore_flow(
             Some(LeaseAcquireResult::Acquired(grant)) => {
                 grants.insert(identity.clone(), grant.clone());
             }
-            Some(LeaseAcquireResult::AlreadyHeld { .. }) | None => {
+            Some(LeaseAcquireResult::AlreadyHeld { holder, .. }) => {
+                // Fail-closed single-embodiment guard: name the holder loudly
+                // instead of collapsing into a generic missing-lease error.
+                tracing::error!(
+                    %identity,
+                    holder = %holder,
+                    "single-embodiment guard: restore refused — identity is already \
+                     embodied by another live runtime instance"
+                );
+                let holder = holder.clone();
+                let acquired = grants.values().cloned().collect::<Vec<_>>();
+                if !acquired.is_empty() {
+                    runtime
+                        .lease_provider()
+                        .release_leases(&acquired)
+                        .await
+                        .map_err(IdentityRuntimeError::Lease)?;
+                }
+                return Err(IdentityRuntimeError::AlreadyEmbodied {
+                    identity: identity.clone(),
+                    holder,
+                });
+            }
+            None => {
                 let acquired = grants.values().cloned().collect::<Vec<_>>();
                 if !acquired.is_empty() {
                     runtime

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -57,6 +57,15 @@ pub enum IdentityRuntimeError {
     NotAddressable(NotAddressable),
     /// Operation rejected: no active lease for this identity.
     NoActiveLease(AgentIdentity),
+    /// Fail-closed single-embodiment guard: the identity's durable lease is
+    /// held by another live runtime instance — a second live embodiment is
+    /// refused, loudly and with the holder named. This is a POLICY point,
+    /// not a structural assumption: multi-bind / forked-session semantics
+    /// (future work) relax exactly this arm.
+    AlreadyEmbodied {
+        identity: AgentIdentity,
+        holder: String,
+    },
     /// Operation rejected: lease was lost.
     LeaseLost(AgentIdentity),
     /// Operation rejected: identity is not in a state that permits this operation.
@@ -93,6 +102,11 @@ impl std::fmt::Display for IdentityRuntimeError {
             Self::UnknownIdentity(id) => write!(f, "unknown identity: {id}"),
             Self::NotAddressable(err) => write!(f, "{err}"),
             Self::NoActiveLease(id) => write!(f, "no active lease for {id}"),
+            Self::AlreadyEmbodied { identity, holder } => write!(
+                f,
+                "identity {identity} is already embodied by runtime instance '{holder}' \
+                 (single-embodiment guard: refusing a second live bind)"
+            ),
             Self::LeaseLost(id) => write!(f, "lease lost for {id}"),
             Self::InvalidState {
                 identity,
@@ -1223,7 +1237,19 @@ impl IdentityRuntime {
             .map_err(IdentityRuntimeError::Lease)?;
         let grant = match lease_results.get(identity) {
             Some(super::types::LeaseAcquireResult::Acquired(grant)) => grant.clone(),
-            _ => return Err(IdentityRuntimeError::NoActiveLease(identity.clone())),
+            Some(super::types::LeaseAcquireResult::AlreadyHeld { holder, .. }) => {
+                tracing::error!(
+                    %identity,
+                    holder = %holder,
+                    "single-embodiment guard: refusing to materialize an identity whose \
+                     durable lease is held by another live runtime instance"
+                );
+                return Err(IdentityRuntimeError::AlreadyEmbodied {
+                    identity: identity.clone(),
+                    holder: holder.clone(),
+                });
+            }
+            None => return Err(IdentityRuntimeError::NoActiveLease(identity.clone())),
         };
         if let Some(record) = continuity.as_ref()
             && let Err(err) = self

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -117,15 +117,15 @@ pub use identity_first::{
     MarkdownAgentMemoryStore, NewAgentMemory,
 };
 pub use memory::{
-    CompactionResetSink, ContentTrustConfig, DistillCause, DistillerConfig, DistillerEngine,
-    DreamOutcome, DreamRun, HygieneCause, HygieneOutcome, HygienistConfig, HygienistEngine,
-    ManifestTier, MemberAgentEventSink, MemoryConflictBridge, MemoryEventSink, MemoryGatingBridge,
-    MemoryKind, MemoryRecord, MemoryScope, MemorySpawnCustomizer, MemoryTimelineEvent,
-    MobPurposeSource, NewMemoryRecord, OperatorResolver, PromotionGateResolver, RecordMeta,
-    SessionStoreEvidenceResolver, SessionTaintTracker, SqliteAgentMemoryStore, StagedMemoryStore,
-    StagedMutationBatch, StagedOp, StewardConfig, StewardEngine, StewardTriggers,
-    TaintLlmWriteGate, TaintObserverGuard, TrustTier, spawn_member_event_observer,
-    spawn_taint_observer,
+    CompactionResetSink, ConsolePrincipalOperatorResolver, ContentTrustConfig, DistillCause,
+    DistillerConfig, DistillerEngine, DreamOutcome, DreamRun, HygieneCause, HygieneOutcome,
+    HygienistConfig, HygienistEngine, ManifestTier, MemberAgentEventSink, MemoryConflictBridge,
+    MemoryEventSink, MemoryGatingBridge, MemoryKind, MemoryRecord, MemoryScope,
+    MemorySpawnCustomizer, MemoryTimelineEvent, MobPurposeSource, NewMemoryRecord,
+    OperatorResolver, PromotionGateResolver, RecordMeta, SessionStoreEvidenceResolver,
+    SessionTaintTracker, SqliteAgentMemoryStore, StagedMemoryStore, StagedMutationBatch, StagedOp,
+    StewardConfig, StewardEngine, StewardTriggers, TaintLlmWriteGate, TaintObserverGuard,
+    TrustTier, spawn_member_event_observer, spawn_taint_observer,
 };
 pub use mob_handle_runtime::{
     AfterCreateHook, CapabilityFlags, MobBootstrapOptions, MobBootstrapSpec, MobRuntime,

--- a/meerkat-mobkit/src/memory/coordinator.rs
+++ b/meerkat-mobkit/src/memory/coordinator.rs
@@ -165,6 +165,50 @@ pub trait OperatorResolver: Send + Sync {
     fn active_operator(&self, realm: &str, identity: &str) -> Option<String>;
 }
 
+/// The provisional §16 Q1 keying, decided 2026-07-04: **OperatorId = console
+/// auth principal.** The console send path notes "principal P is speaking to
+/// identity I" whenever an authenticated principal sends; recall composition
+/// then attributes identity turns to the last such principal (sticky until a
+/// different principal speaks). Identity-keyed, not realm-keyed: the console
+/// does not know memory realms, and the coordinator only ever consults its
+/// own realm's scopes, so single-realm gateways (every shipped deployment)
+/// get exact semantics; multi-realm hosts share the binding across realms —
+/// acceptable for the provisional keying, revisit with explicit operator
+/// registration.
+///
+/// Unauthenticated consoles never note anything, so activation remains
+/// config AND resolver AND a real principal — never config alone.
+#[derive(Default)]
+pub struct ConsolePrincipalOperatorResolver {
+    active: std::sync::RwLock<std::collections::HashMap<String, String>>,
+}
+
+impl ConsolePrincipalOperatorResolver {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that authenticated console `principal` addressed `identity`.
+    pub fn note_interaction(&self, identity: &str, principal: &str) {
+        if principal.is_empty() {
+            return;
+        }
+        if let Ok(mut active) = self.active.write() {
+            active.insert(identity.to_string(), principal.to_string());
+        }
+    }
+}
+
+impl OperatorResolver for ConsolePrincipalOperatorResolver {
+    fn active_operator(&self, _realm: &str, identity: &str) -> Option<String> {
+        self.active
+            .read()
+            .ok()
+            .and_then(|active| active.get(identity).cloned())
+    }
+}
+
 /// §7.2 identity→mob binding seam, mirroring [`OperatorResolver`]. The
 /// hosting runtime knows which mob(s) an identity serves (the same source
 /// that pins `MemoryRecorder::mob` for `propose_to_mob`); this trait keeps
@@ -1749,6 +1793,34 @@ mod tests {
             BUILD_INDEX_BUDGET_BYTES
         );
         Ok(())
+    }
+
+    /// The provisional console-principal resolver: sticky last-principal
+    /// per identity; empty principals and unknown identities resolve None.
+    #[test]
+    fn console_principal_resolver_tracks_last_authenticated_principal() {
+        let resolver = ConsolePrincipalOperatorResolver::new();
+        assert_eq!(resolver.active_operator("realm-a", "personal:alice"), None);
+
+        resolver.note_interaction("personal:alice", "luka@king.com");
+        assert_eq!(
+            resolver.active_operator("realm-a", "personal:alice"),
+            Some("luka@king.com".to_string())
+        );
+        // Identity-keyed provisional semantics: realm does not partition.
+        assert_eq!(
+            resolver.active_operator("realm-b", "personal:alice"),
+            Some("luka@king.com".to_string())
+        );
+        // Sticky until a DIFFERENT principal speaks.
+        resolver.note_interaction("personal:alice", "ops@king.com");
+        assert_eq!(
+            resolver.active_operator("realm-a", "personal:alice"),
+            Some("ops@king.com".to_string())
+        );
+        // Empty principals never bind (unauthenticated consoles).
+        resolver.note_interaction("personal:bob", "");
+        assert_eq!(resolver.active_operator("realm-a", "personal:bob"), None);
     }
 
     struct FixedOperator(&'static str);

--- a/meerkat-mobkit/src/memory/mod.rs
+++ b/meerkat-mobkit/src/memory/mod.rs
@@ -21,9 +21,9 @@ pub mod steward;
 pub mod taint;
 
 pub use coordinator::{
-    MobScopeResolver, OperatorResolver, RecallCoordinator, ScopeBudget, compose_identity_scope_set,
-    compose_identity_scope_set_with_bindings, compose_identity_scope_set_with_operator,
-    compose_scope_budgets,
+    ConsolePrincipalOperatorResolver, MobScopeResolver, OperatorResolver, RecallCoordinator,
+    ScopeBudget, compose_identity_scope_set, compose_identity_scope_set_with_bindings,
+    compose_identity_scope_set_with_operator, compose_scope_budgets,
 };
 pub use distiller::{
     CompactionDiscardSource, CompactionFollowUp, DistillCause, DistillOutcome,

--- a/meerkat-mobkit/src/unified_runtime/http.rs
+++ b/meerkat-mobkit/src/unified_runtime/http.rs
@@ -58,6 +58,7 @@ impl UnifiedRuntime {
             visibility_policy,
             self.access_controller().cloned(),
             self.memory_panel_store(),
+            self.console_operator_resolver(),
         )
     }
 

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -164,6 +164,12 @@ pub struct UnifiedRuntime {
     // the runtime is shared (`Arc`), wherever the store is constructed.
     memory_panel_store:
         std::sync::RwLock<Option<crate::memory::sqlite_store::SqliteAgentMemoryStore>>,
+    /// §16 Q1 provisional operator keying: the console-principal resolver,
+    /// shared between the memory coordinator (reads) and the console send
+    /// path (notes interactions). `&self`-settable like the panel store.
+    console_operator_resolver: std::sync::RwLock<
+        Option<Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>>,
+    >,
 
     // Mobkit-side label sidecar for mob- and run-scoped metadata
     metadata_table: Arc<RuntimeMetadataTable>,
@@ -242,6 +248,7 @@ impl UnifiedRuntime {
             identity_first_context: None,
             access_controller: None,
             memory_panel_store: std::sync::RwLock::new(None),
+            console_operator_resolver: std::sync::RwLock::new(None),
             metadata_table,
             persistent_metadata,
         }
@@ -579,6 +586,28 @@ impl UnifiedRuntime {
         &self,
     ) -> Option<crate::memory::sqlite_store::SqliteAgentMemoryStore> {
         self.memory_panel_store
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Wire the §16 Q1 console-principal operator resolver (set by the
+    /// gateway's memory wiring when `operator_scope = "provisional"`); the
+    /// console send path notes authenticated interactions through it.
+    pub fn set_console_operator_resolver(
+        &self,
+        resolver: Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>,
+    ) {
+        *self
+            .console_operator_resolver
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(resolver);
+    }
+
+    pub fn console_operator_resolver(
+        &self,
+    ) -> Option<Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>> {
+        self.console_operator_resolver
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -101,6 +101,47 @@ fn make_runtime(store: Arc<dyn ContinuityStore>, lease: Arc<dyn LeaseProvider>) 
     })
 }
 
+fn make_runtime_named(
+    store: Arc<dyn ContinuityStore>,
+    lease: Arc<dyn LeaseProvider>,
+    instance: &str,
+) -> IdentityRuntime {
+    IdentityRuntime::new(IdentityRuntimeConfig {
+        continuity_store: store,
+        lease_provider: lease,
+        runtime_instance_id: instance.to_string(),
+        has_runtime_store: false,
+        durability_policy: DurabilityPolicy::SyncWriteThrough,
+        bridge: None,
+        default_timeout: None,
+    })
+}
+
+/// Fail-closed single-embodiment guard: a second runtime instance restoring
+/// an identity whose durable lease another live instance holds must be
+/// refused with the typed AlreadyEmbodied error NAMING the holder — not a
+/// generic missing-lease error. (Policy point: multi-bind relaxes this arm.)
+#[tokio::test]
+async fn identity_first_runtime_second_embodiment_is_refused_loudly() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let runtime_a = make_runtime_named(store.clone(), lease.clone(), "instance-a");
+    let runtime_b = make_runtime_named(store.clone(), lease.clone(), "instance-b");
+
+    let roster = vec![make_spec("triage:main")];
+    restore_flow(&runtime_a, &roster, None, None)
+        .await
+        .expect("instance A embodies the identity");
+
+    match restore_flow(&runtime_b, &roster, None, None).await {
+        Err(IdentityRuntimeError::AlreadyEmbodied { identity, holder }) => {
+            assert_eq!(identity.as_str(), "triage:main");
+            assert_eq!(holder, "instance-a", "the guard must name the holder");
+        }
+        other => panic!("expected AlreadyEmbodied, got {other:?}"),
+    }
+}
+
 fn make_runtime_with_store(
     store: Arc<dyn ContinuityStore>,
     lease: Arc<dyn LeaseProvider>,
@@ -4417,8 +4458,8 @@ async fn identity_first_runtime_restore_flow_rejects_lease_conflicts_before_brid
         .await
         .expect_err("restore flow must reject lease conflict");
     assert!(
-        err.to_string().contains("no active lease"),
-        "unexpected error: {err}"
+        err.to_string().contains("already embodied"),
+        "the single-embodiment guard must name the conflict: {err}"
     );
     assert_eq!(
         bridge.create_calls.load(Ordering::SeqCst),
@@ -4451,8 +4492,8 @@ async fn identity_first_runtime_restore_flow_releases_partial_leases_on_conflict
     .await
     .expect_err("restore flow must reject mixed lease acquisition");
     assert!(
-        err.to_string().contains("no active lease"),
-        "unexpected error: {err}"
+        err.to_string().contains("already embodied"),
+        "the single-embodiment guard must name the conflict: {err}"
     );
     assert_eq!(
         bridge.create_calls.load(Ordering::SeqCst),


### PR DESCRIPTION
Two decided memory-polish items (§16 Q1 + Q2), both on the identity-first policy surface.

## Operator-scope recall (§16 Q1 — provisional keying: console auth principal)
With `agent_memory.operator_scope = "provisional"` the gateway installs a `ConsolePrincipalOperatorResolver`: an authenticated console principal sending to an identity becomes its active operator, and operator-scope records compose into recall — the durable `[POLICY UPDATE]` replacement. Unauthenticated consoles keep the scope inert (config AND resolver AND real principal). Keying stays swappable behind the `OperatorResolver` seam; identity-keyed (realm-agnostic) semantics documented as the provisional tradeoff. Wiring: resolver slot on `UnifiedRuntime` (mirrors the panel-store slot) → `ConsoleJsonState` → noted in `console_send_handler` post-access-gate.

## Fail-closed single-embodiment guard (§16 Q2)
Restore/materialize of an identity whose durable lease another **live** instance holds now fails with the typed `AlreadyEmbodied { identity, holder }` (error-level log naming the holder) instead of a generic `NoActiveLease`. Documented as a policy point — future multi-bind/forked-session semantics relax exactly this arm.

Tests: resolver semantics (sticky principal, empty-principal guard); two-instance embodiment refusal naming the holder; existing lease-conflict tests updated to the typed expectation. Suite 1522/1522 (zero flaky), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)