### PR TITLE
test(schedule): ask-22 carry guard + ask filed — one-shot planning-cursor precision runaway

### DIFF
--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -899,3 +899,53 @@ persistent service with a runtime store must succeed.
 tolerantly — the strand is only reachable for mob-plane (worker) members
 that never ran, a narrow window in practice since workers receive kickoff
 messages at spawn.
+
+## Ask 22 — past-due one-shot regenerates occurrences unboundedly (planning-cursor precision loss) — P0
+
+**Field report (HomeCore on 0.7.25):** one one-shot with a fire time
+near/just-past now produced 223 misfired occurrences + 223 receipts in ~2
+minutes (~1/sec, unbounded) on a clean store; halting required stopping the
+gateway and truncating the schedule tables.
+
+**Root cause (found by Luka; repro sits as a failing test in
+meerkat-schedule/src/driver.rs):** sub-millisecond precision loss in the
+planning-cursor round-trip. A one-shot's `due_at_utc` is a full-precision
+`DateTime<Utc>` (ns); the machine-owned planning cursor is
+`planning_cursor_utc_ms` (ms) — `RecordPlanningWindow` stores
+`truncate_ms(due)`. The planner's guard `next_due_after(Once, cursor)`
+yields when `due > cursor`, and `truncate_ms(due) < due` by up to 999µs, so
+the trigger re-yields the same due forever. The pending-occurrence dedupe
+only covers PENDING dues — the moment the occurrence goes terminal
+(misfired in the incident), nothing blocks the re-plan: new occurrence,
+same due, next ordinal → immediately misfires → terminal → next tick
+re-plans. Aggravations: the same loop shape fires for COMPLETED one-shots
+(re-plan → re-dispatch = double-fire, not just misfire spam), and interval
+triggers are plausibly exposed on their last-planned slot.
+
+Mobkit cross-confirmation: the loop reproduces with pure meerkat service
+APIs (`refill_horizon` + `claim_due_occurrences`) — no mobkit code in the
+cycle; the #237 claim watchdog is read-only and ticks at 60s (cannot drive
+a 1/s loop). The ms/ns mismatch also explains regeneration WITH a pending
+occurrence present: the stored occurrence due is ms-truncated while the
+trigger re-yields the ns-precision due, so the `existing_due` dedupe set
+never matches. Carry guard: `one_shot_misfire_must_not_regenerate`
+(`#[ignore]`d in schedule_wiring tests, un-ignored on the 0.7.20 upgrade).
+
+**Why the machines didn't catch it (recorded for the RCT discipline):**
+(1) an RCT failure, not transition legality — one semantic fact ("planning
+has covered up to T") stored at ms precision but compared at ns across the
+shell/machine boundary; no RCT existed for the cursor's time-precision
+round-trip. (2) The machines verify per-entity safety, not cross-entity
+convergence — every lap of the loop is legal (the M1 cancel-recursion
+family); "a Once trigger plans at most one occurrence, ever" and "the
+planning cursor is monotone/idempotent under re-planning" were never
+encoded as machine-checkable invariants.
+
+**Fix (dogmatic, for 0.7.20):** (1) normalize ALL schedule time facts to ms
+precision at the domain admission boundary (Once due_at, interval
+start/end, planned dues) — one precision for one fact everywhere, matching
+the sqlite `due_at_ms` columns; (2) a machine-owned convergence invariant
+(`trigger_exhausted`-style fact, or RecordPlanningWindow terminal for Once)
+so even a future representation bug converges instead of running away;
+(3) regressions: the failing one-shot misfire repro, completed-one-shot
+no-refire, interval terminal-tail stability over N ticks.

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -1301,6 +1301,112 @@ mod tests {
         );
     }
 
