### PR TITLE
feat: identity-first gateway mode — opt-in durable-identity substrate for mobkit_gateway (studio ask K0, doctrine phase 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Identity-first gateway mode (meerkat-studio ask K0): `identity_first: true`
+  on `mobkit_gateway` init boots the durable-identity substrate — continuity
+  records + lease-fenced embodiment (default providers constructed from the
+  existing store paths), resume-first restore with the Broken-identity
+  repair task, and the identity console RPC surface. An optional
+  `identity_roster` init param seeds the desired identities;
+  `mobkit/ensure_member` upserts the roster and reconciles at runtime, and
+  `retire_member`/`respawn_member` route through the tolerant identity
+  lifecycle — the ask-20 retire/respawn failure class does not exist on this
+  surface (proved by test: retire + respawn of never-ran members succeed).
+  Rust embedders get the same via the new
+  `identity_first::MutableRosterProvider` + `UnifiedRuntime::set_console_identity_roster`
+  + `attach_identity_first_context` (or `UnifiedRuntimeBuilder`'s existing
+  roster/continuity/lease inputs on the definition path).
+
 ### Fixed
 
 - `mobkit_gateway` now installs a tracing subscriber (stderr, `RUST_LOG`

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -55,6 +55,15 @@ struct InitParams {
     surface: Option<String>,
     runtime_profile: Option<String>,
     console_read_only: Option<bool>,
+    /// Run this gateway identity-first (meerkat-studio ask K0): durable
+    /// identities with continuity records, lease-fenced embodiment, and the
+    /// tolerant identity lifecycle paths — instead of the session-owned
+    /// mob-member surface (where the ask-20 retire/respawn class lives).
+    identity_first: Option<bool>,
+    /// Desired identity roster for `identity_first: true` — restored at boot
+    /// and reconciled thereafter. `mobkit/ensure_member` adds to it at
+    /// runtime.
+    identity_roster: Option<Vec<meerkat_mobkit::identity_first::DurableAgentSpec>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -656,6 +665,8 @@ async fn run() -> anyhow::Result<()> {
         .unwrap_or_else(|| runtime_root.join("state"));
     let store_path = store_path.canonicalize().unwrap_or(store_path);
     let persistent_sessions = params.persistent_sessions.unwrap_or(false);
+    let identity_first = params.identity_first.unwrap_or(false);
+    let identity_roster_seed = params.identity_roster.clone().unwrap_or_default();
     let realm = params.realm.as_deref();
     let isolated = params.isolated.unwrap_or(false);
     let _surface = params.surface.unwrap_or_else(|| "tux".to_string());
@@ -915,6 +926,84 @@ async fn run() -> anyhow::Result<()> {
             .await
             .map_err(|error| anyhow!("failed to spawn fallback alpha meerkat: {error}"))?;
     }
+
+    // Identity-first mode (meerkat-studio ask K0): give this gateway the
+    // durable-identity substrate — continuity records, lease-fenced
+    // embodiment, resume-first restore with the Broken-identity repair task,
+    // and the tolerant identity lifecycle paths. Default providers are
+    // constructed from the existing store paths; the roster is seeded from
+    // init params and extended at runtime by `mobkit/ensure_member`.
+    let _identity_roster_provider: Option<
+        Arc<meerkat_mobkit::identity_first::MutableRosterProvider>,
+    > = if identity_first {
+        use meerkat_mobkit::identity_first::{
+            AgentRuntimeServices, DurabilityPolicy, IdentityFirstRuntimeContext, IdentityRuntime,
+            IdentityRuntimeConfig, LocalContinuityStore, LocalLeaseProvider, MobSessionBridge,
+            MutableRosterProvider, restore_flow,
+        };
+
+        let (store_dir, _) = resolve_store_dir(&store_path);
+        fs::create_dir_all(&store_dir)
+            .with_context(|| format!("failed to create {}", store_dir.display()))?;
+        let continuity_db = store_dir.join("continuity.db");
+        let continuity_store = LocalContinuityStore::open(&continuity_db)
+            .with_context(|| format!("failed to open {}", continuity_db.display()))?;
+        // Resume the fencing counter above the persisted high-water so a
+        // restart with existing continuity history never presents a stale
+        // token (mirrors rpc_gateway).
+        let fencing_floor = continuity_store
+            .max_fencing_token()
+            .context("failed to read continuity fencing high-water")?;
+        let lease_provider = LocalLeaseProvider::with_floor(fencing_floor);
+
+        let mob_handle = runtime.mob_handle();
+        let bridge: Arc<dyn meerkat_mobkit::identity_first::SessionBridge> =
+            if let Some(session_service) = runtime.mob_runtime().session_service().cloned() {
+                Arc::new(MobSessionBridge::with_session_service(
+                    mob_handle.clone(),
+                    session_service,
+                ))
+            } else {
+                Arc::new(MobSessionBridge::new(mob_handle.clone()))
+            };
+
+        let irt = IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(continuity_store),
+            lease_provider: Arc::new(lease_provider),
+            runtime_instance_id: format!("mobkit-gateway-{}", std::process::id()),
+            has_runtime_store: persistent_sessions,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge),
+            default_timeout: None,
+        })
+        .with_runtime_services(AgentRuntimeServices::new(mob_handle.clone()));
+
+        let roster = Arc::new(MutableRosterProvider::new(identity_roster_seed));
+        let mob_definition = mob_handle.definition().clone();
+        let irt = Arc::new(irt);
+        restore_flow(&irt, &roster.snapshot(), None, None)
+            .await
+            .context("identity-first restore_flow failed")?;
+        // Attaching the context wires the console's identity RPC surface and
+        // spawns the Broken-identity repair task; the roster slot lets
+        // `mobkit/ensure_member` extend the desired roster at runtime.
+        runtime.set_console_identity_roster(roster.clone());
+        runtime.attach_identity_first_context(Arc::new(IdentityFirstRuntimeContext::new(
+            irt,
+            roster.clone(),
+            None,
+            None,
+            Some(mob_definition),
+        )));
+        tracing::info!(
+            roster = roster.snapshot().len(),
+            continuity_db = %continuity_db.display(),
+            "identity-first gateway mode active"
+        );
+        Some(roster)
+    } else {
+        None
+    };
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -105,6 +105,10 @@ pub struct ConsoleJsonState {
     /// `None` when the operator scope is off (or memory is unconfigured).
     pub(crate) operator_resolver:
         Option<Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>>,
+    /// Identity-first gateways: the mutable desired-identity roster that
+    /// `mobkit/ensure_member` extends (ask K0). `None` on session-owned
+    /// deployments.
+    pub(crate) identity_roster: Option<Arc<crate::identity_first::MutableRosterProvider>>,
 }
 
 #[derive(Debug, Clone)]
@@ -249,6 +253,7 @@ pub fn console_json_router(decisions: RuntimeDecisionState) -> Router {
         access: None,
         memory_panel: None,
         operator_resolver: None,
+        identity_roster: None,
     })
 }
 
