### PR TITLE
meerkat-studio K-asks: error transparency (K2), K1 root-cause + repro, external-tools seam (K4), exact pins (K5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Mob-wide, revival-surviving external-tools seam (meerkat-studio ask K4):
+  `MobBootstrapSpec::with_default_external_tools_provider` forwards to
+  meerkat-mob's per-spawn provider, so tools attached there survive member
+  respawn/revival — unlike the per-spawn `SpawnMemberSpec.external_tools`
+  overlay, which revival drops. Note: a profile's `tools.mcp` allowlist gates
+  what the provider exposes, and an EMPTY allowlist means the full surface.
+
+### Changed
+
+- Console JSON-RPC internal errors now carry the real failure reason on the
+  wire (meerkat-studio ask K2): `message` and `data.detail` hold the error
+  chain instead of an opaque `{"error":"internal_error"}` (the kind marker is
+  kept for existing clients). This deliberately reverses the earlier
+  redaction posture for THIS surface: every caller that reaches these
+  handlers is an operator by construction (auth-gated consoles 401 first;
+  open consoles are a trusted-local deployment choice), and the redaction
+  made every -32000 undiagnosable. `console_send`'s public-message redaction
+  is unchanged (that surface can reflect into agent-visible space). Also
+  covers the intermittent mob-spawn 500s reported as K3 wherever they
+  originate on mobkit's surface.
+- The meerkat family is now exact-pinned (`=0.7.18`) in Cargo.toml
+  (meerkat-studio ask K5): the compatible meerkat version is declared, not
+  archaeologized from Cargo.lock at release tags.
+
+### Known issues
+
+- `mobkit/retire_member` / `mobkit/respawn_member` fail for never-ran
+  members on persistent session services and strand them in `retiring`
+  (meerkat-studio K1) — root-caused upstream (ask 20,
+  docs/design/upstream-asks.md): the ArchiveSession disposal step NotFounds
+  on a member that never committed a runtime snapshot. Repro ships as an
+  `#[ignore]`d test in `tests/studio_k_asks.rs`; the fix lands with the next
+  meerkat release.
+
 - Schedule claim watchdog (both gateways): meerkat's firing driver discards
   its own tick errors, and one poisoned row anywhere in the schedule store
   (a Deleted tombstone the recovery invariant rejects, a stale-schema

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -761,3 +761,94 @@ occurrence scan, and overdue-pending-unclaimed state every 60 s, and logs a
 row-level diagnosis (poisoned row ids via direct sqlite triage) when the
 pipeline is stalled. It makes the failure loud and attributable but cannot
 make the driver claim past a poisoned row.
+
+---
+
+# Batch 4 — meerkat-studio field report (2026-07-06)
+
+Reporter context: desktop app pinning meerkat =0.7.17 / mobkit =0.7.23; thread
+mobs through an embedded gateway (FactoryAgentBuilder →
+PersistentSessionService → MobBootstrapSpec → UnifiedRuntime), helper crews
+through per-thread mobkit_gateway HTTP children. Asks M1–M4 below are the
+reporter's, relayed verbatim-in-substance; ask 20 is mobkit's root-cause of
+the reporter's K1, which turned out to be upstream.
+
+## Ask 20 — retire/respawn of a never-ran member fails ArchiveSession and strands it in `retiring` (reported as mobkit K1) — P0
+
+**Problem statement.** A session-bound mob member that has never run a turn
+has no runtime-store session snapshot (the machine commits at run
+boundaries). Retiring it runs the disposal pipeline to completion, but the
+ArchiveSession step's authority lookup returns NotFound
+(`load_runtime_authority_session_for_control` → no runtime snapshot →
+`Ok(None)` → "mob archive authority returned NotFound for registered runtime
+session …"), which `destroy_disposal_failure` escalates to a fatal error
+("disposal completed but ArchiveSession failed"). The member is left in the
+roster at `state=retiring`, `is_final=false` — permanently. `respawn` runs
+retire first, checks `roster_still_contains_member` — still true — and
+aborts, leaving a cancelled-kickoff zombie. Net: the only per-member control
+primitives on a non-crashing path (see M1) fail for exactly the members an
+operator most wants to manage.
+
+**Evidence.** Deterministic mobkit repro
+(`meerkat-mobkit/tests/studio_k_asks.rs`, the `#[ignore]`d persistent test):
+3-member crew via `ensure_member` on
+FactoryAgentBuilder→PersistentSessionService; both RPCs fail with the exact
+field string; members verified stranded in `retiring`. The identity-first
+bridge already classifies this exact string as recoverable for SESSION-OWNED
+retire (mobkit `is_recoverable_session_owned_retire_cleanup_error`) — the mob-
+member path needs the equivalent judgment at the source.
+
+**Proposed shape.** In meerkat-mob: when disposal COMPLETED and the archive
+miss is `NotFound for registered runtime session` (never-committed snapshot,
+not a lost record — distinguishable by asking the runtime store whether the
+logical runtime id ever existed), treat archive as a no-op success and let
+the retirement commit finish; respawn then proceeds naturally. Alternatively
+commit an initial runtime snapshot at member session registration so the
+lookup never misses. Regression: retire + respawn of a freshly spawned,
+never-prompted member on a persistent service must succeed; a
+`roster.get(...)`-after-failed-retire assertion to pin the no-strand
+invariant.
+
+## M1 — force_cancel_member stack-overflows (SIGABRT) mid-turn — P0
+
+`MobHandle::force_cancel_member` → `MobActor::handle_force_cancel` →
+provisioner `interrupt_member` → `LocalMobRuntimeBridge::interrupt_member` →
+`MeerkatMachine::cancel_after_boundary` recurses inside
+`execute_meerkat_machine_command` until the tokio worker aborts the process.
+Reporter byte-diffed the chain: unchanged 0.7.4 → 0.7.17. No downstream
+consumer can stop a running member; the model turn burns tokens to the next
+boundary. Acceptance: cancel during an in-flight (not idle) turn interrupts
+and returns without crashing; regression test for exactly that.
+
+## M2 — no MCP path for library/factory embedders; per-spawn overlay lossy — P1
+
+`AgentBuildConfig` has `external_tools`/`wait_for_mcp` but no MCP-server
+config; `.rkat/mcp.toml` is CLI-only. The working embedder pattern
+(`McpRouter::new_with_surface_handle(RuntimeExternalToolSurfaceHandle::ephemeral())`
+→ stage_add → apply_staged → wait_until_ready → inject via
+`SpawnMemberSpec.external_tools`) exists only in meerkat test code
+(`service_factory.rs:1827`); `McpRouter::new()` fail-closes stage_add. With
+`builtins = true`, `CompositeDispatcher` does not forward
+`bind_external_tool_surface_handle`/`bind_mcp_server_lifecycle_handle` (only
+`bind_ops_lifecycle`), so session-time late binding never reaches the
+adapter. And `materialize_revived_member_session` composes
+`external_tools_for_profile(&profile, None)` — revived members silently lose
+per-spawn tools. Acceptance: a supported way to attach an MCP stdio server to
+factory-built agents that composes with builtins, survives revival, and needs
+no test-code incantation. (Mobkit shipped its half: a mob-wide
+revival-surviving provider seam, `MobBootstrapSpec::with_default_external_tools_provider`.)
+
+## M3 — semver discipline within 0.7.x — P1
+
+0.7.16 changed `PersistentSessionService::new` (Option → required Arc);
+0.7.12 added a required `content_taint` field to `CommsCommand::PeerMessage`.
+Both broke 0.7-pinned downstreams. Ask: treat public-signature changes as
+breaking (minor bump) or publish a meerkat↔mobkit compatibility matrix.
+(Mobkit now exact-pins its meerkat family and records the pin per release.)
+
+## M4 — durable run/interaction lifecycle query — P2
+
+Run framing is broadcast-only; after a host restart there is no "did
+interaction X reach a terminal state, and which?" query. Reporter hand-rolled
+runs.jsonl + a lookup RPC. A first-class terminal-status-by-interaction/run-id
+query in meerkat-session/runtime deletes that code for every embedder.

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -4879,6 +4879,71 @@ rust_test(
 )
 
 rust_test(
+    name = "studio_k_asks_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "studio_k_asks",
+    crate_root = "tests/studio_k_asks.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/studio_k_asks.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.24",
+        "CARGO_BIN_NAME": "studio_k_asks",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [
+        ":package_runfiles",
+    ],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "swarm_integration_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -5204,6 +5269,7 @@ test_suite(
         ":shutdown_drain_test",
         ":sse_auth_gate_test",
         ":steward_eval_harness_test",
+        ":studio_k_asks_test",
         ":tool_event_stream_contracts_test",
         ":unified_console_test",
         ":wildcard_routes_test",

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -47,25 +47,25 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "0.7"
-meerkat-client = "0.7"
-meerkat-contracts = "0.7"
-meerkat-mob = "0.7"
-meerkat-mob-mcp = "0.7"
-meerkat-mcp = "0.7"
-meerkat-models = "0.7"
+meerkat-core = "=0.7.18"
+meerkat-client = "=0.7.18"
+meerkat-contracts = "=0.7.18"
+meerkat-mob = "=0.7.18"
+meerkat-mob-mcp = "=0.7.18"
+meerkat-mcp = "=0.7.18"
+meerkat-models = "=0.7.18"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "0.7", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
+meerkat = { version = "=0.7.18", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "0.7"
-meerkat-runtime = { version = "0.7", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "0.7", features = ["session-store"] }
-meerkat-store = { version = "0.7", features = ["sqlite"] }
-meerkat-tools = "0.7"
+meerkat-memory = "=0.7.18"
+meerkat-runtime = { version = "=0.7.18", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.7.18", features = ["session-store"] }
+meerkat-store = { version = "=0.7.18", features = ["sqlite"] }
+meerkat-tools = "=0.7.18"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -119,10 +119,10 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "0.7"
-meerkat-schedule = "0.7"
+meerkat-comms = "=0.7.18"
+meerkat-schedule = "=0.7.18"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "0.7", features = ["schema"] }
+meerkat-mob = { version = "=0.7.18", features = ["schema"] }

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -3552,13 +3552,19 @@ fn internal_error(id: Value, message: impl Into<String>) -> Value {
         error = %message,
         "console JSON-RPC internal error"
     );
+    // The real failure reason goes on the wire. It used to be logged here
+    // and replaced with a bare "internal_error", which made every -32000
+    // undiagnosable from the client side (meerkat-studio ask K2: their K1
+    // retire/respawn failures cost a day because this said nothing).
+    // `error` stays "internal_error" as the stable kind discriminator for
+    // existing clients; `detail` carries the human-readable chain.
     response_value(
         id,
         None,
         Some(JsonRpcError {
             code: -32000,
-            message: "internal error".to_string(),
-            data: Some(json!({ "error": "internal_error" })),
+            message: message.clone(),
+            data: Some(json!({ "error": "internal_error", "detail": message })),
         }),
     )
 }
@@ -9443,14 +9449,29 @@ comms = true
         );
     }
 
+    /// DECISION (2026-07-06, meerkat-studio ask K2): console JSON-RPC internal
+    /// errors DO disclose the failure reason. Every caller that reaches these
+    /// handlers is an operator by construction — an auth-gated console 401s
+    /// unauthenticated callers before dispatch, and an open console is a
+    /// trusted-local deployment choice — while the previous redaction made
+    /// every -32000 undiagnosable from the client (the K1 retire/respawn
+    /// failures cost the reporter a day). The `error` field stays a stable
+    /// kind discriminator; `console_send_public_message` keeps ITS redaction
+    /// because that surface can reflect into agent-visible space.
     #[test]
-    fn internal_error_does_not_disclose_backend_details() {
-        let response = super::internal_error(json!(7), "secret backend DSN");
+    fn internal_error_carries_detail_and_stable_kind() {
+        let response = super::internal_error(json!(7), "retire failed: backend says no");
 
         assert_eq!(response["error"]["code"], json!(-32000));
-        assert_eq!(response["error"]["message"], json!("internal error"));
+        assert_eq!(
+            response["error"]["message"],
+            json!("retire failed: backend says no")
+        );
         assert_eq!(response["error"]["data"]["error"], json!("internal_error"));
-        assert!(!response.to_string().contains("secret backend DSN"));
+        assert_eq!(
+            response["error"]["data"]["detail"],
+            json!("retire failed: backend says no")
+        );
     }
 
     #[test]

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -2259,6 +2259,15 @@ pub struct MobBootstrapSpec {
     /// agent memory rides here — see `crate::memory::spawn_customizer`).
     /// Forwarded to `MobBuilder::with_spawn_member_customizer`.
     pub(crate) spawn_member_customizer: Option<Arc<dyn meerkat_mob::SpawnMemberCustomizer>>,
+    /// Mob-wide external-tools provider, forwarded to
+    /// `MobBuilder::with_default_external_tools_provider`. Called at EVERY
+    /// member spawn — including revival — so tools attached here survive
+    /// `materialize_revived_member_session`, unlike the per-spawn
+    /// `SpawnMemberSpec.external_tools` overlay, which revival drops
+    /// (meerkat-studio ask K4/M2). NOTE: a profile's `tools.mcp` allowlist
+    /// gates what this provider exposes to that member, and an EMPTY allowlist
+    /// means the full surface, not none.
+    pub(crate) default_external_tools_provider: Option<meerkat_mob::ExternalToolsProvider>,
     /// Holds the ephemeral temp directory alive for the lifetime of the spec.
     /// Only populated when the builder creates an ephemeral runtime.
     pub(crate) _ephemeral_dir: Option<Arc<tempfile::TempDir>>,
@@ -2292,12 +2301,27 @@ impl MobBootstrapSpec {
             },
             runtime_adapter: None,
             spawn_member_customizer: None,
+            default_external_tools_provider: None,
             _ephemeral_dir: None,
         }
     }
 
     pub fn with_options(mut self, options: MobBootstrapOptions) -> Self {
         self.options = options;
+        self
+    }
+
+    /// Install a mob-wide external-tools provider (e.g. MCP-backed callback
+    /// tools). Unlike the per-spawn `SpawnMemberSpec.external_tools` overlay —
+    /// which member revival silently drops — this provider is consulted on
+    /// every spawn AND every revival, so the tools are durable for the
+    /// member's whole lifecycle. The profile's `tools.mcp` allowlist gates
+    /// what each member sees; an empty allowlist means the full surface.
+    pub fn with_default_external_tools_provider(
+        mut self,
+        provider: meerkat_mob::ExternalToolsProvider,
+    ) -> Self {
+        self.default_external_tools_provider = Some(provider);
         self
     }
 
@@ -2923,6 +2947,10 @@ impl MobRuntime {
 
         if let Some(customizer) = spec.spawn_member_customizer.clone() {
             builder = builder.with_spawn_member_customizer(customizer);
+        }
+
+        if let Some(provider) = spec.default_external_tools_provider.clone() {
+            builder = builder.with_default_external_tools_provider(Some(provider));
         }
 
         if let Some(client) = default_llm_client {

--- a/meerkat-mobkit/tests/hooks.rs
+++ b/meerkat-mobkit/tests/hooks.rs
@@ -480,3 +480,72 @@ async fn respawn_member_replaces_member() {
 
     runtime.shutdown().await;
 }
+
+/// meerkat-studio ask K4: a mob-wide external-tools provider installed via
+/// `MobBootstrapSpec::with_default_external_tools_provider` must be consulted
+/// at EVERY member materialization — the initial spawn AND the respawn
+/// replacement — unlike the per-spawn `SpawnMemberSpec.external_tools`
+/// overlay, which revival drops.
+#[tokio::test]
+async fn default_external_tools_provider_survives_respawn() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct NoTools;
+    #[async_trait::async_trait]
+    impl meerkat_core::AgentToolDispatcher for NoTools {
+        fn tools(&self) -> Arc<[Arc<meerkat_core::types::ToolDef>]> {
+            Vec::<Arc<meerkat_core::types::ToolDef>>::new().into()
+        }
+        async fn dispatch(
+            &self,
+            call: meerkat_core::types::ToolCallView<'_>,
+        ) -> Result<meerkat_core::ToolDispatchOutcome, meerkat_core::ToolError> {
+            Ok(meerkat_core::ToolDispatchOutcome::sync_result(
+                meerkat_core::types::ToolResult::new(call.id.to_string(), "{}".to_string(), false),
+            ))
+        }
+        fn capabilities(&self) -> meerkat_core::agent::DispatcherCapabilities {
+            meerkat_core::agent::DispatcherCapabilities::default()
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider_calls = calls.clone();
+    let provider: meerkat_mob::ExternalToolsProvider = Arc::new(move || {
+        provider_calls.fetch_add(1, Ordering::SeqCst);
+        Some(Arc::new(NoTools) as Arc<dyn meerkat_core::AgentToolDispatcher>)
+    });
+
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let runtime = Box::pin(
+        UnifiedRuntime::builder()
+            .mob_spec(build_mob_spec(&temp_dir).with_default_external_tools_provider(provider))
+            .module_config(empty_module_config())
+            .timeout(Duration::from_secs(2))
+            .build(),
+    )
+    .await
+    .expect("build unified runtime");
+
+    runtime
+        .spawn(spawn_spec("worker", "tooled-member"))
+        .await
+        .expect("spawn tooled-member");
+    let after_spawn = calls.load(Ordering::SeqCst);
+    assert!(
+        after_spawn >= 1,
+        "provider must be consulted at initial spawn"
+    );
+
+    runtime
+        .mob_handle()
+        .respawn(meerkat_mob::ids::AgentIdentity::from("tooled-member"), None)
+        .await
+        .expect("respawn should succeed");
+    assert!(
+        calls.load(Ordering::SeqCst) > after_spawn,
+        "provider must be consulted again at respawn (revival-surviving tools)"
+    );
+
+    runtime.shutdown().await;
+}

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -1,0 +1,342 @@
+// meerkat-studio K-asks regression suite (K1 repro + K2 transparency).
+//
+// K1: mobkit/retire_member + mobkit/respawn_member on members of a
+// multi-member crew created via mobkit/ensure_member. Works on the ephemeral
+// session service; on the persistent chain (studio's construction:
+// FactoryAgentBuilder -> PersistentSessionService -> MobBootstrapSpec ->
+// UnifiedRuntime) BOTH fail for never-ran members: disposal completes but the
+// ArchiveSession step's authority lookup NotFounds (no runtime snapshot was
+// ever committed for an idle member), meerkat-mob escalates to a fatal
+// error, and the member is stranded in state=retiring (respawn aborts after
+// the failed retire, leaving a cancelled-kickoff zombie). Upstream ask 20;
+// the persistent test below is #[ignore]d until the meerkat fix lands.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{Body, to_bytes};
+use axum::http::Request;
+use meerkat::{
+    AgentFactory, Config, FactoryAgentBuilder, PersistentSessionService, build_ephemeral_service,
+};
+use meerkat_client::TestClient;
+use meerkat_mob::{MobDefinition, MobStorage};
+use meerkat_mobkit::{
+    AuthPolicy, BigQueryNaming, ConsolePolicy, DiscoverySpec, MobBootstrapOptions,
+    MobBootstrapSpec, MobKitConfig, RuntimeDecisionInputs, RuntimeOpsPolicy,
+    TrustedOidcRuntimeConfig, UnifiedRuntime, build_runtime_decision_state,
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+async fn rpc(app: &axum::Router, method: &str, params: Value) -> Value {
+    let request = json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params});
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/console/rpc")
+                .header("content-type", "application/json")
+                .body(Body::from(request.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("body");
+    serde_json::from_slice(&body).expect("json")
+}
+
+fn studio_decision_state() -> meerkat_mobkit::RuntimeDecisionState {
+    build_runtime_decision_state(RuntimeDecisionInputs {
+        bigquery: BigQueryNaming {
+            dataset: "studio_dataset".to_string(),
+            table: "studio_table".to_string(),
+        },
+        trusted_mobkit_toml: r#"
+[[modules]]
+id = "router"
+command = "router-bin"
+args = []
+restart_policy = "always"
+"#
+        .to_string(),
+        auth: AuthPolicy {
+            default_provider: meerkat_mobkit::AuthProvider::GoogleOAuth,
+            email_allowlist: vec!["alice@example.com".to_string()],
+        },
+        trusted_oidc: TrustedOidcRuntimeConfig {
+            discovery_json:
+                r#"{"issuer":"https://trusted.mobkit.local","jwks_uri":"https://trusted.mobkit.local/.well-known/jwks.json"}"#
+                    .to_string(),
+            jwks_json: r#"{"keys":[{"kid":"kid-current","kty":"oct","alg":"HS256","k":"cGhhc2U3LXRydXN0ZWQtY3VycmVudC1zZWNyZXQ"}]}"#
+                .to_string(),
+            audience: "meerkat-console".to_string(),
+        },
+        console: ConsolePolicy {
+            require_app_auth: false,
+            ..ConsolePolicy::default()
+        },
+        ops: RuntimeOpsPolicy::default(),
+        release_metadata_json: include_str!("../assets/release-targets.json").to_string(),
+    })
+    .expect("decision state")
+}
+
+#[tokio::test]
+async fn studio_k1_retire_respawn_succeed_on_ephemeral_ensure_member_crew() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let session_path = temp_dir.path().join("sessions");
+    std::fs::create_dir_all(&session_path).expect("session path");
+    let factory = AgentFactory::new(&session_path).comms(true);
+    let session_service = Arc::new(build_ephemeral_service(factory, Config::default(), 16));
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "studio-crew"
+
+[profiles.general]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.general.tools]
+comms = true
+"#,
+    )
+    .expect("definition");
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "studio".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap");
+    let decisions = studio_decision_state();
+    let app = runtime.build_reference_app_router(decisions);
+
+    for member in ["lead", "builder", "reviewer"] {
+        let response = rpc(
+            &app,
+            "mobkit/ensure_member",
+            json!({"role": "general", "agent_identity": member}),
+        )
+        .await;
+        assert!(
+            response.get("error").is_none(),
+            "ensure {member}: {response}"
+        );
+    }
+
+    let retire = rpc(
+        &app,
+        "mobkit/retire_member",
+        json!({"member_id": "builder"}),
+    )
+    .await;
+    assert!(
+        retire.get("error").is_none(),
+        "retire_member on an ephemeral ensure_member crew must succeed: {retire}"
+    );
+
+    let respawn = rpc(
+        &app,
+        "mobkit/respawn_member",
+        json!({"member_id": "reviewer"}),
+    )
+    .await;
+    assert!(
+        respawn.get("error").is_none(),
+        "respawn_member on an ephemeral ensure_member crew must succeed: {respawn}"
+    );
+}
+
+/// Studio's actual construction chain: FactoryAgentBuilder →
+/// PersistentSessionService → MobBootstrapSpec → UnifiedRuntime, then a
+/// 3-member crew via mobkit/ensure_member and per-member retire/respawn.
+#[tokio::test]
+#[ignore = "blocked on meerkat ask 20 (target 0.7.19): ArchiveSession NotFound for never-ran members strands them in retiring; see docs/design/upstream-asks.md"]
+async fn studio_k1_retire_respawn_succeed_on_persistent_ensure_member_crew() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let state = temp_dir.path().join("state");
+    std::fs::create_dir_all(&state).expect("state dir");
+    let session_store: Arc<dyn meerkat::SessionStore> = Arc::new(
+        meerkat_store::SqliteSessionStore::open(state.join("sessions.db")).expect("session store"),
+    );
+    let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> = Arc::new(
+        meerkat_runtime::store::SqliteRuntimeStore::new(state.join("runtime.sqlite"))
+            .expect("runtime store"),
+    );
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let factory = AgentFactory::new(&state).comms(true);
+    let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+    builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
+        session_store.clone(),
+    )));
+    builder.default_blob_store = Some(blob_store.clone());
+    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
+        Arc::clone(&runtime_store),
+        Arc::clone(&blob_store),
+    ));
+    let service = Arc::new(PersistentSessionService::new(
+        builder,
+        16,
+        session_store,
+        runtime_store,
+        blob_store,
+    ));
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "studio-crew-persistent"
+
+[profiles.general]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.general.tools]
+comms = true
+"#,
+    )
+    .expect("definition");
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), service)
+        .with_session_runtime_adapter(adapter.clone())
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "studio-persistent".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap");
+    let app = runtime.build_reference_app_router(studio_decision_state());
+
+    for member in ["lead", "builder", "reviewer"] {
+        let response = rpc(
+            &app,
+            "mobkit/ensure_member",
+            json!({"role": "general", "agent_identity": member}),
+        )
+        .await;
+        assert!(
+            response.get("error").is_none(),
+            "ensure {member}: {response}"
+        );
+    }
+
+    let respawn = rpc(
+        &app,
+        "mobkit/respawn_member",
+        json!({"member_id": "reviewer"}),
+    )
+    .await;
+    let retire = rpc(
+        &app,
+        "mobkit/retire_member",
+        json!({"member_id": "builder"}),
+    )
+    .await;
+    assert!(
+        retire.get("error").is_none(),
+        "retire_member on a persistent ensure_member crew must succeed \
+         (meerkat-studio K1); error: {retire}"
+    );
+
+    assert!(
+        respawn.get("error").is_none(),
+        "respawn_member on a persistent ensure_member crew must succeed \
+         (meerkat-studio K1); error: {respawn}"
+    );
+}
+
+/// meerkat-studio ask K2: a console JSON-RPC internal error must carry the
+/// real failure reason on the wire — `message` and `data.detail` — never a
+/// bare `{"error":"internal_error"}`. Uses an operation that fails
+/// deterministically regardless of upstream fixes: respawning a member that
+/// does not exist.
+#[tokio::test]
+async fn studio_k2_internal_errors_carry_detail_on_the_wire() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let session_path = temp_dir.path().join("sessions");
+    std::fs::create_dir_all(&session_path).expect("session path");
+    let factory = AgentFactory::new(&session_path).comms(true);
+    let session_service = Arc::new(build_ephemeral_service(factory, Config::default(), 16));
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "studio-k2"
+
+[profiles.general]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.general.tools]
+comms = true
+"#,
+    )
+    .expect("definition");
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "studio-k2".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap");
+    let app = runtime.build_reference_app_router(studio_decision_state());
+
+    let response = rpc(
+        &app,
+        "mobkit/respawn_member",
+        json!({"member_id": "no-such-member"}),
+    )
+    .await;
+    let error = response
+        .get("error")
+        .expect("respawn of unknown member errors");
+    let message = error["message"].as_str().unwrap_or_default();
+    assert_ne!(
+        message, "internal error",
+        "the wire message must carry the real reason, not the old opaque \
+         placeholder: {response}"
+    );
+    assert!(
+        !message.is_empty(),
+        "error message must not be empty: {response}"
+    );
+    let detail = error["data"]["detail"].as_str().unwrap_or_default();
+    assert!(
+        !detail.is_empty(),
+        "data.detail must carry the failure chain: {response}"
+    );
+}


