### PR TITLE
deps: meerkat 0.7.19 — schedule firing fixes (asks 16-19), ask-20 disposal fix + wrapper forwarding, M1-M4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Upgraded the meerkat family 0.7.18 → 0.7.19 (exact pins). Carries the full
+  batch-3/4 ask set: schedule firing per-row fault tolerance + tick-health
+  incidents + Deleted-tombstone healing + SQL-bounded claim (asks 16-19 —
+  carry-verified: a poisoned occurrence row no longer starves healthy
+  claims), bounded force_cancel (M1), declarative MCP for library embedders
+  surviving revival (M2), versioning policy (M3), run-status reconciliation
+  query (M4), and the ask-20 host-owned disposal fix. Also regenerates the
+  bundled adaptive layer-decision schema against the 0.7.19 canonical.
+
+### Fixed
+
+- MobKit's session-service wrappers now forward meerkat 0.7.19's
+  `session_known_to_archive_authority` disposal-routing seam (the trait
+  default is fail-closed `true`; an unforwarded wrapper would have swallowed
+  the inner persistent service's real store read — the compose-don't-assume
+  wrapper class). The forwarding-probe test pins it.
+
+### Known issues
+
+- Ask 21 (docs/design/upstream-asks.md): mob-CREATED never-ran members are
+  archive-authority-OWNED yet snapshotless, so the owned-path archive still
+  strands them — 0.7.19's ask-20 fix reroutes only host-adopted sessions.
+  Identity-first gateways (default-on) sidestep this for crews; the window
+  on the worker plane is narrow (workers receive kickoff at spawn).
+
+### Changed
+
 - **`mobkit_gateway` is identity-first by default** (doctrine phase 2):
   every init now builds the durable-identity substrate — continuity store
   with fencing-floor seeding, lease provider, identity console RPC surface,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9c991ca2955b19917ccefc4f5177af920e40c562e07492c09295b0b1f73843"