@@ -281,6 +286,7 @@ pub fn console_json_router_with_aggregator_and_access(
         access,
         memory_panel: None,
         operator_resolver: None,
+        identity_roster: None,
     })
 }
 
@@ -335,6 +341,7 @@ pub(crate) fn console_json_router_with_runtime_and_events(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -355,6 +362,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
     access: Option<AccessController>,
     memory_panel: Option<crate::memory::sqlite_store::SqliteAgentMemoryStore>,
     operator_resolver: Option<Arc<crate::memory::coordinator::ConsolePrincipalOperatorResolver>>,
+    identity_roster: Option<Arc<crate::identity_first::MutableRosterProvider>>,
 ) -> Router {
     let console_aggregator = console_events.clone().map(|events| {
         if let Some(store) = console_log_store {
@@ -400,6 +408,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
         access,
         memory_panel,
         operator_resolver,
+        identity_roster,
     })
 }
 
@@ -609,6 +618,7 @@ pub async fn console_rpc_handler(
         state.access.as_ref(),
         auth_context.access_view.as_ref(),
         state.memory_panel.as_ref(),
+        state.identity_roster.clone(),
     ))
     .await;
     (StatusCode::OK, Json::<Value>(response_value))
@@ -3077,6 +3087,7 @@ pub async fn console_rpc_multipart_handler(
                 state.access.as_ref(),
                 auth_context.access_view.as_ref(),
                 state.memory_panel.as_ref(),
+                state.identity_roster.clone(),
             ))
             .await
         };
