### PR TITLE
deps: meerkat 0.7.20 — ask-22 one-shot runaway fixed (guard green); ask-21b residue filed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the meerkat family 0.7.19 → 0.7.20 (exact pins). Carries the
+  ask-22 fix for the P0 one-shot runaway (trigger yields/compares
+  ms-truncated dues + a machine-owned planning-monotonicity invariant so
+  future representation bugs converge as refill faults instead of
+  generating occurrences unboundedly) — carry-verified by the previously
+  failing `one_shot_misfire_must_not_regenerate` guard, now green. Also
+  carries the ask-21 archive-scoped read fix.
+
+### Known issues
+
+- Ask 21b (docs/design/upstream-asks.md, ask 21 addendum): the 0.7.20
+  archive-scoped read fix commits the durable document, but archiving a
+  never-run registered session still returns NotFound afterwards — the
+  `retiring` strand persists for mob-plane members that never ran.
+  Two-adapter split ruled out empirically on the mobkit side. Identity-first
+  gateways (default-on) remain unaffected for crews.
+
 ## [0.7.25] - 2026-07-07
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dd8e8d9370a2d7a46c00ee917df72581c8f6999a24b0607045f0cd774eab82"
+checksum = "62e012cbe2b69c3e50a1e6bae17476a0e494819275aa6e20470fa2e35fe32c04"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de181d572b1151c0e6fe4f6729079b32a9820c1383c797c1b5b9a3291774d0bc"
+checksum = "869650b79ff162e2a287f82a6588f2adc73bb68e301da0ce205cfc16999da22e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d1649947165b81a0517ba30e60ea1af264dbad4a69656e14bad76d983f5f58"
+checksum = "f836ec991840b2f8e4174ce106b00633a2620c3938a8a2dc5a11659de2ea2798"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae639d2659ecf9ee65a26260f1c376c08e4f8484197fb893b06336aac081a50"
+checksum = "7e4a907a101c2258fef32ef231f90dadb710aba2ad592d909b3daa86bffab6a2"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bc5411215169df61a5ae68164b1c3a0bc585a22db24f0dc228f8412319a18"
+checksum = "3d4267619277346340bbd8fd9823a2b8f0f4d31f43fb874f8fefb008c7964f39"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952de55ba0bb70850499427d7ad4a71b139bfb726768dc26644d60707262ea8"
+checksum = "301c70bb7571cd82d0d49a9f1e08c0d09ab42035a5f27738756cbcd74f73009b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cde341f3a2c0a1354fce8903b2f98c20fa0168e608d8d86c4ae10568577841"
+checksum = "bf56b9a4f0c9635ca1c109db44bd7abc82b2db3b5855fe475a18cf212f5b743b"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721b4e0c90bd14a228bbcba688c1cb5d18b638c4724e6ed8c6a3e4f85435a80"
+checksum = "91b8e16a4d4fdb6902ef408934fdb2f724637fde9ba67f27f83fcae910a85ce5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03f39fd2ce5627bbd316d94a29bb41ba6f6f1d340829f45d13ff8101af9333c"
+checksum = "a0a9060ffaf345fbf4388b3501320f166be241a0ab3d8895b508c3f8c7405848"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665daf868d135e46a1793dbc5e61cb8cd62baab5ca8f32d42546d5188a289693"
+checksum = "0211f36352c0ab261177b2c669c20cf10c231f76ff1665f75494bb91edba8857"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4a19346ed299174e65deed8ff9626608df00d7ee64d0575482e8452f3b3e68"
+checksum = "b5cef2f2264fb39d89a3f2c2e31e9fa053cbcfcac25490560c0d9a987108cae8"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e434c2bc1de2e395eb03976a5de9c24f4da16eabdde545709bc3d5a0a734c79a"
+checksum = "e787fd3c85048d3d7916d353dbcd7e444dc839c6bb3057985b8e8c97b409b95c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808f7f767f96131e2c9c446f8300c175ad81233205cec23c80376e39220eb82d"
+checksum = "5bcec2a493a5f20c9e4811ead60d1907512533319866a5eb5ddb3cd73b9b861b"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f80db51e132bc8bdbe9289cf086dfe2c4fc8ba613701bd10403d65f6b6b287"
+checksum = "3ed0807f6518a6f6891344ac81fdef343d99bfc99d2b5c750c94f866fa7dd5d2"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98ccf4828fe951bc423eccd0dcc7ea1e1d5c21509787a963266ccac1b5b9f1d"
+checksum = "a0640f437ad965fd835b76dcf439ca8d689e6a5213c2fe175197c12d48152576"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0ce895f5d86b17f4e3a7312d012c1ca6a80c8a29b119420c924c511bfe2737"
+checksum = "48e71e068afd696051fe1ac0b4dddec00bf9434bff77a8c4fce602ba061cbc60"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69409c2fd8335b837d64aae2cc403ee7a040e18ddaf5fcf364c7cfbc259bac9"
+checksum = "f63f0f9c5235e45e53d977467e32e0e4e5209ed2fa83b3d63870f29586de87ab"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690bfb536e0b5e5ecd5a3c9d6182b0486c7d1c7751b5b718b91575831d015cc4"
+checksum = "2056d35af16843034b68b27dde42beb5b4555f6e41026150fbd89cc59f79120d"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99f9ccc36d021aa26f9a7061e9fe29f2302ccb775ed5ec5294b22249e595fed"
+checksum = "524d5952c82a80ad3956c0a15a362e8d55b5f40327c3ec4dabcc86c7dd8afc64"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940e364bcd8adc10f86032d7f37d489f42f9585d77ea1b50924bcd47a066490d"
+checksum = "e8b65bf5e306427180cf91f6aa3ef89f5dec2c012ee2fe4817bfadf620494547"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3299d91f71b6b1c7d713da8c494dc4ff6c99bcaa0fcea7a18c7cbd52c539705f"
+checksum = "6958f490538c639817a8e4e46253b0809ddbfe58cad6d4256acd0801a34ec36f"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b8425a78f6e34cf3c4f84e41ba275d618d06ea8b01be004e561c5612128369"
+checksum = "03eecc8e2bd8cfb27c6fb79757112eceb6f49ff359fdaab5c6bbef19894d1826"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0c7ff6bc80255eb8d195b3d45c386aa2757f20d2636d033b26c13fab1eddc1"
+checksum = "4086425cbf4d4c0cf7362c7f6c153c41dbc697256df5d912cebf7c31963de940"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdceeeee6e5d3561bfbf63e3931ae282fb15a072f7bae6c94bee0b658da836d"
+checksum = "ee3975cc220fbe52cdfcc6a059375473e4835f743ab61becfb35de4d04c80b6d"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb23f99bd76b7051244ac12003c5eef138ec617580f7d5ec6c76b60d2a5995e"
+checksum = "8374d6dfaf37fa5295afc07aa7f433b6e63a01b5803882bf3864f21f8a8ca94d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b593dbf357007ea822c39ed025b4ea1b5b9b70d0d67f55e9fa62651658ad3af"
+checksum = "62d3d9c0c864b95fe57f520a0aa4c3ad813ce3374605584d6d65ff6e7aeeeb78"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc289c83ed384f019e6fd7aa1a0f94630ae7096abf99d4adde208c8b02b06b7a"
+checksum = "a9bf4eae77317e143465c779cf3131c9c67d34e461c89d8ff2b8bf3d575cae26"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16279e9215208cc2112cc0a36b4093a6538b0d237c7cb5a0b97e4cad3051eb6"
+checksum = "8b90964b4319dc698fb755ffe891640d8ccb68e13dedf706fe23885cde99796f"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae1d053aa08e135b09e1185be8406fd050fdc763256bc8f2ef627e8a44b867d"
+checksum = "1ba73c91085ba8fe14a10f8f69686c0668505218690822963820af832db15e7b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717efa71340c994460b366238999c7693cc0d7d853ee79a1c10981d11e565acb"
+checksum = "a71c0cbf26e3698a018073f807f6ccc428f62dc7fac47d19db9ef5eeb2f44058"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9287bf1cbb9b274f8abc17861829afe29becf25179c409f483e4d321717c2a61"
+checksum = "28829f67691d2007669c8cf5df70d754f8bf7b12cf087653a602d8beb353497b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -949,3 +949,28 @@ the sqlite `due_at_ms` columns; (2) a machine-owned convergence invariant
 so even a future representation bug converges instead of running away;
 (3) regressions: the failing one-shot misfire repro, completed-one-shot
 no-refire, interval terminal-tail stability over N ticks.
