### PR TITLE
fix(mobkit_gateway): install the tracing subscriber — the console gateway was silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `mobkit_gateway` now installs a tracing subscriber (stderr, `RUST_LOG`
+  honored, default `warn`) and logs a version-stamped startup line.
+  Previously the binary dropped every tracing event in the process —
+  runtime failures, console internal-error logs, and the schedule claim
+  watchdog's stall diagnosis were all invisible; meerkat-studio root-caused
+  their opaque K1/K2 failures to exactly this gap on the child gateways
+  their app spawns. `rpc_gateway` already had the subscriber.
+
 ### Added
 
 - Mob-wide, revival-surviving external-tools seam (meerkat-studio ask K4):

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -798,16 +798,25 @@ bridge already classifies this exact string as recoverable for SESSION-OWNED
 retire (mobkit `is_recoverable_session_owned_retire_cleanup_error`) — the mob-
 member path needs the equivalent judgment at the source.
 
-**Proposed shape.** In meerkat-mob: when disposal COMPLETED and the archive
-miss is `NotFound for registered runtime session` (never-committed snapshot,
-not a lost record — distinguishable by asking the runtime store whether the
-logical runtime id ever existed), treat archive as a no-op success and let
-the retirement commit finish; respawn then proceeds naturally. Alternatively
-commit an initial runtime snapshot at member session registration so the
-lookup never misses. Regression: retire + respawn of a freshly spawned,
-never-prompted member on a persistent service must succeed; a
-`roster.get(...)`-after-failed-retire assertion to pin the no-strand
-invariant.
+**Proposed shape.** In meerkat-mob (the escalation site is the archive
+helper at `src/runtime/provisioner.rs:894`): when disposal COMPLETED and the
+archive miss is `NotFound for registered runtime session`, treat the
+session-owned member as already-archived — per the helper's own doc comment
+— and let the retirement commit finish; respawn then proceeds naturally.
+(Alternative: register/commit an initial runtime snapshot at member session
+creation so the authority never misses; either side of the seam works, the
+judgment belongs upstream.) Do NOT fix this with downstream tolerance:
+retrying fails identically and `list_members` is unchanged afterwards — the
+member is neither respawned nor removed — so a console-layer
+"tolerate and report accepted" patch misreports reality (verified
+empirically by both mobkit and the reporter, independently). mobkit's
+identity-first bridge already carries the exact tolerance string
+(`is_recoverable_session_owned_retire_cleanup_error`) but it never applies
+on the console `handle.retire()`/`respawn()` path, and lifting it there
+would hit the misreporting trap above. Regression: retire + respawn of a
+freshly spawned, never-prompted member on a persistent service must
+succeed; a `roster.get(...)`-after-failed-retire assertion to pin the
+no-strand invariant.
 
 ## M1 — force_cancel_member stack-overflows (SIGABRT) mid-turn — P0
 

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -579,6 +579,25 @@ fn main() {
         );
         return;
     }
+    // Install the tracing subscriber FIRST (mirrors rpc_gateway). Without it
+    // every tracing event in the process is silently dropped: runtime
+    // failures, console internal-error logs, and the schedule claim
+    // watchdog's stall diagnosis all vanish — meerkat-studio root-caused
+    // their opaque K1/K2 failures to exactly this missing init on the child
+    // gateways their app spawns. Stderr, never stdout: stdout carries the
+    // init JSON handshake.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        "mobkit_gateway starting (console/HTTP gateway)"
+    );
     // Meerkat 0.7's generated machine-authority apply path needs deep worker
     // stacks (mirrors meerkat-rpc's explicit 16 MiB tokio worker sizing).
     let runtime = match tokio::runtime::Builder::new_multi_thread()

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -239,3 +239,65 @@ fn mobkit_gateway_rejects_post_init_stdin_rpc_loudly() {
         "post-init stdin RPC must fail loudly and point at rpc_gateway, got: {reconcile_resp}"
     );
 }
+
+/// meerkat-studio K2 root cause on this binary: `mobkit_gateway` had no
+/// tracing subscriber, so every WARN/ERROR in the process — runtime
+/// failures, console internal-error logs, the schedule claim watchdog's
+/// stall diagnosis — was silently dropped. Pin that the binary emits
+/// tracing on stderr: with RUST_LOG=info the bootstrap path logs at least
+/// one INFO line.
+#[test]
+fn mobkit_gateway_emits_tracing_on_stderr() {
+    let bin = env!("CARGO_BIN_EXE_mobkit_gateway");
+    let workspace = TempDir::new().expect("workspace tempdir");
+    let store = TempDir::new().expect("store tempdir");
+
+    let init = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "mobkit/init",
+        "params": {
+            "workspace_root": workspace.path().to_string_lossy(),
+            "store_path": store.path().join("store").to_string_lossy(),
+        },
+    });
+
+    let mut child = Command::new(bin)
+        .current_dir(workspace.path())
+        .env("ANTHROPIC_API_KEY", "sk-ant-regression-test")
+        .env("OPENAI_API_KEY", "sk-regression-test")
+        .env("XDG_STATE_HOME", workspace.path().join("xdg-state"))
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mobkit_gateway");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    writeln!(stdin, "{}", serde_json::to_string(&init).unwrap()).expect("write init");
+    stdin.flush().expect("flush");
+
+    // Wait for the init response so bootstrap tracing has happened.
+    let stdout = child.stdout.take().expect("stdout");
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let _ = reader.read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let _init_response = rx
+        .recv_timeout(Duration::from_mins(1))
+        .expect("gateway responded to init");
+
+    let _ = stdin;
+    let _ = child.kill();
+    let output = child.wait_with_output().expect("gateway output");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("INFO") || stderr.contains("WARN"),
+        "mobkit_gateway must emit tracing on stderr (RUST_LOG=info); \
+         got stderr: {stderr:?}"
+    );
+}


### PR DESCRIPTION
meerkat-studio's deeper root-cause of their K1/K2 experience: `mobkit_gateway` never installed a tracing subscriber, so **every tracing event in the process was silently dropped** — runtime failures, console internal-error WARN logs, and the schedule claim watchdog's stall diagnosis (#237) all vanished on the child gateways their app spawns. `rpc_gateway` has carried the subscriber (with a comment explaining exactly this failure mode) all along; the console gateway just never got it.

- Same init as rpc_gateway: stderr writer, `RUST_LOG` honored, default `warn`, no ANSI (stdout stays clean for the init JSON handshake).
- Version-stamped startup INFO line — operationally useful and the deterministic probe for the regression test.
- Regression test spawns the real binary with `RUST_LOG=info` and asserts stderr carries tracing.
- Ask 20 sharpened with the reporter's independent findings: escalation site `provisioner.rs:894`, the already-archived-per-its-own-doc-comment fix direction, and the empirically verified warning that downstream tolerance misreports (retry fails identically; `list_members` unchanged — the member is neither respawned nor removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)