### PR TITLE
fix(schedule): claim watchdog — name the silent firing-pipeline stall (HomeCore 0.7.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Schedule claim watchdog (both gateways): meerkat's firing driver discards
+  its own tick errors, and one poisoned row anywhere in the schedule store
+  (a Deleted tombstone the recovery invariant rejects, a stale-schema
+  occurrence) aborts every tick before anything is claimed — due occurrences
+  then sit `pending` forever with nothing in any log (the HomeCore 0.7.24
+  report: 31/31 pending, no lease ever taken). The new read-only
+  `spawn_schedule_claim_watchdog` probes the pipeline every 60s and, when
+  due work is not being claimed, logs a row-level diagnosis naming the
+  poisoned row. It cannot make the driver claim past a poisoned row — the
+  driver fixes are upstream asks 16-19 (docs/design/upstream-asks.md).
+
 ## [0.7.24] - 2026-07-06
 
 ### Changed

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -672,3 +672,92 @@ over-cull edge cases; removed when the id lands.
 The two production deployments (OB3, HomeCore) both run strictly one live
 session per identity; MobKit ships a fail-closed single-embodiment guard and
 will file the ask when a real use case materializes.
+
+---
+
+# Batch 3 — schedule firing pipeline (2026-07-06, HomeCore 0.7.24 field report)
+
+Field context: rpc_gateway persistent mode, on-disk SQLite schedule store
+carried across upgrades since ~0.7.13-era binaries. Authoring and planning
+work; NOTHING fires. Every occurrence in the store sat at `phase=pending`
+with `lease_expires_at_ms=NULL` — including a fresh one-shot authored on a
+just-cleaned store — with zero log output at any level. Root-caused in the
+published 0.7.18 sources (all four asks are visible there); mobkit ships a
+read-only watchdog (`spawn_schedule_claim_watchdog`) that names the stall
+and the poisoned row, but only meerkat can make the driver survive one.
+
+## Ask 16 — `spawn_schedule_host` discards every driver tick error
+
+**Problem statement.** `meerkat/src/surface/schedule_host.rs` runs the firing
+loop as `let _ = driver.tick_once().await;` every 250 ms. When ticks fail
+persistently (see asks 17–19 for why they do), schedules silently stop firing
+forever: no ERROR, no WARN, nothing for `RUST_LOG=debug` to show — the error
+value is dropped before tracing can see it. The HomeCore operator offered a
+debug trace; there was literally nothing to capture.
+
+**Proposed shape.** Log `tick_once` errors — on first occurrence and on
+change at ERROR, with a rate-limited heartbeat while the same error persists;
+count consecutive failures in the report struct. A driver that cannot claim
+is an incident, not a no-op.
+
+## Ask 17 — one poisoned row starves every schedule (all-or-nothing scans)
+
+**Problem statement.** `ScheduleDriver::tick_once` begins with
+`service.list()` — which fails wholesale on the FIRST schedule row whose
+recovered machine state is rejected — and `claim_due_occurrences` (sqlite
+store) deserializes and `classify_due_action`s EVERY occurrence row in the
+store inside one transaction before leasing anything. Any single stale or
+invariant-rejected row (old schema_version, `misfire deadline projection
+does not match machine_state`, corrupted JSON) aborts the entire tick. One
+bad row → zero claims, for every schedule, forever — combined with ask 16,
+silently.
+
+**Evidence.** HomeCore: 31/31 occurrences pending, no lease ever taken, on a
+store whose rows span ~5 binary generations. A fresh, valid one-shot on the
+same store never fired — starved by a neighbor row.
+
+**Proposed shape.** Per-row tolerance in both scans: a row that fails
+deserialization or due-classification is skipped and logged (schedule_id /
+occurrence_id + reason), optionally quarantined to a dead-row table or a
+`phase=quarantined` marker so operators can inspect and purge. The tick
+claims everything healthy.
+
+## Ask 18 — Deleted schedule tombstones fail recovery and kill `list()`
+
+**Problem statement.** Deleting a schedule persists a tombstone row whose
+recovered `ScheduleLifecycleMachine` state is then REJECTED on read:
+`RecoveredStateInvariantRejected { phase: Deleted, invariant:
+"deleted_has_no_planning_cursor" }`. Every subsequent `list schedules` (and
+therefore every driver tick and every mobkit boot repair) fails until the
+operator hand-deletes rows in sqlite. The writer and the recovery invariant
+disagree about what a legal Deleted state looks like — one of them is wrong.
+
+**Evidence.** HomeCore boot logs (every boot until manual cleanup of 16
+tombstones): `list schedules: serialization error: generated
+ScheduleLifecycleMachine rejected recovered machine_state: ...`.
+
+**Proposed shape.** Either (a) the delete flow clears the planning cursor
+before persisting the tombstone AND a one-time migration repairs existing
+tombstones, or (b) recovery accepts Deleted-with-cursor and normalizes it.
+Plus an upgrade-carry test: delete a schedule under version N, open under
+N+1, `list()` must succeed.
+
+## Ask 19 — claim scan reads the whole store per tick
+
+**Problem statement.** `claim_due_occurrences_impl` SELECTs and deserializes
+every occurrence (joined with its schedule) with no SQL predicate on phase or
+due time, four times per second. Beyond the poison surface (ask 17), this is
+O(store) per tick: OB3-scale stores (multi-GB, years of terminal receipts and
+occurrences) pay full-table deserialization at 4 Hz.
+
+**Proposed shape.** Push the filter into SQL — `WHERE phase-in-pending-set
+AND due_at_ms <= :now + horizon` (due_at_ms is already a column and already
+indexed by the ORDER BY) — and let per-row tolerance (ask 17) handle the
+stragglers. Terminal rows never enter the scan.
+
+**MobKit interim behavior (ships in 0.7.25).** Read-only
+`spawn_schedule_claim_watchdog` in both gateways: probes `list()`, the
+occurrence scan, and overdue-pending-unclaimed state every 60 s, and logs a
+row-level diagnosis (poisoned row ids via direct sqlite triage) when the
+pipeline is stalled. It makes the failure loud and attributable but cannot
+make the driver claim past a poisoned row.

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -33,6 +33,7 @@ type ScheduleHostInputs = (
     meerkat::ScheduleService,
     meerkat_mobkit::schedule_wiring::ScheduleMobTargetRegistry,
     Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    PathBuf,
 );
 type PersistentSessionServiceParts = (
     Arc<dyn meerkat_mob::MobSessionService>,
@@ -457,11 +458,16 @@ fn build_persistent_session_service(
         Arc::clone(&runtime_store),
         blob_store,
     ));
+    let schedule_store_dir = runtime_db_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf();
     let schedule_host_inputs = schedule_tools.map(|tools| {
         (
             tools.service,
             tools.mob_target_registry,
             Arc::clone(&service),
+            schedule_store_dir.join(meerkat_mobkit::schedule_wiring::SCHEDULE_STORE_FILE),
         )
     });
     Ok((service, adapter, binary_blob_store, schedule_host_inputs))
@@ -704,7 +710,7 @@ async fn run() -> anyhow::Result<()> {
         // Pair the schedule wiring with a clone of the runtime adapter so the
         // firing host can be spawned once the runtime has booted (below).
         let schedule_host_inputs = schedule_host_inputs
-            .map(|(sched, registry, svc)| (sched, registry, svc, adapter.clone()));
+            .map(|(sched, registry, svc, path)| (sched, registry, svc, path, adapter.clone()));
         // The explicit runtime adapter must share the session service's runtime
         // persistence authority or meerkat 0.7 fails the bootstrap closed.
         // `with_session_runtime_adapter` wires the SAME adapter into the session
@@ -787,8 +793,13 @@ async fn run() -> anyhow::Result<()> {
     // turn (session targets via the runtime-backed host, mob targets via the
     // mob runtime). Held for the gateway's lifetime — dropping the handle shuts
     // the host down. Persistent sessions only.
-    let _schedule_host = if let Some((schedule_service, mob_target_registry, service, adapter)) =
-        schedule_host_inputs
+    let (_schedule_host, _schedule_watchdog) = if let Some((
+        schedule_service,
+        mob_target_registry,
+        service,
+        schedule_store_path,
+        adapter,
+    )) = schedule_host_inputs
     {
         let mob_state = runtime.mob_runtime().agent_mob_mcp_state();
         mob_target_registry.set_mob_state(mob_state.clone());
@@ -812,16 +823,26 @@ async fn run() -> anyhow::Result<()> {
                 );
             }
         }
-        meerkat_mobkit::schedule_wiring::spawn_schedule_host(
-            service,
-            adapter,
-            schedule_service,
-            mob_state,
-            None,
-            runtime_id.clone(),
+        // Same silent-stall guard as rpc_gateway: the upstream driver
+        // discards tick errors, so stalls only become visible here.
+        let watchdog = meerkat_mobkit::schedule_wiring::spawn_schedule_claim_watchdog(
+            schedule_service.clone(),
+            schedule_store_path,
+            Default::default(),
+        );
+        (
+            meerkat_mobkit::schedule_wiring::spawn_schedule_host(
+                service,
+                adapter,
+                schedule_service,
+                mob_state,
+                None,
+                runtime_id.clone(),
+            ),
+            Some(watchdog),
         )
     } else {
-        None
+        (None, None)
     };
 
     // Load contacts.toml if present. This enables mobkit/cross_mob/directory

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -3721,6 +3721,7 @@ external_addressable = true
                 tools.mob_target_registry,
                 Arc::clone(&concrete_service),
                 adapter.clone(),
+                state_path.join(meerkat_mobkit::schedule_wiring::SCHEDULE_STORE_FILE),
             )
         });
         // §8.6 Hygienist apply seam: the CONCRETE service implements