+checksum = "99dd8e8d9370a2d7a46c00ee917df72581c8f6999a24b0607045f0cd774eab82"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f5227a4c5a94177c0c75df6873cf3de3884466bfc8820af145ddf176ed01fd"
+checksum = "de181d572b1151c0e6fe4f6729079b32a9820c1383c797c1b5b9a3291774d0bc"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2ab8204fad1bd4f6487ba94994f33e706afb2b3942184c7bf267e3d33d544"
+checksum = "d5d1649947165b81a0517ba30e60ea1af264dbad4a69656e14bad76d983f5f58"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c95828e3c92dd2a05a387224a6cb6caa298e8ee0db635befebf01e182a76417"
+checksum = "eae639d2659ecf9ee65a26260f1c376c08e4f8484197fb893b06336aac081a50"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0da2c8f1952590cf912a70ba3ac7f8a8bd77d6d372593e7e72bd7dbba2f0f3"
+checksum = "e00bc5411215169df61a5ae68164b1c3a0bc585a22db24f0dc228f8412319a18"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38489187351ea3aa76cc0ca8f830aa34ec435967b83d8959a1381bc88a06648d"
+checksum = "0952de55ba0bb70850499427d7ad4a71b139bfb726768dc26644d60707262ea8"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1317114a66141545c60d91933d39465e1cd1ca252bd281c2a949dcfdde1171"
+checksum = "99cde341f3a2c0a1354fce8903b2f98c20fa0168e608d8d86c4ae10568577841"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aceab3b55b00311ad1dae94eebe978b30d30a8752cceaa108e6332e28d5e94"
+checksum = "d721b4e0c90bd14a228bbcba688c1cb5d18b638c4724e6ed8c6a3e4f85435a80"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27244844079258531e9306b2f9b7af7ffad746df583106301e67273e00cc685"
+checksum = "e03f39fd2ce5627bbd316d94a29bb41ba6f6f1d340829f45d13ff8101af9333c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47bc1f5878c911b8fa016873291e2b0bdbbc440f7fe30b114c4e7b856ff16e8"
+checksum = "665daf868d135e46a1793dbc5e61cb8cd62baab5ca8f32d42546d5188a289693"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b16f97e960d5de0b5f465ec329851d1570313bd0b5f5eb133fe61fe43f5ceb"
+checksum = "9c4a19346ed299174e65deed8ff9626608df00d7ee64d0575482e8452f3b3e68"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c45435619d98ac7dd158ec73d47d02164f7abd0b4491a42374d25158a7d53a"
+checksum = "e434c2bc1de2e395eb03976a5de9c24f4da16eabdde545709bc3d5a0a734c79a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecb543859d669a903dd56418c3a407d3ea3d36a95191ea7209acd06cc52faf8"
+checksum = "808f7f767f96131e2c9c446f8300c175ad81233205cec23c80376e39220eb82d"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df26714ccee02b2db71ae0f577fa26aa284f4ea0ef15cb30b84ec6ecf5411f3"
+checksum = "29f80db51e132bc8bdbe9289cf086dfe2c4fc8ba613701bd10403d65f6b6b287"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e61d2badd75a45a7356a68856c739188fe0007ad1ae2d1167fb65edd85e02c"
+checksum = "f98ccf4828fe951bc423eccd0dcc7ea1e1d5c21509787a963266ccac1b5b9f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a02177c9cc7c878830aa38295133ecd65e0851f2f12a66f213cbb76f941d776"
+checksum = "dd0ce895f5d86b17f4e3a7312d012c1ca6a80c8a29b119420c924c511bfe2737"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bdc075aaa5409b75757f650ffbe3a2c5b900e502eda3e41050299694170633f"
+checksum = "f69409c2fd8335b837d64aae2cc403ee7a040e18ddaf5fcf364c7cfbc259bac9"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5bbd1e2d43a673564dc1848372872f8f77c2dda0b0931851722448a3b0673fc"
+checksum = "690bfb536e0b5e5ecd5a3c9d6182b0486c7d1c7751b5b718b91575831d015cc4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6acdfa89aa95af092243b68c956b2e0f037f452542deb38a543479dfad38cec"
+checksum = "c99f9ccc36d021aa26f9a7061e9fe29f2302ccb775ed5ec5294b22249e595fed"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faecdad382ce37b8b360c1840c86b5dd43b32fb2f61fe32432a13e9226985cc1"
+checksum = "940e364bcd8adc10f86032d7f37d489f42f9585d77ea1b50924bcd47a066490d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0003f709c518a7fe6a1048d9f79d682d8c29a6c238e07dd2443dc9fe2125641b"
+checksum = "3299d91f71b6b1c7d713da8c494dc4ff6c99bcaa0fcea7a18c7cbd52c539705f"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b20d97db06eff000be844eec368b8bf0115c605367282353f5d368e2307c51"
+checksum = "d5b8425a78f6e34cf3c4f84e41ba275d618d06ea8b01be004e561c5612128369"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63519d47540976bd941f29711ba6cdd51bed775a6d92637cea044f04f8887f3"
+checksum = "5f0c7ff6bc80255eb8d195b3d45c386aa2757f20d2636d033b26c13fab1eddc1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8913d5a6c3c7aa464a45445fc704a7ba1f04149090c00ed1298eabeeeb06fd2"
+checksum = "cbdceeeee6e5d3561bfbf63e3931ae282fb15a072f7bae6c94bee0b658da836d"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfae812e140d8f21635a563d097b1447cf8fc43ef3e24f37f287cfb8ad405873"
+checksum = "6fb23f99bd76b7051244ac12003c5eef138ec617580f7d5ec6c76b60d2a5995e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3dc9f3f3ea309f5e32dcc28c73e50dfc2183c5224744be6e8e1011dffe427e"
+checksum = "6b593dbf357007ea822c39ed025b4ea1b5b9b70d0d67f55e9fa62651658ad3af"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f765add6e1eb2281e6606ead7f4d9994dec2dc829721bf63a9b35c5ad46d03"
+checksum = "fc289c83ed384f019e6fd7aa1a0f94630ae7096abf99d4adde208c8b02b06b7a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9860d889cbb90e0172b0950aa76b6ff870dae1d8d9efdce96347fdd7e4fc6ae5"
+checksum = "d16279e9215208cc2112cc0a36b4093a6538b0d237c7cb5a0b97e4cad3051eb6"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea168979c803188319f14ea865b1556fd11551200cb6a8f4182ac32106228c23"
+checksum = "1ae1d053aa08e135b09e1185be8406fd050fdc763256bc8f2ef627e8a44b867d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151ae24cd6ecb9f780de8856a0c3a2c6fd36a3e701b74b5e39b18748c9945ec2"
+checksum = "717efa71340c994460b366238999c7693cc0d7d853ee79a1c10981d11e565acb"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686866587e67a7e3fc783d042546d83ef603c5298615b96197137d776e370140"
+checksum = "9287bf1cbb9b274f8abc17861829afe29becf25179c409f483e4d321717c2a61"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -861,3 +861,41 @@ Run framing is broadcast-only; after a host restart there is no "did
 interaction X reach a terminal state, and which?" query. Reporter hand-rolled
 runs.jsonl + a lookup RPC. A first-class terminal-status-by-interaction/run-id
 query in meerkat-session/runtime deletes that code for every embedder.