+    /// Ask-22 upgrade-carry guard: a just-past ONE-SHOT must converge —
+    /// bounded occurrences over repeated refill+claim rounds.
+    ///
+    /// Root cause (found by Luka, fix targeted at meerkat 0.7.20):
+    /// sub-millisecond precision loss in the planning-cursor round-trip —
+    /// the cursor is machine-owned at ms precision (truncate_ms(due)) while
+    /// `next_due_after(Once, cursor)` compares at ns precision, so
+    /// `due > cursor` stays true forever and the planner re-yields the same
+    /// due each tick (one spawn per tick ≈ the field's ~1/sec, unbounded).
+    /// Reproduces with PURE meerkat service APIs (refill_horizon +
+    /// claim_due_occurrences) — no mobkit code in the loop; the claim
+    /// watchdog is read-only and ticks at 60s, exonerated twice over.
+    /// UN-IGNORE on the meerkat 0.7.20 upgrade.
+    #[tokio::test]
+    #[ignore = "blocked on meerkat ask 22 (target 0.7.20): planning-cursor ms/ns precision loss regenerates one-shot occurrences unboundedly"]
+    async fn one_shot_misfire_must_not_regenerate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_path = dir.path().join(SCHEDULE_STORE_FILE);
+        let store = SqliteScheduleStore::open(&store_path).expect("open store");
+        let service = ScheduleService::new(Arc::new(store));
+        // One-shot due WELL past (beyond any catch-up window → misfires).
+        let created = service
+            .create(CreateScheduleRequest {
+                name: Some("oneshot-runaway-probe".to_string()),
+                description: None,
+                trigger: TriggerSpec::Once {
+                    due_at_utc: chrono::Utc::now() - chrono::Duration::seconds(30),
+                },
+                target: TargetBinding::host_runnable(HostRunnableTargetBinding {
+                    runnable: HostRunnableName::parse("runaway.probe").expect("name"),
+                    params: None,
+                }),
+                misfire_policy: meerkat::MisfirePolicy::default(),
+                overlap_policy: meerkat::OverlapPolicy::default(),
+                missing_target_policy: meerkat::MissingTargetPolicy::default(),
+                labels: std::collections::BTreeMap::new(),
+                planning_horizon_days: None,
+                planning_horizon_occurrences: None,
+            })
+            .await
+            .expect("create one-shot");
+
+        let count_occurrences = |path: std::path::PathBuf| -> i64 {
+            let conn = rusqlite::Connection::open(path).expect("open");
+            conn.query_row("SELECT COUNT(*) FROM schedule_occurrences", [], |r| {
+                r.get(0)
+            })
+            .expect("count")
+        };
+
+        // DEBUG: dump schedule + occurrence bookkeeping after create.
+        {
+            let conn = rusqlite::Connection::open(&store_path).expect("open");
+            let (rev, cursor): (i64, Option<i64>) = conn
+                .query_row(
+                    "SELECT revision, planning_cursor_at_ms FROM schedule_schedules LIMIT 1",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .expect("schedule row");
+            eprintln!("after create: schedule revision={rev} planning_cursor_ms={cursor:?}");
+            let mut stmt = conn
+                .prepare(
+                    "SELECT occurrence_ordinal, schedule_revision, phase FROM schedule_occurrences",
+                )
+                .expect("prep");
+            let rows: Vec<(i64, i64, String)> = stmt
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+                .expect("q")
+                .filter_map(Result::ok)
+                .collect();
+            eprintln!("occurrences after create: {rows:?}");
+        }
+        // Simulate driver ticks: refill + claim, several rounds.
+        for round in 0..6 {
+            let _ = service.refill_horizon(&created.schedule_id).await;
+            let _ = service
+                .store()
+                .claim_due_occurrences(meerkat::ClaimDueRequest {
+                    owner_id: "runaway-probe".to_string(),
+                    limit: 8,
+                    lease_duration: chrono::Duration::seconds(60),
+                })
+                .await;
+            {
+                let conn = rusqlite::Connection::open(&store_path).expect("open");
+                let (rev, cursor): (i64, Option<i64>) = conn
+                    .query_row(
+                        "SELECT revision, planning_cursor_at_ms FROM schedule_schedules LIMIT 1",
+                        [],
+                        |r| Ok((r.get(0)?, r.get(1)?)),
+                    )
+                    .expect("schedule row");
+                eprintln!(
+                    "round {round}: occurrences = {} schedule_rev={rev} cursor_ms={cursor:?}",
+                    count_occurrences(store_path.clone())
+                );
+            }
+        }
+        let total = count_occurrences(store_path.clone());
+        assert!(
+            total <= 1,
+            "a one-shot must never regenerate after misfire; got {total} occurrences"
+        );
+    }
+
     /// Healthy pipeline: future work only, nothing overdue → the watchdog has
     /// nothing to say.
     #[tokio::test]


### PR DESCRIPTION
Records ask 22 (the HomeCore one-shot runaway on 0.7.25) with Luka's root cause — planning-cursor ms/ns precision loss (`truncate_ms(due) < due` → `next_due_after(Once, cursor)` re-yields forever; terminal occurrence unblocks the re-plan → one spawn per tick, unbounded) — plus the RCT post-mortem and the dogmatic 0.7.20 fix plan.

Mobkit-side contributions:
- **Cross-confirmation:** the loop reproduces with *pure meerkat service APIs* (`refill_horizon` + `claim_due_occurrences`) — no mobkit code in the cycle. The #237 claim watchdog is exonerated twice over: read-only by design, and its 60s cadence cannot drive a ~1/s loop.
- The ms/ns mismatch also explains regeneration **with a pending occurrence present** (stored due is ms-truncated; trigger re-yields the ns due; the `existing_due` dedupe never matches) — consistent with the repro planning a second occurrence before any misfire.
- **Upgrade-carry guard:** `one_shot_misfire_must_not_regenerate` (`#[ignore]`d, bounded-occurrences assertion over 6 refill+claim rounds) — un-ignored on the meerkat 0.7.20 upgrade alongside the ask-21 K1 test.

0.7.26 ships when meerkat 0.7.20 lands (monitor running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)