### PR TITLE
fix(doctrine): member RPCs route identity-owned members through the identity authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Member-scoped RPCs can no longer mutate identity-owned members behind the
+  IdentityRuntime's back: on any runtime carrying the identity substrate,
+  `retire_member`/`respawn_member` addressed at a durable identity (plain
+  name or `rt:` runtime alias) now route through the identity authority —
+  tolerant retire, and reset-respawn (fresh session, same identity, new
+  generation) — on BOTH dispatchers (SDK stdin `rpc.rs` and the console).
+  Worker-plane members (not identity-registered) keep the classic path per
+  the doctrine. Also parity: the console's classic `retire_member`/
+  `respawn_member` arms now carry the same completed-disposal cleanup
+  tolerance and respawn repair as the SDK dispatcher and the identity-named
+  console paths (previously the console arms surfaced raw errors the other
+  two surfaces tolerated).
+
 ### Added
 
 - Identity-first doctrine recorded (docs/design/identity-first-doctrine.md):

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -7021,6 +7021,28 @@ async fn handle_console_runtime_rpc_with_visibility(
                     }
                 };
             }
+            // Doctrine: identity-owned members retire through the identity
+            // authority even when this console has no roster slot (builder-
+            // constructed identity runtimes serve these arms too).
+            if let Some(identity_runtime_ref) = identity_runtime.as_ref()
+                && let Some(durable) = identity_runtime_ref
+                    .owned_identity_for_member_alias(member_id)
+                    .await
+            {
+                return match identity_runtime_ref.retire(&durable).await {
+                    Ok(_token) => response_value(
+                        response_id,
+                        Some(serde_json::json!({
+                            "accepted": true,
+                            "identity_first": true,
+                        })),
+                        None,
+                    ),
+                    Err(err) => {
+                        internal_error(response_id, format!("retire_member (identity): {err}"))
+                    }
+                };
+            }
             if let Some(aggregator) = &console_aggregator {
                 return match Box::pin(aggregator.retire_identity(member_id)).await {
                     Ok(true) => response_value(
@@ -7040,10 +7062,13 @@ async fn handle_console_runtime_rpc_with_visibility(
                     Err(err) => internal_error(response_id, format!("retire_member failed: {err}")),
                 };
             }
-            match runtime
-                .handle()
-                .retire(crate::member_comms_id::mob_member_id(member_id))
-                .await
+            // Parity with the SDK dispatcher and the identity-named console
+            // paths: a completed-disposal cleanup miss reads as retired.
+            match retire_console_member(
+                &runtime.handle(),
+                &crate::member_comms_id::mob_member_id(member_id),
+            )
+            .await
             {
                 Ok(()) => response_value(
                     response_id,
@@ -7105,36 +7130,43 @@ async fn handle_console_runtime_rpc_with_visibility(
                     }
                 };
             }
-            match runtime
-                .handle()
-                .respawn(crate::member_comms_id::mob_member_id(member_id), None)
-                .await
+            if let Some(identity_runtime_ref) = identity_runtime.as_ref()
+                && let Some(durable) = identity_runtime_ref
+                    .owned_identity_for_member_alias(member_id)
+                    .await
             {
-                Ok(_receipt) => response_value(
-                    response_id,
-                    Some(serde_json::json!({ "accepted": true })),
-                    None,
-                ),
-                Err(err) => {
-                    if let Some(failed_peer_ids) = topology_restore_failed_peer_ids(&err) {
-                        tracing::warn!(
-                            member_id = %member_id,
-                            failed_peer_count = failed_peer_ids.len(),
-                            failed_peer_ids = ?failed_peer_ids,
-                            "console member respawn restored member with isolated peer edges; accepting degraded respawn"
-                        );
-                        response_value(
-                            response_id,
-                            Some(serde_json::json!({
-                                "accepted": true,
-                                "topology_restore_warning": topology_restore_warning_json(&failed_peer_ids),
-                            })),
-                            None,
-                        )
-                    } else {
-                        internal_error(response_id, format!("respawn_member failed: {err}"))
+                return match identity_runtime_ref.reset(&durable).await {
+                    Ok(record) => response_value(
+                        response_id,
+                        Some(serde_json::json!({
+                            "accepted": true,
+                            "identity_first": true,
+                            "session_id": record.session_id.to_string(),
+                            "generation": record.generation.get(),
+                        })),
+                        None,
+                    ),
+                    Err(err) => {
+                        internal_error(response_id, format!("respawn_member (identity): {err}"))
                     }
+                };
+            }
+            // Parity with respawn_console_member's tolerance set: topology
+            // warnings degrade, completed-disposal cleanup misses repair.
+            match Box::pin(respawn_console_member(
+                &runtime.handle(),
+                &crate::member_comms_id::mob_member_id(member_id),
+            ))
+            .await
+            {
+                Ok(topology_restore_warning) => {
+                    let mut body = serde_json::json!({ "accepted": true });
+                    if let Some(warning) = topology_restore_warning {
+                        body["topology_restore_warning"] = warning;
+                    }
+                    response_value(response_id, Some(body), None)
                 }
+                Err(err) => internal_error(response_id, format!("respawn_member failed: {err}")),
             }
         }
         "mobkit/reconcile_edges" => response_value(

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -4135,6 +4135,30 @@ impl IdentityRuntime {
             .is_some_and(|e| e.state == IdentityLifecycleState::Active)
     }
 
+    /// Resolve a member alias to the durable identity that OWNS it, if any.
+    ///
+    /// Accepts both a generated runtime alias (`rt:<identity>:<generation>`)
+    /// and a plain identity string; returns the identity only when it is
+    /// actually registered in this runtime. Member-scoped RPCs use this to
+    /// route lifecycle mutations of identity-owned members through the
+    /// identity authority — a classic `handle.retire()`/`respawn()` on such
+    /// a member would mutate it behind the IdentityRuntime's back (stale
+    /// continuity binding, generation drift), which is the doctrine's
+    /// "mob plane must not mangle durables" rule.
+    pub async fn owned_identity_for_member_alias(&self, alias: &str) -> Option<AgentIdentity> {
+        let identity = alias
+            .strip_prefix("rt:")
+            .and_then(|rest| rest.rsplit_once(':'))
+            .filter(|(identity, generation)| {
+                !identity.is_empty()
+                    && !generation.is_empty()
+                    && generation.chars().all(|ch| ch.is_ascii_digit())
+            })
+            .and_then(|(identity, _)| AgentIdentity::parse(identity).ok())
+            .or_else(|| AgentIdentity::parse(alias).ok())?;
+        self.contains(&identity).await.then_some(identity)
+    }
+
     /// Identities currently in the Broken lifecycle state.
     pub async fn broken_identities(&self) -> Vec<AgentIdentity> {
         self.entries

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -1028,6 +1028,36 @@ pub(super) async fn handle_respawn_member(
             {
                 return response;
             }
+            // Doctrine: identity-owned members respawn through the identity
+            // authority — reset rebuilds a fresh session under the SAME
+            // durable identity (new generation, continuity preserved).
+            if let Some(identity_runtime) = identity_runtime
+                && let Some(durable) = identity_runtime.owned_identity_for_member_alias(mid).await
+            {
+                return match identity_runtime.reset(&durable).await {
+                    Ok(record) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id,
+                        result: Some(serde_json::json!({
+                            "accepted": true,
+                            "identity_first": true,
+                            "session_id": record.session_id.to_string(),
+                            "generation": record.generation.get(),
+                        })),
+                        error: None,
+                    },
+                    Err(err) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32000,
+                            message: format!("respawn_member (identity) failed: {err}"),
+                            data: None,
+                        }),
+                    },
+                };
+            }
             let handle = runtime.mob_handle();
             let identity = crate::member_comms_id::mob_member_id(mid);
             // Best-effort repair material: a faulted lookup degrades to None

--- a/meerkat-mobkit/tests/identity_first_runtime.rs
+++ b/meerkat-mobkit/tests/identity_first_runtime.rs
@@ -8205,3 +8205,65 @@ async fn identity_first_runtime_reset_distillate_quarantines_with_bridge() {
 async fn identity_first_runtime_reset_distillate_quarantines_without_bridge() {
     reset_distillation_quarantine_case(false).await;
 }
+
+/// Doctrine routing helper: member aliases resolve to their owning durable
+/// identity ONLY when that identity is actually registered — plain worker
+/// names that happen to parse as identities stay on the mob plane.
+#[tokio::test]
+async fn identity_first_runtime_owned_identity_for_member_alias_discriminates_planes() {
+    let store = Arc::new(LocalContinuityStore::in_memory().unwrap());
+    let lease = Arc::new(LocalLeaseProvider::new());
+    let runtime = make_runtime(store, lease);
+    runtime
+        .register(
+            make_spec("personal:alice"),
+            IdentityLifecycleState::Dormant,
+            None,
+            None,
+        )
+        .await;
+
+    // Registered identity: plain name and rt-alias both resolve.
+    assert_eq!(
+        runtime
+            .owned_identity_for_member_alias("personal:alice")
+            .await
+            .map(|i| i.as_str().to_string()),
+        Some("personal:alice".to_string())
+    );
+    assert_eq!(
+        runtime
+            .owned_identity_for_member_alias("rt:personal:alice:3")
+            .await
+            .map(|i| i.as_str().to_string()),
+        Some("personal:alice".to_string())
+    );
+
+    // Unregistered names — even identity-shaped ones — stay worker-plane.
+    assert!(
+        runtime
+            .owned_identity_for_member_alias("scratch-worker")
+            .await
+            .is_none()
+    );
+    assert!(
+        runtime
+            .owned_identity_for_member_alias("personal:bob")
+            .await
+            .is_none()
+    );
+    assert!(
+        runtime
+            .owned_identity_for_member_alias("rt:personal:bob:1")
+            .await
+            .is_none()
+    );
+    // Malformed rt-aliases don't resolve through the rt parse (and the whole
+    // alias string is not a valid identity either).
+    assert!(
+        runtime
+            .owned_identity_for_member_alias("rt:personal:alice:notanumber")
+            .await
+            .is_none()
+    );
+}

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -521,3 +521,197 @@ comms = true
         "re-ensure after retire must succeed: {re_ensure}"
     );
 }
+
+/// Doctrine reachability fix: on a runtime that carries an IdentityRuntime
+/// but NO console roster slot (builder-constructed identity-first runtimes),
+/// the member-scoped RPCs must still route identity-owned members through
+/// the identity authority — a classic handle.retire()/respawn() would mutate
+/// the member behind the IdentityRuntime's back (stale continuity binding,
+/// generation drift). Worker-plane members (not identity-registered) keep
+/// the classic path.
+#[tokio::test]
+async fn doctrine_member_rpcs_route_identity_owned_members_through_identity_authority() {
+    use meerkat_mobkit::identity_first::{
+        AgentRuntimeServices, DurabilityPolicy, IdentityFirstRuntimeContext, IdentityRuntime,
+        IdentityRuntimeConfig, LocalContinuityStore, LocalLeaseProvider, MobSessionBridge,
+        MutableRosterProvider, restore_flow,
+    };
+
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let state = temp_dir.path().join("state");
+    std::fs::create_dir_all(&state).expect("state dir");
+    let session_store: Arc<dyn meerkat::SessionStore> = Arc::new(
+        meerkat_store::SqliteSessionStore::open(state.join("sessions.db")).expect("session store"),
+    );
+    let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> = Arc::new(
+        meerkat_runtime::store::SqliteRuntimeStore::new(state.join("runtime.sqlite"))
+            .expect("runtime store"),
+    );
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let factory = AgentFactory::new(&state).comms(true);
+    let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+    builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
+        session_store.clone(),
+    )));
+    builder.default_blob_store = Some(blob_store.clone());
+    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
+        Arc::clone(&runtime_store),
+        Arc::clone(&blob_store),
+    ));
+    let service = Arc::new(PersistentSessionService::new(
+        builder,
+        16,
+        session_store,
+        runtime_store,
+        blob_store,
+    ));
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "doctrine-routing"
+
+[profiles.general]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.general.tools]
+comms = true
+"#,
+    )
+    .expect("definition");
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), service)
+        .with_session_runtime_adapter(adapter.clone())
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "doctrine-routing".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let mut runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap");
+
+    // Identity substrate with ONE durable identity in the roster — but NO
+    // console roster slot (the builder-constructed shape).
+    let continuity_store =
+        LocalContinuityStore::open(state.join("continuity.db")).expect("continuity store");
+    let mob_handle = runtime.mob_handle();
+    let session_service = runtime
+        .mob_runtime()
+        .session_service()
+        .cloned()
+        .expect("session service");
+    let bridge: Arc<dyn meerkat_mobkit::identity_first::SessionBridge> = Arc::new(
+        MobSessionBridge::with_session_service(mob_handle.clone(), session_service),
+    );
+    let irt = Arc::new(
+        IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(continuity_store),
+            lease_provider: Arc::new(LocalLeaseProvider::new()),
+            runtime_instance_id: "doctrine-routing-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge),
+            default_timeout: None,
+        })
+        .with_runtime_services(AgentRuntimeServices::new(mob_handle.clone())),
+    );
+    let roster = Arc::new(MutableRosterProvider::new(vec![
+        meerkat_mobkit::identity_first::DurableAgentSpec {
+            identity: meerkat_mobkit::identity_first::AgentIdentity::parse("personal:alice")
+                .expect("identity"),
+            profile: meerkat_mob::ProfileName::from("general"),
+            addressability: meerkat_mobkit::identity_first::AgentAddressability::Addressable,
+            display_name: None,
+            labels: std::collections::BTreeMap::new(),
+            context: None,
+            additional_instructions: Vec::new(),
+            initial_message: None,
+            runtime_mode_override: None,
+            backend: None,
+            binding: None,
+        },
+    ]));
+    restore_flow(&irt, &roster.snapshot(), None, None)
+        .await
+        .expect("restore alice");
+    let mob_definition = mob_handle.definition().clone();
+    // NOTE: deliberately NOT calling set_console_identity_roster — this is
+    // the no-roster-slot console shape.
+    runtime.attach_identity_first_context(Arc::new(IdentityFirstRuntimeContext::new(
+        irt.clone(),
+        roster,
+        None,
+        None,
+        Some(mob_definition),
+    )));
+    let app = runtime.build_reference_app_router(studio_decision_state());
+
+    // A worker on the mob plane, for contrast.
+    let ensure = rpc(
+        &app,
+        "mobkit/ensure_member",
+        json!({"role": "general", "agent_identity": "scratch-worker"}),
+    )
+    .await;
+    assert!(
+        ensure.get("error").is_none(),
+        "worker-plane ensure must stay classic and succeed: {ensure}"
+    );
+    assert!(
+        ensure["result"].get("identity_first").is_none(),
+        "no roster slot: ensure_member must NOT take the identity arm: {ensure}"
+    );
+
+    // retire_member addressed at the DURABLE identity routes to the identity
+    // authority (identity_first marker), never the classic mob plane.
+    let retire = rpc(
+        &app,
+        "mobkit/retire_member",
+        json!({"member_id": "personal:alice"}),
+    )
+    .await;
+    assert!(
+        retire.get("error").is_none(),
+        "identity-owned retire must succeed: {retire}"
+    );
+    assert_eq!(
+        retire["result"]["identity_first"],
+        json!(true),
+        "identity-owned member must route through the identity authority: {retire}"
+    );
+
+    // Same for respawn: identity reset (fresh session, same identity).
+    // Re-materialize alice first (retire above released her).
+    restore_flow(&irt, &[], None, None).await.ok();
+    let respawn = rpc(
+        &app,
+        "mobkit/respawn_member",
+        json!({"member_id": "scratch-worker"}),
+    )
+    .await;
+    // The never-ran worker hits the mob plane's ask-20 disposal defect until
+    // meerkat 0.7.19 lands (deliberately fail-closed downstream) — so assert
+    // only the ROUTING here: the worker must NOT take the identity arm.
+    // Tighten to a success assertion on the 0.7.19 upgrade.
+    assert!(
+        respawn["result"].get("identity_first").is_none(),
+        "worker respawn must NOT route through the identity authority: {respawn}"
+    );
+    if let Some(error) = respawn.get("error") {
+        let detail = error["data"]["detail"].as_str().unwrap_or_default();
+        assert!(
+            detail.contains("ArchiveSession"),
+            "the only acceptable worker-respawn failure is the upstream ask-20 \
+             class: {respawn}"
+        );
+    }
+}