+
+## Ask 21 — owned-but-snapshotless sessions still strand on archive (ask-20 residue) — P1
+
+**Problem statement.** 0.7.19's ask-20 fix routes disposal on
+`session_known_to_archive_authority`, but that gate only reroutes sessions
+the authority does NOT own (`known=false`, host-adopted). A mob-CREATED
+member that has never run a turn is `known=true` — its durable session
+record exists (create persisted it) — while its RUNTIME SNAPSHOT does not
+(the machine commits at run boundaries). The owned-path archive then fails
+exactly as before: `archive_with_mob_lifecycle_authority` → control-read
+(`load_persisted_session_for_control`) NotFounds on the missing snapshot →
+"disposal completed but ArchiveSession failed: … NotFound for registered
+runtime session" → member stranded `state=retiring`. The authority-read
+(`load_authoritative_session`, store-projection-eligible) and the
+control-read disagree about the same session.
+
+**Evidence.** Deterministic mobkit repro on meerkat =0.7.19
+(`meerkat-mobkit/tests/studio_k_asks.rs`, `#[ignore]`d persistent test):
+3-member `ensure_member` crew on FactoryAgentBuilder→PersistentSessionService;
+probe confirms `session_known_to_archive_authority = Ok(true)` for all three
+idle members; retire still fails with the exact field string. The wrapper-
+forwarding gap on mobkit's side is FIXED (mobkit forwards the seam through
+`PreBuildMobSessionService`/`AfterCreateMobSessionService`); the remaining
+failure is upstream.
+
+**Proposed shape.** Make the owned-path archive tolerate the
+never-committed-snapshot case: when the durable record exists, the runtime is
+registered, and NO snapshot was ever committed, archive the durable record
+and retire/release the runtime binding (the control-read should accept the
+same store-projection eligibility the authority-read already accepts).
+Regression: retire + respawn of a freshly created, never-prompted member on a
+persistent service with a runtime store must succeed.
+
+**MobKit interim behavior.** Identity-first gateways (default-on since
+0.7.25) route crew members through the identity authority, which disposes
+tolerantly — the strand is only reachable for mob-plane (worker) members
+that never ran, a narrow window in practice since workers receive kickoff
+messages at spawn.

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -4923,9 +4923,7 @@ rust_test(
         "fast",
     ],
     size = "small",
