### PR TITLE
fix: definition wiring becomes a reconcilable desired state + cross-mob DX (HomeCore batch)

### DIFF
--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -1235,3 +1235,46 @@ envelope carrying a `reply_to` capability/token the runtime turns into a
 pre-addressed comms call (or a first-class `reply` tool scoped to the
 delivery), so "answer the peer" is an affordance rather than a prompt
 convention. mobkit interim: none (app-side relays).
+
+## Ask 27 — peer sends to unreachable targets must not read as success — P2
+
+Field (HomeCore, mobkit 0.7.30 / meerkat 0.7.25, 2026-07-09): an agent's
+comms `send_message` to a peer whose runtime is not booted (or whose
+transport is unreachable) returns `{"status": "sent", "receipt": {"acked":
+false}}` — indistinguishable from a successful no-ACK-kind delivery from the
+agent's seat. Agents confidently proceed ("ASKED") while nothing was
+delivered; HomeCore now relays cross-runtime asks host-side as a workaround.
+
+Root: `SendOutcome.acked` is only `true` on a verified peer ACK round-trip;
+kinds that do not await an ACK (and every inproc handoff) report
+`acked: false` for BOTH "delivered, no ack awaited" and — on some transport
+paths — "endpoint gone". The agent-facing tool result collapses delivery
+truth into one bit that cannot distinguish outcome classes.
+
+Ask: deliver-or-error at the comms tool seam (a send whose transport
+connect/write fails must surface a typed error to the agent), or a typed
+receipt state the agent can act on — e.g. `delivery: "acked" | "handed_off"
+| "queued" | "unreachable"` — so "the peer never got this" is representable.
+mobkit interim: none (host-side relay).
+
+## Ask 28 — kickoff-scoped objective→outcome correlation (reply-to-kickoff) — P2
+
+Field (HomeCore): the kickoff send's interaction completes on the lead's
+FIRST turn — usually the delegation, often textless. The real outcome lands
+turns later under different interaction ids, so hosts reconstruct
+"objective → final answer" with session-scope matching, a crew-quiescence
+gate over runtime.sqlite, and an empty-answer hold. This same gap is the
+likely trigger for their "peer no longer found/trusted after kickoff
+wind-down" reports: treating kickoff-interaction completion as objective
+completion starts teardown while workers still run, and a worker's report-
+back then races the lead's retirement.
+
+Ask, building on ask 15's interaction threading + ask 26's
+`PeerReplyCapability` shape: a kickoff-scoped correlation seam — the kickoff
+delivery mints a durable objective id that (a) stamps every transcript
+message and delegated turn transitively caused by it, and (b) gives the
+LEAD a pre-addressed "conclude the objective" affordance (mirroring
+`reply_to_peer`) whose payload is the objective's final answer. Hosts then
+await "objective concluded" instead of inferring it from interaction
+completion + quiescence heuristics. mobkit would surface the conclusion as
+a typed console/RPC event.

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -1681,6 +1681,69 @@ rust_test(
 )
 
 rust_test(
+    name = "edge_wiring_reconcile_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "edge_wiring_reconcile",
+    crate_root = "tests/edge_wiring_reconcile.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/edge_wiring_reconcile.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.30",
+        "CARGO_BIN_NAME": "edge_wiring_reconcile",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "event_log_recovery_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -5471,6 +5534,7 @@ test_suite(
         ":cross_mob_uds_test",
         ":discovery_bootstrap_test",
         ":distiller_eval_harness_test",
+        ":edge_wiring_reconcile_test",
         ":event_log_recovery_test",
         ":external_boundary_test",
         ":gateway_concurrent_dispatch_test",

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -6971,6 +6971,13 @@ async fn handle_console_runtime_rpc_with_visibility(
                 .await
                 {
                     Ok(result) => {
+                        // Converge declared definition wiring after every
+                        // materialization — upstream spawn-time wiring is
+                        // bring-up-order dependent (HomeCore, 2026-07-09).
+                        let _ = crate::unified_runtime::edge_reconcile::reconcile_definition_edges(
+                            runtime,
+                        )
+                        .await;
                         let outcome = match result.outcomes.get(&identity) {
                             Some(crate::identity_first::RestoreOutcome::Created { .. }) => {
                                 "created"
@@ -7035,6 +7042,9 @@ async fn handle_console_runtime_rpc_with_visibility(
             let mid = spec.identity.clone();
             match handle.ensure_member(spec).await {
                 Ok(_outcome) => {
+                    let _ =
+                        crate::unified_runtime::edge_reconcile::reconcile_definition_edges(runtime)
+                            .await;
                     let body = match lookup_member_with_session(&handle, &mid).await {
                         Some((entry, _sid)) => member_entry_to_json(&entry),
                         None => Value::Null,
@@ -7244,14 +7254,19 @@ async fn handle_console_runtime_rpc_with_visibility(
                 Err(err) => internal_error(response_id, format!("respawn_member failed: {err}")),
             }
         }
-        "mobkit/reconcile_edges" => response_value(
-            response_id,
-            Some(serde_json::json!({
-                "status": "noop",
-                "reason": "console runtime routes directly to MobRuntime",
-            })),
-            None,
-        ),
+        "mobkit/reconcile_edges" => {
+            // Previously a hardcoded noop ("console runtime routes directly
+            // to MobRuntime") — which left declared definition wiring
+            // unreconcilable from the console surface while the stdin
+            // surface had the real handler (HomeCore, 2026-07-09).
+            let report =
+                crate::unified_runtime::edge_reconcile::reconcile_definition_edges(runtime).await;
+            response_value(
+                response_id,
+                Some(serde_json::to_value(&report).unwrap_or(serde_json::Value::Null)),
+                None,
+            )
+        }
         "mobkit/mob_events/query" | "mobkit/mob_events/subscribe" => {
             let query: EventQuery = if request.params.is_null() {
                 EventQuery::default()

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -846,6 +846,13 @@ pub(super) async fn handle_ensure_member(
             let mid = spec.identity.clone();
             match handle.ensure_member(spec).await {
                 Ok(_outcome) => {
+                    // Declared definition wiring (auto_wire_orchestrator /
+                    // role_wiring) is bring-up-order dependent at spawn time
+                    // upstream; reconcile after every ensure so the crew
+                    // topology converges regardless of the order hosts
+                    // materialize members in. Inert without an edge policy;
+                    // idempotent otherwise.
+                    let _ = runtime.reconcile_edges().await;
                     let entries = handle.list_members_including_retiring().await;
                     let entry = entries.into_iter().find(|e| e.agent_identity == mid);
                     let result = match entry {
@@ -2645,6 +2652,11 @@ fn parse_optional_pubkey(params: &Value, field: &str) -> Result<Option<[u8; 32]>
     if s.is_empty() {
         return Ok(None);
     }
+    // Peer descriptors emit `transport_public_key` with an `ed25519:` scheme
+    // prefix; callers round-tripping that value into `wire_local` had to
+    // strip it by hand (HomeCore DX report, 2026-07-09). Accept both
+    // spellings.
+    let s = s.strip_prefix("ed25519:").unwrap_or(s);
     crate::auth::peer_keys::decode_pubkey_b64(s)
         .map(Some)
         .map_err(|err| format!("{field}: {err}"))
@@ -2687,6 +2699,27 @@ pub(super) async fn handle_peer_pubkey(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// HomeCore DX (2026-07-09): `cross_mob/peer_info` emits
+    /// `transport_public_key` with the `ed25519:` scheme prefix; callers
+    /// round-tripping it into `wire_local` had to strip it by hand.
+    #[test]
+    fn optional_pubkey_accepts_the_ed25519_prefixed_spelling() -> Result<(), String> {
+        use base64::Engine as _;
+        let key = [7u8; 32];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(key);
+        let plain = serde_json::json!({ "remote_pubkey_b64": b64 });
+        let prefixed = serde_json::json!({ "remote_pubkey_b64": format!("ed25519:{b64}") });
+        assert_eq!(
+            parse_optional_pubkey(&plain, "remote_pubkey_b64")?,
+            Some(key)
+        );
+        assert_eq!(
+            parse_optional_pubkey(&prefixed, "remote_pubkey_b64")?,
+            Some(key)
+        );
+        Ok(())
+    }
 
     #[test]
     fn extract_content_rejects_malformed_content_even_with_message_fallback()

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -953,7 +953,10 @@ impl UnifiedRuntimeBuilder {
             error_hook: self.error_hook,
             drain_timeout: self.drain_timeout.unwrap_or(DEFAULT_DRAIN_TIMEOUT),
             discovery: self.discovery,
-            edge_discovery: self.edge_discovery,
+            // A custom embedder policy overrides the definition-derived
+            // default `bootstrap_with_options` installed (HomeCore,
+            // 2026-07-09); with none supplied the default is preserved.
+            edge_discovery: self.edge_discovery.or(runtime.edge_discovery),
             contact_directory: self.contact_directory,
             session_bridge,
             identity_first_context,

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -503,7 +503,25 @@ impl UnifiedRuntime {
     ) -> Result<(String, String, String), CrossMobError> {
         let handle = self.mob_runtime.handle();
         let mob_id = handle.mob_id().to_string();
-        let mid = crate::member_comms_id::mob_member_id(member_id);
+        // Accept every public spelling (the #252 canonicalization class,
+        // mirroring `/agents/{id}/events`): plain member names and runtime
+        // aliases ("rt:lead:0") encode directly to their roster id, but a
+        // DURABLE IDENTITY ("lead") has no encodable roster form — resolve
+        // it via the roster's `agent_identity` label. Unresolvable ids keep
+        // the direct encoding so the error still names the member.
+        let direct = crate::member_comms_id::mob_member_id(member_id);
+        let mid = if handle.get_member(&direct).await.ok().flatten().is_some() {
+            direct
+        } else if let Some(identity) = handle
+            .roster()
+            .await
+            .find_by_label("agent_identity", member_id)
+            .map(|entry| entry.agent_identity.clone())
+        {
+            identity
+        } else {
+            direct
+        };
         let info = self.get_member_peer_info(&handle, &mid, &mob_id).await?;
         let address = format!("inproc://{}", info.comms_name);
         Ok((info.peer_id, info.comms_name, address))

--- a/meerkat-mobkit/src/unified_runtime/edge_reconcile.rs
+++ b/meerkat-mobkit/src/unified_runtime/edge_reconcile.rs
@@ -23,6 +23,91 @@ use super::{
 
 const EDGE_RECONCILE_CONCURRENCY: usize = 64;
 
+/// Default [`super::edge_types::EdgeDiscovery`] policy derived from the mob
+/// definition's declared `wiring` block. Upstream applies
+/// `auto_wire_orchestrator`/`role_wiring` only at SPAWN time and only from
+/// the non-orchestrator side (meerkat-mob `spawn_wiring_targets`), which
+/// makes the result bring-up-order dependent: a lead ensured after its
+/// workers — or any member resumed after a gateway restart — ends up with
+/// `wired_to: []` and the declared crew never forms (HomeCore field report,
+/// 2026-07-09). This policy makes the declaration a RECONCILABLE desired
+/// state: `reconcile_edges` wires whatever the definition implies over the
+/// live roster, order-independently and restart-healingly. It is installed
+/// automatically when the embedder supplies no custom policy and the
+/// definition declares wiring; the reconciler only ever unwires edges it
+/// wired itself, so host-made manual edges are never touched.
+pub struct DefinitionWiringEdgeDiscovery {
+    auto_wire_orchestrator: bool,
+    orchestrator_profile: Option<String>,
+    role_wiring: Vec<(String, String)>,
+}
+
+impl DefinitionWiringEdgeDiscovery {
+    /// `None` when the definition declares no wiring (the reconciler then
+    /// stays inert exactly as before).
+    pub fn from_definition(definition: &meerkat_mob::MobDefinition) -> Option<Self> {
+        let auto_wire_orchestrator =
+            definition.wiring.auto_wire_orchestrator && definition.orchestrator.is_some();
+        if !auto_wire_orchestrator && definition.wiring.role_wiring.is_empty() {
+            return None;
+        }
+        Some(Self {
+            auto_wire_orchestrator,
+            orchestrator_profile: definition
+                .orchestrator
+                .as_ref()
+                .map(|config| config.profile.to_string()),
+            role_wiring: definition
+                .wiring
+                .role_wiring
+                .iter()
+                .map(|rule| (rule.a.to_string(), rule.b.to_string()))
+                .collect(),
+        })
+    }
+
+    fn desired_edges(&self, members: &[EdgeMemberView]) -> Vec<DesiredPeerEdge> {
+        let mut edges = BTreeSet::new();
+        if self.auto_wire_orchestrator
+            && let Some(orchestrator_profile) = &self.orchestrator_profile
+        {
+            for orchestrator in members.iter().filter(|m| &m.role == orchestrator_profile) {
+                for member in members.iter().filter(|m| &m.role != orchestrator_profile) {
+                    if let Ok(edge) = DesiredPeerEdge::new(
+                        orchestrator.agent_identity.clone(),
+                        member.agent_identity.clone(),
+                    ) {
+                        edges.insert(edge);
+                    }
+                }
+            }
+        }
+        for (a, b) in &self.role_wiring {
+            for left in members.iter().filter(|m| &m.role == a) {
+                for right in members.iter().filter(|m| &m.role == b) {
+                    if let Ok(edge) = DesiredPeerEdge::new(
+                        left.agent_identity.clone(),
+                        right.agent_identity.clone(),
+                    ) {
+                        edges.insert(edge);
+                    }
+                }
+            }
+        }
+        edges.into_iter().collect()
+    }
+}
+
+impl super::edge_types::EdgeDiscovery for DefinitionWiringEdgeDiscovery {
+    fn discover_edges(
+        &self,
+        active_members: Vec<EdgeMemberView>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<DesiredPeerEdge>> + Send + '_>>
+    {
+        Box::pin(async move { self.desired_edges(&active_members) })
+    }
+}
+
 impl UnifiedRuntime {
     pub async fn reconcile(
         &self,
@@ -102,6 +187,9 @@ impl UnifiedRuntime {
     /// Refreshes the roster, runs edge discovery if configured, diffs
     /// desired vs managed edges, and calls wire/unwire as needed.
     pub async fn reconcile_edges(&self) -> UnifiedRuntimeReconcileEdgesReport {
+        if self.edge_discovery.is_none() {
+            return UnifiedRuntimeReconcileEdgesReport::default();
+        }
         let active_members = self.mob_handle().list_members_including_retiring().await;
         let report = self.reconcile_edges_from_members(active_members).await;
         if !report.is_complete() {
@@ -121,248 +209,13 @@ impl UnifiedRuntime {
             Some(d) => d,
             None => return UnifiedRuntimeReconcileEdgesReport::default(),
         };
-
-        // Everything in this function speaks the public alias space: roster
-        // ids are comms-safe encodings (meerkat 0.7 `MemberCommsName`), so
-        // decode snapshots on entry and encode only at the wire/unwire calls.
-        let alias_of =
-            |id: &str| -> String { crate::member_comms_id::runtime_alias_str(id).into_owned() };
-
-        let active_ids: BTreeSet<String> = active_members
-            .iter()
-            .map(|m| alias_of(m.agent_identity.as_str()))
-            .collect();
-
-        // Build current wiring map from snapshots
-        let mut current_edges: BTreeSet<(String, String)> = BTreeSet::new();
-        for member in &active_members {
-            for peer in &member.wired_to {
-                let mut a = alias_of(member.agent_identity.as_str());
-                let mut b = alias_of(peer.as_str());
-                if a > b {
-                    std::mem::swap(&mut a, &mut b);
-                }
-                current_edges.insert((a, b));
-            }
-        }
-
-        // Project to EdgeMemberView for the policy closure — it only needs
-        // identity/role/labels/wired_to, not meerkat's private runtime fields.
-        let member_views: Vec<EdgeMemberView> = active_members
-            .into_iter()
-            .map(|m| EdgeMemberView {
-                agent_identity: alias_of(m.agent_identity.as_str()),
-                role: m.role.to_string(),
-                wired_to: m
-                    .wired_to
-                    .iter()
-                    .map(|peer| alias_of(peer.as_str()))
-                    .collect(),
-                labels: m.labels,
-            })
-            .collect();
-
-        // Run edge discovery
-        let raw_desired = edge_discovery.discover_edges(member_views).await;
-
-        // Deduplicate and defensively validate (DesiredPeerEdge enforces
-        // invariants at construction, but we still canonicalize the key set)
-        let desired: BTreeSet<(String, String)> = raw_desired
-            .iter()
-            .map(|e| {
-                let (a, b) = e.endpoints();
-                (a.to_string(), b.to_string())
-            })
-            .collect();
-
-        let mut report = UnifiedRuntimeReconcileEdgesReport {
-            desired_edges: raw_desired,
-            ..Default::default()
-        };
-
-        let managed_snapshot = self.managed_dynamic_edges.read().await.clone();
-        let mut to_wire = Vec::new();
-
-        // Classify desired edges
-        for (a, b) in &desired {
-            // Skip if either endpoint is missing from the active roster
-            if !active_ids.contains(a) || !active_ids.contains(b) {
-                if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
-                    report.skipped_missing_members.push(edge);
-                }
-                continue;
-            }
-            let key = (a.clone(), b.clone());
-            if managed_snapshot.contains(&key) {
-                // Managed by us — check if the actual edge still exists in the
-                // mob graph. If an out-of-band unwire() removed it, re-wire.
-                if current_edges.contains(&key) {
-                    if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
-                        report.retained_edges.push(edge);
-                    }
-                } else {
-                    to_wire.push((a.clone(), b.clone(), "wire (heal)"));
-                }
-            } else if current_edges.contains(&key) {
-                // Exists but not managed by us (static or external) — don't claim
-                if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
-                    report.preexisting_edges.push(edge);
-                }
-            } else {
-                to_wire.push((a.clone(), b.clone(), "wire"));
-            }
-        }
-
-        // Unwire managed edges that are no longer desired
-        let mut stale_pruned = Vec::new();
-        let mut to_unwire = Vec::new();
-        for (a, b) in managed_snapshot
-            .iter()
-            .filter(|key| !desired.contains(*key))
-            .cloned()
-        {
-            let key = (a.clone(), b.clone());
-            // If either endpoint is gone, just prune from managed set
-            if !active_ids.contains(&a) || !active_ids.contains(&b) {
-                stale_pruned.push((a, b));
-                continue;
-            }
-            // If the edge is already gone from the mob graph (out-of-band
-            // unwire/reset), just drop ownership — don't attempt unwire.
-            if !current_edges.contains(&key) {
-                stale_pruned.push((a, b));
-                continue;
-            }
-            to_unwire.push((a, b));
-        }
-
-        let handle = self.mob_handle();
-        let wire_operations = to_wire
-            .iter()
-            .map(|(a, b, operation)| ((a.clone(), b.clone()), (*operation).to_string()))
-            .collect::<BTreeMap<_, _>>();
-        let mut wire_successes = Vec::new();
-        let mut wire_failures = Vec::new();
-        if !to_wire.is_empty() {
-            let batch_edges = to_wire
-                .iter()
-                .map(|(a, b, _)| {
-                    (
-                        crate::member_comms_id::mob_member_id(a.as_str()),
-                        crate::member_comms_id::mob_member_id(b.as_str()),
-                    )
-                })
-                .collect::<Vec<_>>();
-            // The batch report carries roster ids; decode back to aliases and
-            // re-canonicalize (alias-space ordering can differ from roster-id
-            // ordering) so keys line up with `to_wire`.
-            let alias_edge_key = |a: &AgentIdentity, b: &AgentIdentity| -> (String, String) {
-                let mut a = crate::member_comms_id::runtime_alias_str(a.as_str()).into_owned();
-                let mut b = crate::member_comms_id::runtime_alias_str(b.as_str()).into_owned();
-                if a > b {
-                    std::mem::swap(&mut a, &mut b);
-                }
-                (a, b)
-            };
-            match handle.wire_members_batch(batch_edges).await {
-                Ok(batch_report) => {
-                    let mut seen = BTreeSet::new();
-                    for edge in batch_report.wired {
-                        let key = alias_edge_key(&edge.a, &edge.b);
-                        seen.insert(key.clone());
-                        wire_successes.push((key.0, key.1, true));
-                    }
-                    for edge in batch_report.already_wired {
-                        let key = alias_edge_key(&edge.a, &edge.b);
-                        seen.insert(key.clone());
-                        wire_successes.push((key.0, key.1, false));
-                    }
-                    for (a, b, operation) in to_wire {
-                        let key = if a <= b { (a, b) } else { (b, a) };
-                        if !seen.contains(&key) {
-                            wire_failures.push((
-                                key.0,
-                                key.1,
-                                operation.to_string(),
-                                "wire_members_batch omitted edge from report".to_string(),
-                            ));
-                        }
-                    }
-                }
-                Err(err) => {
-                    let error = err.to_string();
-                    for (a, b, operation) in to_wire {
-                        wire_failures.push((a, b, operation.to_string(), error.clone()));
-                    }
-                }
-            }
-        }
-
-        let handle = self.mob_handle();
-        let unwire_results = stream::iter(to_unwire.into_iter().map(|(a, b)| {
-            let handle = handle.clone();
-            async move {
-                let result = handle
-                    .unwire(
-                        crate::member_comms_id::mob_member_id(a.as_str()),
-                        crate::member_comms_id::mob_member_id(b.as_str()),
-                    )
-                    .await
-                    .map_err(|err| format!("{err}"));
-                (a, b, result)
-            }
-        }))
-        .buffer_unordered(EDGE_RECONCILE_CONCURRENCY)
-        .collect::<Vec<_>>()
-        .await;
-
-        let mut managed_edges = self.managed_dynamic_edges.write().await;
-        for (a, b, newly_wired) in wire_successes {
-            managed_edges.insert((a.clone(), b.clone()));
-            if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
-                if newly_wired {
-                    report.wired_edges.push(edge);
-                } else {
-                    report.retained_edges.push(edge);
-                }
-            }
-        }
-        for (a, b, operation, error) in wire_failures {
-            if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
-                report.failures.push(EdgeReconcileFailure {
-                    edge,
-                    operation: wire_operations.get(&(a, b)).cloned().unwrap_or(operation),
-                    error,
-                });
-            }
-        }
-        for (a, b) in stale_pruned {
-            managed_edges.remove(&(a.clone(), b.clone()));
-            if let Ok(edge) = DesiredPeerEdge::new(a, b) {
-                report.pruned_stale_managed_edges.push(edge);
-            }
-        }
-        for (a, b, result) in unwire_results {
-            match result {
-                Ok(()) => {
-                    managed_edges.remove(&(a.clone(), b.clone()));
-                    if let Ok(edge) = DesiredPeerEdge::new(a, b) {
-                        report.unwired_edges.push(edge);
-                    }
-                }
-                Err(error) => {
-                    if let Ok(edge) = DesiredPeerEdge::new(a, b) {
-                        report.failures.push(EdgeReconcileFailure {
-                            edge,
-                            operation: "unwire".into(),
-                            error,
-                        });
-                    }
-                }
-            }
-        }
-
-        report
+        reconcile_edges_over_members(
+            &self.mob_handle(),
+            edge_discovery.as_ref(),
+            &self.managed_dynamic_edges,
+            active_members,
+        )
+        .await
     }
 
     pub(super) async fn reconcile_routing_wiring(
@@ -429,4 +282,274 @@ impl UnifiedRuntime {
             removed_route_keys,
         })
     }
+}
+
+/// Definition-driven, wire-only edge reconcile for surfaces that hold only a
+/// [`crate::MobRuntime`] (the console RPC dispatch): derives the desired
+/// edges from the definition's declared `wiring` block over the live roster
+/// and wires whatever is missing. The transient managed set means this NEVER
+/// unwires — host-made and upstream-made edges are untouched.
+pub async fn reconcile_definition_edges(
+    runtime: &crate::MobRuntime,
+) -> UnifiedRuntimeReconcileEdgesReport {
+    let handle = runtime.handle();
+    let Some(policy) = DefinitionWiringEdgeDiscovery::from_definition(handle.definition()) else {
+        return UnifiedRuntimeReconcileEdgesReport::default();
+    };
+    let active_members = handle.list_members_including_retiring().await;
+    let managed = tokio::sync::RwLock::new(BTreeSet::new());
+    reconcile_edges_over_members(&handle, &policy, &managed, active_members).await
+}
+
+/// The reconcile body, shared by [`UnifiedRuntime::reconcile_edges`] and the
+/// console surface's definition-driven reconcile (which passes a transient
+/// empty managed set — wire-only convergence: it wires missing desired edges
+/// and never unwires anything it did not itself manage).
+pub(crate) async fn reconcile_edges_over_members(
+    mob_handle: &meerkat_mob::runtime::MobHandle,
+    edge_discovery: &dyn super::edge_types::EdgeDiscovery,
+    managed_dynamic_edges: &tokio::sync::RwLock<BTreeSet<(String, String)>>,
+    active_members: Vec<MobMemberListEntry>,
+) -> UnifiedRuntimeReconcileEdgesReport {
+    // Everything in this function speaks the public alias space: roster
+    // ids are comms-safe encodings (meerkat 0.7 `MemberCommsName`), so
+    // decode snapshots on entry and encode only at the wire/unwire calls.
+    let alias_of =
+        |id: &str| -> String { crate::member_comms_id::runtime_alias_str(id).into_owned() };
+
+    let active_ids: BTreeSet<String> = active_members
+        .iter()
+        .map(|m| alias_of(m.agent_identity.as_str()))
+        .collect();
+
+    // Build current wiring map from snapshots
+    let mut current_edges: BTreeSet<(String, String)> = BTreeSet::new();
+    for member in &active_members {
+        for peer in &member.wired_to {
+            let mut a = alias_of(member.agent_identity.as_str());
+            let mut b = alias_of(peer.as_str());
+            if a > b {
+                std::mem::swap(&mut a, &mut b);
+            }
+            current_edges.insert((a, b));
+        }
+    }
+
+    // Project to EdgeMemberView for the policy closure — it only needs
+    // identity/role/labels/wired_to, not meerkat's private runtime fields.
+    let member_views: Vec<EdgeMemberView> = active_members
+        .into_iter()
+        .map(|m| EdgeMemberView {
+            agent_identity: alias_of(m.agent_identity.as_str()),
+            role: m.role.to_string(),
+            wired_to: m
+                .wired_to
+                .iter()
+                .map(|peer| alias_of(peer.as_str()))
+                .collect(),
+            labels: m.labels,
+        })
+        .collect();
+
+    // Run edge discovery
+    let raw_desired = edge_discovery.discover_edges(member_views).await;
+
+    // Deduplicate and defensively validate (DesiredPeerEdge enforces
+    // invariants at construction, but we still canonicalize the key set)
+    let desired: BTreeSet<(String, String)> = raw_desired
+        .iter()
+        .map(|e| {
+            let (a, b) = e.endpoints();
+            (a.to_string(), b.to_string())
+        })
+        .collect();
+
+    let mut report = UnifiedRuntimeReconcileEdgesReport {
+        desired_edges: raw_desired,
+        ..Default::default()
+    };
+
+    let managed_snapshot = managed_dynamic_edges.read().await.clone();
+    let mut to_wire = Vec::new();
+
+    // Classify desired edges
+    for (a, b) in &desired {
+        // Skip if either endpoint is missing from the active roster
+        if !active_ids.contains(a) || !active_ids.contains(b) {
+            if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
+                report.skipped_missing_members.push(edge);
+            }
+            continue;
+        }
+        let key = (a.clone(), b.clone());
+        if managed_snapshot.contains(&key) {
+            // Managed by us — check if the actual edge still exists in the
+            // mob graph. If an out-of-band unwire() removed it, re-wire.
+            if current_edges.contains(&key) {
+                if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
+                    report.retained_edges.push(edge);
+                }
+            } else {
+                to_wire.push((a.clone(), b.clone(), "wire (heal)"));
+            }
+        } else if current_edges.contains(&key) {
+            // Exists but not managed by us (static or external) — don't claim
+            if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
+                report.preexisting_edges.push(edge);
+            }
+        } else {
+            to_wire.push((a.clone(), b.clone(), "wire"));
+        }
+    }
+
+    // Unwire managed edges that are no longer desired
+    let mut stale_pruned = Vec::new();
+    let mut to_unwire = Vec::new();
+    for (a, b) in managed_snapshot
+        .iter()
+        .filter(|key| !desired.contains(*key))
+        .cloned()
+    {
+        let key = (a.clone(), b.clone());
+        // If either endpoint is gone, just prune from managed set
+        if !active_ids.contains(&a) || !active_ids.contains(&b) {
+            stale_pruned.push((a, b));
+            continue;
+        }
+        // If the edge is already gone from the mob graph (out-of-band
+        // unwire/reset), just drop ownership — don't attempt unwire.
+        if !current_edges.contains(&key) {
+            stale_pruned.push((a, b));
+            continue;
+        }
+        to_unwire.push((a, b));
+    }
+
+    let handle = mob_handle.clone();
+    let wire_operations = to_wire
+        .iter()
+        .map(|(a, b, operation)| ((a.clone(), b.clone()), (*operation).to_string()))
+        .collect::<BTreeMap<_, _>>();
+    let mut wire_successes = Vec::new();
+    let mut wire_failures = Vec::new();
+    if !to_wire.is_empty() {
+        let batch_edges = to_wire
+            .iter()
+            .map(|(a, b, _)| {
+                (
+                    crate::member_comms_id::mob_member_id(a.as_str()),
+                    crate::member_comms_id::mob_member_id(b.as_str()),
+                )
+            })
+            .collect::<Vec<_>>();
+        // The batch report carries roster ids; decode back to aliases and
+        // re-canonicalize (alias-space ordering can differ from roster-id
+        // ordering) so keys line up with `to_wire`.
+        let alias_edge_key = |a: &AgentIdentity, b: &AgentIdentity| -> (String, String) {
+            let mut a = crate::member_comms_id::runtime_alias_str(a.as_str()).into_owned();
+            let mut b = crate::member_comms_id::runtime_alias_str(b.as_str()).into_owned();
+            if a > b {
+                std::mem::swap(&mut a, &mut b);
+            }
+            (a, b)
+        };
+        match handle.wire_members_batch(batch_edges).await {
+            Ok(batch_report) => {
+                let mut seen = BTreeSet::new();
+                for edge in batch_report.wired {
+                    let key = alias_edge_key(&edge.a, &edge.b);
+                    seen.insert(key.clone());
+                    wire_successes.push((key.0, key.1, true));
+                }
+                for edge in batch_report.already_wired {
+                    let key = alias_edge_key(&edge.a, &edge.b);
+                    seen.insert(key.clone());
+                    wire_successes.push((key.0, key.1, false));
+                }
+                for (a, b, operation) in to_wire {
+                    let key = if a <= b { (a, b) } else { (b, a) };
+                    if !seen.contains(&key) {
+                        wire_failures.push((
+                            key.0,
+                            key.1,
+                            operation.to_string(),
+                            "wire_members_batch omitted edge from report".to_string(),
+                        ));
+                    }
+                }
+            }
+            Err(err) => {
+                let error = err.to_string();
+                for (a, b, operation) in to_wire {
+                    wire_failures.push((a, b, operation.to_string(), error.clone()));
+                }
+            }
+        }
+    }
+
+    let handle = mob_handle.clone();
+    let unwire_results = stream::iter(to_unwire.into_iter().map(|(a, b)| {
+        let handle = handle.clone();
+        async move {
+            let result = handle
+                .unwire(
+                    crate::member_comms_id::mob_member_id(a.as_str()),
+                    crate::member_comms_id::mob_member_id(b.as_str()),
+                )
+                .await
+                .map_err(|err| format!("{err}"));
+            (a, b, result)
+        }
+    }))
+    .buffer_unordered(EDGE_RECONCILE_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+
+    let mut managed_edges = managed_dynamic_edges.write().await;
+    for (a, b, newly_wired) in wire_successes {
+        managed_edges.insert((a.clone(), b.clone()));
+        if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
+            if newly_wired {
+                report.wired_edges.push(edge);
+            } else {
+                report.retained_edges.push(edge);
+            }
+        }
+    }
+    for (a, b, operation, error) in wire_failures {
+        if let Ok(edge) = DesiredPeerEdge::new(a.clone(), b.clone()) {
+            report.failures.push(EdgeReconcileFailure {
+                edge,
+                operation: wire_operations.get(&(a, b)).cloned().unwrap_or(operation),
+                error,
+            });
+        }
+    }
+    for (a, b) in stale_pruned {
+        managed_edges.remove(&(a.clone(), b.clone()));
+        if let Ok(edge) = DesiredPeerEdge::new(a, b) {
+            report.pruned_stale_managed_edges.push(edge);
+        }
+    }
+    for (a, b, result) in unwire_results {
+        match result {
+            Ok(()) => {
+                managed_edges.remove(&(a.clone(), b.clone()));
+                if let Ok(edge) = DesiredPeerEdge::new(a, b) {
+                    report.unwired_edges.push(edge);
+                }
+            }
+            Err(error) => {
+                if let Ok(edge) = DesiredPeerEdge::new(a, b) {
+                    report.failures.push(EdgeReconcileFailure {
+                        edge,
+                        operation: "unwire".into(),
+                        error,
+                    });
+                }
+            }
+        }
+    }
+
+    report
 }

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -236,6 +236,11 @@ impl UnifiedRuntime {
             console_events.clone(),
         ));
         let workgraph_service = mob_runtime.workgraph_service();
+        let definition_edge_discovery =
+            edge_reconcile::DefinitionWiringEdgeDiscovery::from_definition(
+                mob_runtime.handle().definition(),
+            )
+            .map(|policy| Box::new(policy) as Box<dyn EdgeDiscovery>);
         Self {
             mob_runtime,
             post_spawn_hook: None,
@@ -243,7 +248,14 @@ impl UnifiedRuntime {
             error_hook: None,
             drain_timeout: DEFAULT_DRAIN_TIMEOUT,
             discovery: None,
-            edge_discovery: None,
+            // Default the edge policy to the definition's declared wiring
+            // (auto_wire_orchestrator / role_wiring): upstream applies those
+            // rules only at spawn time and only from the non-orchestrator
+            // side, so bring-up order and restarts leave declared crews
+            // unwired (HomeCore, 2026-07-09). With the default installed,
+            // `reconcile_edges` converges the roster onto the declaration;
+            // embedder-supplied policies (builder) override it.
+            edge_discovery: definition_edge_discovery,
             module_runtime: Arc::new(tokio::sync::Mutex::new(module_runtime)),
             managed_dynamic_edges: tokio::sync::RwLock::new(BTreeSet::new()),
             shutting_down: AtomicBool::new(false),

--- a/meerkat-mobkit/tests/edge_wiring_reconcile.rs
+++ b/meerkat-mobkit/tests/edge_wiring_reconcile.rs
@@ -1,0 +1,190 @@
+//! Regression: declared definition wiring (`auto_wire_orchestrator`,
+//! `role_wiring`) must converge regardless of bring-up order (HomeCore,
+//! 2026-07-09). Upstream applies the rules only at spawn time and only from
+//! the non-orchestrator side, so a lead ensured AFTER its workers ended with
+//! `wired_to: []` and multi-member crews were dead on arrival. The
+//! definition-derived default edge policy plus the reconcile-after-ensure
+//! heal make the declaration a reconcilable desired state.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::uninlined_format_args
+)]
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use meerkat::{AgentFactory, Config, build_ephemeral_service};
+use meerkat_client::TestClient;
+use meerkat_mob::{MobDefinition, MobStorage};
+use meerkat_mobkit::{
+    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, UnifiedRuntime,
+    handle_unified_rpc_json,
+};
+use serde_json::{Value, json};
+
+const CREW_MOB_TOML: &str = r#"
+[mob]
+id = "edge-wiring-crew"
+orchestrator = "lead"
+
+[wiring]
+auto_wire_orchestrator = true
+
+[[wiring.role_wiring]]
+a = "builder"
+b = "reviewer"
+
+[profiles.lead]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.lead.tools]
+comms = true
+
+[profiles.builder]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.builder.tools]
+comms = true
+
+[profiles.reviewer]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.reviewer.tools]
+comms = true
+"#;
+
+/// Gateway-path runtime (MobBootstrapSpec + `UnifiedRuntime::bootstrap`) —
+/// the construction both gateways use, where no embedder edge policy is ever
+/// supplied and the definition-derived default must be installed.
+async fn build_gateway_path_runtime() -> (tempfile::TempDir, UnifiedRuntime) {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let factory = AgentFactory::new(temp_dir.path()).comms(true);
+    let session_service = Arc::new(build_ephemeral_service(factory, Config::default(), 8));
+    let definition = MobDefinition::from_toml(CREW_MOB_TOML).expect("parse crew definition");
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(TestClient::default())),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "edge-wiring-reconcile".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap crew runtime");
+    (temp_dir, runtime)
+}
+
+async fn rpc(runtime: &UnifiedRuntime, method: &str, params: Value) -> Value {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "edge-wiring",
+        "method": method,
+        "params": params,
+    })
+    .to_string();
+    let response =
+        handle_unified_rpc_json(runtime, &request, Duration::from_secs(5), None, None).await;
+    serde_json::from_str(&response).expect("json-rpc response")
+}
+
+async fn ensure(runtime: &UnifiedRuntime, role: &str, identity: &str) {
+    let response = rpc(
+        runtime,
+        "mobkit/ensure_member",
+        json!({ "role": role, "agent_identity": identity }),
+    )
+    .await;
+    assert!(
+        response["error"].is_null(),
+        "ensure_member {identity} failed: {response:#?}"
+    );
+}
+
+async fn wired_to(runtime: &UnifiedRuntime, identity: &str) -> BTreeSet<String> {
+    let response = rpc(runtime, "mobkit/list_members", json!({})).await;
+    let members = response["result"].as_array().expect("members array");
+    members
+        .iter()
+        .find(|m| m["member_id"] == identity || m["agent_identity"] == identity)
+        .unwrap_or_else(|| panic!("member {identity} not found: {members:#?}"))["wired_to"]
+        .as_array()
+        .map(|peers| {
+            peers
+                .iter()
+                .filter_map(|p| p.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The exact field failure: workers ensured FIRST, the lead LAST — upstream's
+/// spawn-side wiring skips the orchestrator's own spawn, so pre-fix the lead
+/// ended with `wired_to: []`.
+#[tokio::test(flavor = "multi_thread")]
+async fn lead_ensured_last_still_wires_to_declared_crew() {
+    let (_dir, runtime) = build_gateway_path_runtime().await;
+
+    ensure(&runtime, "builder", "builder-1").await;
+    ensure(&runtime, "reviewer", "reviewer-1").await;
+    ensure(&runtime, "lead", "lead-1").await;
+
+    let lead = wired_to(&runtime, "lead-1").await;
+    assert!(
+        lead.contains("builder-1") && lead.contains("reviewer-1"),
+        "auto_wire_orchestrator must converge regardless of bring-up order; lead wired_to: {lead:?}"
+    );
+    let builder = wired_to(&runtime, "builder-1").await;
+    assert!(
+        builder.contains("reviewer-1"),
+        "role_wiring builder<->reviewer must hold: {builder:?}"
+    );
+
+    let shutdown = runtime.shutdown().await;
+    assert!(
+        shutdown.mob_stop.is_ok(),
+        "mob stop failed at teardown: {:?}",
+        shutdown.mob_stop
+    );
+}
+
+/// `mobkit/reconcile_edges` heals a manually unwired crew back to the
+/// declaration (restart/out-of-band recovery affordance).
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_edges_rewires_declared_crew() {
+    let (_dir, runtime) = build_gateway_path_runtime().await;
+    ensure(&runtime, "lead", "lead-1").await;
+    ensure(&runtime, "builder", "builder-1").await;
+
+    let response = rpc(&runtime, "mobkit/reconcile_edges", json!({})).await;
+    assert!(
+        response["error"].is_null(),
+        "reconcile_edges failed: {response:#?}"
+    );
+
+    let lead = wired_to(&runtime, "lead-1").await;
+    assert!(
+        lead.contains("builder-1"),
+        "reconcile_edges must wire the declared crew: {lead:?}"
+    );
+
+    let shutdown = runtime.shutdown().await;
+    assert!(
+        shutdown.mob_stop.is_ok(),
+        "mob stop failed at teardown: {:?}",
+        shutdown.mob_stop
+    );
+}


### PR DESCRIPTION
HomeCore field batch (2026-07-09), items 1/3/4 of five (2 and 5 resolved by analysis — see below).

## Item 1 — `auto_wire_orchestrator` dead on console runtimes

Upstream applies `wiring` rules only at **spawn time** and only from the **non-orchestrator side** (`spawn_wiring_targets` skips the orchestrator's own spawn), so bring-up order decided whether a crew formed: a lead ensured after its workers ended `wired_to: []`. And the console surface's `mobkit/reconcile_edges` was a hardcoded noop.

- **`DefinitionWiringEdgeDiscovery`** — default edge policy derived from the definition's declared `wiring` block, installed at `bootstrap_with_options` (the gateway construction path) when no embedder policy is supplied. Only unwires self-managed edges; host-made manual wiring untouched.
- **`ensure_member` heals** on both RPC surfaces — crew topology converges regardless of materialization order, and re-converges after restarts.
- **Console `reconcile_edges` un-stubbed** — real definition-driven, wire-only reconcile.
- **DX riders fixed**: `cross_mob/peer_info` accepts durable identities (roster `agent_identity` label fallback, mirroring `/agents/{id}/events`); `cross_mob/wire_local` accepts the `ed25519:`-prefixed `transport_public_key` spelling.

Regression test reproduces the exact field failure (lead ensured last → `wired_to: {}`) and converges.

## Items 3 + 4 — filed as upstream asks 27 + 28

- **Ask 27**: `SendOutcome.acked=false` conflates "delivered, no ACK awaited" with "endpoint gone" — deliver-or-error at the comms tool seam, or a typed delivery receipt state.
- **Ask 28**: kickoff-scoped objective id + a pre-addressed "conclude the objective" affordance for leads (builds on asks 15/26) — replaces HomeCore's session-matching + quiescence-gate + empty-answer-hold machinery.

## Item 2 (analysis, no code) — post-kickoff reply refused

Raw error is comms `PeerNotFound` under HomeCore's own wrapper. No mobkit path removes peers post-kickoff (the implicit-delegate reaper is 300s-idle, delegates only; the shutdown quiesce runs only inside `shutdown()`). Most consistent trigger: their wind-down — gated on kickoff-interaction completion, which fires on the lead's FIRST turn (the ask-28 gap) — retires the lead while the builder still runs. Needs their gateway logs to close; if no wind-down precedes the refusal it becomes an upstream kickoff-lifecycle item.

## Item 5 (not a regression) — POST /rpc "empty" on 0.7.30

Verified empirically with the **released 0.7.29 binary**: the Rust gateway HTTP surface answers POST `/rpc` with the identical 404-empty on both versions (no `/rpc` route ever existed there; source-verified at both tags). The Python SDK's ASGI `/rpc` works on 0.7.30 (live probe: 200 + real result). Whatever answered on their 0.7.29 lived elsewhere in their stack.

Rides 0.7.31 (gated on meerkat 0.7.26 per Luka).

🤖 Generated with [Claude Code](https://claude.com/claude-code)