@@ -4945,6 +4956,7 @@ async fn handle_console_runtime_rpc(
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -4968,6 +4980,7 @@ async fn handle_console_runtime_rpc_with_visibility(
     access: Option<&AccessController>,
     access_view: Option<&AccessView>,
     memory_panel: Option<&crate::memory::sqlite_store::SqliteAgentMemoryStore>,
+    identity_roster: Option<Arc<crate::identity_first::MutableRosterProvider>>,
 ) -> Value {
     let response_id = request.id.clone().unwrap_or(Value::Null);
     let can_mutate = is_authenticated && !read_only;
@@ -6829,6 +6842,95 @@ async fn handle_console_runtime_rpc_with_visibility(
                 Ok(value) => value,
                 Err(message) => return invalid_params(response_id, message),
             };
+            // Identity-first gateways (ask K0): ensure_member upserts the
+            // desired-identity roster and reconciles — the durable-identity
+            // equivalent of the mob-member spawn, with the tolerant identity
+            // lifecycle underneath (the ask-20 retire/respawn class does not
+            // exist on this surface).
+            if let (Some(identity_runtime_ref), Some(roster)) =
+                (identity_runtime.as_ref(), identity_roster.as_ref())
+            {
+                let identity = match crate::identity_first::AgentIdentity::parse(agent_identity) {
+                    Ok(identity) => identity,
+                    Err(err) => {
+                        return invalid_params(
+                            response_id,
+                            format!("invalid agent_identity: {err}"),
+                        );
+                    }
+                };
+                if resume_session_id.is_some() {
+                    return invalid_params(
+                        response_id,
+                        "resume_session_id is not supported on an identity-first \
+                         gateway: continuity records own session resumption",
+                    );
+                }
+                if binding.is_some() {
+                    return invalid_params(
+                        response_id,
+                        "external runtime bindings are not supported on an \
+                         identity-first gateway yet",
+                    );
+                }
+                let spec = crate::identity_first::DurableAgentSpec {
+                    identity: identity.clone(),
+                    profile: ProfileName::from(role),
+                    addressability: crate::identity_first::AgentAddressability::Addressable,
+                    display_name: None,
+                    labels,
+                    context,
+                    additional_instructions: additional_instructions.unwrap_or_default(),
+                    initial_message: None,
+                    runtime_mode_override: runtime_mode,
+                    backend,
+                    binding: None,
+                };
+                roster.upsert(spec);
+                return match crate::identity_first::restore_flow(
+                    identity_runtime_ref,
+                    &roster.snapshot(),
+                    None,
+                    None,
+                )
+                .await
+                {
+                    Ok(result) => {
+                        let outcome = match result.outcomes.get(&identity) {
+                            Some(crate::identity_first::RestoreOutcome::Created { .. }) => {
+                                "created"
+                            }
+                            Some(crate::identity_first::RestoreOutcome::Resumed { .. }) => {
+                                "resumed"
+                            }
+                            Some(crate::identity_first::RestoreOutcome::Dormant { .. }) => {
+                                "dormant"
+                            }
+                            Some(crate::identity_first::RestoreOutcome::Broken(_)) => "broken",
+                            None => "unchanged",
+                        };
+                        let state = identity_runtime_ref
+                            .status(&identity)
+                            .await
+                            .map(|status| status.state.wire_str().to_string())
+                            .unwrap_or_else(|_| "unknown".to_string());
+                        response_value(
+                            response_id,
+                            Some(serde_json::json!({
+                                "agent_identity": identity.as_str(),
+                                "role": role,
+                                "identity_first": true,
+                                "outcome": outcome,
+                                "state": state,
+                            })),
+                            None,
+                        )
+                    }
+                    Err(err) => {
+                        internal_error(response_id, format!("ensure_member (identity): {err}"))
+                    }
+                };
+            }
             let mut spec = SpawnMemberSpec::new(
                 ProfileName::from(role),
                 crate::member_comms_id::mob_member_id(agent_identity),
@@ -6880,6 +6982,45 @@ async fn handle_console_runtime_rpc_with_visibility(
             {
                 return response_value(response_id, None, Some(error));
             }
+            if let (Some(identity_runtime_ref), Some(roster)) =
+                (identity_runtime.as_ref(), identity_roster.as_ref())
+            {
+                let identity = match crate::identity_first::AgentIdentity::parse(member_id) {
+                    Ok(identity) => identity,
+                    Err(err) => {
+                        return invalid_params(response_id, format!("invalid member_id: {err}"));
+                    }
+                };
+                return match identity_runtime_ref.retire(&identity).await {
+                    Ok(_token) => {
+                        // Off the desired roster too, or the next reconcile
+                        // (or the repair task) re-creates it.
+                        roster.remove(&identity);
+                        response_value(
+                            response_id,
+                            Some(serde_json::json!({
+                                "accepted": true,
+                                "identity_first": true,
+                            })),
+                            None,
+                        )
+                    }
+                    Err(crate::identity_first::IdentityRuntimeError::UnknownIdentity(_)) => {
+                        response_value(
+                            response_id,
+                            None,
+                            Some(JsonRpcError {
+                                code: -32001,
+                                message: format!("unknown identity: {member_id}"),
+                                data: None,
+                            }),
+                        )
+                    }
+                    Err(err) => {
+                        internal_error(response_id, format!("retire_member (identity): {err}"))
+                    }
+                };
+            }
             if let Some(aggregator) = &console_aggregator {
                 return match Box::pin(aggregator.retire_identity(member_id)).await {
                     Ok(true) => response_value(
@@ -6924,6 +7065,45 @@ async fn handle_console_runtime_rpc_with_visibility(
             .await
             {
                 return response_value(response_id, None, Some(error));
+            }
+            if identity_roster.is_some()
+                && let Some(identity_runtime_ref) = identity_runtime.as_ref()
+            {
+                let identity = match crate::identity_first::AgentIdentity::parse(member_id) {
+                    Ok(identity) => identity,
+                    Err(err) => {
+                        return invalid_params(response_id, format!("invalid member_id: {err}"));
+                    }
+                };
+                // Identity-first respawn = reset: retire the live session and
+                // rebuild from the current roster spec under the same durable
+                // identity (fresh session, new generation).
+                return match identity_runtime_ref.reset(&identity).await {
+                    Ok(record) => response_value(
+                        response_id,
+                        Some(serde_json::json!({
+                            "accepted": true,
+                            "identity_first": true,
+                            "session_id": record.session_id.to_string(),
+                            "generation": record.generation.get(),
+                        })),
+                        None,
+                    ),
+                    Err(crate::identity_first::IdentityRuntimeError::UnknownIdentity(_)) => {
+                        response_value(
+                            response_id,
+                            None,
+                            Some(JsonRpcError {
+                                code: -32001,
+                                message: format!("unknown identity: {member_id}"),
+                                data: None,
+                            }),
+                        )
+                    }
+                    Err(err) => {
+                        internal_error(response_id, format!("respawn_member (identity): {err}"))
+                    }
+                };
             }
             match runtime
                 .handle()
@@ -10163,6 +10343,7 @@ comms = true
                 None,
                 None,
                 None,
+                None,
             ))
             .await;
             assert_ne!(
@@ -10272,6 +10453,7 @@ comms = true
                     None,
                     None,
                     None,
+                    None,
                 ))
                 .await;
                 assert_eq!(
@@ -10342,6 +10524,7 @@ comms = true
                 rpc_request_with_params(method, json!({ "identity": "review:singleton" })),
                 true,
                 false,
+                None,
                 None,
                 None,
                 None,
@@ -10612,6 +10795,7 @@ comms = true
             None,
             None,
             None,
+            None,
         ))
         .await;
         assert_eq!(
@@ -10707,6 +10891,7 @@ comms = true
             rpc_request("mobkit/reset_all"),
             true,
             false,
+            None,
             None,
             None,
             None,
@@ -10826,6 +11011,7 @@ comms = true
             rpc_request_with_params("mobkit/retire", json!({ "identity": "review:singleton" })),
             true,
             false,
+            None,
             None,
             None,
             None,
@@ -11187,6 +11373,7 @@ comms = true
             Some(&access_controller),
             Some(&denied_view),
             None,
+            None,
         ))
         .await;
         assert_eq!(
@@ -11240,6 +11427,7 @@ comms = true
             Some(&send_only_controller),
             Some(&send_only_view),
             None,
+            None,
         ))
         .await;
         assert_eq!(
@@ -11276,6 +11464,7 @@ comms = true
             None,
             Some(&send_only_controller),
             Some(&send_only_view),
+            None,
             None,
         ))
         .await;
@@ -11349,6 +11538,7 @@ comms = true
             Some(&wildcard_allow_exact_deny_controller),
             Some(&wildcard_allow_exact_deny_view),
             None,
+            None,
         ))
         .await;
         assert_eq!(
@@ -11385,6 +11575,7 @@ comms = true
             None,
             Some(&wildcard_allow_exact_deny_controller),
             Some(&wildcard_allow_exact_deny_view),
+            None,
             None,
         ))
         .await;
