### PR TITLE
fix(identity-first): Broken identities self-heal via background reconcile retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Broken identities now self-heal: a background continuity-repair task
+  (spawned by both the gateway and `UnifiedRuntimeBuilder` deployments)
+  re-runs the reconcile flow with doubling backoff while any identity sits in
+  the Broken state, so a resume that starts succeeding again — a transient
+  cause cleared, or an upstream fix deployed — restores the identity to
+  functional without a process restart. Previously "degraded pending
+  reconcile retry" promised a retry that only a manual
+  `mobkit/reconcile_identity` RPC or a restart delivered: delivery refuses
+  Broken identities by design, and so does on-demand materialization, which
+  is how HomeCore's 14 preserved-but-parked identities stayed parked. The
+  task is quiet while nothing is Broken (no lease churn on healthy
+  deployments) and the backoff bounds retry log noise.
+
 - Console Memory panel Phase 2/3: Holdings reads real store totals with
   per-scope FLOOR PRESSURE markers and a data-driven STORE FLOOR verdict
   tile plus the pending-harvest queue; Knowledge shows the durable injection

--- a/meerkat-mobkit/src/identity_first/mod.rs
+++ b/meerkat-mobkit/src/identity_first/mod.rs
@@ -38,7 +38,7 @@ pub use orchestrator::{
     lazy_register_flow, restore_flow,
 };
 pub use runtime::{
-    IdentityFirstRuntimeContext, IdentityRuntime, IdentityRuntimeConfig, IdentityRuntimeError,
-    wire_cross_mob_by_identity,
+    ContinuityRepairPolicy, IdentityFirstRuntimeContext, IdentityRuntime, IdentityRuntimeConfig,
+    IdentityRuntimeError, wire_cross_mob_by_identity,
 };
 pub use types::*;

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -359,6 +359,87 @@ impl IdentityFirstRuntimeContext {
             .await
         }
     }
+
+    /// Background repair for Broken identities. A rejected resume degrades the
+    /// identity to Broken while preserving the durable session; the documented
+    /// contract is "the next reconcile retries the resume" — but without this
+    /// task, nothing runs that reconcile: delivery refuses Broken identities
+    /// (REQ-13 fails loudly), `materialize` refuses the Broken state, and the
+    /// only retries were a manual `mobkit/reconcile_identity` RPC or a process
+    /// restart. HomeCore 0.7.23 sat with 14 preserved-but-parked identities
+    /// because of exactly that gap.
+    ///
+    /// The loop sleeps, and only when at least one identity is Broken re-runs
+    /// [`Self::refresh_desired_topology`] — the same idempotent flow the
+    /// reconcile RPC runs (eager: `restore_flow` retries the resume; lazy:
+    /// `lazy_register_flow` re-registers a store-Ready identity as Dormant so
+    /// on-demand materialization retries). Backoff doubles while identities
+    /// stay Broken — persistent causes (e.g. an upstream store regression)
+    /// produce bounded log noise, and transient causes (disk full, lock
+    /// contention) heal without a restart.
+    pub fn spawn_broken_identity_repair_task(
+        self: Arc<Self>,
+        policy: ContinuityRepairPolicy,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut backoff = policy.initial_backoff;
+            loop {
+                tokio::time::sleep(backoff).await;
+                let broken = self.runtime.broken_identities().await;
+                if broken.is_empty() {
+                    backoff = policy.initial_backoff;
+                    continue;
+                }
+                tracing::info!(
+                    broken = broken.len(),
+                    "continuity repair: retrying restore for Broken identities"
+                );
+                if let Err(err) = self.refresh_desired_topology().await {
+                    tracing::warn!(
+                        error = %err,
+                        "continuity repair reconcile failed; backing off"
+                    );
+                    backoff = (backoff * 2).min(policy.max_backoff);
+                    continue;
+                }
+                let still_broken = self.runtime.broken_identities().await;
+                let healed = broken
+                    .iter()
+                    .filter(|id| !still_broken.contains(id))
+                    .count();
+                if healed > 0 {
+                    tracing::info!(
+                        healed,
+                        still_broken = still_broken.len(),
+                        "continuity repair healed identities"
+                    );
+                }
+                backoff = if still_broken.is_empty() {
+                    policy.initial_backoff
+                } else {
+                    (backoff * 2).min(policy.max_backoff)
+                };
+            }
+        })
+    }
+}
+
+/// Retry cadence for [`IdentityFirstRuntimeContext::spawn_broken_identity_repair_task`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContinuityRepairPolicy {
+    /// Delay before the first check and after every fully-healed pass.
+    pub initial_backoff: Duration,
+    /// Ceiling for the doubling backoff while identities stay Broken.
+    pub max_backoff: Duration,
+}
+
+impl Default for ContinuityRepairPolicy {
+    fn default() -> Self {
+        Self {
+            initial_backoff: Duration::from_secs(30),
+            max_backoff: Duration::from_mins(10),
+        }
+    }
 }
 
 /// The identity-first runtime tracks active identities and enforces delivery,