### PR DESCRIPTION
Mobkit's side of the meerkat-studio field report (M1–M4 are relayed to the meerkat team via `docs/design/upstream-asks.md` Batch 4, joining the 0.7.19 scope).

**K2 — error transparency (P0, shipped):** `internal_error` used to log the real reason server-side and put a bare `{"error":"internal_error"}` on the wire. Now `message` + `data.detail` carry the chain; `error` stays as the stable kind marker. This deliberately reverses the earlier redaction posture *for this surface only* — every caller that reaches these handlers is an operator by construction (auth-gated consoles 401 before dispatch; open consoles are a trusted-local deployment choice), and the redaction made every -32000 undiagnosable. The old canary test is rewritten as the decision record; `console_send`'s public-message redaction (agent-visible surface) is unchanged. Contract test: `studio_k2_internal_errors_carry_detail_on_the_wire`.

**K1 — root-caused, upstream (P0, ask 20 filed):** with K2's detail the failure named itself instantly: on studio's exact construction chain (FactoryAgentBuilder → PersistentSessionService → MobBootstrapSpec), retire/respawn of a **never-ran** member completes disposal but the ArchiveSession step NotFounds (idle members never commit a runtime snapshot), meerkat-mob escalates to fatal, the member is stranded at `state=retiring`, and respawn aborts (`roster_still_contains_member`) leaving a cancelled-kickoff zombie. Ephemeral crews are fine (green baseline test). The fix belongs in meerkat-mob's disposal judgment — ask 20 proposes treating never-committed-snapshot archive misses after completed disposal as no-op success (or committing an initial snapshot at registration). Deterministic repro ships `#[ignore]`d in `tests/studio_k_asks.rs`, un-ignored on the 0.7.19 upgrade.

**K4 — durable external-tools seam (P1, shipped):** `MobBootstrapSpec::with_default_external_tools_provider` exposes meerkat-mob's mob-wide provider — consulted at every spawn *and* respawn, so tools survive revival (unlike the per-spawn overlay). Test: `default_external_tools_provider_survives_respawn`. Docs cover the `profile.tools.mcp` allowlist gating surprise (empty allowlist = full surface).

**K5 — exact pins (P2, shipped):** the meerkat family is `=0.7.18` in Cargo.toml; the compatible version is declared per release, not archaeologized from Cargo.lock.

**K3 (P1, dispositioned):** mobkit has no mob-spawn HTTP endpoint — the intermittent 500 under on-demand source builds is the reporter's app-side child-gateway launcher. Everything on mobkit's surface now carries detail per K2, so if any of those 500s do transit mobkit, they'll name themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)