@@ -11424,6 +11615,7 @@ comms = true
             None,
             Some(&wildcard_allow_exact_deny_controller),
             Some(&wildcard_allow_exact_deny_view),
+            None,
             None,
         ))
         .await;

--- a/meerkat-mobkit/src/identity_first/adapters.rs
+++ b/meerkat-mobkit/src/identity_first/adapters.rs
@@ -27,6 +27,68 @@ use crate::unified_runtime::edge_types::{Discovery, EdgeDiscovery};
 
 /// Adapts a legacy `Discovery` trait impl into a `RosterProvider`.
 ///
+/// In-process mutable roster: the desired-identity list for hosts where the
+/// roster is operator-driven rather than app-provided (the identity-first
+/// console gateway: seeded from init params, extended by
+/// `mobkit/ensure_member`, shrunk by identity deletion). `roster()` returns a
+/// snapshot; mutations take effect on the next reconcile
+/// (`restore_flow` / `mobkit/reconcile_identity` / the Broken-identity
+/// repair task).
+#[derive(Default)]
+pub struct MutableRosterProvider {
+    roster: std::sync::RwLock<Vec<DurableAgentSpec>>,
+}
+
+impl MutableRosterProvider {
+    pub fn new(initial: Vec<DurableAgentSpec>) -> Self {
+        Self {
+            roster: std::sync::RwLock::new(initial),
+        }
+    }
+
+    /// Insert or replace (by identity) a desired spec.
+    pub fn upsert(&self, spec: DurableAgentSpec) {
+        let mut roster = self
+            .roster
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match roster
+            .iter_mut()
+            .find(|entry| entry.identity == spec.identity)
+        {
+            Some(entry) => *entry = spec,
+            None => roster.push(spec),
+        }
+    }
+
+    /// Remove an identity from the desired roster. Returns whether it was
+    /// present. Removal does NOT retire the live identity — reconcile owns
+    /// convergence.
+    pub fn remove(&self, identity: &AgentIdentity) -> bool {
+        let mut roster = self
+            .roster
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let before = roster.len();
+        roster.retain(|entry| &entry.identity != identity);
+        roster.len() != before
+    }
+
+    pub fn snapshot(&self) -> Vec<DurableAgentSpec> {
+        self.roster
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl RosterProvider for MutableRosterProvider {
+    async fn roster(&self, _context: &RosterContext) -> Result<Vec<DurableAgentSpec>, RosterError> {
+        Ok(self.snapshot())
+    }
+}
+
 /// Maps `AgentDiscoverySpec` to `DurableAgentSpec` per REQ-27:
 /// - `meerkat_id` → `identity` (parsed as `AgentIdentity`)
 /// - `profile` → `profile`

--- a/meerkat-mobkit/src/identity_first/mod.rs
+++ b/meerkat-mobkit/src/identity_first/mod.rs
@@ -13,7 +13,7 @@ mod types;
 
 pub use adapters::{
     ContinuitySessionStoreAdapter, DiscoveryRosterAdapter, EdgeDiscoveryTopologyAdapter,
-    SessionHookCustomizerAdapter, agent_discovery_to_durable,
+    MutableRosterProvider, SessionHookCustomizerAdapter, agent_discovery_to_durable,
 };
 pub use agent_memory::{
     AgentMemoryConfig, AgentMemoryCustomizer, AgentMemoryError, AgentMemoryForgetResult,

--- a/meerkat-mobkit/src/unified_runtime/http.rs
+++ b/meerkat-mobkit/src/unified_runtime/http.rs
@@ -59,6 +59,7 @@ impl UnifiedRuntime {
             self.access_controller().cloned(),
             self.memory_panel_store(),
             self.console_operator_resolver(),
+            self.console_identity_roster(),
         )
     }
 

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -165,6 +165,11 @@ pub struct UnifiedRuntime {
     // the runtime is shared (`Arc`), wherever the store is constructed.
     memory_panel_store:
         std::sync::RwLock<Option<crate::memory::sqlite_store::SqliteAgentMemoryStore>>,
+    /// Identity-first console gateways: the mutable desired-identity roster
+    /// that `mobkit/ensure_member` extends at runtime (ask K0). Set by the
+    /// host beside `attach_identity_first_context`.
+    console_identity_roster:
+        std::sync::RwLock<Option<Arc<crate::identity_first::MutableRosterProvider>>>,
     /// §16 Q1 provisional operator keying: the console-principal resolver,
     /// shared between the memory coordinator (reads) and the console send
     /// path (notes interactions). `&self`-settable like the panel store.
@@ -250,6 +255,7 @@ impl UnifiedRuntime {
             identity_first_context: None,
             access_controller: None,
             memory_panel_store: std::sync::RwLock::new(None),
+            console_identity_roster: std::sync::RwLock::new(None),
             console_operator_resolver: std::sync::RwLock::new(None),
             metadata_table,
             persistent_metadata,
@@ -588,6 +594,25 @@ impl UnifiedRuntime {
     /// (§9.3). `&self` deliberately: gateways construct the store next to
     /// the memory subsystem wiring, which may run after the runtime is
     /// `Arc`-shared. Routers built *after* this call serve the panel RPCs.
+    pub fn set_console_identity_roster(
+        &self,
+        roster: Arc<crate::identity_first::MutableRosterProvider>,
+    ) {
+        *self
+            .console_identity_roster
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(roster);
+    }
+
+    pub fn console_identity_roster(
+        &self,
+    ) -> Option<Arc<crate::identity_first::MutableRosterProvider>> {
+        self.console_identity_roster
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
     pub fn set_memory_panel_store(
         &self,
         store: crate::memory::sqlite_store::SqliteAgentMemoryStore,

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -354,6 +354,7 @@ fn mobkit_gateway_bootstraps_identity_first_runtime() {
         .recv_timeout(Duration::from_secs(90))
         .expect("gateway responded to identity-first init");
     let _ = child.kill();
+    let _ = child.wait();
     let response: Value = serde_json::from_str(line.trim()).expect("init response json");
     assert!(
         response.get("error").is_none(),

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -301,3 +301,73 @@ fn mobkit_gateway_emits_tracing_on_stderr() {
          got stderr: {stderr:?}"
     );
 }
+
+/// meerkat-studio ask K0: `identity_first: true` on init boots the gateway
+/// with the durable-identity substrate (continuity store + leases + identity
+/// console surface) constructed from the existing store paths.
+#[test]
+fn mobkit_gateway_bootstraps_identity_first_runtime() {
+    let bin = env!("CARGO_BIN_EXE_mobkit_gateway");
+    let workspace = TempDir::new().expect("workspace tempdir");
+    let store = TempDir::new().expect("store tempdir");
+
+    let init = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "mobkit/init",
+        "params": {
+            "workspace_root": workspace.path().to_string_lossy(),
+            "store_path": store.path().join("store").to_string_lossy(),
+            "persistent_sessions": true,
+            "identity_first": true,
+            "identity_roster": [{
+                "identity": "personal:alice",
+                "profile": "alpha",
+            }],
+        },
+    });
+
+    let mut child = Command::new(bin)
+        .current_dir(workspace.path())
+        .env("ANTHROPIC_API_KEY", "sk-ant-regression-test")
+        .env("OPENAI_API_KEY", "sk-regression-test")
+        .env("XDG_STATE_HOME", workspace.path().join("xdg-state"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mobkit_gateway");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    writeln!(stdin, "{}", serde_json::to_string(&init).unwrap()).expect("write init");
+    stdin.flush().expect("flush");
+
+    let stdout = child.stdout.take().expect("stdout");
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let _ = reader.read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let line = rx
+        .recv_timeout(Duration::from_secs(90))
+        .expect("gateway responded to identity-first init");
+    let _ = child.kill();
+    let response: Value = serde_json::from_str(line.trim()).expect("init response json");
+    assert!(
+        response.get("error").is_none(),
+        "identity-first init must succeed: {response}"
+    );
+    assert!(
+        response["result"]["http_base_url"].is_string(),
+        "init response carries the http base url: {response}"
+    );
+    // The identity substrate is durable: continuity.db exists in the store.
+    let continuity = store.path().join("store").join("continuity.db");
+    assert!(
+        continuity.exists(),
+        "identity-first boot must create {}",
+        continuity.display()
+    );
+}

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -340,3 +340,184 @@ comms = true
         "data.detail must carry the failure chain: {response}"
     );
 }
+
+/// meerkat-studio ask K0: the identity-first gateway surface. Same persistent
+/// construction chain and the same three RPCs that fail on the session-owned
+/// surface (the `#[ignore]`d test above) — but with the identity-first
+/// substrate attached, retire and respawn of NEVER-RAN members succeed:
+/// the ask-20 failure class is unreachable by construction.
+#[tokio::test]
+async fn studio_k0_identity_first_gateway_retire_respawn_succeed_on_idle_members() {
+    use meerkat_mobkit::identity_first::{
+        AgentRuntimeServices, DurabilityPolicy, IdentityFirstRuntimeContext, IdentityRuntime,
+        IdentityRuntimeConfig, LocalContinuityStore, LocalLeaseProvider, MobSessionBridge,
+        MutableRosterProvider, restore_flow,
+    };
+
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let state = temp_dir.path().join("state");
+    std::fs::create_dir_all(&state).expect("state dir");
+    let session_store: Arc<dyn meerkat::SessionStore> = Arc::new(
+        meerkat_store::SqliteSessionStore::open(state.join("sessions.db")).expect("session store"),
+    );
+    let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> = Arc::new(
+        meerkat_runtime::store::SqliteRuntimeStore::new(state.join("runtime.sqlite"))
+            .expect("runtime store"),
+    );
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let factory = AgentFactory::new(&state).comms(true);
+    let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+    builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
+        session_store.clone(),
+    )));
+    builder.default_blob_store = Some(blob_store.clone());
+    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
+        Arc::clone(&runtime_store),
+        Arc::clone(&blob_store),
+    ));
+    let service = Arc::new(PersistentSessionService::new(
+        builder,
+        16,
+        session_store,
+        runtime_store,
+        blob_store,
+    ));
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "studio-crew-identity"
+
+[profiles.general]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.general.tools]
+comms = true
+"#,
+    )
+    .expect("definition");
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), service)
+        .with_session_runtime_adapter(adapter.clone())
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "studio-identity".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let mut runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap");
+
+    // Mirror mobkit_gateway's `identity_first: true` bootstrap.
+    let continuity_store =
+        LocalContinuityStore::open(state.join("continuity.db")).expect("continuity store");
+    let fencing_floor = continuity_store
+        .max_fencing_token()
+        .expect("fencing high-water");
+    let mob_handle = runtime.mob_handle();
+    let session_service = runtime
+        .mob_runtime()
+        .session_service()
+        .cloned()
+        .expect("session service");
+    let bridge: Arc<dyn meerkat_mobkit::identity_first::SessionBridge> = Arc::new(
+        MobSessionBridge::with_session_service(mob_handle.clone(), session_service),
+    );
+    let irt = Arc::new(
+        IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(continuity_store),
+            lease_provider: Arc::new(LocalLeaseProvider::with_floor(fencing_floor)),
+            runtime_instance_id: "studio-k0-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge),
+            default_timeout: None,
+        })
+        .with_runtime_services(AgentRuntimeServices::new(mob_handle.clone())),
+    );
+    let roster = Arc::new(MutableRosterProvider::new(Vec::new()));
+    restore_flow(&irt, &roster.snapshot(), None, None)
+        .await
+        .expect("restore_flow (empty roster)");
+    let mob_definition = mob_handle.definition().clone();
+    runtime.set_console_identity_roster(roster.clone());
+    runtime.attach_identity_first_context(Arc::new(IdentityFirstRuntimeContext::new(
+        irt,
+        roster,
+        None,
+        None,
+        Some(mob_definition),
+    )));
+    let app = runtime.build_reference_app_router(studio_decision_state());
+
+    for member in ["lead", "builder", "reviewer"] {
+        let response = rpc(
+            &app,
+            "mobkit/ensure_member",
+            json!({"role": "general", "agent_identity": member}),
+        )
+        .await;
+        assert!(
+            response.get("error").is_none(),
+            "identity ensure {member}: {response}"
+        );
+        assert_eq!(
+            response["result"]["identity_first"],
+            json!(true),
+            "ensure_member must take the identity arm: {response}"
+        );
+        assert_eq!(
+            response["result"]["state"],
+            json!("active"),
+            "ensured identity must be active: {response}"
+        );
+    }
+
+    // The K1-class calls: retire + respawn of NEVER-RAN members. On the
+    // session-owned surface these strand the member; here they succeed.
+    let retire = rpc(
+        &app,
+        "mobkit/retire_member",
+        json!({"member_id": "builder"}),
+    )
+    .await;
+    assert!(
+        retire.get("error").is_none(),
+        "identity retire_member of an idle member must succeed: {retire}"
+    );
+    let respawn = rpc(
+        &app,
+        "mobkit/respawn_member",
+        json!({"member_id": "reviewer"}),
+    )
+    .await;
+    assert!(
+        respawn.get("error").is_none(),
+        "identity respawn_member of an idle member must succeed: {respawn}"
+    );
+    assert!(
+        respawn["result"]["session_id"].is_string(),
+        "respawn must report the fresh session: {respawn}"
+    );
+
+    // retire_member also removed builder from the desired roster: another
+    // ensure re-creates it cleanly.
+    let re_ensure = rpc(
+        &app,
+        "mobkit/ensure_member",
+        json!({"role": "general", "agent_identity": "builder"}),
+    )
+    .await;
+    assert!(
+        re_ensure.get("error").is_none(),
+        "re-ensure after retire must succeed: {re_ensure}"
+    );
+}


