### PR TITLE
examples: catch pack 001 TS/Python smokes up to the current console API

### DIFF
--- a/examples/001-incident-command-center-pack/python_smoke.py
+++ b/examples/001-incident-command-center-pack/python_smoke.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import sys
+import time
 import urllib.request
 
 
@@ -36,10 +37,18 @@ def main() -> int:
     assert console_inspect["identity"]["identity"] == "incident-commander"
     assert console_inspect["identity"]["visibility"] == "addressable"
 
-    timeline = rpc(base_url, "mobkit/console/query_timeline", {
-        "identity": "incident-commander",
-        "limit": 20,
-    })
+    # Boot-time kickoff turns produce the first canonical frames; on a fresh
+    # server they land a few seconds after /console/experience goes 200, so
+    # poll instead of asserting the very first read.
+    deadline = time.time() + 90
+    while True:
+        timeline = rpc(base_url, "mobkit/console/query_timeline", {
+            "identity": "incident-commander",
+            "limit": 20,
+        })
+        if timeline["frames"] or time.time() >= deadline:
+            break
+        time.sleep(1)
     assert timeline["frames"], "expected canonical console timeline frames"
     assert all(frame["identity"] == "incident-commander" for frame in timeline["frames"])
 

--- a/examples/001-incident-command-center-pack/ts_smoke.ts
+++ b/examples/001-incident-command-center-pack/ts_smoke.ts
@@ -11,6 +11,7 @@ type ConsoleFrame = {
   event?: string;
   identity?: string;
   interactionId?: string;
+  kind?: string;
   cursor?: string;
   status?: string;
   data: unknown;
@@ -122,10 +123,9 @@ async function readSseFrames(
 
 async function streamInteraction(identity: string, content: string, origin: string) {
   let acceptedInteractionId = "";
-  const streamPromise = readSseFrames(`${baseUrl}/console/identity/stream`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ identity }),
+  const streamPromise = readSseFrames(
+    `${baseUrl}/console/identity/${encodeURIComponent(identity)}/stream`,
+    {
     minFrames: 1,
     timeoutMs: 90000,
     until: (frame) =>
@@ -133,11 +133,19 @@ async function streamInteraction(identity: string, content: string, origin: stri
       (frame.event === "interaction_complete" || frame.event === "interaction_failed"),
   });
 
-  const sendResult = await callConsoleRpc<{ interaction_id: string; identity: string }>("mobkit/interact", {
-    identity,
-    content,
-    origin,
-  });
+  // mobkit/interact left the stock console surface in the May 2026 console
+  // projection-path migration; mobkit/console/send is the canonical
+  // identity-first send (server-owned acknowledgement + canonical frames).
+  const sendResult = await callConsoleRpc<{ interaction_id: string; identity: string }>(
+    "mobkit/console/send",
+    {
+      identity,
+      content,
+      origin,
+      idempotency_key: `${origin}:${Date.now().toString(36)}`,
+      handling_mode: "queue",
+    },
+  );
   acceptedInteractionId = sendResult.interaction_id;
   const frames = await streamPromise;
   const filtered = frames.filter((frame) => frame.interactionId === sendResult.interaction_id || frame.event === "subscribed");
@@ -189,7 +197,7 @@ async function main() {
     activity_feed?: { filter_presets?: Array<{ id?: string }> };
   }>(`${baseUrl}/console/experience`);
 
-  assert.equal(experience.contract_version, "0.3.0");
+  assert.equal(experience.contract_version, "0.4.0");
   assert.ok(Array.isArray(experience.identity_status?.rows));
   assert.ok(Array.isArray(experience.activity_feed?.filter_presets));
   assert.ok(experience.activity_feed!.filter_presets!.some((preset) => preset.id === "watched-only"));
@@ -226,38 +234,63 @@ async function main() {
     `Console substrate canonical send smoke. Reply with exactly OK. [${Date.now().toString(36)}:canonical]`,
     "ts-smoke:console-send",
   );
-  const timelinePage = await callConsoleRpc<{ frames: ConsoleFrame[]; next_cursor?: string }>(
-    "mobkit/console/query_timeline",
+  // query_timeline replay frames carry `kind` (canonical frame schema,
+  // contract 0.4.0); `event` names are the SSE envelope's. Walk the
+  // paginated replay (next_cursor) — a reasoning-heavy turn emits more
+  // frames than one page — and poll briefly for the durable tail.
+  let replayHasTerminal = false;
+  const replayDeadline = Date.now() + 30000;
+  while (!replayHasTerminal && Date.now() < replayDeadline) {
+    let after: string | undefined = canonicalTurn.accepted.cursor;
+    for (let pages = 0; pages < 40 && after; pages += 1) {
+      const timelinePage: { frames: ConsoleFrame[]; next_cursor?: string } = await callConsoleRpc(
+        "mobkit/console/query_timeline",
+        { identity: "incident-commander", after, limit: 50 },
+      );
+      if (
+        timelinePage.frames.some(
+          (frame) => frame.kind === "interaction_complete" || frame.kind === "turn_completed",
+        )
+      ) {
+        replayHasTerminal = true;
+        break;
+      }
+      if (!timelinePage.frames.length) break;
+      after = timelinePage.next_cursor ?? timelinePage.frames.at(-1)?.cursor;
+    }
+    if (!replayHasTerminal) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+  assert.ok(replayHasTerminal, "query_timeline should replay aggregate frames after the accepted cursor");
+
+  // Replay checkpoints are aggregate CURSORS (`console:N`) under the 0.4.0
+  // replay contract — frame ids 409. The all-events SSE surface is the
+  // aggregate `/console/timeline/stream`.
+  const checkpointCursor = canonicalTurn.accepted.cursor;
+  const cursorSeq = (cursor?: string) => Number((cursor ?? "console:0").split(":")[1] ?? "0");
+  const identityReplay = await readSseFrames(
+    `${baseUrl}/console/identity/incident-commander/stream`,
     {
-      identity: "incident-commander",
-      after: canonicalTurn.accepted.cursor,
-      limit: 20,
+      headers: { "Last-Event-ID": checkpointCursor },
+      minFrames: 2,
     },
   );
+  assert.ok(identityReplay.length > 0, "identity replay frames expected");
   assert.ok(
-    timelinePage.frames.some((frame) => frame.event === "frame_updated" || frame.event === "interaction_complete"),
-    "query_timeline should replay aggregate frames after the accepted cursor",
+    identityReplay.every((frame) => !frame.cursor || cursorSeq(frame.cursor) > cursorSeq(checkpointCursor)),
+    "identity replay must resume after checkpoint",
   );
 
-  const checkpointFrame = frames.find((frame) => frame.id && frame.event === "text_delta");
-  assert.ok(checkpointFrame?.id, "checkpoint frame expected");
-  const identityReplay = await readSseFrames(`${baseUrl}/console/identity/stream`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "Last-Event-ID": checkpointFrame.id!,
-    },
-    body: JSON.stringify({ identity: "incident-commander" }),
-    minFrames: 2,
-  });
-  assert.ok(identityReplay.every((frame) => frame.id !== checkpointFrame.id), "identity replay must resume after checkpoint");
-
-  const allEventsFrames = await readSseFrames(`${baseUrl}/console/events/stream`, {
-    headers: { "Last-Event-ID": checkpointFrame.id! },
+  const allEventsFrames = await readSseFrames(`${baseUrl}/console/timeline/stream`, {
+    headers: { "Last-Event-ID": checkpointCursor },
     minFrames: 2,
   });
   assert.ok(allEventsFrames.length > 0, "all-events replay frames expected");
-  assert.ok(allEventsFrames.every((frame) => frame.id !== checkpointFrame.id), "all-events replay must resume after checkpoint");
+  assert.ok(
+    allEventsFrames.every((frame) => !frame.cursor || cursorSeq(frame.cursor) > cursorSeq(checkpointCursor)),
+    "all-events replay must resume after checkpoint",
+  );
 
   const [alphaTurn, bravoTurn] = await Promise.all([
     streamInteraction(
@@ -294,11 +327,13 @@ async function main() {
     body: JSON.stringify({
       jsonrpc: "2.0",
       id: "ts-smoke-reject",
-      method: "mobkit/interact",
+      method: "mobkit/console/send",
       params: {
         identity: "approval-gate",
         content: "should reject",
         origin: "ts-smoke",
+        idempotency_key: `ts-smoke-reject:${Date.now().toString(36)}`,
+        handling_mode: "queue",
       },
     }),
   });


### PR DESCRIPTION
## Context

Post-#253 verification: extensive browser testing of the example packs to confirm the console-packages reconciliation broke nothing.

## Verdict on #253: no regressions found

- **Pack 001 (incident commander)** browser smoke: **11/11 stages pass** (load, commander chat, image generation/upload, merchant, routing, gating, topology, inspect, **split**, scribe) on the live gpt-5.5 console.
- **Pack 002 (foresight studio, heavily customized console)**: offline + browser smoke pass — the strongest exercise of the #253 component API surface.
- **Pack 004 (MDM console)**: smoke + browser smoke pass.
- **Pack 005 (access control, stock console + ABAC)**: deterministic smoke passes (also compiles console assets from the #253 package sources).
- Manual Playwright pass on the stock console: conversation rendering (markdown emphasis, tool-call cards, work-time chips), turn rail (present, default-on), single-tab strip visible, panel split/close, sidebar grouping/pinning, signals rail — all behave.
- One visual anomaly investigated in depth (a truncated live-turn card rendered beside its complete history copy when the replay window lands mid-turn, with mis-paired emphasis on the truncated text): **A/B-proven pre-existing** — reproduced byte-identically on the pre-#253 UI served against the same backend state via an asset proxy. It's the known live↔history twin class (upstream interaction-id persistence); the store frames are complete and balanced.

## What this PR fixes (stale examples, not #253)

Pack 001's TS/Python smokes were written against the pre-May-2026 console surface and have failed since the console projection-path migration (`1df16d8a`, May 14) — they simply hadn't been run since (they need `OPENAI_API_KEY`, so no CI):

- `contract_version` 0.3.0 → 0.4.0
- `POST /console/identity/stream` → `GET /console/identity/{identity}/stream`
- `mobkit/interact` → `mobkit/console/send` (both the chat leg and the internal-identity `-32002` rejection leg)
- `/console/events/stream` → `/console/timeline/stream`
- Replay checkpoints are aggregate cursors (frame ids → 409 under the 0.4.0 replay contract)
- `query_timeline` replay frames carry `kind` (not `event`) and paginate via `next_cursor` — the replay assertion now walks pages
- Python smoke: poll for boot-kickoff frames instead of asserting the first read (boot race)

All three pack 001 legs green after these fixes. Rides into 0.7.29 with the release (gated on meerkat 0.7.23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)