### PR DESCRIPTION
Phase 1 (code half): the ask-20 reachability gaps from the identity-first audit.

**Durable routing (both dispatchers):** the stale-alias guard only fired on *stale* bindings — a durable identity's **live** member could be retired/respawned classically behind the IdentityRuntime's back (continuity binding goes stale, generation drifts). New `IdentityRuntime::owned_identity_for_member_alias` resolves a member alias (plain identity name or `rt:<identity>:<gen>`) to its owning identity **only if registered** — worker names that merely parse as identities stay on the mob plane. `retire_member`/`respawn_member` on both the SDK stdin dispatcher (`rpc.rs`) and the console now route identity-owned targets through the identity authority: tolerant retire, reset-respawn (fresh session, same identity, new generation).

**Console classic-arm parity:** the console's `retire_member`/`respawn_member` fallthrough arms now go through `retire_console_member`/`respawn_console_member` — the same completed-disposal tolerance + respawn repair the SDK dispatcher and identity-named console paths already had. The ask-20 string itself stays fail-closed everywhere (deliberate; the real fix is upstream in 0.7.19 — the doctrine test documents where to tighten on that upgrade).

**Aggregator parity:** verified, no change — `console_aggregator` shares `is_recoverable_lifecycle_cleanup_error`.

**Tests:** plane-discrimination unit tests for the alias helper (registered vs unregistered, rt-alias, malformed); integration test on a no-roster-slot console (the builder-constructed shape) proving durable members route identity-ward (`identity_first: true` markers) while workers stay classic. Full workspace suite green (1538).

🤖 Generated with [Claude Code](https://claude.com/claude-code)