### PR DESCRIPTION
Phase 0 of the identity-first doctrine (audit-verified; D1 dual-plane + D2 converge-construction approved).

**`identity_first: true`** on `mobkit_gateway` init boots the durable-identity substrate from the existing store paths: `LocalContinuityStore` (+ fencing-floor seeding), `LocalLeaseProvider`, `MobSessionBridge` over the session service, `restore_flow` over an `identity_roster` init seed, and `attach_identity_first_context` (which also wires the console identity RPC surface and spawns the #235 Broken-identity repair task).

**Console member RPCs grow identity arms**, gated on the gateway carrying the identity substrate (`ConsoleJsonState.identity_roster` slot):
- `ensure_member` → upsert the new `identity_first::MutableRosterProvider` + reconcile via `restore_flow` (durable identity stand-up with the same ergonomic entrypoint)
- `retire_member` → tolerant identity retire + desired-roster removal
- `respawn_member` → identity reset (fresh session, new generation, same durable identity)

Session-owned deployments are untouched — the arms are inert without the roster slot.

**Proof test:** `studio_k0_identity_first_gateway_retire_respawn_succeed_on_idle_members` — the exact three RPCs that strand never-ran members on the classic surface (ask 20, `#[ignore]`d sibling test) **succeed** on the identity surface. The failure class is unreachable by construction.

Follow-ups in this 0.7.25 window (tasks #17–19): doctrine doc + skill + docs flip; rpc.rs identity arms + identity-RPC classic-fallback fixes + aggregator parity; shared gateway construction + default-on + capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)