### PR TITLE
fix: callback build-tools clobber + sequential gateway dispatch starvation

### DIFF
--- a/docs/design/schedule-domain-adoption.md
+++ b/docs/design/schedule-domain-adoption.md
@@ -1,0 +1,99 @@
+# Schedule-domain seam adoption (meerkat 0.7.25 → mobkit 0.7.30)
+
+Status: audit complete 2026-07-08; adoption work lands with the meerkat 0.7.25
+pin bump. Companion to the meerkat-side root fix for the two-writer
+schedule-binding race reported from the HomeCore deployment.
+
+## The upstream defect pair (context)
+
+1. **Two-writer slot race.** `FactoryAgentBuilder.default_schedule_tools` has
+   two writers in embedder processes that also stand up meerkat-rpc surfaces:
+   the embedder (binding to its driven store) and
+   `meerkat_rpc::SessionRuntime::{new,new_with_config_store}`, which
+   unconditionally seed the slot with a dispatcher bound to the realm-bundle
+   schedule store inside `sessions.sqlite3`
+   (meerkat-rpc/src/session_runtime.rs ~1737/~1877 on meerkat main). Which
+   binding a build sees depends on construction order; a reset/reprofiled
+   member's rebuild can land on the stale realm-bundle binding.
+2. **Undriven store accepting writes.** meerkat-rpc starts its firing host
+   lazily (only from RPC schedule handlers / eagerly only in the Router), so a
+   direct `SessionRuntime` embedder gets agent schedule tools bound to a store
+   nothing drives — schedules plan occurrences no driver claims, silently.
+
+meerkat 0.7.25 carries the root fix: a composed "schedule domain" seam that
+binds the agent-facing schedule tools AND the firing host from the same
+`ScheduleService` (single-owner binding), plus tools-coupled-to-firing-
+authority (an undriven store is loud, never a silent write sink). Exact API
+shape may shift while it lands — verify against the released crate.
+
+## Mobkit audit (as of 0.7.29, meerkat =0.7.23 pins)
+
+Both defects were checked against mobkit's gateways. Findings:
+
+- **Single writer, attach-first — already holds.** The only
+  `default_schedule_tools` writer in a mobkit process is
+  `schedule_wiring::attach_schedule_tools_with_identity_targets`, called at
+  `FactoryAgentBuilder` construction, before the builder is consumed into a
+  session service and before any member build can run:
+  - rpc_gateway.rs: persistent branch builder + attach (all persistent-branch
+    builds, including callback builds, flow through this one builder).
+  - mobkit_gateway.rs: same pattern in
+    `build_persistent_session_service`.
+  Mobkit does NOT depend on meerkat-rpc, so the second writer
+  (`SessionRuntime` self-seeding) is unreachable in a mobkit-only process.
+  The race bites deployments that ALSO construct meerkat-rpc surfaces
+  against the same realm store (HomeCore).
+- **Tools ↔ firing authority — already coupled.** Whenever tools are
+  attached, `schedule_host_inputs` is `Some` and the gateway unconditionally
+  spawns the firing host AND the claim watchdog from the SAME
+  `ScheduleService` instance (rpc_gateway.rs step-9 preamble;
+  `spawn_schedule_host` + `spawn_schedule_claim_watchdog`). The watchdog is
+  the loudness affordance: "everything stays pending forever" becomes a
+  row-level gateway-log diagnosis.
+- **Ephemeral branch: consistent no-schedule posture.** No store is opened,
+  no tools attached, no host spawned — there is no silent write sink because
+  there is no write path.
+- **Second store location.** Mobkit's gateways open
+  `<state_dir>/schedule.sqlite` only. The realm-bundle schedule store inside
+  `sessions.sqlite3` is never opened by mobkit; stranded rows there are
+  written by non-mobkit surfaces sharing the state dir.
+
+Net: mobkit's current wiring is correct by construction but only
+*incidentally* — nothing prevents a future build path (or an embedder mixing
+surfaces in-process) from reintroducing a second binding.
+
+## Work items for the 0.7.25 pin bump (rides 0.7.30)
+
+1. **Adopt the composed seam.** Replace the
+   `attach_schedule_tools` slot-write + separate `spawn_schedule_host` pair
+   with meerkat's schedule-domain API so tools and firing host are bound from
+   one `ScheduleService` *structurally* (binding tools to store A while the
+   driver runs store B becomes unrepresentable). Keep
+   `MobIdentityScheduleToolDispatcher`, the internal-delivery mob host
+   wrapper, the resumable-target repair, and the claim watchdog on top of the
+   new seam.
+2. **Exactly one reachable store.** After adoption, assert (debug log at
+   boot) which store file backs the domain; keep `schedule.sqlite` as the
+   canonical gateway location unless meerkat's seam dictates the realm
+   bundle. If meerkat's `SessionRuntime` seeding change alters
+   `FactoryAgentBuilder` slot semantics, re-verify no path re-seeds after
+   attach.
+3. **Stranded-data recovery.** Schedules already written into an undriven
+   realm-bundle store (HomeCore: domain:security's daily digest, ~30 pending
+   occurrences in `sessions.sqlite3`) will not retroactively fire from the
+   code fix. Ship the recovery matched to what 0.7.25 exposes: prefer a
+   one-time migration of live schedules into the driven store; otherwise a
+   point-a-driver-once affordance. Guard rails either way:
+   - never blind-open a foreign `sessions.sqlite3` with
+     `SqliteScheduleStore::open` (open runs migrations and would CREATE
+     schedule tables in a file mobkit does not own — probe with a raw
+     read-only connection first);
+   - refuse auto-migration when another process may be driving the source
+     store (double-firing risk); loud log + explicit opt-in flag/RPC.
+
+## Non-goals
+
+- No speculative mobkit-side migration before 0.7.25 lands (the upstream
+  seam may ship its own pointing/migration mechanism; a parallel mobkit
+  implementation risks colliding with it).
+- No change to the ephemeral-gateway posture (no store → no tools → no host).

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -1746,6 +1746,69 @@ rust_test(
 )
 
 rust_test(
+    name = "gateway_concurrent_dispatch_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "gateway_concurrent_dispatch",
+    crate_root = "tests/gateway_concurrent_dispatch.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/gateway_concurrent_dispatch.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.29",
+        "CARGO_BIN_NAME": "gateway_concurrent_dispatch",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "gateway_external_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -5346,6 +5409,7 @@ test_suite(
         ":distiller_eval_harness_test",
         ":event_log_recovery_test",
         ":external_boundary_test",
+        ":gateway_concurrent_dispatch_test",
         ":gateway_external_test",
         ":gateway_memory_config_test",
         ":gating_policy_test",

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -3276,7 +3276,21 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                                 let build = modified_req.build.get_or_insert_with(|| {
                                     meerkat_core::service::SessionBuildOptions::default()
                                 });
-                                build.external_tools = Some(Arc::new(dispatcher));
+                                // COMPOSE over whatever an earlier installer
+                                // put in the slot (HomeCore Bug D: assigning
+                                // wholesale silently discarded the agent-memory
+                                // recorder's `memory` tool for every
+                                // callback-built agent). Python-registered
+                                // tools win name collisions; everything else
+                                // falls through to the pre-installed
+                                // dispatcher.
+                                let pre_installed = build.external_tools.take();
+                                build.external_tools = Some(
+                                    meerkat_mobkit::tool_compose::ComposedExternalTools::over(
+                                        Arc::new(dispatcher),
+                                        pre_installed,
+                                    ),
+                                );
                             }
                         }
                         None => {
@@ -4881,8 +4895,18 @@ external_addressable = true
         )
         .await;
 