@@ -4052,6 +4133,17 @@ impl IdentityRuntime {
             .await
             .get(identity)
             .is_some_and(|e| e.state == IdentityLifecycleState::Active)
+    }
+
+    /// Identities currently in the Broken lifecycle state.
+    pub async fn broken_identities(&self) -> Vec<AgentIdentity> {
+        self.entries
+            .read()
+            .await
+            .iter()
+            .filter(|(_, entry)| entry.state == IdentityLifecycleState::Broken)
+            .map(|(identity, _)| identity.clone())
+            .collect()
     }
 
     /// Get the continuity store reference.

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -939,6 +939,11 @@ impl UnifiedRuntimeBuilder {
         let identity_lease_renewal_task = identity_first_context
             .as_ref()
             .map(|context| context.runtime.clone().spawn_lease_renewal_task());
+        let identity_continuity_repair_task = identity_first_context.as_ref().map(|context| {
+            context
+                .clone()
+                .spawn_broken_identity_repair_task(Default::default())
+        });
 
         // Set immutable outer fields by rebuilding the struct
         let runtime = UnifiedRuntime {
@@ -953,6 +958,9 @@ impl UnifiedRuntimeBuilder {
             session_bridge,
             identity_first_context,
             identity_lease_renewal_task: tokio::sync::Mutex::new(identity_lease_renewal_task),
+            identity_continuity_repair_task: tokio::sync::Mutex::new(
+                identity_continuity_repair_task,
+            ),
             console_log_store,
             ..runtime
         };

--- a/meerkat-mobkit/src/unified_runtime/lifecycle.rs
+++ b/meerkat-mobkit/src/unified_runtime/lifecycle.rs
@@ -162,6 +162,9 @@ impl UnifiedRuntime {
         if let Some(task) = self.identity_lease_renewal_task.lock().await.take() {
             task.abort();
         }
+        if let Some(task) = self.identity_continuity_repair_task.lock().await.take() {
+            task.abort();
+        }
 
         // Phase 1: Drain in-flight events
         let drain_start = std::time::Instant::now();

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -140,6 +140,7 @@ pub struct UnifiedRuntime {
     mob_events_subscriber_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
     implicit_delegate_retirement_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
     identity_lease_renewal_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
+    identity_continuity_repair_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
 
     // Cross-mob communication
     contact_directory: Option<crate::contact_directory::ContactDirectory>,
@@ -241,6 +242,7 @@ impl UnifiedRuntime {
             mob_events_subscriber_task: tokio::sync::Mutex::new(mob_events_task),
             implicit_delegate_retirement_task: tokio::sync::Mutex::new(None),
             identity_lease_renewal_task: tokio::sync::Mutex::new(None),
+            identity_continuity_repair_task: tokio::sync::Mutex::new(None),
             contact_directory: None,
             peer_mob_handles: tokio::sync::RwLock::new(BTreeMap::new()),
             gateway_peer_keys: None,
@@ -524,6 +526,20 @@ impl UnifiedRuntime {
         &mut self,
         context: Arc<crate::identity_first::IdentityFirstRuntimeContext>,
     ) {
+        // Broken identities must self-heal: a rejected resume parks the
+        // identity "pending reconcile retry", and this task is what runs
+        // that retry in a live process (delivery and materialize both
+        // refuse the Broken state by design).
+        let repair_task = context
+            .clone()
+            .spawn_broken_identity_repair_task(Default::default());
+        if let Some(previous) = self
+            .identity_continuity_repair_task
+            .get_mut()
+            .replace(repair_task)
+        {
+            previous.abort();
+        }
         self.identity_first_context = Some(context);
     }
 

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -4893,6 +4893,171 @@ async fn identity_first_runtime_restore_flow_rejected_resume_marks_broken_then_r
     assert_eq!(bridge.create_calls.load(Ordering::SeqCst), 0);
 }
 
+/// Roster provider serving a fixed roster, counting calls — the repair task
+/// must not touch it while nothing is Broken.
+struct StaticRosterProvider {
+    roster: Vec<DurableAgentSpec>,
+    calls: AtomicUsize,
+}
+
+impl StaticRosterProvider {
+    fn new(roster: Vec<DurableAgentSpec>) -> Self {
+        Self {
+            roster,
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl RosterProvider for StaticRosterProvider {
+    async fn roster(&self, _context: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.roster.clone())
+    }
+}
+
+/// Regression for the HomeCore 0.7.23 parked-mob outcome: identities degraded
+/// to Broken by a rejected resume stayed broken indefinitely because nothing
+/// in a live process re-ran the reconcile ("degraded pending reconcile retry"
+/// promised a retry that only a manual RPC or a restart delivered). The
+/// background repair task must retry the resume and heal the identity to
+/// Active — onto the SAME durable session, never a fresh spawn — once the
+/// rejection cause clears.
+#[tokio::test]
+async fn identity_first_runtime_broken_identity_repair_task_heals_without_restart() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    // Boot restore rejects, and so does the first background retry: healing
+    // must survive retries that keep failing before the cause clears.
+    bridge.reject_resume_times(2);
+    let runtime = make_runtime_with_bridge(store.clone(), lease_prov, bridge.clone());
+
+    let id = make_identity("triage:main");
+    let record = make_record("triage:main", 0, 0);
+    let original_session_id = record.session_id.clone();
+    store
+        .upsert_continuity_record(&record, FencingToken::new(0))
+        .await
+        .unwrap();
+    store
+        .save_session_snapshot(
+            &id,
+            &record.session_id,
+            record.generation,
+            CheckpointVersion::new(1),
+            FencingToken::new(0),
+            &SessionSnapshot {
+                data: b"snapshot data".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let roster = vec![make_spec("triage:main")];
+    let result = restore_flow(&runtime, &roster, None, None).await.unwrap();
+    assert!(matches!(
+        result.outcomes.get(&id).unwrap(),
+        RestoreOutcome::Broken(_)
+    ));
+    assert_eq!(
+        runtime.status(&id).await.unwrap().state,
+        IdentityLifecycleState::Broken
+    );
+
+    let context = Arc::new(
+        meerkat_mobkit::identity_first::IdentityFirstRuntimeContext::new(
+            runtime.clone(),
+            Arc::new(StaticRosterProvider::new(roster.clone())),
+            None,
+            None,
+            None,
+        ),
+    );
+    let repair = context.clone().spawn_broken_identity_repair_task(
+        meerkat_mobkit::identity_first::ContinuityRepairPolicy {
+            initial_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(40),
+        },
+    );
+
+    // The task retries on its own: first retry still rejected, second heals.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if runtime.status(&id).await.unwrap().state == IdentityLifecycleState::Active {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "repair task did not heal the Broken identity in time"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    repair.abort();
+
+    // Healed onto the same durable session, honestly, and never fresh-spawned.
+    let status = runtime.status(&id).await.unwrap();
+    assert_eq!(
+        status.session_id,
+        Some(original_session_id),
+        "the healed identity must still be bound to the original durable session"
+    );
+    assert_eq!(
+        bridge.create_calls.load(Ordering::SeqCst),
+        0,
+        "healing must resume, never fresh-spawn"
+    );
+    assert!(bridge.resume_calls.load(Ordering::SeqCst) >= 3);
+}
+
+/// The repair task is a repair task, not a polling reconciler: while nothing
+/// is Broken it must not touch the roster provider (no lease churn, no
+/// restore_flow reruns on healthy deployments).
+#[tokio::test]
+async fn identity_first_runtime_broken_identity_repair_task_is_quiet_when_healthy() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease_prov = Arc::new(LocalLeaseProvider::new());
+    let bridge = Arc::new(CountingBridge::default());
+    let runtime = make_runtime_with_bridge(store.clone(), lease_prov, bridge.clone());
+
+    let roster = vec![make_spec("triage:main")];
+    restore_flow(&runtime, &roster, None, None).await.unwrap();
+    assert_eq!(
+        runtime
+            .status(&make_identity("triage:main"))
+            .await
+            .unwrap()
+            .state,
+        IdentityLifecycleState::Active
+    );
+
+    let provider = Arc::new(StaticRosterProvider::new(roster.clone()));
+    let context = Arc::new(
+        meerkat_mobkit::identity_first::IdentityFirstRuntimeContext::new(
+            runtime.clone(),
+            provider.clone(),
+            None,
+            None,
+            None,
+        ),
+    );
+    let repair = context.clone().spawn_broken_identity_repair_task(
+        meerkat_mobkit::identity_first::ContinuityRepairPolicy {
+            initial_backoff: Duration::from_millis(5),
+            max_backoff: Duration::from_millis(20),
+        },
+    );
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    repair.abort();
+
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        0,
+        "repair task must stay idle while no identity is Broken"
+    );
+}
+
 /// Regression for the reconcile-outcome lie: a bridge resume that fell back to
 /// a fresh spawn (typed `FreshSpawned`) must be reported as `created`, never
 /// `resumed` — reporting keyed on snapshot presence hid the HomeCore loss.


### PR DESCRIPTION
The mobkit half of the HomeCore 0.7.23 degraded-mob report (the meerkat 0.7.15→0.7.17 resume regression itself lands upstream in 0.7.18).

**Gap:** #218/#221 correctly refuse the destructive fresh-spawn fallback and park a rejected resume as Broken "pending reconcile retry" — but nothing in a live process runs that retry. `send()` refuses Broken identities (REQ-13 fail-loud), `materialize()` refuses the Broken state, so the only heal paths were a manual `mobkit/reconcile_identity` RPC or a restart. HomeCore's 14 identities stayed parked indefinitely.

**Fix:** `IdentityFirstRuntimeContext::spawn_broken_identity_repair_task` — sleeps, and only while ≥1 identity is Broken re-runs `refresh_desired_topology()` (the exact flow the reconcile RPC runs, so idempotency is established behavior; in lazy contexts `lazy_register_flow` re-registers a store-Ready identity as Dormant so on-demand materialization retries). Doubling backoff 30s→10min bounds retry log noise for persistent causes; transient causes (disk full, lock contention, upstream store hiccups) now heal without a restart. Spawned by both hosts (builder + gateway `attach_identity_first_context`), aborted on shutdown.

**Tests:** `identity_first_runtime_broken_identity_repair_task_heals_without_restart` (resume rejected at boot AND on the first background retry → task heals to Active on the same durable session, zero fresh-spawns) and `..._is_quiet_when_healthy` (zero roster-provider calls while nothing is Broken). Full workspace suite green (1525 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)