@@ -4532,8 +4533,13 @@ external_addressable = true
     // Run the schedule driver after identity-first restore, so legacy
     // resumable-session repair can see live member bridge-session bindings and
     // due occurrences do not race identity materialization.
-    let _schedule_host = if let Some((schedule_service, mob_target_registry, service, adapter)) =
-        schedule_host_inputs
+    let (_schedule_host, _schedule_watchdog) = if let Some((
+        schedule_service,
+        mob_target_registry,
+        service,
+        adapter,
+        schedule_store_path,
+    )) = schedule_host_inputs
     {
         let mob_state = runtime.mob_runtime().agent_mob_mcp_state();
         mob_target_registry.set_mob_state(mob_state.clone());
@@ -4578,16 +4584,27 @@ external_addressable = true
                 "failed to ensure steward dream schedule; the steward will not dream on this gateway",
             );
         }
-        meerkat_mobkit::schedule_wiring::spawn_schedule_host(
-            service,
-            adapter,
-            schedule_service,
-            mob_state,
-            runnable_host,
-            schedule_owner_id.clone(),
+        // The firing driver discards its own tick errors upstream; the
+        // watchdog is what turns "everything stays pending forever" into a
+        // loud, row-level diagnosis in the gateway log.
+        let watchdog = meerkat_mobkit::schedule_wiring::spawn_schedule_claim_watchdog(
+            schedule_service.clone(),
+            schedule_store_path,
+            Default::default(),
+        );
+        (
+            meerkat_mobkit::schedule_wiring::spawn_schedule_host(
+                service,
+                adapter,
+                schedule_service,
+                mob_state,
+                runnable_host,
+                schedule_owner_id.clone(),
+            ),
+            Some(watchdog),
         )
     } else {
-        None
+        (None, None)
     };
 
     let runtime = Arc::new(runtime);

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -34,10 +34,10 @@ use meerkat::surface::{
 use meerkat::{
     Config, CreateScheduleRequest, FactoryAgentBuilder, HostRunnable, HostRunnableError,
     HostRunnableInvocation, HostRunnableName, HostRunnableOutcome, HostRunnableRegistry,
-    HostRunnableTargetBinding, IntervalTriggerSpec, MobTargetBinding, PersistentSessionService,
-    ScheduleRunnableHost, ScheduleService, ScheduleToolDispatcher, ScheduledMobAction,
-    ScheduledSessionAction, SessionAgentBuilder, SessionTargetBinding, SqliteScheduleStore,
-    TargetBinding, TriggerSpec, UpdateScheduleRequest,
+    HostRunnableTargetBinding, IntervalTriggerSpec, MobTargetBinding, Occurrence, OccurrenceFilter,
+    OccurrencePhase, PersistentSessionService, Schedule, ScheduleRunnableHost, ScheduleService,
+    ScheduleToolDispatcher, ScheduledMobAction, ScheduledSessionAction, SessionAgentBuilder,
+    SessionTargetBinding, SqliteScheduleStore, TargetBinding, TriggerSpec, UpdateScheduleRequest,
 };
 use meerkat_core::service::SessionBuildOptions;
 use meerkat_mob_mcp::{MobMcpScheduleHost, MobMcpState};
@@ -596,6 +596,248 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
     )
 }
 