-    // 9. RPC dispatch loop: process queued requests from the stdin reader task
+    // 9. RPC dispatch loop: each request runs on its own task. The loop must
+    // never await a handler inline — a turn-running RPC can block on a
+    // Python/TS callback round-trip, and the host may issue further RPCs
+    // (e.g. mobkit/agent_memory/recall) from INSIDE that callback. With
+    // sequential dispatch those reentrant requests starve behind the turn
+    // until the callback times out (HomeCore recall deadlock). Both SDK
+    // transports match responses by id, and the HTTP surface already serves
+    // the same methods concurrently, so completion order is free.
+    let identity_ctx = identity_ctx.map(Arc::new);
+    let http_base_url_shared: Arc<str> = http_base_url.clone().into();
     {
+        let mut inflight = tokio::task::JoinSet::new();
         loop {
             let request_line = tokio::select! {
                 line = rpc_rx.recv() => match line {
@@ -4896,17 +4920,36 @@ external_addressable = true
                 &gateway_options.schedules,
                 &gateway_options.gating,
             );
-            let response = handle_unified_rpc_json(
-                &runtime,
-                &request_line,
-                timeout,
-                Some(&http_base_url),
-                identity_ctx.as_ref(),
-            )
-            .await;
-            if !response.is_empty() {
-                let _ = stdout_tx.send(response).await;
-            }
+            let runtime = runtime.clone();
+            let stdout_tx = stdout_tx.clone();
+            let identity_ctx = identity_ctx.clone();
+            let http_base_url = http_base_url_shared.clone();
+            inflight.spawn(async move {
+                let response = handle_unified_rpc_json(
+                    &runtime,
+                    &request_line,
+                    timeout,
+                    Some(http_base_url.as_ref()),
+                    identity_ctx.as_deref(),
+                )
+                .await;
+                if !response.is_empty() {
+                    let _ = stdout_tx.send(response).await;
+                }
+            });
+            // Reap completed handlers so the set does not grow unbounded.
+            while inflight.try_join_next().is_some() {}
+        }
+        // stdin is closed: the client that would consume these responses is
+        // gone or leaving. Give in-flight handlers a short grace period,
+        // then abort rather than waiting out callback timeouts against a
+        // departed host; runtime.shutdown() below still runs.
+        let drain = async { while inflight.join_next().await.is_some() {} };
+        if tokio::time::timeout(Duration::from_secs(5), drain)
+            .await
+            .is_err()
+        {
+            inflight.shutdown().await;
         }
     }
 

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -30,6 +30,7 @@ pub mod protocol;
 pub mod rpc;
 pub mod runtime;
 pub mod schedule_wiring;
+pub mod tool_compose;
 pub mod types;
 pub mod unified_runtime;
 pub mod workgraph_admission;

--- a/meerkat-mobkit/src/tool_compose.rs
+++ b/meerkat-mobkit/src/tool_compose.rs
@@ -1,0 +1,206 @@
+//! Composition for external-tool dispatchers.
+//!
+//! `build.external_tools` is a single slot, and assigning it wholesale is a
+//! recurring defect class: a later installer silently discards whatever an
+//! earlier one put there (the agent-memory recorder's `memory` tool has been
+//! clobbered this way twice — by an example SessionHook, fixed in f8d11e57,
+//! and by the rpc_gateway callback build path, HomeCore "Bug D"). Installers
+//! MUST compose over the existing slot value instead of assigning.
+//!
+//! [`ComposedExternalTools`] is the canonical way to do that: the `primary`
+//! dispatcher (the tools being installed) wins name collisions; anything it
+//! does not advertise falls through to the `fallback` (whatever was already
+//! in the slot). BOTH dispatch entry points forward — the
+//! `ToolDispatchContext` carries per-turn authority witnesses (workgraph
+//! attention projections), and relying on the trait's default
+//! `dispatch_with_context` silently drops it, which was a verified
+//! attention-scope bypass in an earlier wrapper.
+
+use std::sync::Arc;
+
+use meerkat_core::types::{ToolCallView, ToolDef};
+use meerkat_core::{AgentToolDispatcher, ToolDispatchOutcome, ToolError};
+
+/// Two external-tool dispatchers behind one slot: `primary` wins name
+/// collisions, unknown calls fall through to `fallback`.
+pub struct ComposedExternalTools {
+    primary: Arc<dyn AgentToolDispatcher>,
+    fallback: Arc<dyn AgentToolDispatcher>,
+}
+
+impl ComposedExternalTools {
+    /// Compose `primary` over an optional pre-existing dispatcher. With no
+    /// fallback this is the identity — callers can use it unconditionally on
+    /// the slot they are about to fill.
+    pub fn over(
+        primary: Arc<dyn AgentToolDispatcher>,
+        fallback: Option<Arc<dyn AgentToolDispatcher>>,
+    ) -> Arc<dyn AgentToolDispatcher> {
+        match fallback {
+            None => primary,
+            Some(fallback) => Arc::new(Self { primary, fallback }),
+        }
+    }
+
+    fn primary_advertises(&self, name: &str) -> bool {
+        self.primary
+            .tools()
+            .iter()
+            .any(|tool| tool.name.as_ref() == name)
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentToolDispatcher for ComposedExternalTools {
+    fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+        let primary = self.primary.tools();
+        let mut merged: Vec<Arc<ToolDef>> = primary.iter().cloned().collect();
+        for tool in self.fallback.tools().iter() {
+            if !primary.iter().any(|existing| existing.name == tool.name) {
+                merged.push(Arc::clone(tool));
+            }
+        }
+        merged.into()
+    }
+
+    async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+        if self.primary_advertises(call.name) {
+            self.primary.dispatch(call).await
+        } else {
+            self.fallback.dispatch(call).await
+        }
+    }
+
+    async fn dispatch_with_context(
+        &self,
+        call: ToolCallView<'_>,
+        context: &meerkat_core::ToolDispatchContext,
+    ) -> Result<ToolDispatchOutcome, ToolError> {
+        if self.primary_advertises(call.name) {
+            self.primary.dispatch_with_context(call, context).await
+        } else {
+            self.fallback.dispatch_with_context(call, context).await
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Probe {
+        names: Vec<&'static str>,
+        dispatched: AtomicUsize,
+        contexted: AtomicUsize,
+    }
+
+    impl Probe {
+        fn new(names: Vec<&'static str>) -> Arc<Self> {
+            Arc::new(Self {
+                names,
+                dispatched: AtomicUsize::new(0),
+                contexted: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AgentToolDispatcher for Probe {
+        fn tools(&self) -> Arc<[Arc<ToolDef>]> {
+            self.names
+                .iter()
+                .map(|name| {
+                    Arc::new(ToolDef {
+                        name: (*name).into(),
+                        description: String::new(),
+                        input_schema: json!({"type": "object"}),
+                        provenance: None,
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into()
+        }
+
+        async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
+            self.dispatched.fetch_add(1, Ordering::SeqCst);
+            Err(ToolError::not_found(call.name))
+        }
+
+        async fn dispatch_with_context(
+            &self,
+            call: ToolCallView<'_>,
+            _context: &meerkat_core::ToolDispatchContext,
+        ) -> Result<ToolDispatchOutcome, ToolError> {
+            self.contexted.fetch_add(1, Ordering::SeqCst);
+            Err(ToolError::not_found(call.name))
+        }
+    }
+
+    fn call<'a>(name: &'a str, args: &'a serde_json::value::RawValue) -> ToolCallView<'a> {
+        ToolCallView {
+            id: "call-1",
+            name,
+            args,
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_merge_with_primary_winning_name_collisions() {
+        let primary = Probe::new(vec!["shared", "python_tool"]);
+        let fallback = Probe::new(vec!["shared", "memory"]);
+        let composed = ComposedExternalTools::over(primary, Some(fallback));
+        let names: Vec<String> = composed
+            .tools()
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+        assert_eq!(names, vec!["shared", "python_tool", "memory"]);
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_by_advertised_name_on_both_entry_points() {
+        let primary = Probe::new(vec!["python_tool"]);
+        let fallback = Probe::new(vec!["memory"]);
+        let composed = ComposedExternalTools::over(
+            Arc::clone(&primary) as _,
+            Some(Arc::clone(&fallback) as _),
+        );
+        let args = serde_json::value::RawValue::from_string("{}".to_string()).expect("raw");
+
+        let _ = composed.dispatch(call("python_tool", &args)).await;
+        assert_eq!(primary.dispatched.load(Ordering::SeqCst), 1);
+        assert_eq!(fallback.dispatched.load(Ordering::SeqCst), 0);
+
+        let _ = composed.dispatch(call("memory", &args)).await;
+        assert_eq!(fallback.dispatched.load(Ordering::SeqCst), 1);
+
+        // The context entry point must forward AS the context entry point —
+        // the trait default would drop the ToolDispatchContext (verified
+        // witness-loss class).
+        let _ = composed
+            .dispatch_with_context(
+                call("memory", &args),
+                &meerkat_core::ToolDispatchContext::default(),
+            )
+            .await;
+        assert_eq!(fallback.contexted.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            fallback.dispatched.load(Ordering::SeqCst),
+            1,
+            "context calls must not degrade to plain dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_fallback_is_the_identity() {
+        let primary = Probe::new(vec!["only"]);
+        let composed = ComposedExternalTools::over(Arc::clone(&primary) as _, None);
+        assert!(Arc::ptr_eq(
+            &(Arc::clone(&primary) as Arc<dyn AgentToolDispatcher>),
+            &composed
+        ));
+    }
+}

--- a/meerkat-mobkit/tests/gateway_concurrent_dispatch.rs
+++ b/meerkat-mobkit/tests/gateway_concurrent_dispatch.rs
@@ -1,0 +1,214 @@
+//! Regression: the rpc_gateway stdin dispatch loop must serve RPC requests
+//! CONCURRENTLY. A turn- or build-running RPC can block on a host callback
+//! round-trip (`callback/build_agent`, `callback/call_tool`), and the host
+//! may issue further RPCs from inside that callback (HomeCore issued
+//! `mobkit/agent_memory/recall` from a callback tool handler). With the old
+//! sequential loop those reentrant requests queued behind the blocked RPC
+//! until the callback timed out.
+//!
+//! The test drives the real binary: it triggers a spawn whose build round-
+//! trips `callback/build_agent`, withholds the callback response, and
+//! asserts an interleaved `mobkit/status` still answers.
+
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::uninlined_format_args
+)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const MOB_CONFIG: &str = r#"
+[mob]
+id = "gateway-concurrent-dispatch-test"
+
+[profiles.default]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.default.tools]
+comms = true
+"#;
+
+struct Gateway {
+    child: Child,
+    stdin: ChildStdin,
+    lines: mpsc::Receiver<String>,
+}
+
+impl Gateway {
+    fn start() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rpc_gateway"))
+            .arg("--persistent")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn rpc_gateway");
+        let stdin = child.stdin.take().expect("gateway stdin");
+        let stdout = child.stdout.take().expect("gateway stdout");
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            child,
+            stdin,
+            lines: rx,
+        }
+    }
+
+    fn send(&mut self, value: Value) {
+        writeln!(
+            self.stdin,
+            "{}",
+            serde_json::to_string(&value).expect("request json")
+        )
+        .expect("write request");
+        self.stdin.flush().expect("flush request");
+    }
+
+    /// Read messages until `predicate` matches one; unmatched messages are
+    /// handed to `on_other` (e.g. to auto-acknowledge unrelated callbacks).
+    fn wait_for(
+        &mut self,
+        deadline: Duration,
+        mut on_other: impl FnMut(&mut Self, &Value),
+        predicate: impl Fn(&Value) -> bool,
+    ) -> Option<Value> {
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            let remaining = deadline.saturating_sub(start.elapsed());
+            let Ok(line) = self.lines.recv_timeout(remaining) else {
+                return None;
+            };
+            let Ok(message) = serde_json::from_str::<Value>(line.trim()) else {
+                continue;
+            };
+            if predicate(&message) {
+                return Some(message);
+            }
+            on_other(self, &message);
+        }
+        None
+    }
+}
+
+impl Drop for Gateway {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn is_response_with_id(message: &Value, id: &str) -> bool {
+    message.get("method").is_none() && message.get("id").and_then(Value::as_str) == Some(id)
+}
+
+fn is_callback_request(message: &Value, method: &str) -> bool {
+    message.get("method").and_then(Value::as_str) == Some(method) && message.get("id").is_some()
+}
+
+#[test]
+fn rpc_dispatch_serves_requests_while_a_callback_is_pending() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "init",
+        "method": "mobkit/init",
+        "params": {
+            "persistent_state": state_dir.path(),
+            "mob_config": MOB_CONFIG,
+            "has_session_builder": true
+        }
+    }));
+    let init = gateway
+        .wait_for(
+            Duration::from_mins(1),
+            |_, _| {},
+            |m| is_response_with_id(m, "init"),
+        )
+        .expect("init response");
+    assert!(
+        init["result"]["contract_version"].is_string(),
+        "init failed: {init}"
+    );
+
+    // Trigger a member build; with has_session_builder the gateway round-trips
+    // callback/build_agent and the spawn RPC blocks until we answer it.
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "spawn",
+        "method": "mobkit/spawn_member",
+        "params": { "profile": "default", "meerkat_id": "worker-1" }
+    }));
+    let build_callback = gateway
+        .wait_for(
+            Duration::from_mins(1),
+            |_, _| {},
+            |m| is_callback_request(m, "callback/build_agent"),
+        )
+        .expect("callback/build_agent request");
+    let callback_id = build_callback["id"].clone();
+
+    // The regression: with the callback UNANSWERED (the spawn handler is
+    // parked), an interleaved request must still be served. The sequential
+    // loop queued it behind the spawn until the callback timed out.
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "status",
+        "method": "mobkit/status",
+        "params": {}
+    }));
+    let status = gateway
+        .wait_for(
+            Duration::from_secs(15),
+            |_, _| {},
+            |m| is_response_with_id(m, "status"),
+        )
+        .expect("mobkit/status must answer while callback/build_agent is pending");
+    assert!(
+        status["result"]["contract_version"].is_string(),
+        "status failed: {status}"
+    );
+
+    // Unblock the build and let the spawn finish (success or a build error —
+    // either proves the handler was parked on the callback, not lost).
+    // Auto-acknowledge any further callbacks (e.g. callback/after_create).
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": callback_id,
+        "result": {}
+    }));
+    let spawn = gateway
+        .wait_for(
+            Duration::from_mins(1),
+            |gateway, message| {
+                if message.get("method").is_some()
+                    && let Some(id) = message.get("id").cloned()
+                {
+                    gateway.send(json!({ "jsonrpc": "2.0", "id": id, "result": {} }));
+                }
+            },
+            |m| is_response_with_id(m, "spawn"),
+        )
+        .expect("spawn response after callback reply");
+    assert!(
+        spawn.get("result").is_some() || spawn.get("error").is_some(),
+        "spawn response malformed: {spawn}"
+    );
+}


