### PR TITLE
schedule: canonicalize binding member ids before the internal-lane roster lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Schedule self-delivery now reaches identity-first members: the internal
+  delivery lane canonicalizes the binding's member id (decode-then-encode)
+  before the roster lookup. Binding member ids arrive in ROSTER space —
+  identity-first bridge members' roster ids are the comms-encoded runtime id
+  (`mk--…`) — and the previous lookup re-encoded them (the codec re-encodes
+  marker-prefixed input by design), missed the roster, and silently fell
+  through to the external door, reproducing the addressability rejection the
+  internal lane exists to bypass ("mob member is not externally addressable:
+  mk--rt_cdomain_chome_c0" on HomeCore 0.7.28). Plain member names are
+  unaffected (canonicalization is the identity on them). E2e pins the
+  roster-space binding shape end to end; the codec contract test pins
+  decode-then-encode as the only correct roster-key derivation.
+
 ## [0.7.28] - 2026-07-07
 
 ### Changed

--- a/meerkat-mobkit/src/member_comms_id.rs
+++ b/meerkat-mobkit/src/member_comms_id.rs
@@ -373,6 +373,31 @@ mod tests {
         }
     }
 
+    /// Canonicalization contract used by the schedule internal-delivery lane:
+    /// decode-then-encode maps BOTH the alias space and the roster-id space to
+    /// the same roster key, and is the identity on plain member names. Encode
+    /// alone is NOT idempotent on roster ids (the reserved-marker rule
+    /// re-encodes them) — the 0.7.28 HomeCore schedule self-delivery failure.
+    #[test]
+    fn decode_then_encode_canonicalizes_both_id_spaces() {
+        for (input, canonical) in [
+            ("rt:domain:home:0", "mk--rt_cdomain_chome_c0"),
+            ("mk--rt_cdomain_chome_c0", "mk--rt_cdomain_chome_c0"),
+            ("domain:home", "mk--domain_chome"),
+            ("mk--domain_chome", "mk--domain_chome"),
+            ("digest-owner", "digest-owner"),
+        ] {
+            let key = mob_member_id_str(runtime_alias_str(input).as_ref()).into_owned();
+            assert_eq!(key, canonical, "canonical roster key for {input:?}");
+        }
+        // The failure mode this contract exists to prevent:
+        assert_ne!(
+            mob_member_id_str("mk--rt_cdomain_chome_c0"),
+            "mk--rt_cdomain_chome_c0",
+            "encode alone re-encodes roster ids — never use it on binding member ids"
+        );
+    }
+
     /// Decode only applies inside the reserved marker namespace; a raw id that
     /// merely *looks* like an escape body must pass through untouched.
     #[test]

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -598,7 +598,19 @@ impl InternalDeliveryScheduleMobHost {
         if self.handle.definition().id.as_str() != mob_id {
             return None;
         }
-        let member = crate::member_comms_id::mob_member_id(member_id);
+        // Binding member ids arrive in ROSTER space (the authoring rewrite
+        // stores `entry.agent_identity`, and meerkat's delivery-time identity
+        // recovery stamps the same roster id from the session's mob-member
+        // binding) or occasionally in alias space. Roster ids of
+        // identity-first members are already `mk--`-encoded, and the codec
+        // deliberately RE-encodes marker-prefixed input — encoding the raw
+        // binding id double-encodes those and misses the roster (the 0.7.28
+        // HomeCore field failure: the miss fell through to the external
+        // door). Decode-then-encode canonicalizes both spaces to the roster
+        // key; it is the identity on plain member names.
+        let member = crate::member_comms_id::mob_member_id(
+            crate::member_comms_id::runtime_alias_str(member_id).as_ref(),
+        );
         let entry = match self.handle.get_member(&member).await {
             Ok(Some(entry)) => entry,
             Ok(None) => return None,
@@ -1463,6 +1475,15 @@ mod tests {
         register_mob_state: bool,
         external_addressable: bool,
     ) -> (String, String) {
+        one_shot_delivery_e2e_with_member(register_mob_state, external_addressable, "digest-owner")
+            .await
+    }
+
+    async fn one_shot_delivery_e2e_with_member(
+        register_mob_state: bool,
+        external_addressable: bool,
+        member_identity: &str,
+    ) -> (String, String) {
         use meerkat_core::AgentToolDispatcher;
         use serde_json::value::RawValue;
 
@@ -1546,13 +1567,13 @@ schedule = true
         handle
             .ensure_member(meerkat_mob::SpawnMemberSpec::new(
                 meerkat_mob::ProfileName::from("general"),
-                meerkat_mob::ids::AgentIdentity::from("digest-owner"),
+                meerkat_mob::ids::AgentIdentity::from(member_identity),
             ))
             .await
-            .expect("ensure digest-owner");
+            .expect("ensure schedule author member");
         let owner_session = handle
             .resolve_bridge_session_id_observation(&meerkat_mob::ids::AgentIdentity::from(
-                "digest-owner",
+                member_identity,
             ))
             .await
             .expect("owner session id");
@@ -1708,6 +1729,29 @@ schedule = true
         assert_eq!(
             stage, "completed",
             "self-delivery to an internal_only author must succeed: {detail}"
+        );
+    }
+
+    /// HomeCore 0.7.28 field case: identity-first bridge members' ROSTER ids
+    /// are the comms-ENCODED runtime id (`mk--rt_cdomain_chome_c0` for
+    /// `rt:domain:home:0` — bridge.rs member_id_for_spawn_spec), and the
+    /// authoring rewrite stores that roster id in the binding. The internal
+    /// lane must resolve it WITHOUT re-encoding (the codec re-encodes
+    /// marker-prefixed input by design); before the canonicalization fix the
+    /// lookup missed and delivery fell through to the external door:
+    /// "mob member is not externally addressable: mk--rt_cdomain_chome_c0".
+    #[tokio::test(flavor = "multi_thread")]
+    async fn agent_authored_one_shot_delivers_to_internal_only_identity_bridge_member() {
+        let roster_id = crate::member_comms_id::mob_member_id_str("rt:domain:home:0").into_owned();
+        assert!(
+            roster_id.starts_with("mk--"),
+            "repro precondition: the roster id must be marker-encoded"
+        );
+        let (stage, detail) = one_shot_delivery_e2e_with_member(true, false, &roster_id).await;
+        assert_eq!(
+            stage, "completed",
+            "self-delivery to an internal_only identity-bridge member (roster-space \
+             binding id) must take the internal lane: {detail}"
         );
     }
 


### PR DESCRIPTION
## Problem (HomeCore 0.7.28 field report)

Schedule self-delivery to identity-first members still failed with the identical receipt to 0.7.27:

```
failure_class: mob_rejected
detail: "mob member is not externally addressable: mk--rt_cdomain_chome_c0"
```

HomeCore's read was "the #249 lane isn't wired on rpc_gateway" — the wiring is actually identical on both gateways; the receipt's member id was the real clue. `mk--rt_cdomain_chome_c0` is the comms-encoded runtime id `rt:domain:home:0`: **identity-first bridge members' roster ids are already `mk--`-encoded** (`bridge.rs` `member_id_for_spawn_spec` encodes the runtime id), and the authoring rewrite stores that roster id (`entry.agent_identity`) in the binding. The #249 internal lane then called `mob_member_id(member_id)` on it — and the codec **re-encodes marker-prefixed input by design** (`member_comms_id.rs:105`, pinned by `reserved_marker_names_re_encode_so_round_trip_holds`) — so `get_member` looked up a double-encoded key, missed, and the `Ok(None)` fall-through silently delegated to the inner host, whose member path uses the raw string (which IS the roster key) through the **external** work door. Classic plain-named members are codec fixed-points, which is why the 0.7.28 e2e passed while the field failed.

## Fix

Canonicalize before the roster lookup: `mob_member_id(runtime_alias_str(member_id))` — decode-then-encode maps both alias-space (`rt:domain:home:0`) and roster-space (`mk--rt_cdomain_chome_c0`) ids to the same roster key, and is the identity on plain names. Covers all three producers: mobkit's authoring rewrite, meerkat's delivery-time identity recovery (which stamps the same roster id from session metadata), and HomeCore's already-persisted schedule bindings.

## Tests

- NEW e2e `agent_authored_one_shot_delivers_to_internal_only_identity_bridge_member`: member spawned with a marker-encoded roster id (minted through the codec, matching the bridge spawn path), `external_addressable=false`, agent-authored one-shot. **Red-verified**: on the unfixed lookup it fails with the byte-identical field receipt (`delivery_failed` / `mob_rejected` / `"mob member is not externally addressable: mk--rt_cdomain_chome_c0"`); with the fix it completes.
- NEW codec contract test `decode_then_encode_canonicalizes_both_id_spaces` pins decode-then-encode as the only correct roster-key derivation (and pins that encode alone re-encodes roster ids).
- Existing delivery e2e trio still green; full workspace suite 1547/1547.

Per Luka: release waits for meerkat 0.7.23 — this merges to main now, ships in the next mobkit alongside the 0.7.23 pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)