### PR TITLE
memory: memory_wiring module — full memory stack on the Rust builder (OB3 path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- The full agent-memory stack is now reachable from the Rust builder
+  (`UnifiedRuntimeBuilder::persistent_agent_memory_stack`): the bundled
+  SQLite store with the taint firewall plus the Distiller and Steward
+  engines, member-event observer, console panel registration, and the
+  steward dream loop — the same stack the rpc gateway assembles, for
+  embedders that drive the builder directly (no gateway). Assembly lives in
+  the new `memory_wiring` module. v1 boundaries documented there: the
+  Hygienist stays gateway-only, and engines are driven by the observe
+  stream (the gateway's extra injector-side rotation hooks are follow-up).
+
+### Added
+
 - Durable dream verdict sheets: every steward dream run persists to a new
   `dream_runs` table (partition label, timings, ops, and the full
   phases/verdicts/skips detail), and dead-weight usage-audit verdicts land in

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -20,6 +20,7 @@ pub mod http_flow_editor;
 pub mod http_sse;
 pub mod member_comms_id;
 pub mod memory;
+pub mod memory_wiring;
 pub mod mob_handle_runtime;
 pub mod mobpack;
 pub mod mocks;

--- a/meerkat-mobkit/src/memory_wiring.rs
+++ b/meerkat-mobkit/src/memory_wiring.rs
@@ -1,0 +1,208 @@
+//! Reusable assembly for the FULL agent-memory stack (§6 architecture): the
+//! bundled SQLite store with the §10.1 taint firewall, plus the judgment
+//! plane (Distiller, Steward) and the member-event observer feeding them.
+//!
+//! Until this module existed the stack was hand-assembled inside
+//! `rpc_gateway.rs`, which made the judgment plane unreachable for Rust
+//! embedders driving `UnifiedRuntimeBuilder` directly (the OB3 deployment
+//! shape: no gateways, no SDKs — builder or nothing). The builder now exposes
+//! it through [`crate::UnifiedRuntimeBuilder::persistent_agent_memory_stack`].
+//!
+//! Scope notes, deliberate for v1:
+//! - The **Hygienist** stays gateway-wired: it curates transcripts through
+//!   the typed transcript-revision extension on the gateway's concrete
+//!   session service, a seam the builder does not own yet.
+//! - The gateway keeps its existing hand wiring (identical semantics, more
+//!   seams: fail-init surfacing, gating/conflict bridges, schedule-host dream
+//!   suppression). Converging it onto this module is tracked follow-up work.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::MemberAgentEventSink;
+use crate::identity_first::agent_memory::{AgentMemoryConfig, AgentMemoryProvider};
+use crate::memory::distiller::{
+    DistillerConfig, DistillerEngine, DistillerProfile, DistillerTriggers, FactoryDistillerHandle,
+    HnswDiscardSource, SessionStoreTranscriptSource,
+};
+use crate::memory::events::MemoryEventSink;
+use crate::memory::sqlite_store::SqliteAgentMemoryStore;
+use crate::memory::steward::{
+    FactoryStewardHandle, MobPurposeSource, SessionStoreEvidenceResolver, StewardConfig,
+    StewardEngine, StewardProfile, StewardTriggers,
+};
+use crate::memory::taint::{SessionTaintTracker, TaintLlmWriteGate};
+
+/// Engine enables + models for the judgment plane. `Default` = store +
+/// firewall only (no background LLM work), matching the architecture's
+/// "each stage ships alone" posture.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryEnginesConfig {
+    pub distiller: DistillerConfig,
+    pub steward: StewardConfig,
+}
+
+/// The assembled stack. The caller finishes the wiring that needs the live
+/// runtime: register `store` as the console panel store, pass `sinks` to
+/// [`crate::spawn_member_event_observer`], hand `taint`/engines to the
+/// injector, and start the steward dream (schedule host or
+/// `StewardEngine::spawn_dream_loop`).
+pub struct AgentMemoryStack {
+    pub provider: Arc<dyn AgentMemoryProvider>,
+    pub store: SqliteAgentMemoryStore,
+    pub taint: SessionTaintTracker,
+    pub distiller: Option<Arc<DistillerEngine>>,
+    pub steward: Option<Arc<StewardEngine>>,
+    /// Observe-stream consumers (taint + engine triggers), in wiring order.
+    pub sinks: Vec<Arc<dyn MemberAgentEventSink>>,
+}
+
+/// Open the bundled SQLite store with the §10.1 firewall and assemble the
+/// enabled engines. `persistent_state` is the runtime's state dir (engine
+/// LLM factories and the compaction-discard source live under it);
+/// `transcript_store` is a read handle on the session store the mob bridge
+/// persists to (required when either engine is enabled).
+pub fn build_sqlite_memory_stack(
+    memory_dir: &Path,
+    config: &AgentMemoryConfig,
+    engines: &MemoryEnginesConfig,
+    persistent_state: Option<&Path>,
+    transcript_store: Option<Arc<dyn meerkat::SessionStore>>,
+    event_sink: Arc<dyn MemoryEventSink>,
+    mob_purpose: Option<Arc<dyn MobPurposeSource>>,
+) -> Result<AgentMemoryStack, String> {
+    let store = SqliteAgentMemoryStore::open(memory_dir)
+        .map_err(|e| format!("failed to open agent memory store: {e}"))?;
+    attach_memory_engines(
+        store,
+        config,
+        engines,
+        persistent_state,
+        transcript_store,
+        event_sink,
+        mob_purpose,
+    )
+}
+
+/// Stage-2 assembly over an already-open store: wire the §10.1 firewall
+/// (tracker + write gate + event sinks) and the enabled engines. Used by the
+/// builder path, where the store doubles as the provider handed to the
+/// customizer before the runtime exists.
+#[allow(clippy::too_many_arguments)]
+pub fn attach_memory_engines(
+    store: SqliteAgentMemoryStore,
+    config: &AgentMemoryConfig,
+    engines: &MemoryEnginesConfig,
+    persistent_state: Option<&Path>,
+    transcript_store: Option<Arc<dyn meerkat::SessionStore>>,
+    event_sink: Arc<dyn MemoryEventSink>,
+    mob_purpose: Option<Arc<dyn MobPurposeSource>>,
+) -> Result<AgentMemoryStack, String> {
+    // §10.1 taint firewall: the Recorder must not ship without it. This
+    // deliberately REPLACES any trackerless posture gate installed earlier.
+    let taint = SessionTaintTracker::new(config.content_trust.clone());
+    store.set_llm_write_gate(Arc::new(TaintLlmWriteGate::new(
+        Some(taint.clone()),
+        config.llm_writes,
+    )));
+    store.set_event_sink(event_sink.clone());
+    taint.set_event_sink(event_sink.clone());
+
+    let mut sinks: Vec<Arc<dyn MemberAgentEventSink>> = vec![Arc::new(taint.clone())];
+    let realm = config.realm.clone();
+
+    let state_for_engines = |what: &str| -> Result<&Path, String> {
+        persistent_state.ok_or_else(|| format!("agent memory {what} requires persistent_state"))
+    };
+    let transcripts_for_engines = |what: &str| -> Result<Arc<dyn meerkat::SessionStore>, String> {
+        transcript_store
+            .clone()
+            .ok_or_else(|| format!("agent memory {what} requires a session transcript store"))
+    };
+
+    let distiller = if engines.distiller.enabled {
+        let state = state_for_engines("distiller")?;
+        let transcripts = transcripts_for_engines("distiller")?;
+        let mut profile = DistillerProfile::embedded_default();
+        if let Some(model) = engines.distiller.model.as_deref() {
+            profile = profile
+                .with_model_override(model)
+                .map_err(|e| format!("agent memory distiller: {e}"))?;
+        }
+        let handle =
+            FactoryDistillerHandle::new(state, meerkat::Config::default(), &realm, &profile);
+        let engine = Arc::new(DistillerEngine::new(
+            profile,
+            engines.distiller.clone(),
+            Arc::new(handle),
+            Arc::new(store.clone()),
+            Arc::new(store.clone()),
+            Arc::new(SessionStoreTranscriptSource::new(transcripts)),
+            // Meerkat's session semantic memory lives at
+            // <persistent_state>/memory; absent dir ⇒ nothing preserved.
+            Some(Arc::new(HnswDiscardSource::new(state.join("memory")))),
+            Some(taint.clone()),
+            realm.clone(),
+        ));
+        engine.set_event_sink(event_sink.clone());
+        sinks.push(Arc::new(DistillerTriggers::new(engine.clone())));
+        Some(engine)
+    } else {
+        None
+    };
+
+    let steward = if engines.steward.enabled {
+        let state = state_for_engines("steward")?;
+        let transcripts = transcripts_for_engines("steward")?;
+        let mut profile = StewardProfile::embedded_default();
+        if let Some(model) = engines.steward.model.as_deref() {
+            profile = profile
+                .with_model_override(model)
+                .map_err(|e| format!("agent memory steward: {e}"))?;
+        }
+        let transcripts_source: Arc<dyn crate::memory::distiller::TranscriptSource> =
+            Arc::new(SessionStoreTranscriptSource::new(transcripts));
+        // §10.2 P3 validator extension: agent_verified retiers must cite
+        // evidence that resolves against the session store.
+        store.set_evidence_resolver(Arc::new(SessionStoreEvidenceResolver::new(
+            transcripts_source.clone(),
+            tokio::runtime::Handle::current(),
+        )));
+        let handle = FactoryStewardHandle::new(
+            state.to_path_buf(),
+            meerkat::Config::default(),
+            realm.clone(),
+            &profile,
+        );
+        let mut engine = StewardEngine::new(
+            profile,
+            engines.steward.clone(),
+            Arc::new(handle),
+            Arc::new(store.clone()),
+            transcripts_source,
+            realm,
+        )
+        .with_events(event_sink.clone())
+        .with_operator_routing(
+            config.operator_scope
+                == crate::identity_first::agent_memory::AgentMemoryOperatorScope::Provisional,
+        );
+        if let Some(purpose) = mob_purpose {
+            engine = engine.with_mob_context(purpose);
+        }
+        let engine = Arc::new(engine);
+        sinks.push(Arc::new(StewardTriggers::new(engine.clone())));
+        Some(engine)
+    } else {
+        None
+    };
+
+    Ok(AgentMemoryStack {
+        provider: Arc::new(store.clone()),
+        store,
+        taint,
+        distiller,
+        steward,
+        sinks,
+    })
+}

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -86,6 +86,7 @@ pub struct UnifiedRuntimeBuilder {
     agent_memory_provider: Option<Arc<dyn AgentMemoryProvider>>,
     agent_memory_config: Option<AgentMemoryConfig>,
     agent_memory_from_persistent_state: bool,
+    agent_memory_engines: Option<crate::memory_wiring::MemoryEnginesConfig>,
     identity_bootstrap_mode: IdentityBootstrapMode,
     identity_runtime_instance_id: Option<String>,
     scratch_dir: Option<PathBuf>,
@@ -235,6 +236,27 @@ impl UnifiedRuntimeBuilder {
     pub fn persistent_agent_memory(mut self, config: AgentMemoryConfig) -> Self {
         self.agent_memory_from_persistent_state = true;
         self.agent_memory_config = Some(config);
+        self
+    }
+
+    /// Enable the FULL agent-memory stack (bundled SQLite store + the taint
+    /// firewall + the enabled judgment-plane engines) — the same stack the
+    /// rpc gateway assembles, reachable from the Rust builder (the OB3
+    /// deployment shape). Requires `persistent_state()`; the store lives at
+    /// `<persistent_state>/agent-memory-sqlite`.
+    ///
+    /// v1 boundaries (documented in `memory_wiring`): the Hygienist stays
+    /// gateway-only; engines are driven by the member-event observe stream
+    /// (their primary trigger path — the gateway's additional injector-side
+    /// rotation hooks are not wired here yet); the steward dream runs on the
+    /// in-process loop (no schedule host in library mode).
+    pub fn persistent_agent_memory_stack(
+        mut self,
+        config: AgentMemoryConfig,
+        engines: crate::memory_wiring::MemoryEnginesConfig,
+    ) -> Self {
+        self.agent_memory_config = Some(config);
+        self.agent_memory_engines = Some(engines);
         self
     }
 
@@ -591,9 +613,38 @@ impl UnifiedRuntimeBuilder {
             } else {
                 None
             };
+        // Full-stack path: the bundled SQLite store is opened pre-runtime so
+        // it can serve as the provider (recorder + recall) from the first
+        // spawn; the firewall + engines attach post-construction, when the
+        // memory event sink and mob handle exist.
+        let stack_sqlite_store = if self.agent_memory_engines.is_some() {
+            let Some(state_path) = self.persistent_state_path.as_ref() else {
+                return Err(UnifiedRuntimeBuilderError::ConflictingConfiguration(
+                    "persistent_agent_memory_stack() requires persistent_state()".to_string(),
+                ));
+            };
+            let memory_path = state_path.join("agent-memory-sqlite");
+            Some(
+                crate::memory::sqlite_store::SqliteAgentMemoryStore::open(&memory_path).map_err(
+                    |e| {
+                        UnifiedRuntimeBuilderError::Io(format!(
+                            "failed to open agent memory store at {}: {e}",
+                            memory_path.display()
+                        ))
+                    },
+                )?,
+            )
+        } else {
+            None
+        };
         let agent_memory_provider = self
             .agent_memory_provider
             .clone()
+            .or_else(|| {
+                stack_sqlite_store
+                    .clone()
+                    .map(|store| Arc::new(store) as Arc<dyn AgentMemoryProvider>)
+            })
             .or(persistent_agent_memory_provider);
         let agent_memory_injector = agent_memory_provider.as_ref().map(|provider| {
             AgentMemoryRuntimeInjector::new(
@@ -925,6 +976,59 @@ impl UnifiedRuntimeBuilder {
             ));
             store.set_event_sink_if_absent(runtime.memory_event_sink());
             runtime.set_memory_panel_store(store.clone());
+        }
+
+        // Full-stack path (persistent_agent_memory_stack): firewall + engines
+        // + observer over the pre-opened SQLite store.
+        if let (Some(store), Some(engines)) =
+            (stack_sqlite_store, self.agent_memory_engines.as_ref())
+        {
+            let config = self.agent_memory_config.clone().unwrap_or_default();
+            let persistent_state = self.persistent_state_path.clone();
+            let transcript_store: Option<Arc<dyn meerkat::SessionStore>> =
+                if engines.distiller.enabled || engines.steward.enabled {
+                    let state = persistent_state.as_ref().ok_or_else(|| {
+                        UnifiedRuntimeBuilderError::ConflictingConfiguration(
+                            "agent memory engines require persistent_state()".to_string(),
+                        )
+                    })?;
+                    Some(Arc::new(
+                        meerkat_store::SqliteSessionStore::open(state.join("sessions.db"))
+                            .map_err(|e| {
+                                UnifiedRuntimeBuilderError::Io(format!(
+                                    "agent memory session store: {e}"
+                                ))
+                            })?,
+                    ))
+                } else {
+                    None
+                };
+            let stack = crate::memory_wiring::attach_memory_engines(
+                store,
+                &config,
+                engines,
+                persistent_state.as_deref(),
+                transcript_store,
+                runtime.memory_event_sink(),
+                None,
+            )
+            .map_err(UnifiedRuntimeBuilderError::Io)?;
+            runtime.set_memory_panel_store(stack.store.clone());
+            // Observe-stream feed lives for the runtime's lifetime.
+            std::mem::forget(crate::spawn_member_event_observer(
+                runtime.mob_handle(),
+                stack.sinks,
+            ));
+            if let Some(steward) = stack.steward.as_ref() {
+                // Library mode has no schedule host; the guarded interval
+                // loop drives dreams.
+                std::mem::forget(steward.spawn_dream_loop());
+            }
+            tracing::info!(
+                distiller = stack.distiller.is_some(),
+                steward = stack.steward.is_some(),
+                "agent memory stack installed (builder path)"
+            );
         }
 
         let pre_spawn_context = if let Some(hook) = self.pre_spawn_hook {

--- a/meerkat-mobkit/tests/classic_agent_memory.rs
+++ b/meerkat-mobkit/tests/classic_agent_memory.rs
@@ -631,6 +631,71 @@ async fn build_err(builder: meerkat_mobkit::UnifiedRuntimeBuilder) -> String {
     }
 }
 
+/// The full-stack builder path (OB3 deployment shape): store + firewall +
+/// judgment engines assembled from `UnifiedRuntimeBuilder` alone — no
+/// gateway. Asserts the panel store registers (proving the SQLite stack, not
+/// the markdown fallback, is live) and that the recorder-facing provider
+/// writes into it.
+#[tokio::test(flavor = "multi_thread")]
+async fn builder_full_memory_stack_installs_engines_and_panel() {
+    let dir = tempfile::tempdir().expect("state dir");
+    let engines = meerkat_mobkit::memory_wiring::MemoryEnginesConfig {
+        steward: meerkat_mobkit::memory::steward::StewardConfig {
+            enabled: true,
+            ..Default::default()
+        },
+        distiller: meerkat_mobkit::memory::distiller::DistillerConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    };
+    let runtime = UnifiedRuntime::builder()
+        .definition(test_definition())
+        .persistent_state(dir.path().join("state"))
+        .persistent_agent_memory_stack(AgentMemoryConfig::default(), engines)
+        .build()
+        .await
+        .expect("build full memory stack");
+
+    let store = runtime
+        .memory_panel_store()
+        .expect("panel store registered by the builder stack path");
+    // The provider is the same bundled store: a write through it is visible
+    // via the panel handle (recorder-path smoke).
+    store
+        .remember_authored(
+            &meerkat_mobkit::memory::records::MemoryScope::Identity {
+                realm: "default".to_string(),
+                identity: "worker:one".to_string(),
+            },
+            meerkat_mobkit::memory::records::NewMemoryRecord {
+                kind: meerkat_mobkit::memory::records::MemoryKind::Fact,
+                title: "builder stack fact".to_string(),
+                description: String::new(),
+                body: "written through the builder-assembled stack".to_string(),
+                tags: Vec::new(),
+                evidence: Vec::new(),
+                verification: None,
+            },
+            meerkat_mobkit::memory::records::MemoryAuthor::Operator,
+        )
+        .await
+        .expect("write through the stack store");
+    runtime.shutdown().await;
+
+    // Requires persistent_state, loudly.
+    let err = build_err(
+        UnifiedRuntime::builder()
+            .definition(test_definition())
+            .persistent_agent_memory_stack(
+                AgentMemoryConfig::default(),
+                meerkat_mobkit::memory_wiring::MemoryEnginesConfig::default(),
+            ),
+    )
+    .await;
+    assert!(err.contains("requires persistent_state"), "{err}");
+}
+
 #[tokio::test]
 async fn gate_still_rejects_invalid_memory_combinations() {
     // agent_memory() and persistent_agent_memory() are mutually exclusive.

--- a/scripts/memory-bright-line-allow.txt
+++ b/scripts/memory-bright-line-allow.txt
@@ -25,3 +25,4 @@ meerkat-memory  # §8.4 read-only host-side harvest of meerkat's OWN session sem
 src:meerkat-mobkit/src/memory/distiller.rs:hnsw  # §8.4 HnswDiscardSource: read-only compaction-discard harvest over meerkat's own store
 src:meerkat-mobkit/src/memory/distiller.rs:meerkat-memory  # §8.4 harvest import site (meerkat_memory::HnswMemoryStore::open, one query, read-only)
 src:meerkat-mobkit/src/memory/mod.rs:hnsw  # re-export of the §8.4 HnswDiscardSource only
+src:meerkat-mobkit/src/memory_wiring.rs:hnsw  # §8.4 wiring only: constructs the read-only HnswDiscardSource for the Distiller (same pinned exception as distiller.rs)


### PR DESCRIPTION
Final decided memory-polish item: the judgment plane was gateway-only (hand-assembled in `rpc_gateway.rs`), so builder-driven embedders — the OB3 deployment shape — got memory storage but none of the memory intelligence.

- **`memory_wiring` module**: `build_sqlite_memory_stack` / `attach_memory_engines` assemble the bundled SQLite store + taint firewall + optional Distiller/Steward with their observe-stream triggers into an `AgentMemoryStack`.
- **`UnifiedRuntimeBuilder::persistent_agent_memory_stack(config, engines)`**: store opens pre-runtime (recorder + recall live from first spawn); firewall + engines attach post-construction; panel store registers; observer + steward dream loop spawn.

v1 boundaries documented in the module: Hygienist stays gateway-wired (transcript-edit service seam), engines ride the observe stream (gateway's injector-side rotation hooks are follow-up), and converging the gateway onto this module is tracked follow-up.

Test: builder-only full-stack assembly. Suite 1521/1521, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)