+/// Cadence and sensitivity for [`spawn_schedule_claim_watchdog`].
+#[derive(Debug, Clone, Copy)]
+pub struct ScheduleClaimWatchdogConfig {
+    /// Delay between probes.
+    pub poll_interval: Duration,
+    /// A pending occurrence due longer ago than this counts as stalled.
+    pub overdue_threshold: Duration,
+    /// While unhealthy with an unchanged report, re-log every Nth poll.
+    pub heartbeat_polls: u32,
+}
+
+impl Default for ScheduleClaimWatchdogConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_mins(1),
+            overdue_threshold: Duration::from_mins(2),
+            heartbeat_polls: 10,
+        }
+    }
+}
+
+/// Verdict from one firing-pipeline probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScheduleFiringProbe {
+    Healthy,
+    /// The pipeline is not delivering and here is why, as precisely as this
+    /// side of the wire can name it.
+    Stalled {
+        report: String,
+    },
+}
+
+fn triage_poisoned_rows(
+    store_path: &Path,
+    table: &str,
+    id_column: &str,
+    json_column: &str,
+    parse: impl Fn(&[u8]) -> Result<(), String>,
+) -> Vec<String> {
+    let conn = match rusqlite::Connection::open_with_flags(
+        store_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ) {
+        Ok(conn) => conn,
+        Err(err) => return vec![format!("(row triage unavailable: {err})")],
+    };
+    let sql = format!("SELECT {id_column}, {json_column} FROM {table}");
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(stmt) => stmt,
+        Err(err) => return vec![format!("(row triage query failed: {err})")],
+    };
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+    });
+    let mut poisoned = Vec::new();
+    if let Ok(rows) = rows {
+        for row in rows.flatten() {
+            let (id, bytes) = row;
+            if let Err(err) = parse(&bytes) {
+                poisoned.push(format!("{table}.{id_column}={id}: {err}"));
+                if poisoned.len() >= 5 {
+                    poisoned.push(format!("(further poisoned {table} rows elided)"));
+                    break;
+                }
+            }
+        }
+    }
+    poisoned
+}
+
+/// Probe whether the schedule firing pipeline can actually deliver, and if
+/// not, name the reason — down to the poisoned row where possible.
+///
+/// Exists because meerkat's schedule host discards every driver tick error
+/// (`let _ = driver.tick_once()`), and a tick aborts wholesale on the FIRST
+/// poisoned row anywhere in the store: `service.list()` fails on any
+/// unrecoverable schedule row (e.g. a Deleted tombstone rejected by
+/// `deleted_has_no_planning_cursor`), and the claim scan deserializes and
+/// classifies EVERY occurrence row before leasing anything. One stale row →
+/// zero claims, forever, with nothing in any log — HomeCore 0.7.24 sat with
+/// 31 pending occurrences and `lease_expires_at_ms=NULL` across the board.
+pub async fn probe_schedule_firing_pipeline(
+    schedule_service: &ScheduleService,
+    store_path: &Path,
+    overdue_threshold: Duration,
+) -> ScheduleFiringProbe {
+    // 1. The tick preflight: one poisoned schedule row fails the whole list.
+    if let Err(err) = schedule_service.list().await {
+        let mut report = format!(
+            "schedule list is failing, so every firing-driver tick aborts before claiming (nothing will fire): {err}"
+        );
+        let poisoned = triage_poisoned_rows(
+            store_path,
+            "schedule_schedules",
+            "schedule_id",
+            "schedule_json",
+            |bytes| {
+                serde_json::from_slice::<Schedule>(bytes)
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            },
+        );
+        if !poisoned.is_empty() {
+            report.push_str(&format!("; poisoned rows: {}", poisoned.join("; ")));
+        }
+        return ScheduleFiringProbe::Stalled { report };
+    }
+
+    // 2. The claim scan's poison surface: it deserializes every occurrence.
+    let store = schedule_service.store();
+    let now = match store.get_store_time_utc().await {
+        Ok(now) => now,
+        Err(err) => {
+            return ScheduleFiringProbe::Stalled {
+                report: format!("schedule store clock read failed: {err}"),
+            };
+        }
+    };
+    let overdue_before = now
+        - chrono::Duration::from_std(overdue_threshold)
+            .unwrap_or_else(|_| chrono::Duration::seconds(120));
+    let pending_overdue = match store
+        .list_occurrences(OccurrenceFilter {
+            phase: Some(OccurrencePhase::Pending),
+            include_terminal: false,
+            due_before_utc: Some(overdue_before),
+            ..OccurrenceFilter::default()
+        })
+        .await
+    {
+        Ok(occurrences) => occurrences,
+        Err(err) => {
+            let mut report = format!(
+                "occurrence scan is failing, so the firing driver cannot claim anything (nothing will fire): {err}"
+            );
+            let poisoned = triage_poisoned_rows(
+                store_path,
+                "schedule_occurrences",
+                "occurrence_id",
+                "occurrence_json",
+                |bytes| {
+                    serde_json::from_slice::<Occurrence>(bytes)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string())
+                },
+            );
+            if !poisoned.is_empty() {
+                report.push_str(&format!("; poisoned rows: {}", poisoned.join("; ")));
+            }
+            return ScheduleFiringProbe::Stalled { report };
+        }
+    };
+
+    if pending_overdue.is_empty() {
+        return ScheduleFiringProbe::Healthy;
+    }
+
+    // 3. Reads are healthy but due work is not being claimed. Classify each
+    // overdue occurrence the way the claim scan would — a classify error on
+    // ANY row (even one belonging to another schedule) aborts the whole
+    // claim transaction upstream.
+    let mut classify_errors = Vec::new();
+    for occurrence in &pending_overdue {
+        if let Err(err) = occurrence.classify_due_action(now) {
+            classify_errors.push(format!(
+                "occurrence {} (due {}): {err}",
+                occurrence.occurrence_id, occurrence.due_at_utc
+            ));
+            if classify_errors.len() >= 5 {
+                break;
+            }
+        }
+    }
+    let mut report = format!(
+        "{} pending occurrence(s) overdue by more than {}s and never claimed (oldest due {}); the firing driver's claim loop is failing silently",
+        pending_overdue.len(),
+        overdue_threshold.as_secs(),
+        pending_overdue
+            .first()
+            .map(|o| o.due_at_utc.to_rfc3339())
+            .unwrap_or_default(),
+    );
+    if classify_errors.is_empty() {
+        report.push_str(
+            "; every overdue occurrence classifies cleanly, so the abort is in the claim/lease transaction or a row outside the overdue set",
+        );
+    } else {
+        report.push_str(&format!(
+            "; rows failing due-classification: {}",
+            classify_errors.join("; ")
+        ));
+    }
+    ScheduleFiringProbe::Stalled { report }
+}
+
+/// Watchdog for the silent-stall failure mode above: probes the firing
+/// pipeline and logs LOUDLY when due work is not being claimed, naming the
+/// poisoned row when one is identifiable. Purely read-only — it never claims
+/// or transitions occurrences, so it cannot race the real driver.
+///
+/// Logs an ERROR when the stall report first appears or changes, a WARN
+/// heartbeat every `heartbeat_polls` while it persists, and an INFO when the
+/// pipeline recovers.
+pub fn spawn_schedule_claim_watchdog(
+    schedule_service: ScheduleService,
+    store_path: std::path::PathBuf,
+    config: ScheduleClaimWatchdogConfig,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut last_report: Option<String> = None;
+        let mut unhealthy_polls: u32 = 0;
+        loop {
+            tokio::time::sleep(config.poll_interval).await;
+            match probe_schedule_firing_pipeline(
+                &schedule_service,
+                &store_path,
+                config.overdue_threshold,
+            )
+            .await
+            {
+                ScheduleFiringProbe::Healthy => {
+                    if last_report.take().is_some() {
+                        tracing::info!("schedule firing pipeline recovered");
+                    }
+                    unhealthy_polls = 0;
+                }
+                ScheduleFiringProbe::Stalled { report } => {
+                    unhealthy_polls += 1;
+                    if last_report.as_deref() != Some(report.as_str()) {
+                        tracing::error!(%report, "schedule firing pipeline is stalled");
+                    } else if config.heartbeat_polls > 0
+                        && unhealthy_polls.is_multiple_of(config.heartbeat_polls)
+                    {
+                        tracing::warn!(%report, "schedule firing pipeline is still stalled");
+                    }
+                    last_report = Some(report);
+                }
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -930,6 +1172,178 @@ mod tests {
             TriggerSpec::Interval(spec) => spec.every_seconds,
             other => panic!("expected interval trigger, got {other:?}"),
         }
+    }
+
+    /// Author an interval schedule (host-runnable target: no session machinery
+    /// needed) against a REAL sqlite store and plan its horizon, mirroring what
+    /// the firing driver's tick preflight sees.
+    async fn seed_sqlite_schedule(
+        dir: &std::path::Path,
+        start_at_utc: chrono::DateTime<chrono::Utc>,
+    ) -> (ScheduleService, std::path::PathBuf) {
+        let store_path = dir.join(SCHEDULE_STORE_FILE);
+        let store = SqliteScheduleStore::open(&store_path).expect("open sqlite schedule store");
+        let service = ScheduleService::new(Arc::new(store));
+        let created = service
+            .create(CreateScheduleRequest {
+                name: Some("watchdog-fixture".to_string()),
+                description: None,
+                trigger: TriggerSpec::Interval(IntervalTriggerSpec {
+                    start_at_utc,
+                    every_seconds: 3600,
+                    end_at_utc: None,
+                }),
+                target: TargetBinding::host_runnable(HostRunnableTargetBinding {
+                    runnable: HostRunnableName::parse("watchdog.fixture").expect("runnable name"),
+                    params: None,
+                }),
+                misfire_policy: meerkat::MisfirePolicy::default(),
+                overlap_policy: meerkat::OverlapPolicy::default(),
+                missing_target_policy: meerkat::MissingTargetPolicy::default(),
+                labels: std::collections::BTreeMap::new(),
+                planning_horizon_days: None,
+                planning_horizon_occurrences: None,
+            })
+            .await
+            .expect("create schedule");
+        service
+            .refill_horizon(&created.schedule_id)
+            .await
+            .expect("plan occurrences");
+        (service, store_path)
+    }
+
+    fn corrupt_first_row(store_path: &std::path::Path, table: &str, json_column: &str) {
+        let conn = rusqlite::Connection::open(store_path).expect("open store for corruption");
+        let changed = conn
+            .execute(
+                &format!(
+                    "UPDATE {table} SET {json_column} = X'7B22706F69736F6E22' \
+                     WHERE rowid = (SELECT MIN(rowid) FROM {table})"
+                ),
+                [],
+            )
+            .expect("corrupt row");
+        assert_eq!(changed, 1, "one {table} row corrupted");
+    }
+
+    /// Healthy pipeline: future work only, nothing overdue → the watchdog has
+    /// nothing to say.
+    #[tokio::test]
+    async fn schedule_claim_watchdog_probe_is_healthy_on_future_work() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let start = chrono::Utc::now() + chrono::Duration::hours(1);
+        let (service, store_path) = seed_sqlite_schedule(dir.path(), start).await;
+
+        let probe =
+            probe_schedule_firing_pipeline(&service, &store_path, Duration::from_secs(0)).await;
+        assert_eq!(probe, ScheduleFiringProbe::Healthy);
+    }
+
+    /// HomeCore Observation A: due occurrences sit pending with no lease and
+    /// the driver says nothing. The probe must call that out loudly.
+    #[tokio::test]
+    async fn schedule_claim_watchdog_probe_flags_overdue_unclaimed_occurrences() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let start = chrono::Utc::now() + chrono::Duration::hours(1);
+        let (service, store_path) = seed_sqlite_schedule(dir.path(), start).await;
+
+        // Age the first planned occurrence 10 minutes into the past — both the
+        // projection's due_at_utc and the machine state's due_at_utc_ms (they
+        // are recovery-checked against each other), plus the ordering column.
+        let overdue = chrono::Utc::now() - chrono::Duration::minutes(10);
+        {
+            let conn = rusqlite::Connection::open(&store_path).expect("open store");
+            let (rowid, bytes): (i64, Vec<u8>) = conn
+                .query_row(
+                    "SELECT rowid, occurrence_json FROM schedule_occurrences \
+                     ORDER BY rowid LIMIT 1",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .expect("read first occurrence");
+            let mut json: serde_json::Value =
+                serde_json::from_slice(&bytes).expect("occurrence json");
+            let old_due_ms = json["machine_state"]["due_at_utc_ms"]
+                .as_i64()
+                .expect("machine due ms");
+            let shift = old_due_ms - overdue.timestamp_millis();
+            json["due_at_utc"] = serde_json::Value::String(overdue.to_rfc3339());
+            json["machine_state"]["due_at_utc_ms"] =
+                serde_json::Value::from(overdue.timestamp_millis());
+            if let Some(deadline) = json["machine_state"]["misfire_deadline_utc_ms"].as_i64() {
+                json["machine_state"]["misfire_deadline_utc_ms"] =
+                    serde_json::Value::from(deadline - shift);
+            }
+            let updated = serde_json::to_vec(&json).expect("serialize occurrence");
+            conn.execute(
+                "UPDATE schedule_occurrences SET occurrence_json = ?1, due_at_ms = ?2 \
+                 WHERE rowid = ?3",
+                rusqlite::params![updated, overdue.timestamp_millis(), rowid],
+            )
+            .expect("age occurrence");
+        }
+
+        let probe =
+            probe_schedule_firing_pipeline(&service, &store_path, Duration::from_mins(1)).await;
+        let ScheduleFiringProbe::Stalled { report } = probe else {
+            panic!("an overdue unclaimed occurrence must probe as Stalled");
+        };
+        assert!(
+            report.contains("never claimed"),
+            "report must state the claim stall: {report}"
+        );
+    }
+
+    /// HomeCore Observation B: one poisoned schedule row (e.g. a Deleted
+    /// tombstone the recovery invariant rejects) fails the whole list, which
+    /// aborts every driver tick before claiming. The probe must surface the
+    /// list failure and name the poisoned row.
+    #[tokio::test]
+    async fn schedule_claim_watchdog_probe_names_poisoned_schedule_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let start = chrono::Utc::now() + chrono::Duration::hours(1);
+        let (service, store_path) = seed_sqlite_schedule(dir.path(), start).await;
+        corrupt_first_row(&store_path, "schedule_schedules", "schedule_json");
+
+        let probe =
+            probe_schedule_firing_pipeline(&service, &store_path, Duration::from_mins(1)).await;
+        let ScheduleFiringProbe::Stalled { report } = probe else {
+            panic!("a poisoned schedule row must probe as Stalled");
+        };
+        assert!(
+            report.contains("schedule list is failing"),
+            "report must name the failing surface: {report}"
+        );
+        assert!(
+            report.contains("schedule_schedules.schedule_id="),
+            "report must name the poisoned row: {report}"
+        );
+    }
+
+    /// The claim scan deserializes EVERY occurrence row before leasing
+    /// anything, so one poisoned occurrence silently starves all schedules.
+    /// The probe must surface the scan failure and name the row.
+    #[tokio::test]
+    async fn schedule_claim_watchdog_probe_names_poisoned_occurrence_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let start = chrono::Utc::now() + chrono::Duration::hours(1);
+        let (service, store_path) = seed_sqlite_schedule(dir.path(), start).await;
+        corrupt_first_row(&store_path, "schedule_occurrences", "occurrence_json");
+
+        let probe =
+            probe_schedule_firing_pipeline(&service, &store_path, Duration::from_mins(1)).await;
+        let ScheduleFiringProbe::Stalled { report } = probe else {
+            panic!("a poisoned occurrence row must probe as Stalled");
+        };
+        assert!(
+            report.contains("occurrence scan is failing"),
+            "report must name the failing surface: {report}"
+        );
+        assert!(
+            report.contains("schedule_occurrences.occurrence_id="),
+            "report must name the poisoned row: {report}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Mobkit's half of the schedule-firing bug report. Root cause chain (all confirmed in published 0.7.18 sources):

1. `ScheduleDriver::tick_once` starts with `service.list()` → fails wholesale on the first unrecoverable schedule row (Observation B: Deleted tombstones rejected by `deleted_has_no_planning_cursor`).
2. `claim_due_occurrences` (sqlite) deserializes + `classify_due_action`s **every occurrence row in the store** inside one transaction before leasing anything → one stale/invariant-rejected row anywhere aborts the whole claim (Observation A surviving the tombstone cleanup: a poisoned neighbor row starves the fresh one-shot).
3. The surface host runs `let _ = driver.tick_once()` every 250ms → all of the above is **silent**. A RUST_LOG=debug trace would show nothing; the error value is dropped before tracing sees it.

The driver fixes are meerkat's (filed as asks 16–19 in `docs/design/upstream-asks.md`: non-silent ticks, per-row tolerance, tombstone recovery, SQL-filtered claim). What mobkit owns is the silence and the diagnosis:

**`spawn_schedule_claim_watchdog`** (both gateways, read-only, never claims/transitions — cannot race the driver): every 60s probes `service.list()`, the occurrence scan, and overdue-pending-unclaimed state; on stall logs ERROR with a row-level report — poisoned row ids named via direct sqlite triage, per-occurrence classify errors for the overdue set — WARN heartbeat every 10 polls while unchanged, INFO on recovery.

**Tests** (4, against a real sqlite store): healthy-quiet; overdue-unclaimed flags stalled; poisoned schedule row → "schedule list is failing" + names `schedule_schedules.schedule_id=…`; poisoned occurrence row → "occurrence scan is failing" + names the row. (The overdue fixture incidentally exercises meerkat's `misfire deadline projection does not match machine_state` recovery check — the very class of per-row rejection that likely poisons HomeCore's carried rows.)

Release note: 0.7.25 waits for the meerkat release carrying asks 16–19 (monitor running), then ships watchdog + upgrade together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)