-    data = [
-        ":package_runfiles",
-    ],
+    data = [],
     env = {
         "RUST_MIN_STACK": "16777216",
     },

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -47,25 +47,25 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.7.18"
-meerkat-client = "=0.7.18"
-meerkat-contracts = "=0.7.18"
-meerkat-mob = "=0.7.18"
-meerkat-mob-mcp = "=0.7.18"
-meerkat-mcp = "=0.7.18"
-meerkat-models = "=0.7.18"
+meerkat-core = "=0.7.19"
+meerkat-client = "=0.7.19"
+meerkat-contracts = "=0.7.19"
+meerkat-mob = "=0.7.19"
+meerkat-mob-mcp = "=0.7.19"
+meerkat-mcp = "=0.7.19"
+meerkat-models = "=0.7.19"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.7.18", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
+meerkat = { version = "=0.7.19", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.7.18"
-meerkat-runtime = { version = "=0.7.18", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.7.18", features = ["session-store"] }
-meerkat-store = { version = "=0.7.18", features = ["sqlite"] }
-meerkat-tools = "=0.7.18"
+meerkat-memory = "=0.7.19"
+meerkat-runtime = { version = "=0.7.19", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.7.19", features = ["session-store"] }
+meerkat-store = { version = "=0.7.19", features = ["sqlite"] }
+meerkat-tools = "=0.7.19"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -119,10 +119,10 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "=0.7.18"
-meerkat-schedule = "=0.7.18"
+meerkat-comms = "=0.7.19"
+meerkat-schedule = "=0.7.19"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.7.18", features = ["schema"] }
+meerkat-mob = { version = "=0.7.19", features = ["schema"] }

--- a/meerkat-mobkit/src/adaptive_layer_decision.schema.json
+++ b/meerkat-mobkit/src/adaptive_layer_decision.schema.json
@@ -514,6 +514,108 @@
       ],
       "type": "object"
     },
+    "McpHttpConfig": {
+      "additionalProperties": false,
+      "description": "HTTP transport configuration (streamable HTTP or legacy SSE)",
+      "properties": {
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra headers to include on requests",
+          "type": "object"
+        },
+        "transport": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpHttpTransport"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "HTTP transport selection (default: streamable-http)"
+        },
+        "url": {
+          "description": "Server URL",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "McpHttpTransport": {
+      "description": "HTTP transport selection for URL-based servers",
+      "enum": [
+        "streamable-http",
+        "sse"
+      ],
+      "type": "string"
+    },
+    "McpServerConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/McpStdioConfig"
+        },
+        {
+          "$ref": "#/$defs/McpHttpConfig"
+        }
+      ],
+      "description": "Configuration for a single MCP server",
+      "properties": {
+        "connect_timeout_secs": {
+          "description": "Connection timeout in seconds (connect + handshake + list_tools).\nDefaults to 10 seconds when not specified.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Server name (must be unique within scope)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "McpStdioConfig": {
+      "additionalProperties": false,
+      "description": "Stdio transport configuration",
+      "properties": {
+        "args": {
+          "default": [],
+          "description": "Arguments to pass to the command",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "description": "Command to spawn the server",
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Environment variables",
+          "type": "object"
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "type": "object"
+    },
     "MeerkatSchema": {
       "description": "A Meerkat-native JSON schema."
     },
@@ -726,6 +828,7 @@
             "comms": false,
             "image_generation": false,
             "mcp": [],
+            "mcp_servers": [],
             "memory": false,
             "mob": false,
             "rust_bundles": [],
@@ -1337,6 +1440,14 @@
           "description": "MCP server names this profile connects to.",
           "items": {
             "type": "string"
+          },
+          "type": "array"
+        },
+        "mcp_servers": {
+          "default": [],
+          "description": "Declarative MCP server configs for members built from this profile.\n\nDurable on the profile (unlike the in-process-only per-spawn\n`SpawnMemberSpec.external_tools` overlay), so revival recomposes the\nmember's MCP tools from the same profile that built it. These are\nalready profile-scoped; the `mcp` name allowlist above gates only the\nmob-wide default external-tools provider (where an empty list means\nthe full host surface).",
+          "items": {
+            "$ref": "#/$defs/McpServerConfig"
           },
           "type": "array"
         },

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -1593,6 +1593,17 @@ macro_rules! delegate_mob_session_service {
             fn supports_persistent_sessions(&self) -> bool {
                 self.inner.supports_persistent_sessions()
             }
+            // meerkat 0.7.19: disposal routes on this fact. The trait default
+            // is fail-closed (`true`); NOT forwarding it would swallow the
+            // inner persistent service's real store read and resurrect the
+            // ask-20 stranding for host-owned sessions (the external_tools
+            // clobber class: wrappers MUST forward, not default).
+            async fn session_known_to_archive_authority(
+                &self,
+                session_id: &meerkat_core::types::SessionId,
+            ) -> Result<bool, SessionError> {
+                self.inner.session_known_to_archive_authority(session_id).await
+            }
             fn runtime_adapter(&self) -> Option<Arc<meerkat_runtime::MeerkatMachine>> {
                 self.runtime_adapter_override
                     .clone()
@@ -2059,6 +2070,17 @@ impl meerkat_core::service::SessionServiceHistoryExt for AfterCreateMobSessionSe
 impl MobSessionService for AfterCreateMobSessionService {
     fn supports_persistent_sessions(&self) -> bool {
         self.inner.supports_persistent_sessions()
+    }
+
+    // meerkat 0.7.19 disposal-routing seam — forwarded for the same reason
+    // as in `delegate_mob_session_service!` above.
+    async fn session_known_to_archive_authority(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> Result<bool, SessionError> {
+        self.inner
+            .session_known_to_archive_authority(session_id)
+            .await
     }
     fn runtime_adapter(&self) -> Option<Arc<meerkat_runtime::MeerkatMachine>> {
         self.inner.runtime_adapter()
@@ -4757,6 +4779,14 @@ realm_profile = "worker-v2"
             Ok(())
         }
 
+        async fn session_known_to_archive_authority(
+            &self,
+            _session_id: &meerkat_core::types::SessionId,
+        ) -> Result<bool, SessionError> {
+            self.record("session_known_to_archive_authority");
+            Ok(true)
+        }
+
         async fn stage_runtime_system_context_for_active_turn(
             &self,
             _session_id: &meerkat_core::types::SessionId,
@@ -4843,6 +4873,14 @@ realm_profile = "worker-v2"
             )
             .await
             .expect("active-turn rollback should forward");
+        // meerkat 0.7.19 disposal-routing seam: the trait default is
+        // fail-closed `true`, so a wrapper that fails to forward this
+        // silently resurrects the ask-20 stranding for host-owned sessions.
+        let known = wrapped
+            .session_known_to_archive_authority(&session_id)
+            .await
+            .expect("archive-authority probe should forward");
+        assert!(known, "probe answers true");
         assert_eq!(
             probe.calls(),
             vec![
@@ -4851,6 +4889,7 @@ realm_profile = "worker-v2"
                 "active_turn_system_context_boundary_available",
                 "stage_runtime_system_context_for_active_turn",
                 "discard_runtime_system_context_for_active_turn",
+                "session_known_to_archive_authority",
             ]
         );
     }

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -1227,6 +1227,80 @@ mod tests {
         assert_eq!(changed, 1, "one {table} row corrupted");
     }
 
+    /// meerkat 0.7.19 carry guard (asks 16-19): a poisoned occurrence row no
+    /// longer starves the whole claim — the sqlite claim scan skips it as a
+    /// typed row fault and claims healthy due neighbors. This is the exact
+    /// HomeCore shape: one stale row, everything else due.
+    #[tokio::test]
+    async fn schedule_claim_tolerates_poisoned_neighbor_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Schedule A: healthy, due in the past via the aged-occurrence
+        // rewrite used by the watchdog tests. Schedule B: poisoned row.
+        let (service, store_path) =
+            seed_sqlite_schedule(dir.path(), chrono::Utc::now() + chrono::Duration::hours(1)).await;
+        // Age schedule A's first occurrence JUST past due (inside any misfire
+        // window, so it classifies as claimable rather than misfired).
+        let overdue = chrono::Utc::now() - chrono::Duration::seconds(5);
+        {
+            let conn = rusqlite::Connection::open(&store_path).expect("open store");
+            let (rowid, bytes): (i64, Vec<u8>) = conn
+                .query_row(
+                    "SELECT rowid, occurrence_json FROM schedule_occurrences \
+                     ORDER BY rowid LIMIT 1",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .expect("read first occurrence");
+            let mut json: serde_json::Value =
+                serde_json::from_slice(&bytes).expect("occurrence json");
+            let old_due_ms = json["machine_state"]["due_at_utc_ms"]
+                .as_i64()
+                .expect("machine due ms");
+            let shift = old_due_ms - overdue.timestamp_millis();
+            json["due_at_utc"] = serde_json::Value::String(overdue.to_rfc3339());
+            json["machine_state"]["due_at_utc_ms"] =
+                serde_json::Value::from(overdue.timestamp_millis());
+            if let Some(deadline) = json["machine_state"]["misfire_deadline_utc_ms"].as_i64() {
+                json["machine_state"]["misfire_deadline_utc_ms"] =
+                    serde_json::Value::from(deadline - shift);
+            }
+            let updated = serde_json::to_vec(&json).expect("serialize occurrence");
+            conn.execute(
+                "UPDATE schedule_occurrences SET occurrence_json = ?1, due_at_ms = ?2 \
+                 WHERE rowid = ?3",
+                rusqlite::params![updated, overdue.timestamp_millis(), rowid],
+            )
+            .expect("age occurrence");
+            // Poison a NEIGHBOR row: insert a corrupt occurrence for the same
+            // schedule so the claim scan meets it.
+            conn.execute(
+                "INSERT INTO schedule_occurrences \
+                 (occurrence_id, schedule_id, schedule_revision, occurrence_ordinal, \
+                  phase, due_at_ms, occurrence_json) \
+                 SELECT 'poisoned-row', schedule_id, schedule_revision, \
+                        occurrence_ordinal + 999, phase, ?1, X'7B22706F69736F6E22' \
+                 FROM schedule_occurrences WHERE rowid = ?2",
+                rusqlite::params![overdue.timestamp_millis() - 1000, rowid],
+            )
+            .expect("insert poisoned row");
+        }
+
+        let claimed = service
+            .store()
+            .claim_due_occurrences(meerkat::ClaimDueRequest {
+                owner_id: "carry-test".to_string(),
+                limit: 8,
+                lease_duration: chrono::Duration::seconds(60),
+            })
+            .await
+            .expect("claim must tolerate the poisoned neighbor (meerkat >= 0.7.19)");
+        assert_eq!(
+            claimed.claimed.len(),
+            1,
+            "the healthy due occurrence must be claimed despite the poisoned neighbor"
+        );
+    }
+
     /// Healthy pipeline: future work only, nothing overdue → the watchdog has
     /// nothing to say.
     #[tokio::test]

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -174,7 +174,7 @@ comms = true
 /// PersistentSessionService → MobBootstrapSpec → UnifiedRuntime, then a
 /// 3-member crew via mobkit/ensure_member and per-member retire/respawn.
 #[tokio::test]
-#[ignore = "blocked on meerkat ask 20 (target 0.7.19): ArchiveSession NotFound for never-ran members strands them in retiring; see docs/design/upstream-asks.md"]
+#[ignore = "blocked on meerkat ask 21: mob-CREATED never-ran sessions are archive-authority-OWNED (durable record exists) yet snapshotless, so the owned-path archive still NotFounds; 0.7.19's ask-20 fix reroutes only host-adopted (known=false) sessions. Identity-first gateways (default-on) sidestep this for crews."]
 async fn studio_k1_retire_respawn_succeed_on_persistent_ensure_member_crew() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let state = temp_dir.path().join("state");
@@ -730,10 +730,10 @@ comms = true
         json!({"member_id": "scratch-worker"}),
     )
     .await;
-    // The never-ran worker hits the mob plane's ask-20 disposal defect until
-    // meerkat 0.7.19 lands (deliberately fail-closed downstream) — so assert
-    // only the ROUTING here: the worker must NOT take the identity arm.
-    // Tighten to a success assertion on the 0.7.19 upgrade.
+    // Never-ran mob-CREATED members remain archive-blocked (upstream ask 21:
+    // owned-but-snapshotless sessions; 0.7.19's ask-20 fix covers only
+    // host-adopted sessions). Assert the ROUTING here; tighten to strict
+    // success when ask 21 lands.
     assert!(
         respawn["result"].get("identity_first").is_none(),
         "worker respawn must NOT route through the identity authority: {respawn}"
@@ -742,8 +742,7 @@ comms = true
         let detail = error["data"]["detail"].as_str().unwrap_or_default();
         assert!(
             detail.contains("ArchiveSession"),
-            "the only acceptable worker-respawn failure is the upstream ask-20 \
-             class: {respawn}"
+            "the only acceptable worker-respawn failure is the ask-21 class: {respawn}"
         );
     }
 }


### PR DESCRIPTION
The release gate for 0.7.25: meerkat 0.7.19 carries the full batch-3/4 ask set.

**Verified through mobkit's stack:**
- **Asks 16–19 (the HomeCore schedule stall):** new carry test `schedule_claim_tolerates_poisoned_neighbor_row` proves a poisoned occurrence row no longer starves healthy claims — the claim scan skips it as a typed row fault. The watchdog (from #237) stays as the loud-diagnosis layer; its probe tests still pass (strict list/scan reads still name poisoned rows).
- **Ask 20:** the host-adopted disposal fix landed upstream, and this PR fixes the mobkit half that would have silently defeated it: our session-service wrappers now **forward** the new `session_known_to_archive_authority` disposal-routing seam (trait default is fail-closed `true` — an unforwarded wrapper swallows the persistent service's real store read; the compose-don't-assume wrapper class). Forwarding-probe test extended to pin it.
- **Ask 21 filed (residue):** mob-CREATED never-ran members are authority-OWNED (durable record exists) yet snapshotless — the owned-path archive still strands them; 0.7.19 reroutes only `known=false` sessions. Probe-verified (`known=Ok(true)` for idle crew members). The K1 persistent repro stays `#[ignore]`d with the ask-21 note; identity-first gateways (default-on since #244) sidestep it for crews, and the worker-plane window is narrow (workers get kickoff at spawn).
- **M1–M4** land upstream (bounded force_cancel, declarative MCP, versioning policy, run-status query) — no mobkit changes required.
- Regenerated the bundled adaptive layer-decision schema against the 0.7.19 canonical.

Full workspace suite green (1540). Release 0.7.25 follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)