+
+### Ask 21 addendum (21b) — 0.7.20 verification: read fixed, archive still NotFounds afterwards
+
+Verified against meerkat =0.7.20 with the mobkit repro: the archive-scoped
+read (`load_persisted_session_for_archive`) works — traces show the durable
+document COMMITTING (`discarding stale live session … reason=StoredArchived`)
+— yet `archive_with_mob_lifecycle_authority` still returns
+`SessionError::NotFound` for the never-run registered session, so the
+provisioner escalation ("mob archive authority returned NotFound for
+registered runtime session") and the `retiring` strand persist unchanged.
+The failure now sits AFTER the snapshot resolution — candidates: the
+runtime-retire realization for a registered-but-snapshotless machine session
+(the register-before-retire fallback may still NotFound on the second
+retire), or the post-commit archived-typed-NotFound contract folding into
+the error path mid-protocol.
+
+Empirically ruled out on the mobkit side: the two-adapter split (a separate
+`with_session_runtime_adapter` machine vs the service's cached adapter) —
+the repro fails identically when the mob shares the concrete service's own
+cached machine as the sole authority. Wrapper forwarding of
+`session_known_to_archive_authority` verified live (probe: `Ok(true)`).
+
+Repro unchanged: `meerkat-mobkit/tests/studio_k_asks.rs`, `#[ignore]`d
+persistent test; the trace capture recipe is a `tracing_subscriber` init
+with `meerkat_mob=debug,meerkat_session=debug` in the test body.

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -4923,7 +4923,9 @@ rust_test(
         "fast",
     ],
     size = "small",
-    data = [],
+    data = [
+        ":package_runfiles",
+    ],
     env = {
         "RUST_MIN_STACK": "16777216",
     },

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -47,25 +47,25 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.7.19"
-meerkat-client = "=0.7.19"
-meerkat-contracts = "=0.7.19"
-meerkat-mob = "=0.7.19"
-meerkat-mob-mcp = "=0.7.19"
-meerkat-mcp = "=0.7.19"
-meerkat-models = "=0.7.19"
+meerkat-core = "=0.7.20"
+meerkat-client = "=0.7.20"
+meerkat-contracts = "=0.7.20"
+meerkat-mob = "=0.7.20"
+meerkat-mob-mcp = "=0.7.20"
+meerkat-mcp = "=0.7.20"
+meerkat-models = "=0.7.20"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.7.19", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
+meerkat = { version = "=0.7.20", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.7.19"
-meerkat-runtime = { version = "=0.7.19", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.7.19", features = ["session-store"] }
-meerkat-store = { version = "=0.7.19", features = ["sqlite"] }
-meerkat-tools = "=0.7.19"
+meerkat-memory = "=0.7.20"
+meerkat-runtime = { version = "=0.7.20", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.7.20", features = ["session-store"] }
+meerkat-store = { version = "=0.7.20", features = ["sqlite"] }
+meerkat-tools = "=0.7.20"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -119,10 +119,10 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "=0.7.19"
-meerkat-schedule = "=0.7.19"
+meerkat-comms = "=0.7.20"
+meerkat-schedule = "=0.7.20"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.7.19", features = ["schema"] }
+meerkat-mob = { version = "=0.7.20", features = ["schema"] }

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -1313,9 +1313,10 @@ mod tests {
     /// Reproduces with PURE meerkat service APIs (refill_horizon +
     /// claim_due_occurrences) — no mobkit code in the loop; the claim
     /// watchdog is read-only and ticks at 60s, exonerated twice over.
-    /// UN-IGNORE on the meerkat 0.7.20 upgrade.
+    /// Fixed in meerkat 0.7.20: trigger yields/compares ms-truncated dues,
+    /// and the ScheduleLifecycleMachine owns a planning-monotonicity
+    /// invariant so future representation bugs converge as refill faults.
     #[tokio::test]
-    #[ignore = "blocked on meerkat ask 22 (target 0.7.20): planning-cursor ms/ns precision loss regenerates one-shot occurrences unboundedly"]
     async fn one_shot_misfire_must_not_regenerate() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store_path = dir.path().join(SCHEDULE_STORE_FILE);

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -174,7 +174,7 @@ comms = true
 /// PersistentSessionService → MobBootstrapSpec → UnifiedRuntime, then a
 /// 3-member crew via mobkit/ensure_member and per-member retire/respawn.
 #[tokio::test]
-#[ignore = "blocked on meerkat ask 21: mob-CREATED never-ran sessions are archive-authority-OWNED (durable record exists) yet snapshotless, so the owned-path archive still NotFounds; 0.7.19's ask-20 fix reroutes only host-adopted (known=false) sessions. Identity-first gateways (default-on) sidestep this for crews."]
+#[ignore = "blocked on meerkat ask 21b: the 0.7.20 archive-scoped read fix lands (document commits durably) but the archive still returns NotFound for never-run registered sessions afterwards — see docs/design/upstream-asks.md ask 21 addendum. Two-adapter split ruled out empirically (fails with the service's own cached machine as the sole authority)."]
 async fn studio_k1_retire_respawn_succeed_on_persistent_ensure_member_crew() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let state = temp_dir.path().join("state");
@@ -194,10 +194,6 @@ async fn studio_k1_retire_respawn_succeed_on_persistent_ensure_member_crew() {
         session_store.clone(),
     )));
     builder.default_blob_store = Some(blob_store.clone());
-    let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
-        Arc::clone(&runtime_store),
-        Arc::clone(&blob_store),
-    ));
     let service = Arc::new(PersistentSessionService::new(
         builder,
         16,
@@ -219,8 +215,11 @@ comms = true
 "#,
     )
     .expect("definition");
+    // NOTE: deliberately NOT passing a separate with_session_runtime_adapter
+    // — the mob must share the concrete service's own cached machine so the
+    // archive protocol and the session lifecycle run on ONE authority
+    // (two-adapter discriminator for the ask-21 residue).
     let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), service)
-        .with_session_runtime_adapter(adapter.clone())
         .with_options(MobBootstrapOptions {
             allow_ephemeral_sessions: true,
             notify_orchestrator_on_resume: true,
@@ -730,10 +729,9 @@ comms = true
         json!({"member_id": "scratch-worker"}),
     )
     .await;
-    // Never-ran mob-CREATED members remain archive-blocked (upstream ask 21:
-    // owned-but-snapshotless sessions; 0.7.19's ask-20 fix covers only
-    // host-adopted sessions). Assert the ROUTING here; tighten to strict
-    // success when ask 21 lands.
+    // Never-ran member respawn remains archive-blocked (ask 21b residue —
+    // the 0.7.20 read fix commits the document but the archive still
+    // NotFounds afterwards). Assert the ROUTING; tighten when 21b lands.
     assert!(
         respawn["result"].get("identity_first").is_none(),
         "worker respawn must NOT route through the identity authority: {respawn}"
@@ -742,7 +740,7 @@ comms = true
         let detail = error["data"]["detail"].as_str().unwrap_or_default();
         assert!(
             detail.contains("ArchiveSession"),
-            "the only acceptable worker-respawn failure is the ask-21 class: {respawn}"
+            "the only acceptable worker-respawn failure is the ask-21b class: {respawn}"
         );
     }
 }


### PR DESCRIPTION
The 0.7.26 release gate.

**Ask 22 — verified fixed (the P0):** the previously failing carry guard `one_shot_misfire_must_not_regenerate` is un-ignored and **green** — meerkat 0.7.20 yields/compares ms-truncated dues and adds a machine-owned planning-monotonicity invariant (future representation bugs converge as visible refill faults instead of unbounded occurrence generation). The poisoned-neighbor claim guard stays green too.

**Ask 21 — read fix landed, residue filed as 21b:** the archive-scoped read works (traces show the durable document committing), but archiving a never-run registered session still returns NotFound afterwards — the `retiring` strand persists. Debug-traced, and the two-adapter split was ruled out empirically on our side (fails identically with the service's own cached machine as the sole authority; wrapper forwarding probe-verified live). Ask 21 addendum in `docs/design/upstream-asks.md` names the remaining candidates (runtime-retire realization for registered-but-snapshotless machine sessions / post-commit archived-NotFound contract fold). The K1 persistent guard stays `#[ignore]`d referencing 21b; identity-first gateways remain unaffected for crews.

Full workspace suite green (1541). Release 0.7.26 follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)