### PR TITLE
meerkat 0.7.23: ask 21d verified fixed, doctrine worker-respawn tightened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- meerkat family pinned to `=0.7.23` (from `=0.7.22`). Ask 21d verified
+  fixed: never-run identity-first mob workers no longer strand in
+  archive-NotFound during disposal — the doctrine worker-respawn test now
+  asserts success (tolerance branch removed). With 21c (0.7.22) and 21d
+  (0.7.23) the whole never-run-member disposal family (asks 20/21/21b/21c/
+  21d) is closed on BOTH constructions. API drift absorbed: the
+  runtime-backed schedule host takes an optional `WorkGraphService`
+  (mobkit passes `None` — WorkGraph is not wired yet), and
+  `flow_tool_overlay` → `turn_tool_overlay` on turn semantics/metadata.
+
 ### Fixed
 
 - Schedule self-delivery now reaches identity-first members: the internal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa0bc4f882eeb1400cbee3102754fb36ce5d1cd0831ce1dad6bc0a60b71d55f"
+checksum = "6790c92539f289fcd19eed3bf4ac034f3066e9ddddb6569dfe40381368ecbead"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67e253300ccf1db607dc9c464188e4aacb2e4de49b9f5cc82e9ff5c3186600a"
+checksum = "df1f7267466411257b2b579ff16a28b2801fafa076d57cada2b8b8203b5ac808"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e383e6168f7527d18c3357394558ea4125126ba80429852565c741b5cc9d6a38"
+checksum = "f4946b41c5b5f437c2a16f5ec2e22b13dd6f34111c5d745254a961f6ec6ae5b6"
 dependencies = [
  "async-trait",
  "axum",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc94a7c078546ee1d6f12f300f2dc58564a436475b217bb9259ee441dcb67b1e"
+checksum = "ab4dc9da2679c25eb6f047d35de888dbb0471c169c08753ce7af0b6d2a9386a6"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547f9d74b4ab5fb1c1b28c781d0194b9934d3ebde6fdf6c2a65a3d75df5175fc"
+checksum = "b129c93d463efc0c42f5304bb21b6b1571273944560f5ee1470a8060fc9dff4a"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9dbf28d0e3faea94ceb432053cca60e5cc080ebc923b4396987adc2c91db9ce"
+checksum = "d87919f45fc1376bcc37e2feb9de068e85982a20d465812fa8276c0d8d0dd3a3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6591a3189d2576c4b3f5a7bf1c7e97d390c7d6929246937d11cdb20d468e4faf"
+checksum = "045c878e74883f0a73824fa5ad85c1efbc6aada3f32cb885d2ed2ae05ea3fb59"
 dependencies = [
  "base64",
  "chrono",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c953ae6a32c9c7fcd28c33b7428e14e45c05c105abc8bef5ddb65ced644a4f39"
+checksum = "6cc8ad0c9c579a35af04eaab3b7bc22ba5e0a8eac6979a030dceeda1c18fcda6"
 dependencies = [
  "async-trait",
  "base64",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1f93178f395ba74d697231001bb1a81d70b0496dd50d98aaa775e3db105a68"
+checksum = "153ac82c2b54be6965048a4721e83dfdaab14f28362f59e737c1feba2685e05b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1861f5a020be8c4adf0fa8e848963d000d39189204d53718ba1347e3623c7a3"
+checksum = "d1cc2316164cf3330bf16798295766f7737ce9b2b738ec326b6640d8026a0c95"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc6d28719e55ba608dda2e37faaa0599d1c8ec6b9b11c09e4aa09665556f5b7"
+checksum = "0eb82f96d9a273dbc367db58c72ee20ce03324381ebc1c028106982c63bcb081"
 dependencies = [
  "async-trait",
  "axum",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c21a2829a4391d7e5d1698c1b5f6f4b05ac5d55ed81cf8969920d6f1958d1a7"
+checksum = "85335e3cb3ce9518cbf81631782126aa93e94eb2e5b6f769b8d65705b55d4bab"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe9ec56ff193db240a17def919819cb6df9dc37507fb71b69242e8f59452da8"
+checksum = "f059c05ef138e5f8492dcc12e023d74e1782c415bc0f7b6f07ee1095ccf3412f"
 dependencies = [
  "quote",
  "syn",
@@ -1979,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daa6e812fc2b4b677b48dda959a42fa76b500a8accfe0d1772d11cd247aa37c"
+checksum = "9c79fb25cccdb810ad8de418d500b522421ea2f23c5a416f3f12aeb1a4fff221"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237071cb01b39d51d4f397f8934457461f073dd943c9c17434c7ad6bb4f0508c"
+checksum = "c3eacf2a76bc4a4c4c98902886448469cfd0171b998a4640a8aebc819e3091fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6e414f3fad3de360293c757637489acafbc8777402d30cef1a79798375dae4"
+checksum = "d59eba0b4e1231360260efff9deec564bf5e0613d0a69772bced2c8ffc35845e"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b28e2b235567ac51d9d48766e36528f13aeab6ae49f7cddb7e5060cc7baa1ae"
+checksum = "d05ace9ca90c8ab8a2a3a5d2c57b57ea8ff2e420c275f7ef166578ba55d1574b"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd893d5911ba0e8d303669224dd16b3bb4e4faa53e12b1c6df1cc3efc10d564b"
+checksum = "6f98b5232296b64ef712891f2f9da317a5e3c2fadd019befed2e65ac627ec8cb"
 dependencies = [
  "async-trait",
  "futures",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988fa08958d3cae29be7d04d10632f49d13effacf4f07418cf2979d75b4a627a"
+checksum = "de01a4b4561c1a3a7a21710f9ca5162e7ca7a334d245b0f3587047d0df7bcb09"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7ac9bb28fe35af20e757e54fa7b276cda78fe90f9ca667a4c04c6b2870bb2"
+checksum = "9fe88304592f73b55ce740efe9b61be96ef7bb3c720f2da58e067ddc4d05a08b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62100c46656c262ab02e5a978f7244a23665cbfae6178c6c6299d03dc4814d91"
+checksum = "bf4d783af95afe6277cc1b1f5cc0c1fb338efef40c3448aaf560eac31f46a4a3"
 dependencies = [
  "async-trait",
  "futures",
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41df30082df83b5aaf33b8dd5d59590d3d88d7e52f64e554ca5ffd4a4cc6eff6"
+checksum = "9098520eae5b236e1d0bac28fadab7002491267fab501a456f8f01407b49dd6b"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0d74ba678acf615963855f930a80674c853ac03d0193373ac01bdac912004c"
+checksum = "2d94d4b63a2e5f604b44f89b55b9429f9c2303b3fa7a83b718f582440b56964a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd222c148cf5e535844f5fe8184e5f8d9b60c85e7f2aa3fb2f70a9332913af1f"
+checksum = "998ee7237af90c3d0e642c9e8860d91d1e3809a8ea7c3bb8c255e55aee6f0815"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0d73d4df422dedf8acd94d1d5e58355254ebb4742569ff6c883f144969a238"
+checksum = "fc0532abed14efa265aeb7a82a772779678029b92a45882c5f8bd7940f1ada9e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87fcf3606ca70a599845d7f986833b8dd3013db7463f005b7b4992944d543f9"
+checksum = "bf4c98498d8742063d9e84ffeea7e21a55306c01a9be6666cda6e3126e7f2cc3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613df0e9e7a7db9353c95a5355183afebece78f7d6a2614db4ad65ca7704423a"
+checksum = "b2068611d6fbedee9c4876dacca00817d1ba2d90576f87445417a6c3a752b04a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d20ff3db19b651681b987d2ae7198b0ae9436f3a063474ffeac9635e99c9fb"
+checksum = "6bc8760da3da438b81e476ff34b227e91e1162635acc96f521db7900979f43ea"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a979acc312f1f5d4dfb179ad058e91fd6de47b39dcb6e39b50466e2d0d2448"
+checksum = "00ddcaddab7244dce02125aa08339fd643a86ce08e699ec6e4058aa5275df49a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea9ebfcf51c51fc7052a5ce968d2684cef3a18628698d46320562a6f077ca6b"
+checksum = "0dca21e61d7111949bcc8aff06cded52e4319557e72d44c0582d137283de6417"
 dependencies = [
  "async-trait",
  "base64",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.22"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ec9ce6de42ba06f4d361ba7b67b788bdf12b54ff8cdf69ae61341bb54892ba"
+checksum = "dc6b635a14767138d9996b0bee0b761f5245926e39eb2c1d85b0512829a14b95"
 dependencies = [
  "async-trait",
  "chrono",

--- a/examples/004-mdm-console-pack/target.rs
+++ b/examples/004-mdm-console-pack/target.rs
@@ -180,7 +180,7 @@ impl CoreExecutor for TargetCoreExecutor {
                 metadata
                     .and_then(|meta| meta.handling_mode)
                     .unwrap_or(HandlingMode::Queue),
-                metadata.and_then(|meta| meta.flow_tool_overlay.clone()),
+                metadata.and_then(|meta| meta.turn_tool_overlay.clone()),
                 pre_turn_context_appends,
                 metadata.cloned(),
             ),

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -47,25 +47,25 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.7.22"
-meerkat-client = "=0.7.22"
-meerkat-contracts = "=0.7.22"
-meerkat-mob = "=0.7.22"
-meerkat-mob-mcp = "=0.7.22"
-meerkat-mcp = "=0.7.22"
-meerkat-models = "=0.7.22"
+meerkat-core = "=0.7.23"
+meerkat-client = "=0.7.23"
+meerkat-contracts = "=0.7.23"
+meerkat-mob = "=0.7.23"
+meerkat-mob-mcp = "=0.7.23"
+meerkat-mcp = "=0.7.23"
+meerkat-models = "=0.7.23"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.7.22", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
+meerkat = { version = "=0.7.23", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.7.22"
-meerkat-runtime = { version = "=0.7.22", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.7.22", features = ["session-store"] }
-meerkat-store = { version = "=0.7.22", features = ["sqlite"] }
-meerkat-tools = "=0.7.22"
+meerkat-memory = "=0.7.23"
+meerkat-runtime = { version = "=0.7.23", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.7.23", features = ["session-store"] }
+meerkat-store = { version = "=0.7.23", features = ["sqlite"] }
+meerkat-tools = "=0.7.23"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -119,10 +119,10 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "=0.7.22"
-meerkat-schedule = "=0.7.22"
+meerkat-comms = "=0.7.23"
+meerkat-schedule = "=0.7.23"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.7.22", features = ["schema"] }
+meerkat-mob = { version = "=0.7.23", features = ["schema"] }

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -5337,7 +5337,7 @@ image_generation = true
             event_tx: None,
             runtime: meerkat_core::service::StartTurnRuntimeSemantics {
                 handling_mode: meerkat_core::types::HandlingMode::Steer,
-                flow_tool_overlay: None,
+                turn_tool_overlay: None,
                 pre_turn_context_appends: Vec::new(),
                 typed_turn_appends: Vec::new(),
                 // Render metadata now lives only on the typed turn-metadata

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -744,6 +744,9 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
     // meerkat 0.7.13 (upstream ask 10): thread a host-runnable registry so
     // host-registered runnables (e.g. the memory steward's dream) can be
     // driven as schedule occurrences. `None` keeps mob/session targets only.
+    // meerkat 0.7.23: the runtime-backed session host injects the WorkGraph
+    // attention projection at apply time when given a WorkGraphService.
+    // MobKit does not wire WorkGraph yet — None keeps prompts un-decorated.
     spawn_runtime_backed_schedule_host_with_mobs(
         service,
         adapter,
@@ -752,6 +755,7 @@ pub fn spawn_schedule_host<B: SessionAgentBuilder + 'static>(
         SessionBuildOptions::default(),
         mob_host,
         runnable_host,
+        None,
         owner_id,
     )
 }

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -731,20 +731,15 @@ comms = true
         json!({"member_id": "scratch-worker"}),
     )
     .await;
-    // Never-ran worker respawn on THIS construction still archive-NotFounds
-    // on meerkat 0.7.22 (ask 21d residue: retire_runtime_before_archive
-    // retires the runtime, yet the archive still resolves NotFound with the
-    // session left registered — unlike the classic persistent chain, which
-    // converged with ask 21c). Assert the ROUTING; tighten when 21d lands.
+    // Never-ran worker respawn converges since meerkat 0.7.23 (ask 21d:
+    // archive-NotFound on a terminal-phase registered runtime completes
+    // disposal instead of escalating).
     assert!(
         respawn["result"].get("identity_first").is_none(),
         "worker respawn must NOT route through the identity authority: {respawn}"
     );
-    if let Some(error) = respawn.get("error") {
-        let detail = error["data"]["detail"].as_str().unwrap_or_default();
-        assert!(
-            detail.contains("ArchiveSession"),
-            "the only acceptable worker-respawn failure is the ask-21d class: {respawn}"
-        );
-    }
+    assert!(
+        respawn.get("error").is_none(),
+        "worker respawn must succeed on the mob plane: {respawn}"
+    );
 }


### PR DESCRIPTION
## What

Upgrade the meerkat family `=0.7.22` → `=0.7.23`.

**Ask 21d verification (identity-first construction):** meerkat #849 fixes the last never-run-member disposal strand — archive-NotFound on a terminal-phase registered runtime now completes disposal (durable retire + unregister) instead of escalating. `doctrine_member_rpcs_route_identity_owned_members_through_identity_authority` passes with the tolerance branch **removed** (worker respawn must succeed). Together with 21c (0.7.22), the whole ask 20/21/21b/21c/21d never-run family is closed on **both** constructions.

**API drift absorbed** (WorkGraph attention wiring, meerkat #850/#851):
- `spawn_runtime_backed_schedule_host_with_mobs` gained `workgraph_service: Option<WorkGraphService>` — mobkit passes `None` (WorkGraph not wired yet; prompts stay un-decorated).
- `flow_tool_overlay` → `turn_tool_overlay` on `StartTurnRuntimeSemantics`/`RuntimeTurnMetadata` (one lib-test struct literal, one example accessor).

**Verification:** all 5 K-asks tests + 48 schedule/delivery tests green under a per-test timeout profile (a hang is a fail); BUILD.bazel regen no-op; full `make ci` green.

mobkit 0.7.29 releases after this merge — carries PR #252 (schedule internal-lane member-id canonicalization, the HomeCore self-delivery fix) and PR #255 (example smoke fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)