### PR TITLE
deps: meerkat 0.7.18 — carried-store cold-restart resume fix (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the meerkat family 0.7.17 → 0.7.18. Carries the fix for the
+  HomeCore cold-restart regression (meerkat #837): idle members whose
+  turn-less boots chained resume-system-prompt-refresh rewrite commits were
+  refused resume with "incoming append-only save would change retained
+  transcript revision graph" — the rewrite-chain walk now proves continuity
+  in authority order and no longer fails closed on the chained-refresh
+  shape. New mobkit-side idle-member coverage: repeated turn-less restarts
+  (with prompt drift presented) must keep resuming onto the same durable
+  session and replay history on the eventual turn.
+
 ### Added
 
 - Broken identities now self-heal: a background continuity-repair task

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313cebbc395f5945a2c631491e2bae3753d1d1c57b2f936c1dc2b06083366786"
+checksum = "8b9c991ca2955b19917ccefc4f5177af920e40c562e07492c09295b0b1f73843"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39541c58056213182004614b4e410d6327355faf4f9b4807e0ccf3d18d14bb7f"
+checksum = "c8f5227a4c5a94177c0c75df6873cf3de3884466bfc8820af145ddf176ed01fd"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a3e79cd49a6dd4c971c169a290cdf361678c07d4f874f8bdf7231c858af43"
+checksum = "bca2ab8204fad1bd4f6487ba94994f33e706afb2b3942184c7bf267e3d33d544"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8cfddffc98d5cc5209e5139f5ed337c0c39887e9875b153955a7736d5bb433"
+checksum = "0c95828e3c92dd2a05a387224a6cb6caa298e8ee0db635befebf01e182a76417"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2f4f0ba5e2d140b80559c578baa317739956eb6585a0489042ef463b37cd92"
+checksum = "8d0da2c8f1952590cf912a70ba3ac7f8a8bd77d6d372593e7e72bd7dbba2f0f3"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32936163f364d1f07d18cc89c06e51b048c370379a1d3ff151fa7da7c490f739"
+checksum = "38489187351ea3aa76cc0ca8f830aa34ec435967b83d8959a1381bc88a06648d"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1c3715b410049b3d1e45f1b0be0f55f25f9918e3d9f7836c18a0136dfb9db8"
+checksum = "9b1317114a66141545c60d91933d39465e1cd1ca252bd281c2a949dcfdde1171"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffabd0254f4476775500dd7394e670e32543aacc5fceadd6e89d281342bdd63"
+checksum = "b3aceab3b55b00311ad1dae94eebe978b30d30a8752cceaa108e6332e28d5e94"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3ff6e828a18531536c9b1b556692e6586b511948129095823426b7941525b2"
+checksum = "f27244844079258531e9306b2f9b7af7ffad746df583106301e67273e00cc685"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb57680df01dc330c18408ad51952d6895442c2880e1c894d7fcf64940e9426"
+checksum = "a47bc1f5878c911b8fa016873291e2b0bdbbc440f7fe30b114c4e7b856ff16e8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d439df7c9739474e3cc7e4d6acee190399233fb68ea850928abc2324939b9cc6"
+checksum = "53b16f97e960d5de0b5f465ec329851d1570313bd0b5f5eb133fe61fe43f5ceb"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034d676b1ba7a16a699da8be0d03973d549d3dd343e443a7b01c2a2ce06750f8"
+checksum = "d9c45435619d98ac7dd158ec73d47d02164f7abd0b4491a42374d25158a7d53a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27609e26ac01ac0151f31820100af87f9e5221fba24f2f136c95c9a9bf56a745"
+checksum = "eecb543859d669a903dd56418c3a407d3ea3d36a95191ea7209acd06cc52faf8"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee31d0f883cbdcfb6075b89ebce71d6d4e3953367678a9f65e54ac5de3135e1"
+checksum = "9df26714ccee02b2db71ae0f577fa26aa284f4ea0ef15cb30b84ec6ecf5411f3"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a654b2239f8153a2ba5a8b9f932009bdf949cd4faf94711e08e3e23d091b86e8"
+checksum = "c3e61d2badd75a45a7356a68856c739188fe0007ad1ae2d1167fb65edd85e02c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465702aa08d4df950b3cfa5e489812d06e957d951ac5e95931b66424af8b6750"
+checksum = "9a02177c9cc7c878830aa38295133ecd65e0851f2f12a66f213cbb76f941d776"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256939b83725f322c1a08d04e2577a1f736f36df216ded1ba88a005300042d2d"
+checksum = "1bdc075aaa5409b75757f650ffbe3a2c5b900e502eda3e41050299694170633f"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b05d6dc683e78a70ba7a7c9227c561ffc6cadbbed1a690022e26854f69a023"
+checksum = "c5bbd1e2d43a673564dc1848372872f8f77c2dda0b0931851722448a3b0673fc"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f2c433c00b5ee54eaed5e647017593049ea46caf326498f4613939d4cdc249"
+checksum = "a6acdfa89aa95af092243b68c956b2e0f037f452542deb38a543479dfad38cec"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ffc108dd340f9b0692a8deb4d6435be2b2eb4522e1afaa4d7f4754255243c2"
+checksum = "faecdad382ce37b8b360c1840c86b5dd43b32fb2f61fe32432a13e9226985cc1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161299736585fcda0b3c69fbcc0b6f94505c56b2709b9106ac5c1aad47275d83"
+checksum = "0003f709c518a7fe6a1048d9f79d682d8c29a6c238e07dd2443dc9fe2125641b"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7335f28d77035e6a4e13d0e9e5e82adb624a7eff15cd40e69dd3ab8bee806"
+checksum = "e3b20d97db06eff000be844eec368b8bf0115c605367282353f5d368e2307c51"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40b9446eaf82b98aed2729e93ea90c906a4d97cddad492cbd7f132e0b51f723"
+checksum = "f63519d47540976bd941f29711ba6cdd51bed775a6d92637cea044f04f8887f3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb0c3fdda14e419e6952818c6107a56eb68d4b8ef30970dde57ab193b627906"
+checksum = "e8913d5a6c3c7aa464a45445fc704a7ba1f04149090c00ed1298eabeeeb06fd2"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8602dc1ed869ad557876f37db5780a9485e7b628ebfc77f49f1d2ec6192244e"
+checksum = "bfae812e140d8f21635a563d097b1447cf8fc43ef3e24f37f287cfb8ad405873"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6467447d0cfce7b910c416fa473254e5255ea04f27188c0626917e4411bcbfea"
+checksum = "8c3dc9f3f3ea309f5e32dcc28c73e50dfc2183c5224744be6e8e1011dffe427e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f44060a7deb44f8defed8c6f0800bb59102dba3a027685d88ff458e129c40f7"
+checksum = "36f765add6e1eb2281e6606ead7f4d9994dec2dc829721bf63a9b35c5ad46d03"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d9162bce6631384d6112b5a831fa9a0e498856dfa8e884ecf71b2e758c3835"
+checksum = "9860d889cbb90e0172b0950aa76b6ff870dae1d8d9efdce96347fdd7e4fc6ae5"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fe1a2b48a4c018c9158b462ce7d6bac65d69aaa225e054be12bdbbbb66ca10"
+checksum = "ea168979c803188319f14ea865b1556fd11551200cb6a8f4182ac32106228c23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c38b97bb1a446c59cfc934ab01f8c18f8c2e8847d8b8e2b8de5ca31164ba67a"
+checksum = "151ae24cd6ecb9f780de8856a0c3a2c6fd36a3e701b74b5e39b18748c9945ec2"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd4e4ec85a1009b0ca886cf40184b9341c2ab220186fb499acb1c14b92ce310"
+checksum = "686866587e67a7e3fc783d042546d83ef603c5298615b96197137d776e370140"
 dependencies = [
  "async-trait",
  "chrono",

--- a/meerkat-mobkit/tests/identity_first_cold_restart_continuity.rs
+++ b/meerkat-mobkit/tests/identity_first_cold_restart_continuity.rs
@@ -111,6 +111,36 @@ impl AgentCustomizer for NoopCustomizer {
     }
 }
 
+/// Injects a per-boot "host context" instruction — drifting system-prompt
+/// parts are what made field deployments commit resume refresh rewrites on
+/// every idle boot (the chain meerkat #837 fixed). Kept here so the idle
+/// cycles below at least present drift; see the test's doc for what this
+/// harness can and cannot rebuild.
+struct DriftingContextCustomizer {
+    tag: std::sync::Mutex<String>,
+}
+#[async_trait]
+impl AgentCustomizer for DriftingContextCustomizer {
+    async fn customize_build(
+        &self,
+        _context: &AgentBuildContext,
+        _spec: &DurableAgentSpec,
+        draft: &mut AgentBuildDraft,
+    ) -> Result<(), CustomizerError> {
+        let tag = self.tag.lock().unwrap().clone();
+        draft.additional_instructions = vec![format!("Host context: {tag}")];
+        Ok(())
+    }
+    async fn after_create(
+        &self,
+        _identity: &AgentIdentity,
+        _session_id: &meerkat_core::types::SessionId,
+        _context: &SessionCreatedContext,
+    ) -> Result<(), CustomizerError> {
+        Ok(())
+    }
+}
+
 /// Records the serialized LLM request each turn and answers "ok" so turns
 /// complete without a real provider.
 #[derive(Clone, Default)]
@@ -367,6 +397,158 @@ async fn identity_first_cold_restart_preserves_transcript() {
             "the transcript must survive a SECOND restart (token {TOKEN} missing)"
         );
 
+        unified.shutdown().await;
+    }
+}
+
+/// Idle-member coverage for the HomeCore 0.7.23 regression (meerkat #837): a
+/// member restarted repeatedly with NO turns in between must keep resuming
+/// onto the same durable session, and the eventual turn must replay history.
+///
+/// Field shape: turn-less boots committed chained resume-system-prompt-refresh
+/// rewrites; meerkat 0.7.16/0.7.17's rewrite-chain walk miswalked the chain
+/// and failed closed as a cycle, refusing resume on every boot (14 of 15
+/// HomeCore identities). The survivor had run a turn after its refresh — the
+/// shape the sibling test above exercises, which is why it kept passing.
+///
+/// Honesty note: the failing chain was built by PRE-0.7.21 boots (before
+/// resume inherited the persisted System message) and carried in the store;
+/// current-version code does not rebuild that legacy shape, so this test does
+/// NOT go red on meerkat 0.7.17 — the authoritative red/green repro lives
+/// upstream (#837, seeded with real 0.7.13/0.7.14/0.7.15 binaries). What this
+/// variant pins on the mobkit side: idle restart cycles (with prompt drift
+/// presented) stay Resumed end to end — the gap in our coverage that let the
+/// idle-member shape ship unexercised.
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_first_cold_restart_turnless_resume_chain_preserves_transcript() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let state_path = temp.path().join("state");
+    let alice = id("personal:alice");
+    let roster = vec![spec(
+        "personal:alice",
+        AgentAddressability::Addressable,
+        "personal",
+    )];
+    const TOKEN: &str = "MARKER-IDLE-CHAIN-7-ZULU";
+    let customizer = DriftingContextCustomizer {
+        tag: std::sync::Mutex::new("boot-1".to_string()),
+    };
+
+    // --- Boot 1: create, one turn carrying the token, shut down ---
+    let original_session_id;
+    {
+        let capture = CaptureClient::default();
+        let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
+        let result = restore_flow(
+            &identity_rt,
+            &roster,
+            Some(&EmptyTopology as &dyn TopologyProvider),
+            Some(&customizer as &dyn AgentCustomizer),
+        )
+        .await
+        .expect("restore_flow (boot 1)");
+        match result.outcomes.get(&alice).expect("alice outcome") {
+            RestoreOutcome::Created { record, .. } => {
+                original_session_id = record.session_id.clone();
+            }
+            other => panic!("expected Created on first boot, got {other:?}"),
+        }
+        identity_rt
+            .send(
+                &alice,
+                &meerkat_core::ContentInput::Text(format!("Please note this token: {TOKEN}")),
+            )
+            .await
+            .expect("send turn 1");
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while capture.count() < 1 {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for turn 1 to reach the LLM"
+            );
+            sleep(Duration::from_millis(100)).await;
+        }
+        sleep(Duration::from_millis(500)).await;
+        unified.shutdown().await;
+    }
+
+    // --- Boots 2-4: resume, NO turn, shut down. Each boot may stack another
+    // turn-less refresh commit onto the history graph — the chain that
+    // 0.7.16/0.7.17 miswalked. ---
+    for boot_n in 2..=4 {
+        *customizer.tag.lock().unwrap() = format!("boot-{boot_n}");
+        let capture = CaptureClient::default();
+        let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
+        let result = restore_flow(
+            &identity_rt,
+            &roster,
+            Some(&EmptyTopology as &dyn TopologyProvider),
+            Some(&customizer as &dyn AgentCustomizer),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("restore_flow (turn-less boot {boot_n}): {e}"));
+        match result.outcomes.get(&alice).expect("alice outcome") {
+            RestoreOutcome::Resumed { record, .. } => {
+                assert_eq!(
+                    record.session_id, original_session_id,
+                    "turn-less boot {boot_n} must resume the SAME durable session"
+                );
+            }
+            other => panic!(
+                "turn-less boot {boot_n} must report Resumed (idle members must not \
+                 degrade), got: {other:?}"
+            ),
+        }
+        // Give any resume-time refresh rewrite a moment to commit, then stop.
+        sleep(Duration::from_millis(500)).await;
+        unified.shutdown().await;
+    }
+
+    // --- Boot 5: resume once more and run a turn. The turn's run-boundary
+    // commit is where the miswalked chain used to fail closed. ---
+    {
+        *customizer.tag.lock().unwrap() = "boot-5".to_string();
+        let capture = CaptureClient::default();
+        let (unified, identity_rt) = boot(&state_path, capture.clone()).await;
+        let result = restore_flow(
+            &identity_rt,
+            &roster,
+            Some(&EmptyTopology as &dyn TopologyProvider),
+            Some(&customizer as &dyn AgentCustomizer),
+        )
+        .await
+        .expect("restore_flow (boot 5)");
+        match result.outcomes.get(&alice).expect("alice outcome") {
+            RestoreOutcome::Resumed { record, .. } => {
+                assert_eq!(
+                    record.session_id, original_session_id,
+                    "boot 5 must still resume the SAME durable session"
+                );
+            }
+            other => panic!("boot 5 must report Resumed, got: {other:?}"),
+        }
+        identity_rt
+            .send(
+                &alice,
+                &meerkat_core::ContentInput::Text("What token did I give you earlier?".to_string()),
+            )
+            .await
+            .expect("send the post-idle-chain turn");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while capture.count() < 1 {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for the post-idle-chain turn to reach the LLM"
+            );
+            sleep(Duration::from_millis(100)).await;
+        }
+        let last_request = capture
+            .last()
+            .expect("a post-idle-chain request was captured");
+        assert!(
+            last_request.contains(TOKEN),
+            "after three turn-less restarts the transcript must still replay (token {TOKEN})"
+        );
         unified.shutdown().await;
     }
 }


### PR DESCRIPTION
Upgrades the meerkat family 0.7.17 → 0.7.18 (lockfile only; no API breaks this time).

**What 0.7.18 fixes (meerkat #837):** the HomeCore 0.7.23 field regression — idle members restarted with no turns in between accumulate chained resume-system-prompt-refresh rewrite commits; 0.7.16/0.7.17's rewrite-chain walk selected an older refresh commit under the fuzzy refresh-equivalence edge and failed closed as a cycle, refusing resume on every boot (14 of 15 identities; the survivor had run turns after its refresh). Upstream reproduced end-to-end against stores seeded by real 0.7.13/0.7.14/0.7.15 binaries.

**Mobkit-side additions:**
- New idle-member regression coverage in `identity_first_cold_restart_continuity.rs`: create + turn, three turn-less restarts (per-boot prompt drift presented via customizer), then a final resume + turn that must replay history on the same durable session. Honesty note in the test doc: the legacy chain can only be rebuilt by pre-0.7.21 binaries, so this pins the idle shape end-to-end while the red/green chain repro stays upstream.
- Verified `make ci` fully green on 0.7.18.

Together with #235 (already on main), a deployment on this release both resumes the parked identities at boot and self-heals any that degrade mid-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)