### PR DESCRIPTION
Two HomeCore-reported rpc_gateway defects, both on the SDK callback path.

## 1. `callback/build_agent` clobbered pre-installed external tools (Bug D)

The gateway assigned `build.external_tools = Some(callback_dispatcher)` wholesale, discarding whatever an earlier installer put in the slot — in practice the agent-memory recorder's native `memory` tool (default-on via the memory customizer). Every callback-built agent silently lost its recorder. Third instance of the compose-don't-assign defect class (example SessionHook f8d11e57, workgraph ctx wrapper).

Fix: new `meerkat_mobkit::tool_compose::ComposedExternalTools` — the canonical compose utility. Primary (the tools being installed) wins name collisions; unknown calls fall through to the pre-existing dispatcher. Both `dispatch` AND `dispatch_with_context` forward, so the `ToolDispatchContext` attention witness survives (the trait default drops it — verified bypass class from the workgraph battery). Gateway call site now composes over `build.external_tools.take()`.

Note for embedders: a host tool named `memory` now shadows the native recorder by design (primary wins) — matching what HomeCore's workaround expects.

## 2. Sequential stdin dispatch starved reentrant RPCs (recall deadlock)

The dispatch loop awaited each `handle_unified_rpc_json` inline. A turn- or build-running RPC that blocks on a host callback round-trip (`callback/call_tool`, `callback/build_agent`) held the loop, so any RPC the host issued from *inside* that callback — HomeCore's `mobkit/agent_memory/recall` from a tool handler — queued behind it until the 120s callback timeout. Writes only "worked" because callers didn't block on their responses inside the callback.

Fix: each request runs on its own task (`JoinSet`). Safety: both SDK transports match responses by id (out-of-order safe), and the HTTP surface already serves the same methods concurrently against the same runtime, so this adds no new race class. On stdin EOF, in-flight handlers get a 5s grace, then abort (the client that would consume the responses is gone).

## Tests

- `tests/gateway_concurrent_dispatch.rs` drives the real binary: triggers a spawn whose build round-trips `callback/build_agent`, withholds the response, and asserts an interleaved `mobkit/status` still answers. **Verified red against the old sequential loop** (fails at the 15s starvation assertion), green with the fix.
- 3 unit tests on `ComposedExternalTools` (merge order, name routing on both entry points, no-fallback identity, context calls must not degrade to plain dispatch).
- Gateway/external/identity-first/incident-pack suites + Python SDK suite (577 passed) green.

Rides the 0.7.30 release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)