### PR TITLE
feat(doctrine): mobkit_gateway identity-first by default + shared substrate + capabilities flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`mobkit_gateway` is identity-first by default** (doctrine phase 2):
+  every init now builds the durable-identity substrate — continuity store
+  with fencing-floor seeding, lease provider, identity console RPC surface,
+  Broken-identity repair task — via the new shared
+  `gateway_wiring::open_identity_substrate` (the same code path
+  `rpc_gateway` uses, ending the two-half-wired-gateways drift that caused
+  the K1/K2 field failures). `identity_first: false` on init is a
+  one-release opt-out restoring the pure mob-plane gateway. On an
+  identity-first gateway `ensure_member` stands up durable identities;
+  pass `plane: "worker"` to pin a spawn to the ephemeral mob plane
+  (idle-retire reaping, no continuity record).
+- `mobkit/capabilities` on both dispatchers now carries a top-level
+  `identity_first` flag — the zero-flag-day migration signal consumers gate
+  on (meerkat-studio contract point 5).
+
 ### Fixed
 
 - Member-scoped RPCs can no longer mutate identity-owned members behind the

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -665,7 +665,10 @@ async fn run() -> anyhow::Result<()> {
         .unwrap_or_else(|| runtime_root.join("state"));
     let store_path = store_path.canonicalize().unwrap_or(store_path);
     let persistent_sessions = params.persistent_sessions.unwrap_or(false);
-    let identity_first = params.identity_first.unwrap_or(false);
+    // Doctrine default: the identity substrate is ON. `identity_first: false`
+    // remains as a one-release opt-out for deployments that need the pure
+    // mob-plane console back (changelog-flagged).
+    let identity_first = params.identity_first.unwrap_or(true);
     let identity_roster_seed = params.identity_roster.clone().unwrap_or_default();
     let realm = params.realm.as_deref();
     let isolated = params.isolated.unwrap_or(false);
@@ -938,23 +941,15 @@ async fn run() -> anyhow::Result<()> {
     > = if identity_first {
         use meerkat_mobkit::identity_first::{
             AgentRuntimeServices, DurabilityPolicy, IdentityFirstRuntimeContext, IdentityRuntime,
-            IdentityRuntimeConfig, LocalContinuityStore, LocalLeaseProvider, MobSessionBridge,
-            MutableRosterProvider, restore_flow,
+            IdentityRuntimeConfig, MobSessionBridge, MutableRosterProvider, restore_flow,
         };
 
         let (store_dir, _) = resolve_store_dir(&store_path);
         fs::create_dir_all(&store_dir)
             .with_context(|| format!("failed to create {}", store_dir.display()))?;
         let continuity_db = store_dir.join("continuity.db");
-        let continuity_store = LocalContinuityStore::open(&continuity_db)
-            .with_context(|| format!("failed to open {}", continuity_db.display()))?;
-        // Resume the fencing counter above the persisted high-water so a
-        // restart with existing continuity history never presents a stale
-        // token (mirrors rpc_gateway).
-        let fencing_floor = continuity_store
-            .max_fencing_token()
-            .context("failed to read continuity fencing high-water")?;
-        let lease_provider = LocalLeaseProvider::with_floor(fencing_floor);
+        let substrate = meerkat_mobkit::gateway_wiring::open_identity_substrate(&continuity_db)
+            .map_err(|e| anyhow!("{e}"))?;
 
         let mob_handle = runtime.mob_handle();
         let bridge: Arc<dyn meerkat_mobkit::identity_first::SessionBridge> =
@@ -968,8 +963,8 @@ async fn run() -> anyhow::Result<()> {
             };
 
         let irt = IdentityRuntime::new(IdentityRuntimeConfig {
-            continuity_store: Arc::new(continuity_store),
-            lease_provider: Arc::new(lease_provider),
+            continuity_store: substrate.continuity_store,
+            lease_provider: substrate.lease_provider,
             runtime_instance_id: format!("mobkit-gateway-{}", std::process::id()),
             has_runtime_store: persistent_sessions,
             durability_policy: DurabilityPolicy::SyncWriteThrough,

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -3550,7 +3550,9 @@ external_addressable = true
     // ("stale fencing token: presented 1, current N"), aborting boot on every
     // restart with existing history. Capture the local store's high-water here
     // and seed the lease provider with it below.
-    let mut local_fencing_floor: u64 = 0;
+    let mut local_default_lease_provider: Option<
+        Arc<dyn meerkat_mobkit::identity_first::contracts::LeaseProvider>,
+    > = None;
     let identity_continuity_store: Option<
         Arc<dyn meerkat_mobkit::identity_first::ContinuityStore>,
     > = if has_roster_provider {
@@ -3564,24 +3566,10 @@ external_addressable = true
             } else {
                 std::env::temp_dir().join(format!("mobkit-continuity-{}.db", std::process::id()))
             };
-            let store = meerkat_mobkit::identity_first::LocalContinuityStore::open(&db_path)
-                .unwrap_or_else(|e| {
-                    fail_init(
-                        &request_id,
-                        -32603,
-                        format!("failed to open continuity store: {e}"),
-                    );
-                });
-            // Fail loudly rather than silently degrading to floor 0 — a 0 floor
-            // would re-arm the very restart-abort this seeding prevents.
-            local_fencing_floor = store.max_fencing_token().unwrap_or_else(|e| {
-                fail_init(
-                    &request_id,
-                    -32603,
-                    format!("failed to read continuity fencing high-water: {e}"),
-                )
-            });
-            Arc::new(store)
+            let substrate = meerkat_mobkit::gateway_wiring::open_identity_substrate(&db_path)
+                .unwrap_or_else(|e| fail_init(&request_id, -32603, e));
+            local_default_lease_provider = Some(substrate.lease_provider);
+            substrate.continuity_store
         })
     } else {
         None
@@ -3592,14 +3580,13 @@ external_addressable = true
         Some(if has_lease_provider {
             Arc::new(meerkat_mobkit::identity_first::GatewayLeaseProvider::new(
                 bridge.clone(),
-            ))
+            )) as Arc<dyn meerkat_mobkit::identity_first::contracts::LeaseProvider>
         } else {
-            // Resume the fencing counter above the persisted high-water so a
-            // restart with existing continuity history never presents a stale
-            // token (see `local_fencing_floor` above).
-            Arc::new(
-                meerkat_mobkit::identity_first::LocalLeaseProvider::with_floor(local_fencing_floor),
-            )
+            // From the shared substrate: fencing counter resumes above the
+            // persisted high-water (see gateway_wiring::open_identity_substrate).
+            local_default_lease_provider
+                .clone()
+                .expect("local substrate initialized with the continuity store")
         })
     } else {
         None

--- a/meerkat-mobkit/src/gateway_wiring.rs
+++ b/meerkat-mobkit/src/gateway_wiring.rs
@@ -1,0 +1,46 @@
+//! Shared gateway construction seams (doctrine D2: converge construction,
+//! merge binaries later).
+//!
+//! The K1/K2 field failures came from the two gateway binaries embedding the
+//! same `UnifiedRuntime` with DIVERGENT wiring — `rpc_gateway` built the full
+//! identity substrate, `mobkit_gateway` built none. Every piece both binaries
+//! must construct identically belongs here so the drift class is structural
+//! history. The full store construction converges with the 0.8 binary merge;
+//! v1 shares the identity substrate, whose divergence caused the field
+//! failures.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::identity_first::{
+    ContinuityStore, LocalContinuityStore, LocalLeaseProvider, contracts::LeaseProvider,
+};
+
+/// The durable-identity substrate a gateway builds from its state directory:
+/// the continuity store and a lease provider whose fencing counter resumes
+/// ABOVE the persisted high-water, so a restart with existing continuity
+/// history never presents a stale token.
+pub struct GatewayIdentitySubstrate {
+    pub continuity_store: Arc<dyn ContinuityStore>,
+    pub lease_provider: Arc<dyn LeaseProvider>,
+}
+
+/// Open the local identity substrate at `continuity_db`.
+///
+/// Fails loudly rather than degrading: a 0 fencing floor on an existing
+/// store would re-arm the restart-abort class the floor seeding prevents.
+pub fn open_identity_substrate(continuity_db: &Path) -> Result<GatewayIdentitySubstrate, String> {
+    let store = LocalContinuityStore::open(continuity_db).map_err(|e| {
+        format!(
+            "failed to open continuity store {}: {e}",
+            continuity_db.display()
+        )
+    })?;
+    let fencing_floor = store
+        .max_fencing_token()
+        .map_err(|e| format!("failed to read continuity fencing high-water: {e}"))?;
+    Ok(GatewayIdentitySubstrate {
+        continuity_store: Arc::new(store),
+        lease_provider: Arc::new(LocalLeaseProvider::with_floor(fencing_floor)),
+    })
+}

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -5170,6 +5170,12 @@ async fn handle_console_runtime_rpc_with_visibility(
                 Some(serde_json::json!({
                     "contract_version": crate::rpc::MOBKIT_CONTRACT_VERSION,
                     "methods": methods,
+                    // Doctrine: consumers gate their migration on this flag —
+                    // when true, the member RPCs re-dispatch durable targets
+                    // through the identity authority and ensure_member stands
+                    // up durable identities (pass plane:"worker" to opt a
+                    // spawn onto the ephemeral mob plane).
+                    "identity_first": identity_runtime.is_some(),
                     "read_only": read_only,
                     // The console routes to MobRuntime directly and has no
                     // access to the module runtime, so loaded_modules is always [].
@@ -6846,9 +6852,17 @@ async fn handle_console_runtime_rpc_with_visibility(
             // desired-identity roster and reconciles — the durable-identity
             // equivalent of the mob-member spawn, with the tolerant identity
             // lifecycle underneath (the ask-20 retire/respawn class does not
-            // exist on this surface).
-            if let (Some(identity_runtime_ref), Some(roster)) =
-                (identity_runtime.as_ref(), identity_roster.as_ref())
+            // exist on this surface). Doctrine escape hatch: plane:"worker"
+            // pins the spawn to the ephemeral mob plane (idle-retire reaping,
+            // no continuity record) for helper churn that must not become a
+            // durable identity.
+            let worker_plane = matches!(
+                request.params.get("plane").and_then(Value::as_str),
+                Some("worker")
+            );
+            if !worker_plane
+                && let (Some(identity_runtime_ref), Some(roster)) =
+                    (identity_runtime.as_ref(), identity_roster.as_ref())
             {
                 let identity = match crate::identity_first::AgentIdentity::parse(agent_identity) {
                     Ok(identity) => identity,

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -13,6 +13,7 @@ pub mod console_contracts;
 pub(crate) mod console_spawn;
 pub mod contact_directory;
 pub mod decisions;
+pub mod gateway_wiring;
 pub mod governance;
 pub mod http_auth;
 pub mod http_console;

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -1443,6 +1443,10 @@ async fn handle_unified_rpc_json_inner(
                     "contract_version": MOBKIT_CONTRACT_VERSION,
                     "runtime_type": "unified",
                     "methods": methods,
+                    // Doctrine flag: when true the identity RPC set is live
+                    // and member RPCs route durable targets through the
+                    // identity authority.
+                    "identity_first": identity_ctx.is_some(),
                     "loaded_modules": loaded,
                     "runtime_capabilities": {
                         "can_spawn_members": true,

--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -302,9 +302,10 @@ fn mobkit_gateway_emits_tracing_on_stderr() {
     );
 }
 
-/// meerkat-studio ask K0: `identity_first: true` on init boots the gateway
-/// with the durable-identity substrate (continuity store + leases + identity
-/// console surface) constructed from the existing store paths.
+/// Doctrine default-on: a plain init (no identity_first param) boots the
+/// gateway with the durable-identity substrate (continuity store + leases +
+/// identity console surface) constructed from the existing store paths.
+/// `identity_first: false` remains as a one-release opt-out (tested below).
 #[test]
 fn mobkit_gateway_bootstraps_identity_first_runtime() {
     let bin = env!("CARGO_BIN_EXE_mobkit_gateway");
@@ -319,7 +320,6 @@ fn mobkit_gateway_bootstraps_identity_first_runtime() {
             "workspace_root": workspace.path().to_string_lossy(),
             "store_path": store.path().join("store").to_string_lossy(),
             "persistent_sessions": true,
-            "identity_first": true,
             "identity_roster": [{
                 "identity": "personal:alice",
                 "profile": "alpha",
@@ -369,6 +369,66 @@ fn mobkit_gateway_bootstraps_identity_first_runtime() {
     assert!(
         continuity.exists(),
         "identity-first boot must create {}",
+        continuity.display()
+    );
+}
+
+/// The one-release opt-out: `identity_first: false` boots the pure mob-plane
+/// gateway — no continuity store is created.
+#[test]
+fn mobkit_gateway_identity_first_opt_out_skips_the_substrate() {
+    let bin = env!("CARGO_BIN_EXE_mobkit_gateway");
+    let workspace = TempDir::new().expect("workspace tempdir");
+    let store = TempDir::new().expect("store tempdir");
+
+    let init = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "mobkit/init",
+        "params": {
+            "workspace_root": workspace.path().to_string_lossy(),
+            "store_path": store.path().join("store").to_string_lossy(),
+            "identity_first": false,
+        },
+    });
+
+    let mut child = Command::new(bin)
+        .current_dir(workspace.path())
+        .env("ANTHROPIC_API_KEY", "sk-ant-regression-test")
+        .env("OPENAI_API_KEY", "sk-regression-test")
+        .env("XDG_STATE_HOME", workspace.path().join("xdg-state"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mobkit_gateway");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    writeln!(stdin, "{}", serde_json::to_string(&init).unwrap()).expect("write init");
+    stdin.flush().expect("flush");
+
+    let stdout = child.stdout.take().expect("stdout");
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let _ = reader.read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let line = rx
+        .recv_timeout(Duration::from_mins(1))
+        .expect("gateway responded to opt-out init");
+    let _ = child.kill();
+    let _ = child.wait();
+    let response: Value = serde_json::from_str(line.trim()).expect("init response json");
+    assert!(
+        response.get("error").is_none(),
+        "opt-out init must succeed: {response}"
+    );
+    let continuity = store.path().join("store").join("continuity.db");
+    assert!(
+        !continuity.exists(),
+        "identity_first: false must not create {}",
         continuity.display()
     );
 }

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -161,6 +161,13 @@ comms = true
         respawn.get("error").is_none(),
         "respawn_member on an ephemeral ensure_member crew must succeed: {respawn}"
     );
+
+    let caps = rpc(&app, "mobkit/capabilities", json!({})).await;
+    assert_eq!(
+        caps["result"]["identity_first"],
+        json!(false),
+        "a mob-plane-only console must advertise identity_first=false: {caps}"
+    );
 }
 
 /// Studio's actual construction chain: FactoryAgentBuilder →
@@ -519,6 +526,31 @@ comms = true
     assert!(
         re_ensure.get("error").is_none(),
         "re-ensure after retire must succeed: {re_ensure}"
+    );
+
+    // Capabilities advertise the doctrine flag — consumers gate their
+    // migration on it (studio contract point 5).
+    let caps = rpc(&app, "mobkit/capabilities", json!({})).await;
+    assert_eq!(
+        caps["result"]["identity_first"],
+        json!(true),
+        "identity-first gateway must advertise identity_first: {caps}"
+    );
+
+    // plane:"worker" pins a spawn to the ephemeral mob plane even here.
+    let worker = rpc(
+        &app,
+        "mobkit/ensure_member",
+        json!({"role": "general", "agent_identity": "scratch-helper", "plane": "worker"}),
+    )
+    .await;
+    assert!(
+        worker.get("error").is_none(),
+        "worker-plane ensure on an identity gateway must succeed: {worker}"
+    );
+    assert!(
+        worker["result"].get("identity_first").is_none(),
+        "plane:worker must NOT create a durable identity: {worker}"
     );
 }
 


### PR DESCRIPTION
Phase 2 of the identity-first doctrine (final piece of the 0.7.25 set; tasks #17–19 complete with this).

- **`gateway_wiring::open_identity_substrate`** — the shared construction seam for the durable-identity substrate (continuity store + fencing-floor-seeded lease provider). Both binaries now build it from one code path, structurally ending the two-half-wired-gateways drift that caused the K1/K2 field failures. (Full store-construction sharing lands with the 0.8 binary merge, per D2.)
- **`mobkit_gateway` is identity-first by default**: every init builds the substrate, restores the `identity_roster` seed, and wires the identity console surface + the #235 repair task. `identity_first: false` is a one-release opt-out (pure mob-plane gateway, no continuity.db — tested at the binary level).
- **`plane: "worker"`** on `ensure_member` pins a spawn to the ephemeral mob plane on identity-first gateways (helper churn that must not become a durable identity) — tested.
- **`mobkit/capabilities`** on both dispatchers carries a top-level `identity_first` flag — studio's zero-flag-day migration signal (contract point 5) — tested true on identity gateways and false on mob-plane-only consoles.

OB3 impact: none — library-builder path untouched; the eternal-fleet and worker planes behave identically. Full workspace suite green (1539).

🤖 Generated with [Claude Code](https://claude.com/claude-code)