### PR TITLE
feat: live (realtime) member sessions through the gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    env:
+      # ~88 debug test binaries each statically link the full meerkat stack;
+      # with the 0.7.31 realtime deps aboard, full debuginfo blows past the
+      # runner disk even after the reclaim step (ENOSPC with 119GB free at
+      # job start). Line tables keep file:line backtraces at a fraction of
+      # the size; local builds are unaffected.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       # The workspace debug build (meerkat 0.7.25 dep tree + all test
       # binaries) plus the rust-cache restore no longer fits beside the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -406,6 +406,16 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -806,10 +816,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1011,6 +1042,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1214,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1192,6 +1243,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,9 +1276,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1684,6 +1753,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-gemini",
  "meerkat-hooks",
+ "meerkat-live",
  "meerkat-llm-core",
  "meerkat-mcp",
  "meerkat-memory",
@@ -1770,7 +1840,7 @@ checksum = "170685135e79de676a40e94647d80b768c99e32167631b59f48999be73fb1bc9"
 dependencies = [
  "inventory",
  "meerkat-core",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "strum",
 ]
@@ -1809,7 +1879,7 @@ dependencies = [
  "meerkat-skills",
  "parking_lot",
  "rand_core 0.6.4",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1836,7 +1906,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-schedule",
  "meerkat-workgraph",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "strum",
@@ -1860,7 +1930,7 @@ dependencies = [
  "js-sys",
  "jsonschema",
  "parking_lot",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2",
@@ -2062,7 +2132,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-skills",
  "rusqlite",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -2094,7 +2164,7 @@ dependencies = [
  "meerkat-session",
  "notify",
  "rusqlite",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2",
@@ -2122,7 +2192,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-mob",
  "meerkat-runtime",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2156,6 +2226,7 @@ dependencies = [
  "meerkat-comms",
  "meerkat-contracts",
  "meerkat-core",
+ "meerkat-live",
  "meerkat-mcp",
  "meerkat-memory",
  "meerkat-mob",
@@ -2171,7 +2242,7 @@ dependencies = [
  "reqwest 0.12.28",
  "ring",
  "rusqlite",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2213,11 +2284,13 @@ dependencies = [
  "meerkat-core",
  "meerkat-llm-core",
  "meerkat-models",
+ "oai-rt-rs",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tokio_with_wasm",
  "tracing",
 ]
@@ -2276,7 +2349,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-machine-schema",
  "meerkat-skills",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2384,7 +2457,7 @@ dependencies = [
  "nix 0.29.0",
  "parking_lot",
  "rusqlite",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "shlex",
@@ -2412,7 +2485,7 @@ dependencies = [
  "meerkat-machine-schema",
  "meerkat-skills",
  "rusqlite",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2",
@@ -2435,6 +2508,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2490,6 +2573,23 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2666,6 +2766,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oai-rt-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa624202cb21ad8d10f56124160a83b425564a4951d04c07837a0d060cd242f"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2867,49 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3162,17 +3325,23 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3183,6 +3352,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3260,7 +3430,7 @@ dependencies = [
  "process-wrap",
  "reqwest 0.13.4",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -3354,6 +3524,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3578,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,9 +3607,21 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -3426,6 +3641,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3789,6 +4027,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,6 +4205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3968,6 +4237,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -3975,7 +4260,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -4212,6 +4497,25 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -4231,6 +4535,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4274,6 +4584,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4520,7 +4836,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
@@ -4678,6 +4994,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/docs/design/live-sessions.md
+++ b/docs/design/live-sessions.md
@@ -1,0 +1,127 @@
+# Live (realtime) member sessions through the gateway
+
+Status: in progress on `feat/live-sessions` (2026-07-09). Target: mobkit
+0.7.31+. Consumer shape: a LAN client (HomeCore's robot, a satellite
+process) opens a realtime audio/text channel to a MOB MEMBER (identity
+target) and converses; tool calls flow through the member's normal tool
+surface (callback bridge + gating); the conversation persists into the
+member's durable transcript.
+
+## Upstream shape (meerkat 0.7.25, surveyed)
+
+- `meerkat-live` is deliberately embeddable: `LiveAdapterHost` (the
+  transport-side orchestrator) + an axum WS router
+  (`live_ws_router(Arc<LiveWsState>)`, path `/live/ws`) that mounts on any
+  existing `Router`. It has NO meerkat-runtime dependency; canonical
+  semantics arrive through two injected traits: `LiveProjectionSink` and
+  `LiveToolDispatcher`. WebRTC optional behind the `webrtc` feature.
+- The reference composition lives in the `meerkat-rpc` BINARY crate and is
+  NOT re-exported: `SessionServiceProjectionSink` (implements the sink +
+  `LiveChannelCloseFeedback` + `LiveChannelStatusFeedback` +
+  `LiveWsTokenAuthority`), `RuntimeLiveToolDispatcher`,
+  `handlers/live.rs` (the `live/*` RPC methods), and
+  `build_per_open_realtime_session_factory` (per-open credential
+  resolution). mobkit must port this glue.
+- Lifecycle authority is machine-owned: every open/close/status/token step
+  requires a non-forgeable authority minted by `MeerkatMachine` live
+  methods (`resolve_live_open_admission`, `resolve_live_close_result`,
+  `record_live_websocket_token_issued`,
+  `resolve_live_websocket_token_admission`, ...). All present in published
+  meerkat-runtime 0.7.25 under the `live` feature (mobkit already enables
+  it).
+- Session-scoped seams the sink needs are inherent methods on
+  `PersistentSessionService<B>`: `append_external_user_content`,
+  `append_external_assistant_output`, `append_realtime_transcript_event`,
+  `dispatch_external_tool_call`, `record_live_terminal_error`,
+  `record_live_output_audio_degraded`. Realtime transcript events commit
+  into the ONE canonical Session history through the same append-only save
+  path as normal turns (so the Bug B-2 rollback fix in
+  `ContinuitySessionStoreAdapter` covers live turns too).
+- Tool dispatch: `LiveToolDispatcher::dispatch_live_tool_call(session_id,
+  call)` → `dispatch_external_tool_call` → the session agent's NORMAL
+  external-tool dispatch. The gateway's `CallbackToolDispatcher` (and
+  composed recorder tools, and gating) apply to live turns unchanged. No
+  separate tool registry.
+- Tokens: single-use, 60s TTL, pinned to (token, channel). Bootstrap
+  returned by open: `{channel_id, transport: {type:"websocket", url,
+  token}, capabilities, continuity}`. Continuity is TranscriptOnly in
+  practice (no provider-native resume ships).
+- Credentials resolve PER OPEN via
+  `AgentFactory::build_openai_realtime_session_factory(config_source)`
+  where `RealtimeCurrentConfigSource` is just `async fn current_config() ->
+  Config`. Facade features required: `live` + `openai-realtime`. Only
+  `gpt-realtime-2` (OpenAI) is realtime-capable in the shipped catalog.
+
+## mobkit design
+
+New module `meerkat-mobkit/src/live_wiring.rs`:
+
+1. **`GatewayLiveProjectionSink<B: SessionAgentBuilder>`** — port of
+   meerkat-rpc's `SessionServiceProjectionSink`, holding
+   `Arc<PersistentSessionService<B>>` + `Arc<MeerkatMachine>` (the
+   gateway's existing `adapter` instance — one machine per process, same
+   one wired for image generation and the schedule host). Implements
+   `LiveProjectionSink`, `LiveChannelCloseFeedback`,
+   `LiveChannelStatusFeedback`, `LiveWsTokenAuthority`. Keeps the
+   pending-turn buffering semantics verbatim (per-(session, response_id)
+   display-text finals drained at TurnCompleted; spoken-transcript lane
+   commits via the realtime staging materializer; R6: mismatched
+   response_id never flushes another turn's transcript; fail-closed
+   delta identity via `LiveTranscriptIdentity::require_delta_identity`).
+2. **`GatewayLiveToolDispatcher<B>`** — `dispatch_external_tool_call` on
+   the service.
+3. **`GatewayLiveContext`** — `{host: Arc<LiveAdapterHost>, ws_state:
+   Arc<LiveWsState>, session_factory: Arc<dyn RealtimeSessionFactory>,
+   ws_base_url}` built by `attach_live(...)` in the gateway (persistent
+   mode only — live needs the runtime-backed service). The gateway merges
+   `meerkat_live::live_ws_router(ws_state)` onto the reference app router,
+   so the live WS shares the existing HTTP listener/port (HomeCore's
+   `app.py` proxy or direct LAN access both work).
+4. **Credential source**: `EnvRealtimeConfigSource` implementing
+   `RealtimeCurrentConfigSource` by returning the gateway's effective
+   `Config` (same `Config::default()` the agent builds use). Per-open
+   resolution then rides the session identity's auth binding or the
+   provider default (env `OPENAI_API_KEY`), matching text-model behavior.
+   Embedders with real config stores can swap the source later.
+5. **RPC surface** (unified stdin + console): `mobkit/live/open`,
+   `mobkit/live/status`, `mobkit/live/close`, `mobkit/live/refresh`,
+   `mobkit/live/send_input`, `mobkit/live/commit_input`,
+   `mobkit/live/interrupt`. Params accept an IDENTITY TARGET —
+   `{identity: "reachy"}` or `{member_id}` or raw `{session_id}` —
+   resolved via `resolve_bridge_session_id` + the roster `agent_identity`
+   label fallback (the same canonicalization class as
+   `/agents/{id}/events` and `cross_mob/peer_info`). Handlers are ports of
+   `meerkat-rpc/handlers/live.rs` against `GatewayLiveContext`. Methods
+   answer `-32050 live_unavailable` when the gateway has no live context
+   (ephemeral mode, or feature disabled).
+6. **Realtime model selection (v1)**: the member session's model decides
+   (profile `model = "gpt-realtime-2"` for a voice-first member). For
+   members whose text model differs, `mobkit/live/open` accepts an
+   optional `model` override forwarded into `RealtimeSessionOpenConfig`;
+   a per-profile `realtime_model` map can ride `runtime_options.live` in a
+   follow-up once field usage settles. (Deliberately NOT a mob.toml
+   profile field — profiles are upstream schema.)
+7. **Gating**: `runtime_options.live = true | {ws: true}` opt-in on
+   `mobkit/init` (default OFF). ABAC: live methods map to `agent.send` on
+   the target member (console surface); stdin surface is host-trusted as
+   usual.
+
+## What we deliberately do NOT do in v1
+
+- WebRTC (feature-gated upstream; WS covers the LAN robot).
+- Provider-native resume (upstream returns TranscriptOnly anyway).
+- Console UI affordance (phase 2, with the SDK methods).
+- A second listener/port: the WS mounts on the existing gateway HTTP app.
+
+## Test plan
+
+- Sink unit tests: delta identity fail-closed, pending-turn drain keyed by
+  response_id, terminal-error drain-all (ported assertions).
+- A `FakeRealtimeSessionFactory` (scripted `RealtimeSessionEvent`s) driving
+  an end-to-end open → observation → transcript-commit → close against a
+  real persistent service + machine, asserting the member session's
+  transcript contains the committed turn.
+- Token admission: minted token admits once on the right channel; replay
+  and cross-channel use rejected (machine-backed single-use).
+- RPC: identity-target resolution parity (identity/member alias/session id
+  spellings), live_unavailable off-state.

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -1935,6 +1935,68 @@ rust_test(
 )
 
 rust_test(
+    name = "gateway_live_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "gateway_live",
+    crate_root = "tests/gateway_live.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+    ],
+    srcs = [
+        "tests/gateway_live.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.7.30",
+        "CARGO_BIN_NAME": "gateway_live",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "live",
+    ],
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "gateway_memory_config_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -57,12 +57,15 @@ meerkat-mcp = "=0.7.25"
 meerkat-models = "=0.7.25"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.7.25", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store"] }
+meerkat = { version = "=0.7.25", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
 meerkat-memory = "=0.7.25"
+# Live (realtime) member sessions: `live_wiring` hosts the projection sink,
+# the WS transport state, and the mobkit/live/* handlers on top of this crate.
+meerkat-live = "=0.7.25"
 meerkat-runtime = { version = "=0.7.25", features = ["sqlite-store", "live"] }
 meerkat-session = { version = "=0.7.25", features = ["session-store"] }
 meerkat-store = { version = "=0.7.25", features = ["sqlite"] }

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -82,6 +82,23 @@ struct GatewayRuntimeOptions {
     /// WorkGraph service construction switch (default on). `false` disables
     /// the store, member tools, overlays, and the mobkit/workgraph/* RPCs.
     workgraph: GatewayWorkgraphOption,
+    /// Live (realtime) transport opt-in (default off). Persistent mode only.
+    live: GatewayLiveOption,
+}
+
+/// `runtime_options.live` wire forms: `true` mounts the live WebSocket
+/// transport on the gateway's HTTP listener with bootstrap URLs derived from
+/// the loopback base; `{"public_base_url": "ws://192.168.0.123:8080"}`
+/// additionally rewrites the minted bootstrap URLs for clients that reach
+/// the gateway through a proxy or a LAN address (the token/channel query
+/// parameters are appended to this base).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+enum GatewayLiveOption {
+    #[default]
+    Disabled,
+    Enabled {
+        public_base_url: Option<String>,
+    },
 }
 
 /// `runtime_options.workgraph` wire forms. Booleans keep the original
@@ -163,6 +180,7 @@ impl Default for GatewayRuntimeOptions {
             demo_llm: false,
             agent_memory: None,
             workgraph: GatewayWorkgraphOption::Enabled,
+            live: GatewayLiveOption::Disabled,
         }
     }
 }
@@ -1726,6 +1744,7 @@ fn parse_gateway_runtime_options(
         "implicit_delegate_idle_retire_secs",
         "implicit_delegate_idle_sweep_interval_ms",
         "workgraph",
+        "live",
     ];
     let unsupported = runtime_options
         .keys()
@@ -1820,6 +1839,33 @@ fn parse_gateway_runtime_options(
                 return Err(
                     "runtime_options.workgraph must be a boolean or a non-empty string \
                      (the directory for the durable workgraph store)"
+                        .to_string(),
+                );
+            }
+        };
+    }
+    if let Some(value) = runtime_options.get("live") {
+        parsed.live = match value {
+            Value::Bool(true) => GatewayLiveOption::Enabled {
+                public_base_url: None,
+            },
+            Value::Bool(false) => GatewayLiveOption::Disabled,
+            Value::Object(map) => {
+                let enabled = map.get("enabled").and_then(Value::as_bool).unwrap_or(true);
+                if enabled {
+                    GatewayLiveOption::Enabled {
+                        public_base_url: map
+                            .get("public_base_url")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                    }
+                } else {
+                    GatewayLiveOption::Disabled
+                }
+            }
+            _ => {
+                return Err(
+                    "runtime_options.live must be a boolean or an object                      ({enabled?, public_base_url?})"
                         .to_string(),
                 );
             }
@@ -3697,358 +3743,377 @@ external_addressable = true
     // Stable owner id for the schedule driver, captured before `definition` is
     // moved into the bootstrap spec.
     let schedule_owner_id = definition.id.to_string();
-    let (mob_spec, _temp_dir, schedule_host_inputs, transcript_edit_service, workgraph_service) =
-        if let Some(ref state_path) = persistent_state {
-            if let Err(e) = std::fs::create_dir_all(state_path) {
-                fail_init(
-                    &request_id,
-                    -32603,
-                    format!("failed to create persistent state directory: {e}"),
-                );
-            }
-            let sqlite_path = state_path.join("sessions.db");
-            let session_store: Arc<dyn meerkat::SessionStore> =
-                if let Some(adapter) = identity_session_store_adapter.clone() {
-                    adapter
-                } else {
-                    match meerkat_store::SqliteSessionStore::open(sqlite_path) {
-                        Ok(s) => Arc::new(s),
-                        Err(e) => fail_init(
-                            &request_id,
-                            -32603,
-                            format!("failed to open SQLite session store: {e}"),
-                        ),
-                    }
-                };
-            let mob_storage = MobStorage::in_memory();
-            let binary_blob_store: Arc<dyn BinaryBlobStore> =
-                match ObjectStoreBlobStore::local(state_path.join("blobs")) {
-                    Ok(store) => Arc::new(store),
+    let (
+        mob_spec,
+        _temp_dir,
+        schedule_host_inputs,
+        transcript_edit_service,
+        workgraph_service,
+        live_inputs,
+    ) = if let Some(ref state_path) = persistent_state {
+        if let Err(e) = std::fs::create_dir_all(state_path) {
+            fail_init(
+                &request_id,
+                -32603,
+                format!("failed to create persistent state directory: {e}"),
+            );
+        }
+        let sqlite_path = state_path.join("sessions.db");
+        let session_store: Arc<dyn meerkat::SessionStore> =
+            if let Some(adapter) = identity_session_store_adapter.clone() {
+                adapter
+            } else {
+                match meerkat_store::SqliteSessionStore::open(sqlite_path) {
+                    Ok(s) => Arc::new(s),
                     Err(e) => fail_init(
                         &request_id,
                         -32603,
-                        format!("failed to open binary blob store: {e}"),
+                        format!("failed to open SQLite session store: {e}"),
                     ),
-                };
-            let blob_store: Arc<dyn meerkat_core::BlobStore> =
-                Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
-            // Persistent runtime store at <state_path>/runtime.sqlite — must
-            // be Some() on the session service so archive/retire can mutate
-            // the authoritative session, and must be persistent so resume
-            // works across gateway restart.
-            let runtime_db_path = state_path.join("runtime.sqlite");
-            let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
-                match meerkat_runtime::store::SqliteRuntimeStore::new(&runtime_db_path) {
-                    Ok(store) => Arc::new(store),
-                    Err(err) => {
-                        tracing::warn!(
-                            path = %runtime_db_path.display(),
-                            error = %err,
-                            "failed to open SqliteRuntimeStore; falling back to InMemoryRuntimeStore. \
-                             Sessions will not survive process restart and archive operations may fail.",
-                        );
-                        Arc::new(meerkat_runtime::InMemoryRuntimeStore::new())
-                    }
-                };
-            let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
-                Arc::clone(&runtime_store),
-                Arc::clone(&blob_store),
-            ));
-            // Match the ephemeral path's capability mask — only comms is enabled
-            // by default. Apps control additional capabilities via their mob
-            // definition profiles, not the gateway factory.
-            let mut factory = AgentFactory::new(state_path)
-                .builtins(false)
-                .shell(shell)
-                .comms(true);
-            if image_generation {
-                factory = factory.with_image_generation_machine(adapter.clone());
-            }
-            let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
-            inner_builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
-                session_store.clone(),
-            )));
-            inner_builder.default_blob_store = Some(blob_store.clone());
-            // Attach meerkat's per-session schedule tools so SDK-hosted members whose
-            // profile sets tools.schedule=true get the meerkat_schedule_* surface (the
-            // slot lives on the inner FactoryAgentBuilder and propagates through the
-            // callback wrapper). The returned service backs the firing host spawned
-            // after the runtime boots — meerkat's runtime-backed host is now generic
-            // over the session builder, so scheduled sessions materialize through the
-            // SDK build callback and keep their identity-scoped tools.
-            let schedule_tools =
-                meerkat_mobkit::schedule_wiring::attach_schedule_tools_with_identity_targets(
-                    &inner_builder,
-                    state_path,
-                );
-            // WorkGraph: durable store beside the schedule store (or in the
-            // explicitly configured directory), realm scoped to the mob
-            // definition id. Fills the member tool slot, threads to the
-            // bootstrap spec (mob-executor attention overlays + child-mob
-            // inheritance), the schedule host, and the RPC surface. The
-            // state dir travels along for the cross-process admission
-            // sidecar (a durable store is shareable across processes).
-            let workgraph = match &gateway_options.workgraph {
-                GatewayWorkgraphOption::Disabled => None,
-                GatewayWorkgraphOption::Enabled => {
-                    meerkat_mobkit::workgraph_wiring::attach_workgraph_tools(
-                        &inner_builder,
-                        state_path,
-                        &schedule_owner_id,
-                    )
-                    .map(|(service, slot)| (service, slot, state_path.clone()))
-                }
-                GatewayWorkgraphOption::DurableDir(dir) => {
-                    // An explicit directory overrides the state-dir default.
-                    // Open failure keeps the boot-without-workgraph posture
-                    // (attach_workgraph_tools warns with the path).
-                    let _ = std::fs::create_dir_all(dir);
-                    meerkat_mobkit::workgraph_wiring::attach_workgraph_tools(
-                        &inner_builder,
-                        dir,
-                        &schedule_owner_id,
-                    )
-                    .map(|(service, slot)| (service, slot, dir.clone()))
                 }
             };
-            let workgraph_service = workgraph.as_ref().map(|(service, _, _)| service.clone());
-            let agent_mob_tools_slot = Arc::clone(&inner_builder.default_mob_tools);
-            let callback_builder = StdioCallbackAgentBuilder {
-                inner: inner_builder,
-                bridge: bridge.clone(),
-                has_session_builder,
-                session_store: Some(session_store.clone()),
-            };
-            // Keep the CONCRETE typed service for the firing host (the runtime-backed
-            // host needs PersistentSessionService<StdioCallbackAgentBuilder>, not the
-            // erased Arc<dyn MobSessionService> the spec consumes).
-            let concrete_service = Arc::new(meerkat_session::PersistentSessionService::new(
-                callback_builder,
-                gateway_options.max_sessions,
-                session_store,
-                Arc::clone(&runtime_store),
-                blob_store,
-            ));
-            let schedule_host_inputs = schedule_tools.map(|tools| {
-                (
-                    tools.service,
-                    tools.mob_target_registry,
-                    Arc::clone(&concrete_service),
-                    adapter.clone(),
-                    state_path.join(meerkat_mobkit::schedule_wiring::SCHEDULE_STORE_FILE),
-                )
-            });
-            // §8.6 Hygienist apply seam: the CONCRETE service implements
-            // meerkat's transcript-edit extension; the erased MobSessionService
-            // does not carry it, so the typed handle is kept here.
-            let transcript_edit_service: Option<
-                Arc<dyn meerkat_mobkit::memory::hygienist::TranscriptEditSessionService>,
-            > = Some(Arc::clone(&concrete_service) as _);
-            let session_service: Arc<dyn meerkat_mob::MobSessionService> = concrete_service;
-            let mut spec = MobBootstrapSpec::new(definition, mob_storage, session_service)
-                .with_session_runtime_adapter(adapter.clone())
-                // Order matters: workgraph before agent mob tools so child mobs
-                // inherit the service at mob-state install time.
-                .with_workgraph_service(workgraph_service.clone())
-                // Agent mob tools + the schedule host's mob authority (HomeCore
-                // 0.7.26 last-link fix): without this, agent-authored schedules
-                // can't rewrite to mob-member targets or deliver them.
-                .with_agent_mob_tools(agent_mob_tools_slot)
-                .with_options(MobBootstrapOptions {
-                    allow_ephemeral_sessions: true,
-                    notify_orchestrator_on_resume: true,
-                    default_llm_client: default_llm_client.clone(),
-                });
-            if let Some((_, admission_slot, workgraph_state_dir)) = &workgraph {
-                // Durable (cross-process shareable) store: register the
-                // tool-plane admission slot and the sidecar lock beside it.
-                spec = spec
-                    .with_workgraph_admission_slot(admission_slot.clone())
-                    .with_workgraph_admission_sidecar(workgraph_state_dir);
-            }
-            spec.runtime_adapter = Some(adapter);
-            spec.binary_blob_store = Some(binary_blob_store);
-            (
-                spec,
-                None,
-                schedule_host_inputs,
-                transcript_edit_service,
-                workgraph_service,
-            )
-        } else {
-            // Ephemeral mode (original behavior).
-            // Use MemoryStore to avoid JSONL writes — the gateway uses EphemeralSessionService
-            // so agent-level persistence is not needed. This avoids failures on read-only
-            // filesystems (e.g., GKE containers) where the default JSONL store can't write.
-            let temp_dir = if scratch_dir.is_none() {
-                Some(tempfile::tempdir().expect("create temp dir for agent working space"))
-            } else {
-                None
-            };
-            let agent_workspace = scratch_dir
-                .as_deref()
-                .or_else(|| temp_dir.as_ref().map(|dir| dir.path()))
-                .expect("scratch dir or temp dir");
-            if let Err(err) = std::fs::create_dir_all(agent_workspace) {
-                fail_init(
+        let mob_storage = MobStorage::in_memory();
+        let binary_blob_store: Arc<dyn BinaryBlobStore> =
+            match ObjectStoreBlobStore::local(state_path.join("blobs")) {
+                Ok(store) => Arc::new(store),
+                Err(e) => fail_init(
                     &request_id,
                     -32603,
-                    format!("failed to create scratch directory: {err}"),
-                );
-            }
-            let binary_blob_store: Arc<dyn BinaryBlobStore> =
-                Arc::new(ObjectStoreBlobStore::memory());
-            let blob_store: Arc<dyn meerkat_core::BlobStore> =
-                Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
-            let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
-                Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
-            let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
-                Arc::clone(&runtime_store),
-                Arc::clone(&blob_store),
-            ));
-            let mut factory = AgentFactory::new(agent_workspace)
-                .builtins(false)
-                .shell(shell)
-                .comms(true)
-                .session_store(Arc::new(meerkat::MemoryStore::new()));
-            if image_generation {
-                factory = factory.with_image_generation_machine(adapter.clone());
-            }
-            let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
-            inner_builder.default_blob_store = Some(blob_store.clone());
-            // No-persistent_state launches default to a memory-backed
-            // workgraph (tools stay profile-gated, so nothing changes for
-            // members that do not opt in); an explicit directory gets the
-            // durable store instead — and, being cross-process shareable, a
-            // cross-process admission sidecar beside it.
-            let mut workgraph_sidecar_dir: Option<PathBuf> = None;
-            let workgraph_service = match &gateway_options.workgraph {
-                GatewayWorkgraphOption::Disabled => None,
-                GatewayWorkgraphOption::DurableDir(dir) => {
-                    let _ = std::fs::create_dir_all(dir);
-                    workgraph_sidecar_dir = Some(dir.clone());
-                    meerkat_mobkit::workgraph_wiring::open_workgraph_service(
-                        dir,
-                        &schedule_owner_id,
-                    )
+                    format!("failed to open binary blob store: {e}"),
+                ),
+            };
+        let blob_store: Arc<dyn meerkat_core::BlobStore> =
+            Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
+        // Persistent runtime store at <state_path>/runtime.sqlite — must
+        // be Some() on the session service so archive/retire can mutate
+        // the authoritative session, and must be persistent so resume
+        // works across gateway restart.
+        let runtime_db_path = state_path.join("runtime.sqlite");
+        let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
+            match meerkat_runtime::store::SqliteRuntimeStore::new(&runtime_db_path) {
+                Ok(store) => Arc::new(store),
+                Err(err) => {
+                    tracing::warn!(
+                        path = %runtime_db_path.display(),
+                        error = %err,
+                        "failed to open SqliteRuntimeStore; falling back to InMemoryRuntimeStore. \
+                         Sessions will not survive process restart and archive operations may fail.",
+                    );
+                    Arc::new(meerkat_runtime::InMemoryRuntimeStore::new())
                 }
-                GatewayWorkgraphOption::Enabled => {
-                    if has_continuity_store {
-                        // Identity-first launch persisting through the
-                        // SDK-hosted continuity store: everything else about
-                        // it is durable, but the continuity store is a stdio
-                        // callback (no local db path to co-locate a default
-                        // workgraph.sqlite3 with), so the workgraph silently
-                        // rides memory unless a path is configured.
-                        tracing::warn!(
-                            "workgraph is MEMORY-BACKED for this launch: the continuity store \
+            };
+        let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
+            Arc::clone(&runtime_store),
+            Arc::clone(&blob_store),
+        ));
+        // Match the ephemeral path's capability mask — only comms is enabled
+        // by default. Apps control additional capabilities via their mob
+        // definition profiles, not the gateway factory.
+        let mut factory = AgentFactory::new(state_path)
+            .builtins(false)
+            .shell(shell)
+            .comms(true);
+        if image_generation {
+            factory = factory.with_image_generation_machine(adapter.clone());
+        }
+        // Live (realtime) needs the SAME factory shape for its per-open
+        // credential-resolving realtime session factory; clone before
+        // the builder consumes it.
+        let live_agent_factory = factory.clone();
+        let live_machine = Arc::clone(&adapter);
+        let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+        inner_builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
+            session_store.clone(),
+        )));
+        inner_builder.default_blob_store = Some(blob_store.clone());
+        // Attach meerkat's per-session schedule tools so SDK-hosted members whose
+        // profile sets tools.schedule=true get the meerkat_schedule_* surface (the
+        // slot lives on the inner FactoryAgentBuilder and propagates through the
+        // callback wrapper). The returned service backs the firing host spawned
+        // after the runtime boots — meerkat's runtime-backed host is now generic
+        // over the session builder, so scheduled sessions materialize through the
+        // SDK build callback and keep their identity-scoped tools.
+        let schedule_tools =
+            meerkat_mobkit::schedule_wiring::attach_schedule_tools_with_identity_targets(
+                &inner_builder,
+                state_path,
+            );
+        // WorkGraph: durable store beside the schedule store (or in the
+        // explicitly configured directory), realm scoped to the mob
+        // definition id. Fills the member tool slot, threads to the
+        // bootstrap spec (mob-executor attention overlays + child-mob
+        // inheritance), the schedule host, and the RPC surface. The
+        // state dir travels along for the cross-process admission
+        // sidecar (a durable store is shareable across processes).
+        let workgraph = match &gateway_options.workgraph {
+            GatewayWorkgraphOption::Disabled => None,
+            GatewayWorkgraphOption::Enabled => {
+                meerkat_mobkit::workgraph_wiring::attach_workgraph_tools(
+                    &inner_builder,
+                    state_path,
+                    &schedule_owner_id,
+                )
+                .map(|(service, slot)| (service, slot, state_path.clone()))
+            }
+            GatewayWorkgraphOption::DurableDir(dir) => {
+                // An explicit directory overrides the state-dir default.
+                // Open failure keeps the boot-without-workgraph posture
+                // (attach_workgraph_tools warns with the path).
+                let _ = std::fs::create_dir_all(dir);
+                meerkat_mobkit::workgraph_wiring::attach_workgraph_tools(
+                    &inner_builder,
+                    dir,
+                    &schedule_owner_id,
+                )
+                .map(|(service, slot)| (service, slot, dir.clone()))
+            }
+        };
+        let workgraph_service = workgraph.as_ref().map(|(service, _, _)| service.clone());
+        let agent_mob_tools_slot = Arc::clone(&inner_builder.default_mob_tools);
+        let callback_builder = StdioCallbackAgentBuilder {
+            inner: inner_builder,
+            bridge: bridge.clone(),
+            has_session_builder,
+            session_store: Some(session_store.clone()),
+        };
+        // Keep the CONCRETE typed service for the firing host (the runtime-backed
+        // host needs PersistentSessionService<StdioCallbackAgentBuilder>, not the
+        // erased Arc<dyn MobSessionService> the spec consumes).
+        let concrete_service = Arc::new(meerkat_session::PersistentSessionService::new(
+            callback_builder,
+            gateway_options.max_sessions,
+            session_store,
+            Arc::clone(&runtime_store),
+            blob_store,
+        ));
+        let schedule_host_inputs = schedule_tools.map(|tools| {
+            (
+                tools.service,
+                tools.mob_target_registry,
+                Arc::clone(&concrete_service),
+                adapter.clone(),
+                state_path.join(meerkat_mobkit::schedule_wiring::SCHEDULE_STORE_FILE),
+            )
+        });
+        // §8.6 Hygienist apply seam: the CONCRETE service implements
+        // meerkat's transcript-edit extension; the erased MobSessionService
+        // does not carry it, so the typed handle is kept here.
+        let transcript_edit_service: Option<
+            Arc<dyn meerkat_mobkit::memory::hygienist::TranscriptEditSessionService>,
+        > = Some(Arc::clone(&concrete_service) as _);
+        // Live (realtime) transport inputs: the concrete service +
+        // machine + factory, captured only on opt-in
+        // (`runtime_options.live`). Ephemeral mode cannot serve live —
+        // the projection sink and machine authorities are
+        // persistent-service seams.
+        let live_inputs = if matches!(gateway_options.live, GatewayLiveOption::Enabled { .. }) {
+            Some((
+                Arc::clone(&concrete_service),
+                live_machine,
+                live_agent_factory,
+            ))
+        } else {
+            None
+        };
+        let session_service: Arc<dyn meerkat_mob::MobSessionService> = concrete_service;
+        let mut spec = MobBootstrapSpec::new(definition, mob_storage, session_service)
+            .with_session_runtime_adapter(adapter.clone())
+            // Order matters: workgraph before agent mob tools so child mobs
+            // inherit the service at mob-state install time.
+            .with_workgraph_service(workgraph_service.clone())
+            // Agent mob tools + the schedule host's mob authority (HomeCore
+            // 0.7.26 last-link fix): without this, agent-authored schedules
+            // can't rewrite to mob-member targets or deliver them.
+            .with_agent_mob_tools(agent_mob_tools_slot)
+            .with_options(MobBootstrapOptions {
+                allow_ephemeral_sessions: true,
+                notify_orchestrator_on_resume: true,
+                default_llm_client: default_llm_client.clone(),
+            });
+        if let Some((_, admission_slot, workgraph_state_dir)) = &workgraph {
+            // Durable (cross-process shareable) store: register the
+            // tool-plane admission slot and the sidecar lock beside it.
+            spec = spec
+                .with_workgraph_admission_slot(admission_slot.clone())
+                .with_workgraph_admission_sidecar(workgraph_state_dir);
+        }
+        spec.runtime_adapter = Some(adapter);
+        spec.binary_blob_store = Some(binary_blob_store);
+        (
+            spec,
+            None,
+            schedule_host_inputs,
+            transcript_edit_service,
+            workgraph_service,
+            live_inputs,
+        )
+    } else {
+        // Ephemeral mode (original behavior).
+        // Use MemoryStore to avoid JSONL writes — the gateway uses EphemeralSessionService
+        // so agent-level persistence is not needed. This avoids failures on read-only
+        // filesystems (e.g., GKE containers) where the default JSONL store can't write.
+        let temp_dir = if scratch_dir.is_none() {
+            Some(tempfile::tempdir().expect("create temp dir for agent working space"))
+        } else {
+            None
+        };
+        let agent_workspace = scratch_dir
+            .as_deref()
+            .or_else(|| temp_dir.as_ref().map(|dir| dir.path()))
+            .expect("scratch dir or temp dir");
+        if let Err(err) = std::fs::create_dir_all(agent_workspace) {
+            fail_init(
+                &request_id,
+                -32603,
+                format!("failed to create scratch directory: {err}"),
+            );
+        }
+        let binary_blob_store: Arc<dyn BinaryBlobStore> = Arc::new(ObjectStoreBlobStore::memory());
+        let blob_store: Arc<dyn meerkat_core::BlobStore> =
+            Arc::new(Base64BlobStoreAdapter::new(binary_blob_store.clone()));
+        let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> =
+            Arc::new(meerkat_runtime::InMemoryRuntimeStore::new());
+        let adapter = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
+            Arc::clone(&runtime_store),
+            Arc::clone(&blob_store),
+        ));
+        let mut factory = AgentFactory::new(agent_workspace)
+            .builtins(false)
+            .shell(shell)
+            .comms(true)
+            .session_store(Arc::new(meerkat::MemoryStore::new()));
+        if image_generation {
+            factory = factory.with_image_generation_machine(adapter.clone());
+        }
+        let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+        inner_builder.default_blob_store = Some(blob_store.clone());
+        // No-persistent_state launches default to a memory-backed
+        // workgraph (tools stay profile-gated, so nothing changes for
+        // members that do not opt in); an explicit directory gets the
+        // durable store instead — and, being cross-process shareable, a
+        // cross-process admission sidecar beside it.
+        let mut workgraph_sidecar_dir: Option<PathBuf> = None;
+        let workgraph_service = match &gateway_options.workgraph {
+            GatewayWorkgraphOption::Disabled => None,
+            GatewayWorkgraphOption::DurableDir(dir) => {
+                let _ = std::fs::create_dir_all(dir);
+                workgraph_sidecar_dir = Some(dir.clone());
+                meerkat_mobkit::workgraph_wiring::open_workgraph_service(dir, &schedule_owner_id)
+            }
+            GatewayWorkgraphOption::Enabled => {
+                if has_continuity_store {
+                    // Identity-first launch persisting through the
+                    // SDK-hosted continuity store: everything else about
+                    // it is durable, but the continuity store is a stdio
+                    // callback (no local db path to co-locate a default
+                    // workgraph.sqlite3 with), so the workgraph silently
+                    // rides memory unless a path is configured.
+                    tracing::warn!(
+                        "workgraph is MEMORY-BACKED for this launch: the continuity store \
                              is SDK-hosted (no local path) and no persistent_state dir is set, \
                              so goals, work items and attention bindings will NOT survive a \
                              gateway restart. Set runtime_options.workgraph to a directory \
                              path (or provide persistent_state) to place a durable \
                              workgraph.sqlite3.",
-                        );
-                    }
-                    Some(
-                        meerkat_mobkit::workgraph_wiring::ephemeral_workgraph_service(
-                            &schedule_owner_id,
-                        ),
-                    )
+                    );
                 }
-            };
-            // One admission slot per builder that carries the tool surface;
-            // the bootstrap spec registers them all so every dispatcher gets
-            // the runtime-wide admission (round-3 R1).
-            let mut workgraph_admission_slots = Vec::new();
-            if let Some(service) = workgraph_service.as_ref() {
-                workgraph_admission_slots.push(
-                    meerkat_mobkit::workgraph_wiring::install_workgraph_tools(
-                        &inner_builder,
-                        service,
+                Some(
+                    meerkat_mobkit::workgraph_wiring::ephemeral_workgraph_service(
+                        &schedule_owner_id,
                     ),
-                );
+                )
             }
-            let callback_builder = StdioCallbackAgentBuilder {
-                inner: inner_builder,
-                bridge: bridge.clone(),
-                has_session_builder,
-                session_store: None,
-            };
-            let mut transcript_edit_service: Option<
-                Arc<dyn meerkat_mobkit::memory::hygienist::TranscriptEditSessionService>,
-            > = None;
-            let session_service: Arc<dyn meerkat_mob::MobSessionService> =
-                if let Some(session_adapter) = identity_session_store_adapter.clone() {
-                    let session_store: Arc<dyn meerkat::SessionStore> = session_adapter.clone();
-                    let mut factory = AgentFactory::new(agent_workspace)
-                        .builtins(false)
-                        .shell(shell)
-                        .comms(true)
-                        .session_store(Arc::new(meerkat::MemoryStore::new()));
-                    if image_generation {
-                        factory = factory.with_image_generation_machine(adapter.clone());
-                    }
-                    let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
-                    inner_builder.default_session_store = Some(Arc::new(
-                        meerkat_store::StoreAdapter::new(session_store.clone()),
-                    ));
-                    inner_builder.default_blob_store = Some(blob_store.clone());
-                    if let Some(service) = workgraph_service.as_ref() {
-                        workgraph_admission_slots.push(
-                            meerkat_mobkit::workgraph_wiring::install_workgraph_tools(
-                                &inner_builder,
-                                service,
-                            ),
-                        );
-                    }
-                    let callback_builder = StdioCallbackAgentBuilder {
-                        inner: inner_builder,
-                        bridge: bridge.clone(),
-                        has_session_builder,
-                        session_store: Some(session_store.clone()),
-                    };
-                    let concrete = Arc::new(meerkat_session::PersistentSessionService::new(
-                        callback_builder,
-                        gateway_options.max_sessions,
-                        session_store,
-                        Arc::clone(&runtime_store),
-                        blob_store.clone(),
-                    ));
-                    transcript_edit_service = Some(Arc::clone(&concrete) as _);
-                    concrete
-                } else {
-                    Arc::new(EphemeralSessionService::new(
-                        callback_builder,
-                        gateway_options.max_sessions,
-                    ))
-                };
-
-            let mut spec =
-                MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
-                    .with_session_runtime_adapter(adapter.clone())
-                    .with_workgraph_service(workgraph_service.clone())
-                    .with_options(MobBootstrapOptions {
-                        allow_ephemeral_sessions: true,
-                        notify_orchestrator_on_resume: true,
-                        default_llm_client: default_llm_client.clone(),
-                    });
-            for slot in workgraph_admission_slots {
-                spec = spec.with_workgraph_admission_slot(slot);
-            }
-            if let Some(dir) = workgraph_sidecar_dir.as_deref() {
-                spec = spec.with_workgraph_admission_sidecar(dir);
-            }
-            spec.runtime_adapter = Some(adapter);
-            spec.binary_blob_store = Some(binary_blob_store);
-            // Ephemeral sessions have no persistent service; firing is persistent-only.
-            (
-                spec,
-                temp_dir,
-                None,
-                transcript_edit_service,
-                workgraph_service,
-            )
         };
+        // One admission slot per builder that carries the tool surface;
+        // the bootstrap spec registers them all so every dispatcher gets
+        // the runtime-wide admission (round-3 R1).
+        let mut workgraph_admission_slots = Vec::new();
+        if let Some(service) = workgraph_service.as_ref() {
+            workgraph_admission_slots.push(
+                meerkat_mobkit::workgraph_wiring::install_workgraph_tools(&inner_builder, service),
+            );
+        }
+        let callback_builder = StdioCallbackAgentBuilder {
+            inner: inner_builder,
+            bridge: bridge.clone(),
+            has_session_builder,
+            session_store: None,
+        };
+        let mut transcript_edit_service: Option<
+            Arc<dyn meerkat_mobkit::memory::hygienist::TranscriptEditSessionService>,
+        > = None;
+        let session_service: Arc<dyn meerkat_mob::MobSessionService> =
+            if let Some(session_adapter) = identity_session_store_adapter.clone() {
+                let session_store: Arc<dyn meerkat::SessionStore> = session_adapter.clone();
+                let mut factory = AgentFactory::new(agent_workspace)
+                    .builtins(false)
+                    .shell(shell)
+                    .comms(true)
+                    .session_store(Arc::new(meerkat::MemoryStore::new()));
+                if image_generation {
+                    factory = factory.with_image_generation_machine(adapter.clone());
+                }
+                let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+                inner_builder.default_session_store = Some(Arc::new(
+                    meerkat_store::StoreAdapter::new(session_store.clone()),
+                ));
+                inner_builder.default_blob_store = Some(blob_store.clone());
+                if let Some(service) = workgraph_service.as_ref() {
+                    workgraph_admission_slots.push(
+                        meerkat_mobkit::workgraph_wiring::install_workgraph_tools(
+                            &inner_builder,
+                            service,
+                        ),
+                    );
+                }
+                let callback_builder = StdioCallbackAgentBuilder {
+                    inner: inner_builder,
+                    bridge: bridge.clone(),
+                    has_session_builder,
+                    session_store: Some(session_store.clone()),
+                };
+                let concrete = Arc::new(meerkat_session::PersistentSessionService::new(
+                    callback_builder,
+                    gateway_options.max_sessions,
+                    session_store,
+                    Arc::clone(&runtime_store),
+                    blob_store.clone(),
+                ));
+                transcript_edit_service = Some(Arc::clone(&concrete) as _);
+                concrete
+            } else {
+                Arc::new(EphemeralSessionService::new(
+                    callback_builder,
+                    gateway_options.max_sessions,
+                ))
+            };
+
+        let mut spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), session_service)
+            .with_session_runtime_adapter(adapter.clone())
+            .with_workgraph_service(workgraph_service.clone())
+            .with_options(MobBootstrapOptions {
+                allow_ephemeral_sessions: true,
+                notify_orchestrator_on_resume: true,
+                default_llm_client: default_llm_client.clone(),
+            });
+        for slot in workgraph_admission_slots {
+            spec = spec.with_workgraph_admission_slot(slot);
+        }
+        if let Some(dir) = workgraph_sidecar_dir.as_deref() {
+            spec = spec.with_workgraph_admission_sidecar(dir);
+        }
+        spec.runtime_adapter = Some(adapter);
+        spec.binary_blob_store = Some(binary_blob_store);
+        // Ephemeral sessions have no persistent service; firing is persistent-only.
+        (
+            spec,
+            temp_dir,
+            None,
+            transcript_edit_service,
+            workgraph_service,
+            None,
+        )
+    };
 
     // Wire callback/after_create — notify Python/TS SDK after each session creation.
     // Uses notify_reliable to avoid silent drops under backpressure.
@@ -4849,6 +4914,33 @@ external_addressable = true
         .unwrap_or_else(minimal_decision_state);
     decision_state.console.ui = gateway_options.console_ui.clone();
     let app = runtime.build_reference_app_router(decision_state);
+    // Live (realtime) transport: mount the live WebSocket router on the SAME
+    // HTTP listener the console uses (no second port — a LAN client or the
+    // host's reverse proxy reaches it at {base}/live/ws), and erase the
+    // live/* RPC handler over the gateway's concrete session-builder type
+    // for the stdin dispatch loop.
+    let (app, live_rpc) =
+        if let Some((live_service, live_machine, live_agent_factory)) = live_inputs {
+            let ws_base_url = match &gateway_options.live {
+                GatewayLiveOption::Enabled {
+                    public_base_url: Some(public),
+                } => public.trim_end_matches('/').to_string(),
+                _ => format!("ws://127.0.0.1:{port}"),
+            };
+            let live_ctx = Arc::new(meerkat_mobkit::live_wiring::attach_live(
+                Arc::clone(&live_service),
+                Arc::clone(&live_machine),
+                &live_agent_factory,
+                meerkat::Config::default(),
+                ws_base_url,
+            ));
+            let app = app.merge(meerkat_live::live_ws_router(Arc::clone(&live_ctx.ws_state)));
+            let handler =
+                meerkat_mobkit::live_wiring::live_rpc_handler(live_ctx, live_service, live_machine);
+            (app, Some(handler))
+        } else {
+            (app, None)
+        };
     let serve_task = tokio::spawn({
         let mut shutdown_rx = shutdown_rx.clone();
         async move {
@@ -4924,13 +5016,15 @@ external_addressable = true
             let stdout_tx = stdout_tx.clone();
             let identity_ctx = identity_ctx.clone();
             let http_base_url = http_base_url_shared.clone();
+            let live_rpc = live_rpc.clone();
             inflight.spawn(async move {
-                let response = handle_unified_rpc_json(
+                let response = meerkat_mobkit::rpc::handle_unified_rpc_json_with_live(
                     &runtime,
                     &request_line,
                     timeout,
                     Some(http_base_url.as_ref()),
                     identity_ctx.as_deref(),
+                    live_rpc.as_ref(),
                 )
                 .await;
                 if !response.is_empty() {

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -34,8 +34,7 @@ use meerkat_mobkit::{
     ObjectStoreBlobStore, PersistedEvent, PersistentMetadataStore, PreSpawnData, ReleaseMetadata,
     RestartPolicy, RuntimeDecisionState, RuntimeOpsPolicy, RuntimeOptions, RuntimeRoute,
     ScheduleDefinition, SqliteConsoleLogStore, SqliteMetadataStore, TrustedOidcRuntimeConfig,
-    UnifiedRuntime, handle_mobkit_rpc_json, handle_unified_rpc_json,
-    load_console_ui_config_from_path_for_realm,
+    UnifiedRuntime, handle_mobkit_rpc_json, load_console_ui_config_from_path_for_realm,
     mob_handle_runtime::{
         ensure_shell_tooling_build_substrate, mob_definition_may_use_image_generation,
         mob_definition_may_use_shell,

--- a/meerkat-mobkit/src/lib.rs
+++ b/meerkat-mobkit/src/lib.rs
@@ -19,6 +19,7 @@ pub mod http_auth;
 pub mod http_console;
 pub mod http_flow_editor;
 pub mod http_sse;
+pub mod live_wiring;
 pub mod member_comms_id;
 pub mod memory;
 pub mod memory_wiring;

--- a/meerkat-mobkit/src/live_wiring.rs
+++ b/meerkat-mobkit/src/live_wiring.rs
@@ -1,0 +1,2635 @@
+//! Live (realtime) member sessions through the mobkit gateways.
+//!
+//! Port of meerkat-rpc's `SessionServiceProjectionSink`
+//! (`meerkat-rpc/src/live_projection_sink.rs`), `RuntimeLiveToolDispatcher`
+//! (`router.rs`), the `live/*` handlers (`handlers/live.rs`, websocket arms
+//! only) and the per-open factory composition (`live_wiring.rs`) onto
+//! mobkit's `PersistentSessionService<B>` + `MeerkatMachine` pair. The
+//! reference composition lives in the meerkat-rpc BINARY crate and is not
+//! re-exported, so mobkit carries this glue itself (design:
+//! `docs/design/live-sessions.md`).
+//!
+//! Translation map vs the reference:
+//! - `SessionRuntime::runtime_adapter()` → the gateway's `MeerkatMachine`
+//!   (the same one wired for schedules and image generation — one machine
+//!   per process, machine-owned live lifecycle authority).
+//! - `SessionRuntime::<session seam>` → the same-named inherent method on
+//!   `PersistentSessionService<B>` (`append_realtime_transcript_event`,
+//!   `append_external_user_content`, `append_external_assistant_output`,
+//!   `dispatch_external_tool_call`); `record_live_terminal_error` /
+//!   `record_live_output_audio_degraded` route through the `SessionService`
+//!   trait impl the persistent service overrides.
+//! - `interrupt_live_with_machine_authority` →
+//!   `interrupt_with_machine_authority(id, machine.session_control_authority())`.
+//! - `in_flight_realtime_assistant_response_ids` →
+//!   `load_authoritative_session` + the `Session` accessor.
+//! - `live_open_config_for_session` → rebuilt here from the published
+//!   `PersistentSessionService` snapshot seams + the facade's pub
+//!   `realtime_projection_*` free functions. The reference additionally
+//!   recovers archived/staged sessions before projecting
+//!   (`recover_live_session_for_realtime_open`); mobkit member sessions are
+//!   held live by the bridge, so an archived target surfaces as a typed
+//!   not-found instead of being silently resumed.
+//! - `ensure_live_peer_ingress` has no mobkit equivalent: member comms
+//!   ingress is wired at member build time by the mob runtime, not lazily
+//!   per live open.
+//!
+//! Everything else is kept verbatim: the pending-turn buffer keyed on
+//! `(SessionId, response_id)` (R6), the display-text vs spoken-transcript
+//! lane split (T6/CC2/CC3), fail-closed delta identity (#199), the
+//! `LiveProjectionError::from_session_error` classification, and the
+//! machine-authority-first shape of every handler (no public result or
+//! error class is minted surface-side).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+use meerkat::AgentFactory;
+use meerkat::session_runtime::LiveOpenPrecheckError;
+use meerkat::session_runtime::live_orchestration::{
+    precheck_identity, realtime_projection_messages, realtime_projection_root_system_message,
+    realtime_projection_runtime_system_context,
+};
+use meerkat::session_runtime::realtime_credentials::RealtimeCurrentConfigSource;
+use meerkat_client::realtime_session::{RealtimeSessionFactory, RealtimeSessionOpenConfig};
+use meerkat_contracts::{
+    LiveChannelParams, LiveCloseResult, LiveCommitInputParams, LiveCommitInputResult,
+    LiveInterruptResult, LiveOpenResult, LiveOpenTransport, LiveRefreshResult, LiveSendInputParams,
+    LiveSendInputResult, LiveStatusResult, RealtimeCapabilities, RealtimeTurningMode,
+    WireLiveAdapterStatus, WireLiveDegradationReason,
+};
+use meerkat_core::live_adapter::{
+    LiveAdapterCommand, LiveAdapterErrorCode, LiveAudioConfig, LiveChannelCapabilities,
+    LiveContinuityMode, LiveProjectionSnapshot, LiveTransportBootstrap,
+};
+use meerkat_core::service::SessionService as _;
+use meerkat_core::types::{AssistantBlock, ContentInput, Message, SessionId, StopReason, Usage};
+use meerkat_core::{Config, ConfigError, RealtimeTranscriptEvent};
+use meerkat_live::{
+    LiveAdapterHost, LiveAdapterHostError, LiveChannelCloseFeedback, LiveChannelCloseObservation,
+    LiveChannelId, LiveChannelStatusFeedback, LiveChannelStatusObservation, LiveProjectionError,
+    LiveProjectionSink, LiveTokenString, LiveToolDispatcher, LiveTranscriptIdentity,
+    LiveTranscriptIdentityError, LiveWsState, LiveWsTokenAdmission,
+    LiveWsTokenAdmissionPublicErrorClass, LiveWsTokenAdmissionRejection, LiveWsTokenAuthority,
+    LiveWsTokenIssue, live_input_chunk_from_wire,
+};
+use meerkat_runtime::MeerkatMachine;
+use meerkat_session::{PersistentSessionService, SessionAgentBuilder};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::rpc::{JSONRPC_VERSION, JsonRpcError, JsonRpcResponse};
+
+/// JSON-RPC error code for live methods invoked on a gateway with no live
+/// context (ephemeral mode, or live disabled at init). The CALLER owns this
+/// arm — `handle_live_method` is only reachable with a live context — but
+/// the code and the `data.kind` discriminator live here so every surface
+/// answers identically.
+pub const LIVE_UNAVAILABLE_CODE: i64 = -32050;
+
+/// `data.kind` discriminator carried by [`live_unavailable_response`].
+pub const LIVE_UNAVAILABLE_KIND: &str = "live_unavailable";
+
+const INVALID_PARAMS_CODE: i64 = -32602;
+const METHOD_NOT_FOUND_CODE: i64 = -32601;
+const INTERNAL_ERROR_CODE: i64 = -32000;
+
+/// One buffered assistant **display-text** fragment awaiting an
+/// authoritative `signal_turn_completed` flush.
+///
+/// CC2/CC3 (upstream Round-4 reconciliation, kept verbatim): the production
+/// assistant-transcript commit path is canonical via the realtime-staging
+/// pipeline (`append_realtime_transcript_event` → session staging →
+/// materializer flush at `AssistantTurnCompleted`). The buffered-final path
+/// retained here covers **only** the display-text lane: spoken transcript
+/// commits through staging (buffering it here would commit twice), and
+/// display text keeps this lane because no typed `AssistantTextFinal`
+/// observation exists upstream yet.
+#[derive(Debug, Clone)]
+enum PendingAssistantContent {
+    /// Display lane — flushes as `AssistantBlock::Text`.
+    Text(String),
+}
+
+#[derive(Debug, Default)]
+struct PendingTurn {
+    /// Display-text fragments in arrival order. Consecutive fragments
+    /// coalesce into a single `AssistantBlock::Text` at flush time.
+    blocks: Vec<PendingAssistantContent>,
+}
+
+/// Per-(session, response_id) buffer of assistant finals awaiting an
+/// authoritative `TurnCompleted`.
+///
+/// R6: keyed by `(SessionId, Option<String>)` where the second element is
+/// the provider's `response_id`. Keyed only on `SessionId`, an interrupted,
+/// stale, or overlapping `response.done` carrying the next turn's
+/// `stop_reason`/`usage` would flush the wrong buffered transcript. Orphan
+/// completions (no `response_id` from the provider) bucket under the same
+/// `None` slot, preserving legacy behaviour for adapters without response
+/// identity. Extracted from the sink so the keying contract is unit-testable
+/// without a `PersistentSessionService`.
+#[derive(Default)]
+struct PendingTurnLedger {
+    /// The lock is held only for short, sync sections — never across
+    /// `.await`.
+    slots: StdMutex<HashMap<(SessionId, Option<String>), PendingTurn>>,
+}
+
+impl PendingTurnLedger {
+    fn buffer(
+        &self,
+        session_id: &SessionId,
+        response_id: Option<&str>,
+        content: PendingAssistantContent,
+    ) {
+        let Ok(mut slots) = self.slots.lock() else {
+            // Lock poisoning would mean a previous panic in this struct; the
+            // only operations holding the guard are short sync reads/writes.
+            // Falling through silently preserves the prior buffer rather
+            // than breaking the in-flight turn.
+            return;
+        };
+        slots
+            .entry((session_id.clone(), response_id.map(ToString::to_string)))
+            .or_default()
+            .blocks
+            .push(content);
+    }
+
+    /// Drain the matching slot at turn-completed time.
+    ///
+    /// R6: callers must pass the same `response_id` they buffered under so
+    /// the matching slot drains; mismatched ids leave the buffer alone — a
+    /// stale/overlapping `response.done` cannot flush a different turn's
+    /// transcript.
+    fn drain(&self, session_id: &SessionId, response_id: Option<&str>) -> PendingTurn {
+        let Ok(mut slots) = self.slots.lock() else {
+            return PendingTurn::default();
+        };
+        slots
+            .remove(&(session_id.clone(), response_id.map(ToString::to_string)))
+            .unwrap_or_default()
+    }
+
+    /// Drain every slot for `session_id` regardless of `response_id`.
+    ///
+    /// Used on terminal error: when the channel is torn down every buffered
+    /// final becomes non-canonical, so per-response keying does not need to
+    /// be honoured for cleanup.
+    fn drain_all(&self, session_id: &SessionId) {
+        let Ok(mut slots) = self.slots.lock() else {
+            return;
+        };
+        slots.retain(|(sid, _resp), _| sid != session_id);
+    }
+}
+
+/// Bridges [`LiveProjectionSink`] callbacks (plus the transport feedback and
+/// WS-token-authority seams) into the gateway's persistent session service
+/// and machine. Port of meerkat-rpc's `SessionServiceProjectionSink`.
+pub struct GatewayLiveProjectionSink<B: SessionAgentBuilder + 'static> {
+    service: Arc<PersistentSessionService<B>>,
+    machine: Arc<MeerkatMachine>,
+    pending_turns: PendingTurnLedger,
+}
+
+impl<B: SessionAgentBuilder + 'static> GatewayLiveProjectionSink<B> {
+    pub fn new(service: Arc<PersistentSessionService<B>>, machine: Arc<MeerkatMachine>) -> Self {
+        Self {
+            service,
+            machine,
+            pending_turns: PendingTurnLedger::default(),
+        }
+    }
+}
+
+/// Build the realtime-transcript event the sink stages on the
+/// **display-text** lane. Extracted so unit tests can assert the exact event
+/// shape without a service.
+///
+/// #199: the required delta identity triple (`response_id` / `delta_id` /
+/// `item_id`) resolves through the canonical fail-closed accessor
+/// [`LiveTranscriptIdentity::require_delta_identity`]; a delta missing any
+/// required id yields a typed [`LiveTranscriptIdentityError`] so the
+/// projection rejects the malformed delta instead of emitting empty-string
+/// identity truth.
+fn build_assistant_text_delta_event(
+    delta: &str,
+    identity: LiveTranscriptIdentity<'_>,
+) -> Result<RealtimeTranscriptEvent, LiveTranscriptIdentityError> {
+    let resolved = identity.require_delta_identity()?;
+    Ok(RealtimeTranscriptEvent::AssistantTextDelta {
+        response_id: resolved.response_id.to_string(),
+        delta_id: resolved.delta_id.to_string(),
+        item_id: resolved.item_id.to_string(),
+        previous_item_id: resolved.previous_item_id.map(ToString::to_string),
+        content_index: resolved.content_index.unwrap_or(0),
+        delta: delta.to_string(),
+    })
+}
+
+/// Build the realtime-transcript event the sink stages on the
+/// **spoken-transcript** lane (T9/T10: the dedicated
+/// `AssistantTranscriptDelta` variant, so the materializer flushes
+/// `AssistantBlock::Transcript { source: Spoken }` rather than `Text`).
+fn build_assistant_transcript_delta_event(
+    delta: &str,
+    identity: LiveTranscriptIdentity<'_>,
+) -> Result<RealtimeTranscriptEvent, LiveTranscriptIdentityError> {
+    let resolved = identity.require_delta_identity()?;
+    Ok(RealtimeTranscriptEvent::AssistantTranscriptDelta {
+        response_id: resolved.response_id.to_string(),
+        delta_id: resolved.delta_id.to_string(),
+        item_id: resolved.item_id.to_string(),
+        previous_item_id: resolved.previous_item_id.map(ToString::to_string),
+        content_index: resolved.content_index.unwrap_or(0),
+        delta: delta.to_string(),
+    })
+}
+
+/// A malformed delta (missing required identity) is a projection rejection,
+/// not an internal fault: it lands in [`LiveProjectionError::Rejected`],
+/// mirroring the `SessionError::Unsupported` classification.
+fn identity_error_to_projection(err: LiveTranscriptIdentityError) -> LiveProjectionError {
+    LiveProjectionError::Rejected(err.to_string())
+}
+
+/// Collapse arrival-order display-text fragments into a single
+/// `AssistantBlock::Text` (or empty list if no fragments were buffered).
+fn collapse_pending_blocks(buffered: Vec<PendingAssistantContent>) -> Vec<AssistantBlock> {
+    if buffered.is_empty() {
+        return Vec::new();
+    }
+    let mut acc = String::new();
+    for PendingAssistantContent::Text(fragment) in buffered {
+        acc.push_str(&fragment);
+    }
+    vec![AssistantBlock::Text {
+        text: acc,
+        meta: None,
+    }]
+}
+
+/// Classify a [`meerkat_core::SessionError`] through the single canonical
+/// classification owner [`LiveProjectionError::from_session_error`] so every
+/// variant lands in a distinct typed `LiveProjectionError` — no variant is
+/// collapsed into a prose-only `Internal(to_string())` at this surface.
+fn session_error_to_projection(
+    err: meerkat_core::SessionError,
+    id: &SessionId,
+) -> LiveProjectionError {
+    LiveProjectionError::from_session_error(id, err)
+}
+
+#[async_trait]
+impl<B: SessionAgentBuilder + 'static> LiveChannelCloseFeedback for GatewayLiveProjectionSink<B> {
+    async fn record_live_channel_closed(
+        &self,
+        channel_id: &LiveChannelId,
+        observation: &LiveChannelCloseObservation,
+    ) -> Result<meerkat_live::LiveChannelCloseCommitAuthority, String> {
+        let session_id = self
+            .machine
+            .live_session_for_active_channel(channel_id)
+            .await
+            .ok_or_else(|| {
+                format!("generated live active-channel authority absent for channel {channel_id}")
+            })?;
+        self.machine
+            .resolve_live_close_result(&session_id, observation)
+            .await
+            .map_err(|err| err.to_string())?
+            .into_channel_close_commit_authority()
+            .ok_or_else(|| {
+                format!(
+                    "generated live close authority omitted host commit handoff for channel {channel_id}"
+                )
+            })
+    }
+}
+
+#[async_trait]
+impl<B: SessionAgentBuilder + 'static> LiveChannelStatusFeedback for GatewayLiveProjectionSink<B> {
+    async fn record_live_channel_status(
+        &self,
+        channel_id: &LiveChannelId,
+        observation: &LiveChannelStatusObservation,
+    ) -> Result<meerkat_live::LiveChannelStatusCommitAuthority, String> {
+        if observation.channel_id() != channel_id.as_str() {
+            return Err(format!(
+                "generated live status observation channel mismatch: observed {}, requested {}",
+                observation.channel_id(),
+                channel_id
+            ));
+        }
+        let session_id = self
+            .machine
+            .live_session_for_status_channel(channel_id)
+            .await
+            .ok_or_else(|| {
+                format!("generated live status-channel authority absent for channel {channel_id}")
+            })?;
+        self.machine
+            .resolve_live_channel_status_result(&session_id, observation)
+            .await
+            .map_err(|err| err.to_string())?
+            .into_channel_status_commit_authority()
+            .ok_or_else(|| {
+                format!(
+                    "generated live status authority omitted host commit handoff for channel {channel_id}"
+                )
+            })
+    }
+}
+
+#[async_trait]
+impl<B: SessionAgentBuilder + 'static> LiveWsTokenAuthority for GatewayLiveProjectionSink<B> {
+    async fn record_live_ws_token_issued(
+        &self,
+        session_id: &SessionId,
+        channel_id: &LiveChannelId,
+        token: &LiveTokenString,
+        issued_at_ms: u64,
+        ttl_ms: u64,
+    ) -> Result<LiveWsTokenIssue, String> {
+        let authority = self
+            .machine
+            .record_live_websocket_token_issued(
+                session_id,
+                channel_id,
+                token.as_str(),
+                issued_at_ms,
+                ttl_ms,
+            )
+            .await
+            .map_err(|err| err.to_string())?;
+        let token = LiveTokenString::new(authority.token).map_err(|err| err.to_string())?;
+        Ok(LiveWsTokenIssue {
+            token,
+            expires_at_ms: authority.expires_at_ms,
+            sequence: authority.sequence,
+        })
+    }
+
+    async fn resolve_live_ws_token_admission(
+        &self,
+        channel_id: &LiveChannelId,
+        token: &str,
+        observed_at_ms: u64,
+    ) -> Result<LiveWsTokenAdmission, String> {
+        // Admission resolves against the token's OWNING session when the
+        // machine knows the token; otherwise against the channel's bound
+        // session; otherwise through the unbound rejection path. All three
+        // arms end in generated machine authority — the transport never
+        // decides token facts.
+        let token_owner = self.machine.live_session_for_websocket_token(token).await;
+        let authority = match token_owner {
+            Some(session_id) => {
+                self.machine
+                    .resolve_live_websocket_token_admission(
+                        &session_id,
+                        channel_id,
+                        token,
+                        observed_at_ms,
+                    )
+                    .await
+            }
+            None => match self
+                .machine
+                .live_session_for_active_channel(channel_id)
+                .await
+            {
+                Some(session_id) => {
+                    self.machine
+                        .resolve_live_websocket_token_admission(
+                            &session_id,
+                            channel_id,
+                            token,
+                            observed_at_ms,
+                        )
+                        .await
+                }
+                None => {
+                    self.machine
+                        .resolve_unbound_live_websocket_token_admission(
+                            channel_id,
+                            token,
+                            observed_at_ms,
+                        )
+                        .await
+                }
+            },
+        }
+        .map_err(|err| err.to_string())?;
+
+        Ok(LiveWsTokenAdmission {
+            channel_id: channel_id.clone(),
+            admitted: authority.admitted,
+            rejection: authority
+                .rejection
+                .map(live_ws_token_admission_rejection_from_machine),
+            public_error_class: authority
+                .public_error_class
+                .map(live_ws_token_public_error_class_from_machine),
+            sequence: authority.sequence,
+        })
+    }
+}
+
+fn live_ws_token_admission_rejection_from_machine(
+    rejection: meerkat_runtime::meerkat_machine::dsl::LiveWebsocketTokenAdmissionRejection,
+) -> LiveWsTokenAdmissionRejection {
+    use meerkat_runtime::meerkat_machine::dsl::LiveWebsocketTokenAdmissionRejection as Dsl;
+    match rejection {
+        Dsl::TokenNotFound => LiveWsTokenAdmissionRejection::TokenNotFound,
+        Dsl::TokenExpired => LiveWsTokenAdmissionRejection::TokenExpired,
+        Dsl::TokenChannelMismatch => LiveWsTokenAdmissionRejection::TokenChannelMismatch,
+        Dsl::TokenAlreadyConsumed => LiveWsTokenAdmissionRejection::TokenAlreadyConsumed,
+        Dsl::ChannelNotBound => LiveWsTokenAdmissionRejection::ChannelNotBound,
+    }
+}
+
+fn live_ws_token_public_error_class_from_machine(
+    public_error_class: meerkat_runtime::meerkat_machine::dsl::LiveWebsocketTokenAdmissionPublicErrorClass,
+) -> LiveWsTokenAdmissionPublicErrorClass {
+    use meerkat_runtime::meerkat_machine::dsl::LiveWebsocketTokenAdmissionPublicErrorClass as Dsl;
+    match public_error_class {
+        Dsl::InvalidToken => LiveWsTokenAdmissionPublicErrorClass::InvalidToken,
+    }
+}
+
+#[async_trait]
+impl<B: SessionAgentBuilder + 'static> LiveProjectionSink for GatewayLiveProjectionSink<B> {
+    async fn append_user_transcript(
+        &self,
+        session_id: &SessionId,
+        text: &str,
+        identity: LiveTranscriptIdentity<'_>,
+    ) -> Result<(), LiveProjectionError> {
+        // P2#1: with a stable `provider_item_id`, route through the typed
+        // realtime transcript seam so its idempotent ordering / dedup owns
+        // the canonical commit (duplicate provider finals collapse by
+        // item_id + content_index instead of producing duplicate user turns).
+        if let Some(item_id) = identity.provider_item_id {
+            let event = RealtimeTranscriptEvent::UserTranscriptFinal {
+                item_id: item_id.to_string(),
+                previous_item_id: identity.previous_item_id.map(ToString::to_string),
+                content_index: identity.content_index.unwrap_or(0),
+                text: text.to_string(),
+            };
+            return self
+                .service
+                .append_realtime_transcript_event(session_id, event)
+                .await
+                .map(|_outcome| ())
+                .map_err(|err| session_error_to_projection(err, session_id));
+        }
+
+        // Legacy fallback: providers without a stable item id cannot be
+        // deduplicated by the realtime layer, so commit directly into
+        // canonical history.
+        self.service
+            .append_external_user_content(session_id, ContentInput::Text(text.to_string()))
+            .await
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn append_assistant_text_delta(
+        &self,
+        session_id: &SessionId,
+        delta: &str,
+        identity: LiveTranscriptIdentity<'_>,
+    ) -> Result<(), LiveProjectionError> {
+        // A3/A11/T6: display-text delta lane, staged through the typed
+        // realtime seam with the full identity tuple.
+        let event = build_assistant_text_delta_event(delta, identity)
+            .map_err(identity_error_to_projection)?;
+        self.service
+            .append_realtime_transcript_event(session_id, event)
+            .await
+            .map(|_outcome| ())
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn append_assistant_transcript_delta(
+        &self,
+        session_id: &SessionId,
+        delta: &str,
+        identity: LiveTranscriptIdentity<'_>,
+    ) -> Result<(), LiveProjectionError> {
+        // T6/T9/T10: spoken-transcript delta lane; the staging site tags the
+        // owning item `TranscriptLane::Spoken` so the materializer flushes
+        // `AssistantBlock::Transcript { source: Spoken }`.
+        let event = build_assistant_transcript_delta_event(delta, identity)
+            .map_err(identity_error_to_projection)?;
+        self.service
+            .append_realtime_transcript_event(session_id, event)
+            .await
+            .map(|_outcome| ())
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn append_assistant_text_final(
+        &self,
+        session_id: &SessionId,
+        text: &str,
+        _identity: LiveTranscriptIdentity<'_>,
+        _stop_reason: StopReason,
+        _usage: Usage,
+        response_id: Option<&str>,
+    ) -> Result<(), LiveProjectionError> {
+        // P1#1 + T6: buffer display-text finals on the per-(session,
+        // response_id) slot; `signal_turn_completed` drains and flushes with
+        // the authoritative stop_reason/usage (the values stamped on this
+        // event are provider best-effort sentinels). Display text is
+        // preserved across barge-in (T7).
+        self.pending_turns.buffer(
+            session_id,
+            response_id,
+            PendingAssistantContent::Text(text.to_string()),
+        );
+        Ok(())
+    }
+
+    async fn append_assistant_transcript_final(
+        &self,
+        session_id: &SessionId,
+        text: &str,
+        identity: LiveTranscriptIdentity<'_>,
+        _stop_reason: StopReason,
+        _usage: Usage,
+        response_id: Option<&str>,
+    ) -> Result<(), LiveProjectionError> {
+        // R5-7: forward the authoritative final transcript text into the
+        // realtime-staging pipeline. The materializer respects barge-in
+        // discards, creates the staged item for final-only providers,
+        // promotes the lane to Spoken, and REPLACES the staged segment with
+        // this authoritative text (repairing dropped deltas).
+        // `stop_reason`/`usage` are ignored here — the canonical values
+        // arrive atomically with `TurnCompleted`. The identity-carried
+        // `response_id` takes precedence over the arg form; empty ids are
+        // rejected downstream by the materializer as a typed Rejected.
+        let response_id = identity
+            .response_id
+            .map(ToString::to_string)
+            .or_else(|| response_id.map(ToString::to_string))
+            .unwrap_or_default();
+        let event = RealtimeTranscriptEvent::AssistantTranscriptFinalText {
+            response_id,
+            item_id: identity
+                .provider_item_id
+                .map(ToString::to_string)
+                .unwrap_or_default(),
+            content_index: identity.content_index.unwrap_or(0),
+            text: text.to_string(),
+        };
+        self.service
+            .append_realtime_transcript_event(session_id, event)
+            .await
+            .map(|_outcome| ())
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn truncate_assistant_transcript(
+        &self,
+        session_id: &SessionId,
+        provider_item_id: Option<&str>,
+        _previous_item_id: Option<&str>,
+        content_index: Option<u32>,
+        response_id: Option<&str>,
+        text: Option<&str>,
+    ) -> Result<(), LiveProjectionError> {
+        // P1#3: never fabricate empty identity — the realtime layer rejects
+        // empty response_ids, which made the pre-fix projection inert.
+        // Surface a typed Rejected when the provider genuinely omitted the
+        // id (a provider-fact gap, not a silently-dropped event).
+        let Some(response_id) = response_id else {
+            return Err(LiveProjectionError::Rejected(
+                "AssistantTranscriptTruncated missing response_id from adapter".to_string(),
+            ));
+        };
+        let Some(item_id) = provider_item_id else {
+            return Err(LiveProjectionError::Rejected(
+                "AssistantTranscriptTruncated missing provider_item_id from adapter".to_string(),
+            ));
+        };
+        let event = RealtimeTranscriptEvent::AssistantTranscriptTruncated {
+            response_id: response_id.to_string(),
+            item_id: item_id.to_string(),
+            content_index: content_index.unwrap_or(0),
+            text: text.unwrap_or_default().to_string(),
+        };
+        self.service
+            .append_realtime_transcript_event(session_id, event)
+            .await
+            .map(|_outcome| ())
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn signal_turn_interrupt(
+        &self,
+        session_id: &SessionId,
+        response_id: Option<&str>,
+    ) -> Result<(), LiveProjectionError> {
+        // A6/CC4: barge-in coordinates ACROSS the two layers holding
+        // in-flight transcript state — (1) the realtime-staging pipeline,
+        // where `AssistantTurnInterrupted` must be synthesized for every
+        // in-flight response so staged deltas do not survive into the next
+        // turn's materializer sweep, and (2) the buffered display-text path,
+        // which is preserved (the user is not "speaking over" written
+        // output). G4: the observation-carried `response_id` is
+        // authoritative even before any delta staged; the fallback discovers
+        // every staged in-flight response id, and the two sources union.
+        let mut response_ids: Vec<String> = Vec::new();
+        if let Some(rid) = response_id.filter(|s| !s.is_empty()) {
+            response_ids.push(rid.to_string());
+        }
+        match self.service.load_authoritative_session(session_id).await {
+            Ok(Some(session)) => {
+                for id in session.in_flight_realtime_assistant_response_ids() {
+                    if !response_ids.contains(&id) {
+                        response_ids.push(id);
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(
+                meerkat_core::SessionError::NotFound { .. }
+                | meerkat_core::SessionError::Unsupported(_),
+            ) => {}
+            Err(err) => return Err(session_error_to_projection(err, session_id)),
+        }
+        for rid in response_ids {
+            let event = RealtimeTranscriptEvent::AssistantTurnInterrupted { response_id: rid };
+            match self
+                .service
+                .append_realtime_transcript_event(session_id, event)
+                .await
+            {
+                Ok(_) => {}
+                Err(
+                    meerkat_core::SessionError::NotFound { .. }
+                    | meerkat_core::SessionError::Unsupported(_),
+                ) => {}
+                Err(err) => return Err(session_error_to_projection(err, session_id)),
+            }
+        }
+
+        // Project through the same machine-authority interrupt path the
+        // user-facing `mobkit/live/interrupt` RPC uses. Tolerate
+        // `NotRunning` (typical when no turn is in flight) so a late
+        // provider-side interrupt does not poison the channel.
+        match self
+            .service
+            .interrupt_with_machine_authority(session_id, self.machine.session_control_authority())
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(meerkat_core::SessionError::NotRunning { .. }) => Ok(()),
+            Err(err) => Err(session_error_to_projection(err, session_id)),
+        }
+    }
+
+    async fn signal_turn_completed(
+        &self,
+        session_id: &SessionId,
+        stop_reason: StopReason,
+        usage: Usage,
+        response_id: Option<&str>,
+    ) -> Result<(), LiveProjectionError> {
+        // CC2: synthesize `AssistantTurnCompleted` BEFORE draining the
+        // buffered display-text path — the staging materializer commits any
+        // staged spoken-transcript items for `response_id` here (the
+        // provider emits `TurnCompleted` directly, never a staged
+        // `AssistantTurnCompleted`, so without this synthesis staged deltas
+        // leak forever). Orphan completions (no `response_id`) skip the
+        // synthesis (staging rejects empty ids) but still flush the buffer.
+        let mut realtime_materialized = false;
+        if let Some(rid) = response_id.filter(|s| !s.is_empty()) {
+            let event = RealtimeTranscriptEvent::AssistantTurnCompleted {
+                response_id: rid.to_string(),
+                stop_reason,
+                usage: usage.clone(),
+            };
+            match self
+                .service
+                .append_realtime_transcript_event(session_id, event)
+                .await
+            {
+                Ok(outcome) => {
+                    // If the materializer fired it has already recorded the
+                    // authoritative usage for this turn; the drain below must
+                    // then forward `Usage::default()` to stay single-counted.
+                    realtime_materialized = !outcome.is_inert();
+                }
+                Err(
+                    meerkat_core::SessionError::NotFound { .. }
+                    | meerkat_core::SessionError::Unsupported(_),
+                ) => {}
+                Err(err) => return Err(session_error_to_projection(err, session_id)),
+            }
+        }
+
+        // R6: drain only the matching (session, response_id) display-text
+        // slot. If realtime materialized and nothing was buffered, skip the
+        // empty append entirely — no synthetic empty assistant block and no
+        // double-recorded usage.
+        let pending = self.pending_turns.drain(session_id, response_id);
+        let blocks = collapse_pending_blocks(pending.blocks);
+        if realtime_materialized && blocks.is_empty() {
+            return Ok(());
+        }
+        let usage_for_drain = if realtime_materialized {
+            Usage::default()
+        } else {
+            usage
+        };
+        self.service
+            .append_external_assistant_output(session_id, blocks, stop_reason, usage_for_drain)
+            .await
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn signal_terminal_error(
+        &self,
+        session_id: &SessionId,
+        code: LiveAdapterErrorCode,
+        message: &str,
+    ) -> Result<(), LiveProjectionError> {
+        // R6: drop ALL buffered finals across every response_id slot —
+        // terminal error invalidates every in-flight response.
+        self.pending_turns.drain_all(session_id);
+        tracing::warn!(
+            target: "meerkat_mobkit::live_wiring",
+            session_id = %session_id,
+            ?code,
+            message,
+            "live adapter terminal error",
+        );
+        // Route the typed terminal cause onto the session's owned event
+        // stream via the canonical `SessionService::record_live_terminal_error`
+        // seam — observable to session subscribers, not only tracing.
+        self.service
+            .record_live_terminal_error(session_id, code)
+            .await
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn signal_output_audio_degraded(
+        &self,
+        session_id: &SessionId,
+        dropped: u64,
+    ) -> Result<(), LiveProjectionError> {
+        // K16: transport delivery degradation is a typed session-observable
+        // fact, never a transport-local counter or a tracing-only warning.
+        self.service
+            .record_live_output_audio_degraded(session_id, dropped)
+            .await
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+
+    async fn append_realtime_transcript(
+        &self,
+        session_id: &SessionId,
+        event: &RealtimeTranscriptEvent,
+    ) -> Result<(), LiveProjectionError> {
+        // P1#2: forward provider-emitted realtime transcript events into the
+        // same idempotent ordering / staging path used by deltas +
+        // truncation; without this override `ItemObserved` /
+        // `AssistantTurnCompleted` etc. would be silently dropped.
+        self.service
+            .append_realtime_transcript_event(session_id, event.clone())
+            .await
+            .map(|_outcome| ())
+            .map_err(|err| session_error_to_projection(err, session_id))
+    }
+}
+
+/// Routes live tool calls into the member session's NORMAL external-tool
+/// dispatch (callback bridge, composed recorder tools, gating — unchanged).
+/// Port of meerkat-rpc's `RuntimeLiveToolDispatcher`.
+pub struct GatewayLiveToolDispatcher<B: SessionAgentBuilder + 'static> {
+    service: Arc<PersistentSessionService<B>>,
+}
+
+impl<B: SessionAgentBuilder + 'static> GatewayLiveToolDispatcher<B> {
+    pub fn new(service: Arc<PersistentSessionService<B>>) -> Self {
+        Self { service }
+    }
+}
+
+#[async_trait]
+impl<B: SessionAgentBuilder + 'static> LiveToolDispatcher for GatewayLiveToolDispatcher<B> {
+    async fn dispatch_live_tool_call(
+        &self,
+        session_id: &SessionId,
+        call: meerkat_core::ToolCall,
+    ) -> Result<meerkat_core::ops::ToolDispatchOutcome, meerkat_live::LiveToolDispatchError> {
+        self.service
+            .dispatch_external_tool_call(session_id, call)
+            .await
+            .map_err(|err| meerkat_live::LiveToolDispatchError::from_session_error(session_id, err))
+    }
+}
+
+/// [`RealtimeCurrentConfigSource`] serving the gateway's effective `Config`.
+///
+/// mobkit gateways have no durable config store; per-open realtime
+/// credential resolution rides the session identity's auth binding or the
+/// provider default (env `OPENAI_API_KEY`) against this fixed config —
+/// matching text-model behaviour. Embedders with real config stores can swap
+/// in `StoreBackedRealtimeConfigSource` later.
+pub struct EnvRealtimeConfigSource {
+    config: Config,
+}
+
+impl EnvRealtimeConfigSource {
+    pub fn new(config: Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl RealtimeCurrentConfigSource for EnvRealtimeConfigSource {
+    async fn current_config(&self) -> Result<Config, ConfigError> {
+        Ok(self.config.clone())
+    }
+}
+
+/// Everything a gateway needs to serve live channels: the adapter host, the
+/// WS transport state (mount via `meerkat_live::live_ws_router(ws_state)` on
+/// the gateway's HTTP app), the per-open realtime session factory, and the
+/// externally-reachable base URL the WS bootstrap embeds.
+#[derive(Clone)]
+pub struct GatewayLiveContext {
+    pub host: Arc<LiveAdapterHost>,
+    pub ws_state: Arc<LiveWsState>,
+    pub session_factory: Arc<dyn RealtimeSessionFactory>,
+    pub ws_base_url: String,
+}
+
+/// Compose the live stack for a persistent-mode gateway.
+///
+/// One `GatewayLiveProjectionSink` instance serves all four injected trait
+/// seams (projection sink, close feedback, status feedback, WS token
+/// authority), exactly like the upstream wiring. The tool dispatcher rides
+/// the host builder with the upstream default tool timeout
+/// (`meerkat_live::DEFAULT_LIVE_TOOL_TIMEOUT`). Credentials resolve PER OPEN
+/// via the facade's `PerOpenCredentialRealtimeSessionFactory` over
+/// [`EnvRealtimeConfigSource`].
+pub fn attach_live<B: SessionAgentBuilder + 'static>(
+    service: Arc<PersistentSessionService<B>>,
+    machine: Arc<MeerkatMachine>,
+    factory: &AgentFactory,
+    config: Config,
+    ws_base_url: String,
+) -> GatewayLiveContext {
+    let sink = Arc::new(GatewayLiveProjectionSink::new(
+        Arc::clone(&service),
+        machine,
+    ));
+    let dispatcher: Arc<dyn LiveToolDispatcher> = Arc::new(GatewayLiveToolDispatcher::new(service));
+    let host = Arc::new(
+        LiveAdapterHost::new(Arc::clone(&sink) as Arc<dyn LiveProjectionSink>)
+            .with_live_tool_dispatcher(dispatcher),
+    );
+    let ws_state = Arc::new(LiveWsState::new(
+        Arc::clone(&host),
+        Arc::clone(&sink) as Arc<dyn LiveChannelCloseFeedback>,
+        Arc::clone(&sink) as Arc<dyn LiveChannelStatusFeedback>,
+        sink as Arc<dyn LiveWsTokenAuthority>,
+    ));
+    let session_factory = factory
+        .build_openai_realtime_session_factory(Arc::new(EnvRealtimeConfigSource::new(config)));
+    GatewayLiveContext {
+        host,
+        ws_state,
+        session_factory,
+        ws_base_url,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// mobkit/live/* handlers — port of meerkat-rpc/src/handlers/live.rs
+// (websocket arms; webrtc and truncate deliberately not ported, per design
+// §"What we deliberately do NOT do in v1").
+// ---------------------------------------------------------------------------
+
+/// The gateway-side params for `mobkit/live/open`. The member target
+/// (`identity` / `member_id` / `session_id`) is resolved by the CALLER
+/// before `handle_live_method`; unknown fields are ignored here so the
+/// target spellings pass through untouched.
+#[derive(Debug, Deserialize)]
+struct GatewayLiveOpenParams {
+    #[serde(default)]
+    turning_mode: Option<RealtimeTurningMode>,
+    #[serde(default)]
+    transport: Option<LiveOpenTransport>,
+    /// v1 realtime-model override (design §6): members whose text model is
+    /// not realtime-capable open the channel against this model instead.
+    #[serde(default)]
+    model: Option<String>,
+}
+
+fn live_success(rpc_id: Value, result: Value) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: JSONRPC_VERSION.to_string(),
+        id: rpc_id,
+        result: Some(result),
+        error: None,
+    }
+}
+
+fn live_error(rpc_id: Value, code: i64, message: impl Into<String>) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: JSONRPC_VERSION.to_string(),
+        id: rpc_id,
+        result: None,
+        error: Some(JsonRpcError::new(code, message)),
+    }
+}
+
+/// The CALLER answers this when the gateway has no [`GatewayLiveContext`]
+/// (ephemeral mode, or `runtime_options.live` off). Kept here so every
+/// surface emits the identical `-32050` / `data.kind = "live_unavailable"`
+/// shape.
+/// Type-erased live RPC entry point. The gateway — which knows the concrete
+/// session-builder type `B` — captures its `GatewayLiveContext`, service, and
+/// machine into this closure so the shared (non-generic) RPC dispatch in
+/// `crate::rpc` can serve `mobkit/live/*` without a type parameter.
+pub type LiveRpcHandler = Arc<
+    dyn Fn(
+            Option<meerkat_core::types::SessionId>,
+            String,
+            Value,
+            Value,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = JsonRpcResponse> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Erase `handle_live_method` over the gateway's concrete types.
+pub fn live_rpc_handler<B: SessionAgentBuilder + 'static>(
+    ctx: Arc<GatewayLiveContext>,
+    service: Arc<PersistentSessionService<B>>,
+    machine: Arc<MeerkatMachine>,
+) -> LiveRpcHandler {
+    Arc::new(move |resolved_session, method, params, rpc_id| {
+        let ctx = Arc::clone(&ctx);
+        let service = Arc::clone(&service);
+        let machine = Arc::clone(&machine);
+        Box::pin(async move {
+            handle_live_method(
+                &ctx,
+                &service,
+                &machine,
+                resolved_session,
+                &method,
+                &params,
+                rpc_id,
+            )
+            .await
+        })
+    })
+}
+
+#[must_use]
+pub fn live_unavailable_response(rpc_id: Value) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: JSONRPC_VERSION.to_string(),
+        id: rpc_id,
+        result: None,
+        error: Some(
+            JsonRpcError::new(
+                LIVE_UNAVAILABLE_CODE,
+                "live sessions are not available on this gateway",
+            )
+            .with_data(serde_json::json!({ "kind": LIVE_UNAVAILABLE_KIND })),
+        ),
+    }
+}
+
+fn parse_live_params<T: DeserializeOwned>(
+    params: &Value,
+    rpc_id: &Value,
+) -> Result<T, Box<JsonRpcResponse>> {
+    serde_json::from_value(params.clone()).map_err(|err| {
+        Box::new(live_error(
+            rpc_id.clone(),
+            INVALID_PARAMS_CODE,
+            format!("invalid params: {err}"),
+        ))
+    })
+}
+
+/// Dispatch a `mobkit/live/*` method against a live-enabled gateway.
+///
+/// `resolved_session` is the member target already canonicalized by the
+/// caller (identity → member alias → raw session id — the same
+/// canonicalization class as `/agents/{id}/events`); only `mobkit/live/open`
+/// consumes it, every other method addresses a `channel_id`. `service` and
+/// `machine` are passed alongside the (deliberately non-generic)
+/// [`GatewayLiveContext`] because open/refresh must re-project the member
+/// session and every handler resolves results through machine authority.
+pub async fn handle_live_method<B: SessionAgentBuilder + 'static>(
+    ctx: &GatewayLiveContext,
+    service: &Arc<PersistentSessionService<B>>,
+    machine: &Arc<MeerkatMachine>,
+    resolved_session: Option<SessionId>,
+    method: &str,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    match method {
+        "mobkit/live/open" => {
+            let Some(session_id) = resolved_session else {
+                return live_error(
+                    rpc_id,
+                    INVALID_PARAMS_CODE,
+                    "live/open requires a resolvable member target \
+                     (identity, member_id, or session_id)",
+                );
+            };
+            handle_live_open(ctx, service, machine, &session_id, params, rpc_id).await
+        }
+        "mobkit/live/status" => handle_live_status(ctx, machine, params, rpc_id).await,
+        "mobkit/live/close" => handle_live_close(ctx, machine, params, rpc_id).await,
+        "mobkit/live/refresh" => handle_live_refresh(ctx, service, machine, params, rpc_id).await,
+        "mobkit/live/send_input" => handle_live_send_input(ctx, machine, params, rpc_id).await,
+        "mobkit/live/commit_input" => handle_live_commit_input(ctx, machine, params, rpc_id).await,
+        "mobkit/live/interrupt" => handle_live_interrupt(ctx, machine, params, rpc_id).await,
+        other => live_error(
+            rpc_id,
+            METHOD_NOT_FOUND_CODE,
+            format!("unknown live method {other}"),
+        ),
+    }
+}
+
+/// Project the member session into a [`RealtimeSessionOpenConfig`].
+///
+/// mobkit mirror of the facade `LiveOrchestrator::live_open_config_for_session`
+/// (which is pinned to `FactoryAgentBuilder` + the staged-session registry,
+/// so a generic-`B` gateway cannot borrow it): the same three published
+/// service seams feed the same three pub projection free functions. No
+/// staged/archived recovery — mobkit member sessions are held live by the
+/// bridge, and an archived target surfaces as `NotFound`.
+async fn live_open_config_for_session<B: SessionAgentBuilder + 'static>(
+    service: &PersistentSessionService<B>,
+    session_id: &SessionId,
+    turning_mode: RealtimeTurningMode,
+) -> Result<RealtimeSessionOpenConfig, meerkat_core::SessionError> {
+    let session = service
+        .export_realtime_open_session_snapshot(session_id)
+        .await?;
+    let llm_identity = service.live_session_llm_identity(session_id).await?;
+    let visible_tools = service.live_visible_tool_defs(session_id).await?;
+    Ok(RealtimeSessionOpenConfig::new(
+        turning_mode,
+        llm_identity,
+        visible_tools,
+        realtime_projection_messages(&session)?,
+    )
+    .with_runtime_system_context(realtime_projection_runtime_system_context(&session)?)
+    .with_system_prompt(match realtime_projection_root_system_message(&session)? {
+        Some(Message::System(system)) => Some(system.content),
+        // The projector only ever yields `Message::System` (or `None`);
+        // any other shape means no root system prompt to project.
+        _ => None,
+    }))
+}
+
+/// #176: project the factory's typed realtime audio policy into the typed
+/// [`LiveAudioConfig`] the snapshot carries. `None` when the factory does
+/// not advertise both directions of audio, so the caller fails closed
+/// rather than inventing a sample rate.
+fn live_audio_config_from_capabilities(
+    capabilities: &RealtimeCapabilities,
+) -> Option<LiveAudioConfig> {
+    let input = capabilities.audio_input_format.as_ref()?;
+    let output = capabilities.audio_output_format.as_ref()?;
+    Some(LiveAudioConfig {
+        input_sample_rate_hz: input.sample_rate_hz,
+        input_channels: u16::from(input.channels),
+        output_sample_rate_hz: output.sample_rate_hz,
+        output_channels: u16::from(output.channels),
+    })
+}
+
+/// #176: derive the WS `&format=` query token from the typed audio policy.
+/// The WS transport stamps inbound binary-chunk sample rates from this
+/// token, and the only layout it accepts today is 16-bit signed LE PCM,
+/// 24 kHz, mono. Fail closed (`None`) when the resolved policy does not map
+/// — a mismatch would silently stamp the wrong rate onto every frame.
+fn live_ws_audio_format_param(audio: &LiveAudioConfig) -> Option<&'static str> {
+    const PCM_24K_MONO_RATE_HZ: u32 = 24_000;
+    const PCM_24K_MONO_CHANNELS: u16 = 1;
+    if audio.input_sample_rate_hz == PCM_24K_MONO_RATE_HZ
+        && audio.input_channels == PCM_24K_MONO_CHANNELS
+    {
+        Some("pcm_24k_mono")
+    } else {
+        None
+    }
+}
+
+/// A8: build a `LiveProjectionSnapshot` from the resolved open config.
+/// `snapshot_version = 0` is the open-time placeholder; the refresh path
+/// overwrites it via `host.next_snapshot_version(channel_id)` (R8).
+fn build_live_projection_snapshot(
+    session_id: &SessionId,
+    open_config: &RealtimeSessionOpenConfig,
+    audio_config: Option<LiveAudioConfig>,
+) -> LiveProjectionSnapshot {
+    LiveProjectionSnapshot {
+        session_id: session_id.clone(),
+        snapshot_version: 0,
+        seed_messages: open_config.seed_messages.clone(),
+        visible_tools: open_config.visible_tools.clone(),
+        // R10: the typed `system_prompt` field is the single owner of live
+        // prompt truth — never re-derived from `seed_messages[0]` (the
+        // history projector drops `Message::System`, so seed inference
+        // silently wipes the prompt on the refresh path).
+        system_prompt: open_config.system_prompt.clone(),
+        model_id: open_config.llm_identity.model.clone(),
+        provider_id: open_config.llm_identity.provider,
+        audio_config,
+        // R3: typed runtime system-context rides the snapshot so adapters
+        // fold it into the provider session as authoritative instructions.
+        runtime_system_context: open_config.runtime_system_context.clone(),
+    }
+}
+
+/// A8: `Fresh` on empty seed history, `TranscriptOnly` once seeded.
+/// Provider-native resume is not wired by any shipped provider.
+fn continuity_from_snapshot(snapshot: &LiveProjectionSnapshot) -> LiveContinuityMode {
+    if snapshot.seed_messages.is_empty() {
+        LiveContinuityMode::Fresh
+    } else {
+        LiveContinuityMode::TranscriptOnly
+    }
+}
+
+async fn abandon_live_open_admission(
+    machine: &Arc<MeerkatMachine>,
+    session_id: &SessionId,
+    channel_id: &LiveChannelId,
+) {
+    if let Err(err) = machine
+        .abandon_live_open_admission(session_id, channel_id)
+        .await
+    {
+        tracing::warn!(
+            target: "meerkat_mobkit::live_wiring",
+            ?channel_id,
+            ?session_id,
+            ?err,
+            "generated live-open admission abandonment failed"
+        );
+    }
+}
+
+/// #355: open-failure cleanup is fail-closed, not best-effort. Attempt the
+/// generated graceful close first (retains a queryable closed-channel
+/// status); if the close authority rejects, omits the host handoff, or the
+/// host commit fails, fall through to `abandon_live_open_admission` so a
+/// failed open never leaves an orphaned machine-owned channel binding.
+async fn close_live_channel_after_open_failure(
+    host: &LiveAdapterHost,
+    machine: &Arc<MeerkatMachine>,
+    session_id: &SessionId,
+    channel_id: &LiveChannelId,
+) {
+    match host.reserve_channel_close_observation(channel_id).await {
+        Ok(observation) => {
+            let committed = commit_live_close_for_open_failure(
+                host,
+                machine,
+                session_id,
+                channel_id,
+                &observation,
+            )
+            .await;
+            if !committed {
+                abandon_live_open_admission(machine, session_id, channel_id).await;
+            }
+        }
+        Err(LiveAdapterHostError::ChannelNotFound(_)) => {
+            abandon_live_open_admission(machine, session_id, channel_id).await;
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "meerkat_mobkit::live_wiring",
+                ?channel_id,
+                ?session_id,
+                ?err,
+                "failed to close live channel after open failure; evicting admission"
+            );
+            abandon_live_open_admission(machine, session_id, channel_id).await;
+        }
+    }
+}
+
+/// Returns `true` only when the host commit succeeded (the machine-owned
+/// channel binding is cleared); `false` after logging the typed cause.
+async fn commit_live_close_for_open_failure(
+    host: &LiveAdapterHost,
+    machine: &Arc<MeerkatMachine>,
+    session_id: &SessionId,
+    channel_id: &LiveChannelId,
+    observation: &LiveChannelCloseObservation,
+) -> bool {
+    let authority = match machine
+        .resolve_live_close_result(session_id, observation)
+        .await
+    {
+        Ok(authority) => authority,
+        Err(err) => {
+            tracing::warn!(
+                target: "meerkat_mobkit::live_wiring",
+                ?channel_id,
+                ?session_id,
+                ?err,
+                "generated live-close authority rejected open-failure cleanup; evicting admission"
+            );
+            return false;
+        }
+    };
+    let Some(close_commit_authority) = authority.channel_close_commit_authority() else {
+        tracing::warn!(
+            target: "meerkat_mobkit::live_wiring",
+            ?channel_id,
+            ?session_id,
+            "generated live-close result omitted host commit authority; evicting admission"
+        );
+        return false;
+    };
+    if let Err(err) = host
+        .commit_channel_close_observation(observation, close_commit_authority)
+        .await
+    {
+        tracing::warn!(
+            target: "meerkat_mobkit::live_wiring",
+            ?channel_id,
+            ?session_id,
+            ?err,
+            "host live-close commit failed after generated open-failure cleanup; evicting admission"
+        );
+        return false;
+    }
+    true
+}
+
+#[allow(clippy::too_many_lines)]
+async fn handle_live_open<B: SessionAgentBuilder + 'static>(
+    ctx: &GatewayLiveContext,
+    service: &Arc<PersistentSessionService<B>>,
+    machine: &Arc<MeerkatMachine>,
+    session_id: &SessionId,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: GatewayLiveOpenParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    // The mobkit gateway mounts the WS transport only; a webrtc request is
+    // a caller error, not a silent websocket fallback.
+    match parsed.transport {
+        None | Some(LiveOpenTransport::Websocket) => {}
+        Some(_) => {
+            return live_error(
+                rpc_id,
+                INVALID_PARAMS_CODE,
+                "only the websocket live transport is supported by this gateway",
+            );
+        }
+    }
+
+    // R3-1: honor the caller's optional `turning_mode`; default
+    // `ProviderManaged`. Text-only callers that drive `commit_input` must
+    // pass `ExplicitCommit` (the OpenAI realtime API rejects
+    // `input_audio_buffer.commit` outside explicit-commit sessions).
+    let turning_mode = parsed
+        .turning_mode
+        .unwrap_or(RealtimeTurningMode::ProviderManaged);
+    let mut open_config =
+        match live_open_config_for_session(service, session_id, turning_mode).await {
+            Ok(config) => config,
+            Err(meerkat_core::SessionError::NotFound { .. }) => {
+                return live_error(
+                    rpc_id,
+                    INVALID_PARAMS_CODE,
+                    format!("session {session_id} not found"),
+                );
+            }
+            Err(err) => {
+                return live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    format!("failed to build session config: {err}"),
+                );
+            }
+        };
+    // Design §6: the member session's model decides; an explicit `model`
+    // override swaps the realtime model for this channel without touching
+    // the member's text identity. Applied before precheck + admission so
+    // both gate — and the machine binds — the identity actually opened.
+    if let Some(model) = parsed.model {
+        open_config.llm_identity.model = model;
+    }
+
+    // B19 precheck runs BEFORE any channel infra is minted (the reference
+    // prechecks after `open_channel_with_authority` and then unwinds; with
+    // the identity already resolved there is nothing to unwind here).
+    if let Err(precheck_err) = precheck_identity(&open_config.llm_identity) {
+        let (code, message) = match &precheck_err {
+            LiveOpenPrecheckError::ModelNotRealtime { .. } => {
+                (INVALID_PARAMS_CODE, precheck_err.to_string())
+            }
+            _ => (INTERNAL_ERROR_CODE, precheck_err.to_string()),
+        };
+        return live_error(rpc_id, code, message);
+    }
+    // B18: the factory that mints the adapter owns provider support.
+    if !ctx
+        .session_factory
+        .supports_provider(open_config.llm_identity.provider)
+    {
+        return live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            format!(
+                "provider {} has no live adapter wired in this build",
+                open_config.llm_identity.provider.as_str()
+            ),
+        );
+    }
+
+    let live_open_identity = open_config.llm_identity.clone();
+    let candidate_channel_id = LiveChannelId::random_uuid();
+    let open_authority = match machine
+        .resolve_live_open_admission(session_id, &candidate_channel_id, &live_open_identity)
+        .await
+    {
+        Ok(authority) => authority,
+        Err(err) => {
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("live open authority rejected admission: {err}"),
+            );
+        }
+    };
+    if !open_authority.admitted() {
+        use meerkat_runtime::meerkat_machine::dsl::LiveOpenAdmissionRejection;
+        return match open_authority.rejection() {
+            Some(LiveOpenAdmissionRejection::AlreadyBound) => live_error(
+                rpc_id,
+                INVALID_PARAMS_CODE,
+                format!("session {session_id} already has an active live channel"),
+            ),
+            Some(LiveOpenAdmissionRejection::ChannelAlreadyBound) => live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("generated duplicate live channel id {candidate_channel_id}"),
+            ),
+            None => live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                "live open authority rejected admission without a reason",
+            ),
+        };
+    }
+
+    let Some(channel_open_authority) = open_authority.channel_open_authority() else {
+        abandon_live_open_admission(machine, session_id, &candidate_channel_id).await;
+        return live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            "live open admission was accepted without a generated host handoff",
+        );
+    };
+
+    let channel_id = match ctx
+        .host
+        .open_channel_with_authority(channel_open_authority)
+        .await
+    {
+        Ok(ch) => ch,
+        Err(LiveAdapterHostError::SessionAlreadyBound(sid)) => {
+            abandon_live_open_admission(machine, session_id, &candidate_channel_id).await;
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!(
+                    "live host transport cache still has active channel for session {sid} \
+                     after generated admission"
+                ),
+            );
+        }
+        Err(err) => {
+            abandon_live_open_admission(machine, session_id, &candidate_channel_id).await;
+            return live_error(rpc_id, INTERNAL_ERROR_CODE, err.to_string());
+        }
+    };
+
+    // #176: resolve the typed audio policy from the factory's capabilities
+    // (the provider/model audio-format owner) — the WS `&format=` token and
+    // the snapshot `audio_config` both read this single typed value.
+    let resolved_audio_config =
+        live_audio_config_from_capabilities(&ctx.session_factory.capabilities());
+    // E25: open the provider-native adapter directly. The factory already
+    // consumed seed_messages + runtime_system_context, so no
+    // `LiveAdapterCommand::Open` is dispatched afterwards (R2: re-seeding
+    // would compound the provider transcript).
+    let capabilities: LiveChannelCapabilities;
+    let continuity: LiveContinuityMode;
+    match ctx.session_factory.open_live_adapter(&open_config).await {
+        Ok(adapter) => {
+            // P2#3: the adapter's real capability set, queried before the
+            // host takes canonical ownership of the Arc.
+            capabilities = adapter.capabilities();
+            if let Err(err) = ctx.host.attach_adapter(&channel_id, adapter).await {
+                close_live_channel_after_open_failure(&ctx.host, machine, session_id, &channel_id)
+                    .await;
+                return live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    format!("failed to attach adapter: {err}"),
+                );
+            }
+            let snapshot = build_live_projection_snapshot(
+                session_id,
+                &open_config,
+                resolved_audio_config.clone(),
+            );
+            continuity = continuity_from_snapshot(&snapshot);
+        }
+        Err(err) => {
+            close_live_channel_after_open_failure(&ctx.host, machine, session_id, &channel_id)
+                .await;
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("failed to open provider session: {err}"),
+            );
+        }
+    }
+
+    let token = match ctx
+        .ws_state
+        .mint_token(session_id, channel_id.clone())
+        .await
+    {
+        Ok(token) => token,
+        Err(err) => {
+            close_live_channel_after_open_failure(&ctx.host, machine, session_id, &channel_id)
+                .await;
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("live WebSocket token authority rejected issue: {err}"),
+            );
+        }
+    };
+    let token_str = token.to_string();
+    let Some(audio_config) = resolved_audio_config.as_ref() else {
+        close_live_channel_after_open_failure(&ctx.host, machine, session_id, &channel_id).await;
+        return live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            "live websocket transport requires a resolved audio policy; no realtime \
+             factory audio format was available",
+        );
+    };
+    let Some(format_param) = live_ws_audio_format_param(audio_config) else {
+        close_live_channel_after_open_failure(&ctx.host, machine, session_id, &channel_id).await;
+        return live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            format!(
+                "resolved live audio policy (input {}Hz/{}ch) has no websocket binary \
+                 format the transport can negotiate",
+                audio_config.input_sample_rate_hz, audio_config.input_channels,
+            ),
+        );
+    };
+    // G38: the bearer token is pinned to the channel via the `channel`
+    // query param so a leaked token cannot replay against another channel.
+    let transport = LiveTransportBootstrap::Websocket {
+        url: format!(
+            "{base_url}{path}?token={token_str}&channel={channel_id}&format={format_param}",
+            base_url = ctx.ws_base_url,
+            path = meerkat_live::LIVE_WS_PATH,
+        ),
+        token: token_str,
+    };
+
+    // CC5/CC6/G8: project core typed shapes into the wire mirrors at the
+    // boundary so SDK codegen sees typed unions, byte-compatible payloads.
+    let result = LiveOpenResult {
+        channel_id: channel_id.to_string(),
+        transport: transport.into(),
+        capabilities: capabilities.into(),
+        continuity: continuity.into(),
+    };
+    match serde_json::to_value(result) {
+        Ok(value) => live_success(rpc_id, value),
+        Err(err) => live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            format!("failed to serialize LiveOpenResult: {err}"),
+        ),
+    }
+}
+
+fn live_refresh_result_from_machine_authority(
+    authority: &meerkat_runtime::meerkat_machine::LiveRefreshResultAuthority,
+) -> LiveRefreshResult {
+    // Exhaustive: a future generated status variant forces a compile error
+    // here, so the wire projection can never silently misreport.
+    match authority.status {
+        meerkat_runtime::meerkat_machine::dsl::LiveRefreshPublicStatus::Queued => {
+            LiveRefreshResult::queued()
+        }
+    }
+}
+
+fn live_close_result_from_machine_authority(
+    authority: &meerkat_runtime::meerkat_machine::LiveCloseResultAuthority,
+) -> LiveCloseResult {
+    match authority.status {
+        meerkat_runtime::meerkat_machine::dsl::LiveClosePublicStatus::Closed => {
+            LiveCloseResult::closed()
+        }
+    }
+}
+
+/// #234: typed result shapes for command acceptances, projected only from
+/// generated machine authority. Serde failures surface as `String` so the
+/// caller maps them onto the RPC error channel.
+fn live_command_result_from_machine_authority(
+    authority: &meerkat_runtime::meerkat_machine::LiveCommandResultAuthority,
+    expected: meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind,
+) -> Result<Value, String> {
+    use meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind;
+
+    if authority.command != expected {
+        return Err(format!(
+            "LiveCommandResultResolved emitted command {:?} for expected {:?}",
+            authority.command, expected
+        ));
+    }
+
+    match expected {
+        LiveCommandPublicKind::SendInput => serde_json::to_value(LiveSendInputResult::sent())
+            .map_err(|err| format!("failed to serialize LiveSendInputResult: {err}")),
+        LiveCommandPublicKind::CommitInput => {
+            serde_json::to_value(LiveCommitInputResult::committed())
+                .map_err(|err| format!("failed to serialize LiveCommitInputResult: {err}"))
+        }
+        LiveCommandPublicKind::Interrupt => {
+            serde_json::to_value(LiveInterruptResult::interrupted())
+                .map_err(|err| format!("failed to serialize LiveInterruptResult: {err}"))
+        }
+        LiveCommandPublicKind::TruncateAssistantOutput => {
+            Err("live/truncate is not surfaced by the mobkit gateway".to_string())
+        }
+    }
+}
+
+fn live_status_result_from_machine_authority(
+    channel_id: String,
+    authority: &meerkat_runtime::meerkat_machine::LiveChannelStatusAuthority,
+) -> Result<LiveStatusResult, String> {
+    Ok(LiveStatusResult {
+        channel_id,
+        status: wire_live_status_from_machine_authority(authority)?,
+    })
+}
+
+fn wire_live_status_from_machine_authority(
+    authority: &meerkat_runtime::meerkat_machine::LiveChannelStatusAuthority,
+) -> Result<WireLiveAdapterStatus, String> {
+    use meerkat_runtime::meerkat_machine::dsl::LiveChannelPublicStatus;
+
+    match authority.status {
+        LiveChannelPublicStatus::Idle => Ok(WireLiveAdapterStatus::Idle),
+        LiveChannelPublicStatus::Opening => Ok(WireLiveAdapterStatus::Opening),
+        LiveChannelPublicStatus::Ready => Ok(WireLiveAdapterStatus::Ready),
+        LiveChannelPublicStatus::Closing => Ok(WireLiveAdapterStatus::Closing),
+        LiveChannelPublicStatus::Closed => Ok(WireLiveAdapterStatus::Closed),
+        LiveChannelPublicStatus::Degraded => {
+            let reason = authority.degradation_reason.ok_or_else(|| {
+                "LiveChannelStatusResolved emitted degraded status without reason".to_string()
+            })?;
+            Ok(WireLiveAdapterStatus::Degraded {
+                reason: wire_live_degradation_reason_from_machine_authority(
+                    reason,
+                    authority.degradation_detail.as_deref(),
+                ),
+            })
+        }
+    }
+}
+
+fn wire_live_degradation_reason_from_machine_authority(
+    reason: meerkat_runtime::meerkat_machine::dsl::LiveChannelDegradationReason,
+    detail: Option<&str>,
+) -> WireLiveDegradationReason {
+    use meerkat_runtime::meerkat_machine::dsl::LiveChannelDegradationReason;
+
+    match reason {
+        LiveChannelDegradationReason::RateLimited => WireLiveDegradationReason::RateLimited,
+        LiveChannelDegradationReason::ProviderThrottled => {
+            WireLiveDegradationReason::ProviderThrottled
+        }
+        LiveChannelDegradationReason::NetworkUnstable => WireLiveDegradationReason::NetworkUnstable,
+        LiveChannelDegradationReason::Other => WireLiveDegradationReason::Other {
+            detail: detail.unwrap_or_default().to_string(),
+        },
+        LiveChannelDegradationReason::Unknown => WireLiveDegradationReason::Unknown {
+            debug: detail
+                .unwrap_or("unknown live channel degradation")
+                .to_string(),
+        },
+    }
+}
+
+fn live_command_rejection_response_from_machine_authority(
+    rpc_id: Value,
+    authority: &meerkat_runtime::meerkat_machine::LiveCommandRejectionAuthority,
+    expected: meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind,
+    channel_id: &LiveChannelId,
+    host_error: &LiveAdapterHostError,
+) -> JsonRpcResponse {
+    use meerkat_runtime::meerkat_machine::dsl::{
+        LiveCommandRejectionPublicErrorClass, LiveCommandRejectionReason,
+    };
+
+    if authority.command != expected {
+        return live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            format!(
+                "LiveCommandRejectionResolved emitted command {:?} for expected {:?}",
+                authority.command, expected
+            ),
+        );
+    }
+
+    let code = match authority.public_error_class {
+        LiveCommandRejectionPublicErrorClass::InvalidParams => INVALID_PARAMS_CODE,
+        LiveCommandRejectionPublicErrorClass::InternalError => INTERNAL_ERROR_CODE,
+    };
+    let message = match authority.rejection {
+        LiveCommandRejectionReason::ChannelNotFound => format!("channel {channel_id} not found"),
+        LiveCommandRejectionReason::NoAdapter => {
+            format!("channel {channel_id} has no adapter attached")
+        }
+        LiveCommandRejectionReason::ChannelNotReady
+        | LiveCommandRejectionReason::UnsupportedCommand
+        | LiveCommandRejectionReason::AdapterError
+        | LiveCommandRejectionReason::InternalHostError => host_error.to_string(),
+    };
+    live_error(rpc_id, code, message)
+}
+
+async fn live_command_error_response(
+    rpc_id: Value,
+    machine: &Arc<MeerkatMachine>,
+    session_id: &SessionId,
+    channel_id: &LiveChannelId,
+    command: meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind,
+    host_error: &LiveAdapterHostError,
+) -> JsonRpcResponse {
+    let authority = match machine
+        .resolve_live_command_rejection_result(session_id, channel_id, command, host_error)
+        .await
+    {
+        Ok(authority) => authority,
+        Err(error) => {
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("live command rejection authority rejected result: {error}"),
+            );
+        }
+    };
+    live_command_rejection_response_from_machine_authority(
+        rpc_id, &authority, command, channel_id, host_error,
+    )
+}
+
+async fn live_unbound_command_error_response(
+    rpc_id: Value,
+    machine: &Arc<MeerkatMachine>,
+    channel_id: &LiveChannelId,
+    command: meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind,
+) -> JsonRpcResponse {
+    let authority = match machine
+        .resolve_unbound_live_command_rejection_result(channel_id, command)
+        .await
+    {
+        Ok(authority) => authority,
+        Err(error) => {
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("unbound live command rejection authority rejected result: {error}"),
+            );
+        }
+    };
+    let host_error = LiveAdapterHostError::ChannelNotFound(channel_id.clone());
+    live_command_rejection_response_from_machine_authority(
+        rpc_id,
+        &authority,
+        command,
+        channel_id,
+        &host_error,
+    )
+}
+
+fn live_channel_request_rejection_response_from_machine_authority(
+    rpc_id: Value,
+    authority: &meerkat_runtime::meerkat_machine::LiveChannelRequestRejectionAuthority,
+    expected: meerkat_runtime::meerkat_machine::dsl::LiveChannelRequestPublicKind,
+    channel_id: &LiveChannelId,
+    detail: Option<String>,
+) -> JsonRpcResponse {
+    use meerkat_runtime::meerkat_machine::dsl::{
+        LiveChannelRequestRejectionPublicErrorClass, LiveChannelRequestRejectionReason,
+    };
+
+    if authority.request != expected {
+        return live_error(
+            rpc_id,
+            INTERNAL_ERROR_CODE,
+            format!(
+                "LiveChannelRequestRejectionResolved emitted request {:?} for expected {:?}",
+                authority.request, expected
+            ),
+        );
+    }
+
+    let code = match authority.public_error_class {
+        LiveChannelRequestRejectionPublicErrorClass::InvalidParams => INVALID_PARAMS_CODE,
+        LiveChannelRequestRejectionPublicErrorClass::InternalError => INTERNAL_ERROR_CODE,
+    };
+    let message = match authority.rejection {
+        LiveChannelRequestRejectionReason::ChannelNotFound => {
+            format!("channel {channel_id} not found")
+        }
+        LiveChannelRequestRejectionReason::NoAdapter => {
+            format!("channel {channel_id} has no adapter attached")
+        }
+        LiveChannelRequestRejectionReason::InvalidToken
+        | LiveChannelRequestRejectionReason::InvalidPayload
+        | LiveChannelRequestRejectionReason::WebrtcAnswerError
+        | LiveChannelRequestRejectionReason::InternalHostError => detail.unwrap_or_else(|| {
+            format!(
+                "live channel request {:?} rejected for channel {}",
+                authority.request, channel_id
+            )
+        }),
+    };
+    live_error(rpc_id, code, message)
+}
+
+async fn live_channel_request_error_response(
+    rpc_id: Value,
+    machine: &Arc<MeerkatMachine>,
+    session_id: &SessionId,
+    channel_id: &LiveChannelId,
+    request: meerkat_runtime::meerkat_machine::dsl::LiveChannelRequestPublicKind,
+    host_error: &LiveAdapterHostError,
+) -> JsonRpcResponse {
+    let authority = match machine
+        .resolve_live_channel_request_rejection_result(session_id, channel_id, request, host_error)
+        .await
+    {
+        Ok(authority) => authority,
+        Err(error) => {
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("live channel request rejection authority rejected result: {error}"),
+            );
+        }
+    };
+    live_channel_request_rejection_response_from_machine_authority(
+        rpc_id,
+        &authority,
+        request,
+        channel_id,
+        Some(host_error.to_string()),
+    )
+}
+
+async fn live_unbound_channel_request_error_response(
+    rpc_id: Value,
+    machine: &Arc<MeerkatMachine>,
+    channel_id: &LiveChannelId,
+    request: meerkat_runtime::meerkat_machine::dsl::LiveChannelRequestPublicKind,
+) -> JsonRpcResponse {
+    let authority = match machine
+        .resolve_unbound_live_channel_request_rejection_result(channel_id, request)
+        .await
+    {
+        Ok(authority) => authority,
+        Err(error) => {
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!(
+                    "unbound live channel request rejection authority rejected result: {error}"
+                ),
+            );
+        }
+    };
+    let host_error = LiveAdapterHostError::ChannelNotFound(channel_id.clone());
+    live_channel_request_rejection_response_from_machine_authority(
+        rpc_id,
+        &authority,
+        request,
+        channel_id,
+        Some(host_error.to_string()),
+    )
+}
+
+async fn handle_live_status(
+    ctx: &GatewayLiveContext,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveChannelParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+
+    let request_kind = meerkat_runtime::meerkat_machine::dsl::LiveChannelRequestPublicKind::Status;
+    let Some(session_id) = machine.live_session_for_status_channel(&channel_id).await else {
+        return live_unbound_channel_request_error_response(
+            rpc_id,
+            machine,
+            &channel_id,
+            request_kind,
+        )
+        .await;
+    };
+
+    match ctx.host.channel_status_observation(&channel_id).await {
+        Ok(observation) => {
+            let authority = match machine
+                .resolve_live_channel_status_result(&session_id, &observation)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live status authority rejected result: {error}"),
+                    );
+                }
+            };
+            let result =
+                match live_status_result_from_machine_authority(parsed.channel_id, &authority) {
+                    Ok(result) => result,
+                    Err(error) => return live_error(rpc_id, INTERNAL_ERROR_CODE, error),
+                };
+            match serde_json::to_value(result) {
+                Ok(value) => live_success(rpc_id, value),
+                Err(err) => live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    format!("failed to serialize LiveStatusResult: {err}"),
+                ),
+            }
+        }
+        Err(err) => {
+            live_channel_request_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                request_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
+async fn handle_live_close(
+    ctx: &GatewayLiveContext,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveChannelParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+
+    let request_kind = meerkat_runtime::meerkat_machine::dsl::LiveChannelRequestPublicKind::Close;
+    let Some(session_id) = machine.live_session_for_active_channel(&channel_id).await else {
+        return live_unbound_channel_request_error_response(
+            rpc_id,
+            machine,
+            &channel_id,
+            request_kind,
+        )
+        .await;
+    };
+
+    match ctx
+        .host
+        .reserve_channel_close_observation(&channel_id)
+        .await
+    {
+        Ok(observation) => {
+            let authority = match machine
+                .resolve_live_close_result(&session_id, &observation)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live close authority rejected result: {error}"),
+                    );
+                }
+            };
+            let Some(close_commit_authority) = authority.channel_close_commit_authority() else {
+                return live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    "live close authority omitted host commit handoff",
+                );
+            };
+            if let Err(error) = ctx
+                .host
+                .commit_channel_close_observation(&observation, close_commit_authority)
+                .await
+            {
+                return live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    format!("live close host commit failed after generated authority: {error}"),
+                );
+            }
+            let result = live_close_result_from_machine_authority(&authority);
+            match serde_json::to_value(result) {
+                Ok(body) => live_success(rpc_id, body),
+                Err(error) => live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    format!("live close authority projection failed: {error}"),
+                ),
+            }
+        }
+        Err(err) => {
+            live_channel_request_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                request_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
+/// P1#5: enqueue a mutable live-config update against the active channel.
+/// Config-only by design — history is `live/open`'s seed step (re-seeding on
+/// refresh compounds the provider transcript). Identity swaps require close
+/// and reopen. R7: the honest reply is `status: queued`; the adapter pump
+/// applies asynchronously and failures surface on the realtime stream.
+async fn handle_live_refresh<B: SessionAgentBuilder + 'static>(
+    ctx: &GatewayLiveContext,
+    service: &Arc<PersistentSessionService<B>>,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveChannelParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+
+    let request_kind = meerkat_runtime::meerkat_machine::dsl::LiveChannelRequestPublicKind::Refresh;
+    let Some(session_id) = machine.live_session_for_active_channel(&channel_id).await else {
+        return live_unbound_channel_request_error_response(
+            rpc_id,
+            machine,
+            &channel_id,
+            request_kind,
+        )
+        .await;
+    };
+
+    let open_config = match live_open_config_for_session(
+        service,
+        &session_id,
+        RealtimeTurningMode::ProviderManaged,
+    )
+    .await
+    {
+        Ok(config) => config,
+        Err(err) => {
+            return live_error(
+                rpc_id,
+                INTERNAL_ERROR_CODE,
+                format!("failed to build session config: {err}"),
+            );
+        }
+    };
+    // R8: stamp the host's monotonic per-channel version so adapters gating
+    // on `snapshot_version` for stale-refresh detection see strictly
+    // increasing generations. #176: refresh has no factory audio policy in
+    // scope; the format negotiated at open time stays in force.
+    let mut snapshot = build_live_projection_snapshot(&session_id, &open_config, None);
+    match ctx.host.next_snapshot_version(&channel_id).await {
+        Ok(v) => snapshot.snapshot_version = v,
+        Err(err) => {
+            return live_channel_request_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                request_kind,
+                &err,
+            )
+            .await;
+        }
+    }
+
+    match ctx.host.enqueue_refresh(&channel_id, snapshot).await {
+        Ok(acceptance) => {
+            let authority = match machine
+                .resolve_live_refresh_queued_result(&session_id, &acceptance)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live refresh queued authority rejected result: {error}"),
+                    );
+                }
+            };
+            let result = live_refresh_result_from_machine_authority(&authority);
+            match serde_json::to_value(result) {
+                Ok(body) => live_success(rpc_id, body),
+                Err(error) => live_error(
+                    rpc_id,
+                    INTERNAL_ERROR_CODE,
+                    format!("live refresh queued authority projection failed: {error}"),
+                ),
+            }
+        }
+        Err(err) => {
+            live_channel_request_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                request_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
+async fn handle_live_send_input(
+    ctx: &GatewayLiveContext,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveSendInputParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+    let chunk = match live_input_chunk_from_wire(parsed.chunk) {
+        Ok(chunk) => chunk,
+        Err(err) => {
+            return live_error(rpc_id, INVALID_PARAMS_CODE, err.to_string());
+        }
+    };
+
+    let command_kind = meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind::SendInput;
+    let Some(session_id) = machine.live_session_for_active_channel(&channel_id).await else {
+        return live_unbound_command_error_response(rpc_id, machine, &channel_id, command_kind)
+            .await;
+    };
+
+    match ctx.host.send_input_observed(&channel_id, chunk).await {
+        Ok(acceptance) => {
+            let authority = match machine
+                .resolve_live_command_result(&session_id, &acceptance)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live send_input authority rejected result: {error}"),
+                    );
+                }
+            };
+            match live_command_result_from_machine_authority(&authority, command_kind) {
+                Ok(value) => live_success(rpc_id, value),
+                Err(error) => live_error(rpc_id, INTERNAL_ERROR_CODE, error),
+            }
+        }
+        Err(err) => {
+            live_command_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                command_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
+/// I50/G9: flush buffered uncommitted input; the optional
+/// `response_modality` requests a text-only response on an audio-first
+/// channel without flipping the channel-wide modality.
+async fn handle_live_commit_input(
+    ctx: &GatewayLiveContext,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveCommitInputParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+    // R5-3: the wire mirror is `TryFrom`-only; an unrecognized future
+    // modality rejects loudly instead of silently coercing.
+    let response_modality = match parsed.response_modality.map(TryInto::try_into) {
+        Some(Ok(modality)) => Some(modality),
+        Some(Err(err)) => {
+            return live_error(
+                rpc_id,
+                INVALID_PARAMS_CODE,
+                format!("invalid response_modality: {err}"),
+            );
+        }
+        None => None,
+    };
+
+    let command_kind = meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind::CommitInput;
+    let Some(session_id) = machine.live_session_for_active_channel(&channel_id).await else {
+        return live_unbound_command_error_response(rpc_id, machine, &channel_id, command_kind)
+            .await;
+    };
+
+    match ctx
+        .host
+        .send_command_observed(
+            &channel_id,
+            LiveAdapterCommand::CommitInput { response_modality },
+        )
+        .await
+    {
+        Ok(acceptance) => {
+            let authority = match machine
+                .resolve_live_command_result(&session_id, &acceptance)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live commit_input authority rejected result: {error}"),
+                    );
+                }
+            };
+            match live_command_result_from_machine_authority(&authority, command_kind) {
+                Ok(value) => live_success(rpc_id, value),
+                Err(error) => live_error(rpc_id, INTERNAL_ERROR_CODE, error),
+            }
+        }
+        Err(err) => {
+            live_command_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                command_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
+/// A7: explicit barge-in surface — without it callers can only rely on
+/// provider-native VAD.
+async fn handle_live_interrupt(
+    ctx: &GatewayLiveContext,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveChannelParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+    let command_kind = meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind::Interrupt;
+    let Some(session_id) = machine.live_session_for_active_channel(&channel_id).await else {
+        return live_unbound_command_error_response(rpc_id, machine, &channel_id, command_kind)
+            .await;
+    };
+
+    match ctx
+        .host
+        .send_command_observed(&channel_id, LiveAdapterCommand::Interrupt)
+        .await
+    {
+        Ok(acceptance) => {
+            let authority = match machine
+                .resolve_live_command_result(&session_id, &acceptance)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live interrupt authority rejected result: {error}"),
+                    );
+                }
+            };
+            match live_command_result_from_machine_authority(&authority, command_kind) {
+                Ok(value) => live_success(rpc_id, value),
+                Err(error) => live_error(rpc_id, INTERNAL_ERROR_CODE, error),
+            }
+        }
+        Err(err) => {
+            live_command_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                command_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn test_session_id() -> SessionId {
+        SessionId::parse("00000000-0000-0000-0000-000000000001").unwrap()
+    }
+
+    fn other_session_id() -> SessionId {
+        SessionId::parse("00000000-0000-0000-0000-000000000002").unwrap()
+    }
+
+    /// #301 port: the surface mapper routes through the canonical typed
+    /// owner so distinct `SessionError` variants land in distinct typed
+    /// `LiveProjectionError` variants — no collapse into
+    /// `Internal(to_string())`.
+    #[test]
+    fn session_error_maps_to_distinct_typed_projection_variants() {
+        let id = SessionId::new();
+
+        assert!(matches!(
+            session_error_to_projection(
+                meerkat_core::SessionError::NotFound { id: id.clone() },
+                &id,
+            ),
+            LiveProjectionError::SessionNotFound(_)
+        ));
+        assert!(matches!(
+            session_error_to_projection(
+                meerkat_core::SessionError::Unsupported("nope".to_string()),
+                &id,
+            ),
+            LiveProjectionError::Rejected(_)
+        ));
+        assert!(matches!(
+            session_error_to_projection(meerkat_core::SessionError::Busy { id: id.clone() }, &id),
+            LiveProjectionError::SessionBusy(_)
+        ));
+        assert!(matches!(
+            session_error_to_projection(
+                meerkat_core::SessionError::NotRunning { id: id.clone() },
+                &id,
+            ),
+            LiveProjectionError::SessionNotRunning(_)
+        ));
+        assert!(matches!(
+            session_error_to_projection(meerkat_core::SessionError::PersistenceDisabled, &id),
+            LiveProjectionError::CapabilityDisabled { .. }
+        ));
+    }
+
+    /// T10 port: the display-text lane builds the `AssistantTextDelta`
+    /// variant with the full identity tuple.
+    #[test]
+    fn assistant_text_delta_helper_builds_text_delta_event() {
+        let identity = LiveTranscriptIdentity {
+            provider_item_id: Some("item_text"),
+            previous_item_id: Some("item_prev"),
+            content_index: Some(2),
+            response_id: Some("resp_text"),
+            delta_id: Some("delta_text"),
+        };
+        let event = build_assistant_text_delta_event("display fragment", identity)
+            .expect("complete identity must build a typed delta event");
+        match event {
+            RealtimeTranscriptEvent::AssistantTextDelta {
+                response_id,
+                delta_id,
+                item_id,
+                previous_item_id,
+                content_index,
+                delta,
+            } => {
+                assert_eq!(response_id, "resp_text");
+                assert_eq!(delta_id, "delta_text");
+                assert_eq!(item_id, "item_text");
+                assert_eq!(previous_item_id.as_deref(), Some("item_prev"));
+                assert_eq!(content_index, 2);
+                assert_eq!(delta, "display fragment");
+            }
+            other => panic!("display-text delta path must build AssistantTextDelta, got {other:?}"),
+        }
+    }
+
+    /// T10 port: the spoken-transcript lane builds the dedicated
+    /// `AssistantTranscriptDelta` variant so the materializer flushes
+    /// `AssistantBlock::Transcript` rather than `Text`.
+    #[test]
+    fn assistant_transcript_delta_helper_builds_transcript_delta_event() {
+        let identity = LiveTranscriptIdentity {
+            provider_item_id: Some("item_tx"),
+            previous_item_id: Some("item_prev"),
+            content_index: Some(0),
+            response_id: Some("resp_tx"),
+            delta_id: Some("delta_tx"),
+        };
+        let event = build_assistant_transcript_delta_event("spoken fragment", identity)
+            .expect("complete identity must build a typed transcript delta event");
+        match event {
+            RealtimeTranscriptEvent::AssistantTranscriptDelta {
+                response_id,
+                delta_id,
+                item_id,
+                previous_item_id,
+                content_index,
+                delta,
+            } => {
+                assert_eq!(response_id, "resp_tx");
+                assert_eq!(delta_id, "delta_tx");
+                assert_eq!(item_id, "item_tx");
+                assert_eq!(previous_item_id.as_deref(), Some("item_prev"));
+                assert_eq!(content_index, 0);
+                assert_eq!(delta, "spoken fragment");
+            }
+            other => panic!(
+                "spoken-transcript delta path must build AssistantTranscriptDelta, got {other:?}"
+            ),
+        }
+    }
+
+    /// #199 port: a delta missing a required identity id fails closed with
+    /// a typed error rather than emitting empty-string identity.
+    #[test]
+    fn missing_delta_identity_fails_closed_typed() {
+        let missing_response = LiveTranscriptIdentity {
+            provider_item_id: Some("item"),
+            previous_item_id: None,
+            content_index: Some(0),
+            response_id: None,
+            delta_id: Some("delta"),
+        };
+        assert_eq!(
+            build_assistant_text_delta_event("fragment", missing_response),
+            Err(LiveTranscriptIdentityError::MissingResponseId)
+        );
+
+        let missing_delta = LiveTranscriptIdentity {
+            provider_item_id: Some("item"),
+            previous_item_id: None,
+            content_index: Some(0),
+            response_id: Some("resp"),
+            delta_id: None,
+        };
+        assert_eq!(
+            build_assistant_transcript_delta_event("fragment", missing_delta),
+            Err(LiveTranscriptIdentityError::MissingDeltaId)
+        );
+
+        let missing_item = LiveTranscriptIdentity {
+            provider_item_id: None,
+            previous_item_id: None,
+            content_index: Some(0),
+            response_id: Some("resp"),
+            delta_id: Some("delta"),
+        };
+        assert_eq!(
+            build_assistant_text_delta_event("fragment", missing_item),
+            Err(LiveTranscriptIdentityError::MissingItemId)
+        );
+    }
+
+    /// R6 port: two finals from different provider responses must NOT pool
+    /// into the same buffer slot; each completion drains only its own slot,
+    /// and a mismatched drain leaves the buffer untouched.
+    #[test]
+    fn r6_pending_turn_ledger_keys_on_response_id() {
+        let ledger = PendingTurnLedger::default();
+        let session_id = test_session_id();
+
+        ledger.buffer(
+            &session_id,
+            Some("resp_a"),
+            PendingAssistantContent::Text("from resp_a".to_string()),
+        );
+        ledger.buffer(
+            &session_id,
+            Some("resp_b"),
+            PendingAssistantContent::Text("from resp_b".to_string()),
+        );
+
+        // A completion carrying a response id no slot was buffered under
+        // must not flush another turn's transcript.
+        assert!(
+            ledger
+                .drain(&session_id, Some("resp_stale"))
+                .blocks
+                .is_empty()
+        );
+
+        let drained_a = collapse_pending_blocks(ledger.drain(&session_id, Some("resp_a")).blocks);
+        assert_eq!(drained_a.len(), 1);
+        match &drained_a[0] {
+            AssistantBlock::Text { text, .. } => assert_eq!(text, "from resp_a"),
+            other => panic!("expected text block, got {other:?}"),
+        }
+
+        // resp_b's buffer survived resp_a's completion.
+        let drained_b = collapse_pending_blocks(ledger.drain(&session_id, Some("resp_b")).blocks);
+        assert_eq!(drained_b.len(), 1);
+        match &drained_b[0] {
+            AssistantBlock::Text { text, .. } => assert_eq!(text, "from resp_b"),
+            other => panic!("expected text block, got {other:?}"),
+        }
+
+        // Both slots consumed exactly once.
+        assert!(ledger.drain(&session_id, Some("resp_a")).blocks.is_empty());
+        assert!(ledger.drain(&session_id, Some("resp_b")).blocks.is_empty());
+    }
+
+    /// Terminal-error port: `drain_all` clears every slot for the session
+    /// (including the `None` orphan slot) while other sessions' buffers
+    /// survive.
+    #[test]
+    fn terminal_error_drains_all_response_slots_for_session_only() {
+        let ledger = PendingTurnLedger::default();
+        let session_id = test_session_id();
+        let other = other_session_id();
+
+        ledger.buffer(
+            &session_id,
+            Some("resp_a"),
+            PendingAssistantContent::Text("a".to_string()),
+        );
+        ledger.buffer(
+            &session_id,
+            None,
+            PendingAssistantContent::Text("orphan".to_string()),
+        );
+        ledger.buffer(
+            &other,
+            Some("resp_x"),
+            PendingAssistantContent::Text("x".to_string()),
+        );
+
+        ledger.drain_all(&session_id);
+
+        assert!(ledger.drain(&session_id, Some("resp_a")).blocks.is_empty());
+        assert!(ledger.drain(&session_id, None).blocks.is_empty());
+        let survived = ledger.drain(&other, Some("resp_x"));
+        assert_eq!(survived.blocks.len(), 1);
+    }
+
+    /// P1#1/T6 port: consecutive same-lane fragments coalesce into ONE
+    /// `AssistantBlock::Text` in arrival order; an empty buffer collapses
+    /// to no blocks (the orphan-completion shape).
+    #[test]
+    fn collapse_pending_blocks_coalesces_fragments_in_arrival_order() {
+        let blocks = collapse_pending_blocks(vec![
+            PendingAssistantContent::Text("part one ".to_string()),
+            PendingAssistantContent::Text("part two".to_string()),
+        ]);
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            AssistantBlock::Text { text, .. } => assert_eq!(text, "part one part two"),
+            other => panic!("expected Text block, got {other:?}"),
+        }
+
+        assert!(collapse_pending_blocks(Vec::new()).is_empty());
+    }
+
+    /// Token-admission mapping port: every generated rejection variant maps
+    /// onto its transport twin, and the public error class collapses to the
+    /// transport's `InvalidToken`.
+    #[test]
+    fn ws_token_admission_mapping_covers_all_machine_variants() {
+        use meerkat_runtime::meerkat_machine::dsl::{
+            LiveWebsocketTokenAdmissionPublicErrorClass as DslClass,
+            LiveWebsocketTokenAdmissionRejection as Dsl,
+        };
+
+        let cases = [
+            (
+                Dsl::TokenNotFound,
+                LiveWsTokenAdmissionRejection::TokenNotFound,
+            ),
+            (
+                Dsl::TokenExpired,
+                LiveWsTokenAdmissionRejection::TokenExpired,
+            ),
+            (
+                Dsl::TokenChannelMismatch,
+                LiveWsTokenAdmissionRejection::TokenChannelMismatch,
+            ),
+            (
+                Dsl::TokenAlreadyConsumed,
+                LiveWsTokenAdmissionRejection::TokenAlreadyConsumed,
+            ),
+            (
+                Dsl::ChannelNotBound,
+                LiveWsTokenAdmissionRejection::ChannelNotBound,
+            ),
+        ];
+        for (machine, transport) in cases {
+            assert_eq!(
+                live_ws_token_admission_rejection_from_machine(machine),
+                transport
+            );
+        }
+
+        assert_eq!(
+            live_ws_token_public_error_class_from_machine(DslClass::InvalidToken),
+            LiveWsTokenAdmissionPublicErrorClass::InvalidToken
+        );
+    }
+
+    /// `EnvRealtimeConfigSource` serves exactly the config it was given —
+    /// per-open resolution then rides the session identity's auth binding
+    /// against that config, matching text-model behaviour.
+    #[tokio::test]
+    async fn env_realtime_config_source_returns_given_config() {
+        let mut config = Config::default();
+        config.realm.insert(
+            "live-wiring-test".to_string(),
+            meerkat_core::RealmConfigSection::default(),
+        );
+
+        let source = EnvRealtimeConfigSource::new(config);
+        let served = source.current_config().await.expect("static config source");
+        assert!(served.realm.contains_key("live-wiring-test"));
+
+        // Stable across opens: the source never consults the environment or
+        // mutates between calls.
+        let served_again = source.current_config().await.expect("static config source");
+        assert!(served_again.realm.contains_key("live-wiring-test"));
+    }
+}

--- a/meerkat-mobkit/src/memory/taint.rs
+++ b/meerkat-mobkit/src/memory/taint.rs
@@ -750,10 +750,9 @@ fn peer_projection_sender_identity(line: &str) -> Option<&str> {
             Some((name, _)) => name.trim(),
             None => rest.strip_suffix(':').unwrap_or(rest).trim(),
         }
-    } else if let Some(rest) = line.strip_prefix("Peer response from ") {
-        rest.split(" (to request:").next()?.trim()
     } else {
-        return None;
+        let rest = line.strip_prefix("Peer response from ")?;
+        rest.split(" (to request:").next()?.trim()
     };
     if name.is_empty() {
         return None;

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -1235,12 +1235,35 @@ pub fn handle_unified_rpc_json<'a>(
     http_base_url: Option<&'a str>,
     identity_ctx: Option<&'a IdentityFirstContext>,
 ) -> Pin<Box<dyn Future<Output = String> + Send + 'a>> {
+    handle_unified_rpc_json_with_live(
+        runtime,
+        request_json,
+        timeout,
+        http_base_url,
+        identity_ctx,
+        None,
+    )
+}
+
+/// [`handle_unified_rpc_json`] plus the gateway's type-erased live handler
+/// (`mobkit/live/*`). `None` keeps every live method answering the typed
+/// `live_unavailable` error — the posture of an ephemeral gateway or a
+/// deployment that did not opt into `runtime_options.live`.
+pub fn handle_unified_rpc_json_with_live<'a>(
+    runtime: &'a UnifiedRuntime,
+    request_json: &'a str,
+    timeout: Duration,
+    http_base_url: Option<&'a str>,
+    identity_ctx: Option<&'a IdentityFirstContext>,
+    live: Option<&'a crate::live_wiring::LiveRpcHandler>,
+) -> Pin<Box<dyn Future<Output = String> + Send + 'a>> {
     Box::pin(handle_unified_rpc_json_inner(
         runtime,
         request_json,
         timeout,
         http_base_url,
         identity_ctx,
+        live,
     ))
 }
 
@@ -1250,6 +1273,7 @@ async fn handle_unified_rpc_json_inner(
     timeout: Duration,
     http_base_url: Option<&str>,
     identity_ctx: Option<&IdentityFirstContext>,
+    live: Option<&crate::live_wiring::LiveRpcHandler>,
 ) -> String {
     let raw_request: Value = match serde_json::from_str(request_json) {
         Ok(raw_request) => raw_request,
@@ -1401,6 +1425,19 @@ async fn handle_unified_rpc_json_inner(
             if workgraph_configured {
                 methods.extend_from_slice(workgraph_methods::WORKGRAPH_READ_METHODS);
                 methods.extend_from_slice(workgraph_methods::WORKGRAPH_MUTATE_METHODS);
+            }
+            // Live methods are advertised only when the gateway attached a
+            // live transport (`runtime_options.live`, persistent mode).
+            if live.is_some() {
+                methods.extend_from_slice(&[
+                    "mobkit/live/open",
+                    "mobkit/live/status",
+                    "mobkit/live/close",
+                    "mobkit/live/refresh",
+                    "mobkit/live/send_input",
+                    "mobkit/live/commit_input",
+                    "mobkit/live/interrupt",
+                ]);
             }
             if identity_ctx.is_some() {
                 methods.extend_from_slice(&[
@@ -3874,6 +3911,25 @@ async fn handle_unified_rpc_json_inner(
                 },
             }
         }
+        method if method.starts_with("mobkit/live/") => match live {
+            None => crate::live_wiring::live_unavailable_response(response_id),
+            Some(live) => {
+                // Member target resolution accepts every public spelling
+                // (the #252 canonicalization class): raw session_id, plain
+                // member name / runtime alias, or a durable identity via
+                // the roster agent_identity label. Unresolvable targets
+                // flow through as None — the mobkit/live/* handlers answer
+                // with a typed invalid-params error naming the requirement.
+                let resolved_session = resolve_live_target(runtime, &request.params).await;
+                live(
+                    resolved_session,
+                    method.to_string(),
+                    request.params.clone(),
+                    response_id,
+                )
+                .await
+            }
+        },
         method if workgraph_methods::is_workgraph_method(method) => {
             let service = runtime.workgraph_service();
             let admission = runtime.workgraph_admission();
@@ -4731,6 +4787,39 @@ fn error_response(response_id: Value, code: i64, message: impl Into<String>) -> 
             data,
         }),
     })
+}
+
+/// Resolve a `mobkit/live/*` member target to the member's bridge session.
+/// Accepts `{session_id}` verbatim, `{identity}` / `{member_id}` as a plain
+/// member name, runtime alias, or durable identity (roster `agent_identity`
+/// label fallback — the same resolution as `/agents/{id}/events` and
+/// `cross_mob/peer_info`).
+async fn resolve_live_target(
+    runtime: &UnifiedRuntime,
+    params: &Value,
+) -> Option<meerkat_core::types::SessionId> {
+    if let Some(raw) = params.get("session_id").and_then(Value::as_str) {
+        return meerkat_core::types::SessionId::parse(raw).ok();
+    }
+    let raw = params
+        .get("identity")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("member_id").and_then(Value::as_str))?;
+    let handle = runtime.mob_handle();
+    let direct = crate::member_comms_id::mob_member_id(raw);
+    let member_id = if handle.get_member(&direct).await.ok().flatten().is_some() {
+        direct
+    } else if let Some(identity) = handle
+        .roster()
+        .await
+        .find_by_label("agent_identity", raw)
+        .map(|entry| entry.agent_identity.clone())
+    {
+        identity
+    } else {
+        direct
+    };
+    handle.resolve_bridge_session_id(&member_id).await
 }
 
 fn maybe_error_response(

--- a/meerkat-mobkit/src/runtime/bootstrap.rs
+++ b/meerkat-mobkit/src/runtime/bootstrap.rs
@@ -16,6 +16,12 @@ pub fn start_mobkit_runtime_with_options(
     timeout: Duration,
     options: RuntimeOptions,
 ) -> Result<MobkitRuntimeHandle, MobkitRuntimeError> {
+    // Pay reqwest's one-time process init (the macOS system-proxy scan,
+    // ~700ms observed since the realtime feature unification enabled
+    // reqwest's `system-proxy`) at startup, not inside the first HTTP-backed
+    // RPC's latency window (the BigQuery adapter's timeout contract measures
+    // that window).
+    let _ = crate::runtime::session_store::shared_bigquery_http_client();
     let delivery_runtime_epoch_ms = current_time_ms();
     let mut lifecycle_events = Vec::new();
     let mut seq = 0_u64;

--- a/meerkat-mobkit/src/runtime/session_store.rs
+++ b/meerkat-mobkit/src/runtime/session_store.rs
@@ -68,6 +68,19 @@ pub enum BigQuerySessionStoreError {
     ProcessFailed { command: String, stderr: String },
 }
 
+/// One process-wide HTTP client for the BigQuery adapter. First
+/// `reqwest::Client::build()` in a process performs the system-proxy scan
+/// (macOS SystemConfiguration — ~700ms observed once the `system-proxy`
+/// feature is unified in by the realtime provider chain); sharing the built
+/// client pays that exactly once, off the per-RPC path after first use, and
+/// per-request timeouts replace per-adapter client rebuilds.
+pub(crate) fn shared_bigquery_http_client() -> reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| reqwest::Client::builder().build().unwrap_or_default())
+        .clone()
+}
+
 #[derive(Debug, Clone)]
 pub struct BigQuerySessionStoreAdapter {
     dataset: String,
@@ -311,18 +324,14 @@ impl BigQuerySessionStoreAdapter {
     }
 
     pub fn new_native(dataset: impl Into<String>, table: impl Into<String>) -> Self {
-        let http_timeout = Duration::from_secs(30);
         Self {
             dataset: dataset.into(),
             table: table.into(),
             project_id: None,
             api_base_url: Self::DEFAULT_API_BASE_URL.to_string(),
             access_token: None,
-            client: reqwest::Client::builder()
-                .timeout(http_timeout)
-                .build()
-                .unwrap_or_default(),
-            http_timeout,
+            client: shared_bigquery_http_client(),
+            http_timeout: Duration::from_secs(30),
         }
     }
 
@@ -342,11 +351,13 @@ impl BigQuerySessionStoreAdapter {
     }
 
     pub fn with_http_timeout(mut self, timeout: Duration) -> Self {
+        // The timeout applies per REQUEST (see `authorized_request`) over one
+        // shared client: reqwest's first `Client::build()` in a process pays
+        // the macOS system-proxy scan (~700ms observed) since the realtime
+        // feature unification enabled reqwest's `system-proxy`; rebuilding a
+        // client per adapter put that scan — and a connector build — inside
+        // every RPC's latency window.
         self.http_timeout = timeout;
-        self.client = reqwest::Client::builder()
-            .timeout(timeout)
-            .build()
-            .unwrap_or_default();
         self
     }
 
@@ -590,6 +601,7 @@ impl BigQuerySessionStoreAdapter {
         let mut request = self
             .client
             .request(method, endpoint)
+            .timeout(self.http_timeout)
             .bearer_auth(access_token)
             .header("accept", "application/json");
         if let Some(body) = body {

--- a/meerkat-mobkit/tests/gateway_live.rs
+++ b/meerkat-mobkit/tests/gateway_live.rs
@@ -1,0 +1,211 @@
+//! Gateway-level tests for the live (realtime) surface: opt-in gating,
+//! method advertisement, identity-target resolution errors, and the mounted
+//! WebSocket route. A full provider round-trip needs a realtime credential
+//! and a live provider — out of scope here; the projection/token semantics
+//! are unit-tested in `src/live_wiring.rs` and upstream.
+
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::uninlined_format_args
+)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const MOB_CONFIG: &str = r#"
+[mob]
+id = "gateway-live-test"
+
+[profiles.default]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.default.tools]
+comms = true
+"#;
+
+struct Gateway {
+    child: Child,
+    stdin: ChildStdin,
+    lines: mpsc::Receiver<String>,
+}
+
+impl Gateway {
+    fn start() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rpc_gateway"))
+            .arg("--persistent")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn rpc_gateway");
+        let stdin = child.stdin.take().expect("gateway stdin");
+        let stdout = child.stdout.take().expect("gateway stdout");
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            child,
+            stdin,
+            lines: rx,
+        }
+    }
+
+    fn send(&mut self, value: Value) {
+        writeln!(
+            self.stdin,
+            "{}",
+            serde_json::to_string(&value).expect("request json")
+        )
+        .expect("write request");
+        self.stdin.flush().expect("flush request");
+    }
+
+    fn wait_for_response(&mut self, id: &str, deadline: Duration) -> Value {
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            let remaining = deadline.saturating_sub(start.elapsed());
+            let Ok(line) = self.lines.recv_timeout(remaining) else {
+                break;
+            };
+            let Ok(message) = serde_json::from_str::<Value>(line.trim()) else {
+                continue;
+            };
+            if message.get("method").is_none()
+                && message.get("id").and_then(Value::as_str) == Some(id)
+            {
+                return message;
+            }
+        }
+        panic!("no response for id {id} within {deadline:?}");
+    }
+}
+
+impl Drop for Gateway {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn init_params(state_dir: &tempfile::TempDir, live: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "init",
+        "method": "mobkit/init",
+        "params": {
+            "persistent_state": state_dir.path(),
+            "mob_config": MOB_CONFIG,
+            "runtime_options": { "live": live }
+        }
+    })
+}
+
+#[test]
+fn live_methods_answer_unavailable_without_opt_in() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+    gateway.send(init_params(&state_dir, json!(false)));
+    let init = gateway.wait_for_response("init", Duration::from_mins(1));
+    assert!(init["result"]["contract_version"].is_string(), "{init}");
+
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "open",
+        "method": "mobkit/live/open",
+        "params": { "identity": "worker-1" }
+    }));
+    let response = gateway.wait_for_response("open", Duration::from_secs(15));
+    assert_eq!(response["error"]["code"], json!(-32050), "{response}");
+    assert_eq!(response["error"]["data"]["kind"], json!("live_unavailable"));
+
+    // The catalog does not advertise live methods either.
+    gateway.send(json!({
+        "jsonrpc": "2.0", "id": "caps", "method": "mobkit/capabilities", "params": {}
+    }));
+    let caps = gateway.wait_for_response("caps", Duration::from_secs(15));
+    let methods = caps["result"]["methods"].as_array().expect("methods");
+    assert!(!methods.iter().any(|m| m == "mobkit/live/open"), "{caps}");
+}
+
+#[test]
+fn live_opt_in_advertises_methods_and_mounts_the_ws_route() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+    gateway.send(init_params(&state_dir, json!(true)));
+    let init = gateway.wait_for_response("init", Duration::from_mins(1));
+    assert!(init["result"]["contract_version"].is_string(), "{init}");
+    let base = init["result"]["http_base_url"]
+        .as_str()
+        .expect("http_base_url")
+        .to_string();
+
+    gateway.send(json!({
+        "jsonrpc": "2.0", "id": "caps", "method": "mobkit/capabilities", "params": {}
+    }));
+    let caps = gateway.wait_for_response("caps", Duration::from_secs(15));
+    let methods = caps["result"]["methods"].as_array().expect("methods");
+    for method in [
+        "mobkit/live/open",
+        "mobkit/live/status",
+        "mobkit/live/close",
+        "mobkit/live/refresh",
+    ] {
+        assert!(methods.iter().any(|m| m == method), "missing {method}");
+    }
+
+    // Unresolvable member target → typed invalid params, not a hang.
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "open-missing",
+        "method": "mobkit/live/open",
+        "params": { "identity": "nobody-here" }
+    }));
+    let response = gateway.wait_for_response("open-missing", Duration::from_secs(15));
+    assert_eq!(response["error"]["code"], json!(-32602), "{response}");
+
+    // The WS route is mounted on the gateway's OWN listener: a tokenless
+    // GET to /live/ws is rejected by the transport (any HTTP status proves
+    // the route exists; an unmounted path would be the axum 404 fallback
+    // with an empty body — the transport rejection carries one).
+    let url = format!("{base}/live/ws");
+    let response = ureq_get_status(&url);
+    assert!(
+        response != 404,
+        "live ws route must be mounted (got 404 from {url})"
+    );
+}
+
+/// Minimal blocking GET returning the HTTP status (no external HTTP dep —
+/// hand-rolled over std TcpStream; the gateway listens on loopback).
+fn ureq_get_status(url: &str) -> u16 {
+    use std::io::{Read, Write as _};
+    let rest = url.strip_prefix("http://").expect("http url");
+    let (host, path) = rest.split_once('/').expect("path");
+    let mut stream = std::net::TcpStream::connect(host).expect("connect");
+    write!(
+        stream,
+        "GET /{path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"
+    )
+    .expect("write request");
+    let mut buf = Vec::new();
+    let _ = stream.read_to_end(&mut buf);
+    let head = String::from_utf8_lossy(&buf);
+    head.split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .expect("status code")
+}

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -1925,6 +1925,50 @@ class MobHandle:
         return int(pruned)
 
     # -----------------------------------------------------------------
+    # Live (realtime) sessions — mobkit/live/* (mobkit 0.7.31)
+    # -----------------------------------------------------------------
+
+    async def live_open(
+        self, identity: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        """Open a realtime (live) channel on a member's session.
+
+        Returns the transport bootstrap::
+
+            {"channel_id": ..., "transport": {"type": "websocket",
+             "url": ..., "token": ...}, "capabilities": {...},
+             "continuity": {...}}
+
+        The token is single-use with a short TTL — hand the URL to the
+        client (robot, satellite process) immediately.  Optional kwargs are
+        forwarded (e.g. ``model=`` to override the realtime model,
+        ``turning_mode=``).
+        """
+        params: dict[str, Any] = {"identity": identity, **kwargs}
+        raw = await self._runtime._rpc("mobkit/live/open", params)
+        return raw if isinstance(raw, dict) else {}
+
+    async def live_status(self, identity: str, **kwargs: Any) -> dict[str, Any]:
+        """Status of the member's live channel (open/closed, channel id)."""
+        params: dict[str, Any] = {"identity": identity, **kwargs}
+        raw = await self._runtime._rpc("mobkit/live/status", params)
+        return raw if isinstance(raw, dict) else {}
+
+    async def live_close(self, identity: str, **kwargs: Any) -> dict[str, Any]:
+        """Close the member's live channel."""
+        params: dict[str, Any] = {"identity": identity, **kwargs}
+        raw = await self._runtime._rpc("mobkit/live/close", params)
+        return raw if isinstance(raw, dict) else {}
+
+    async def live_refresh(self, identity: str, **kwargs: Any) -> dict[str, Any]:
+        """Push refreshed mutable config (instructions/tools/audio) into an
+        open live channel without rebuilding the transport.  Model/provider
+        swaps require close + reopen."""
+        params: dict[str, Any] = {"identity": identity, **kwargs}
+        raw = await self._runtime._rpc("mobkit/live/refresh", params)
+        return raw if isinstance(raw, dict) else {}
+
+    # -----------------------------------------------------------------
     # Cross-mob operations
     # -----------------------------------------------------------------
 

--- a/sdk/python/tests/test_rpc_method_names.py
+++ b/sdk/python/tests/test_rpc_method_names.py
@@ -1548,3 +1548,38 @@ async def test_wire_local_omits_pubkey_when_absent():
     )
     assert calls[0][0] == "mobkit/cross_mob/wire_local"
     assert "remote_pubkey_b64" not in calls[0][1]
+
+
+@pytest.mark.asyncio
+async def test_live_method_names_and_identity_param():
+    handle, calls = make_mock_mob_handle({
+        "mobkit/live/open": {
+            "channel_id": "ch-1",
+            "transport": {"type": "websocket", "url": "ws://x/live/ws", "token": "t"},
+        },
+        "mobkit/live/status": {"open": True, "channel_id": "ch-1"},
+        "mobkit/live/close": {"closed": True},
+        "mobkit/live/refresh": {"refreshed": True},
+    })
+
+    opened = await handle.live_open("reachy", model="gpt-realtime-2")
+    assert opened["channel_id"] == "ch-1"
+    assert opened["transport"]["type"] == "websocket"
+
+    status = await handle.live_status("reachy")
+    assert status["open"] is True
+
+    closed = await handle.live_close("reachy")
+    assert closed["closed"] is True
+
+    refreshed = await handle.live_refresh("reachy")
+    assert refreshed["refreshed"] is True
+
+    assert [c[0] for c in calls] == [
+        "mobkit/live/open",
+        "mobkit/live/status",
+        "mobkit/live/close",
+        "mobkit/live/refresh",
+    ]
+    assert calls[0][1] == {"identity": "reachy", "model": "gpt-realtime-2"}
+    assert calls[1][1] == {"identity": "reachy"}

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2153,6 +2153,63 @@ export class MobHandle {
     return typeof pruned === "number" ? pruned : 0;
   }
 
+  // -- Live (realtime) sessions — mobkit/live/* (mobkit 0.7.31) ------------
+
+  /**
+   * Open a realtime (live) channel on a member's session. Returns the
+   * transport bootstrap `{channel_id, transport: {type: "websocket", url,
+   * token}, capabilities, continuity}`. The token is single-use with a
+   * short TTL — hand the URL to the client immediately.
+   */
+  async liveOpen(
+    identity: string,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const raw = await this._runtime._rpc("mobkit/live/open", {
+      identity,
+      ...(options ?? {}),
+    });
+    return asWireRecord(raw);
+  }
+
+  async liveStatus(
+    identity: string,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const raw = await this._runtime._rpc("mobkit/live/status", {
+      identity,
+      ...(options ?? {}),
+    });
+    return asWireRecord(raw);
+  }
+
+  async liveClose(
+    identity: string,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const raw = await this._runtime._rpc("mobkit/live/close", {
+      identity,
+      ...(options ?? {}),
+    });
+    return asWireRecord(raw);
+  }
+
+  /**
+   * Push refreshed mutable config (instructions/tools/audio) into an open
+   * live channel without rebuilding the transport. Model/provider swaps
+   * require close + reopen.
+   */
+  async liveRefresh(
+    identity: string,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const raw = await this._runtime._rpc("mobkit/live/refresh", {
+      identity,
+      ...(options ?? {}),
+    });
+    return asWireRecord(raw);
+  }
+
   // -- Topology -----------------------------------------------------------
 
   async rediscover(): Promise<RediscoverReport | null> {

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -2510,3 +2510,34 @@ describe("MobHandle.workgraphAttentionPrune()", () => {
     assert.equal(pruned, 0);
   });
 });
+
+
+describe("MobHandle live methods", () => {
+  it("sends identity + options and parses the bootstrap", async () => {
+    const { handle, calls, setResponse } = createMockRuntime();
+    setResponse(() => ({
+      channel_id: "ch-1",
+      transport: { type: "websocket", url: "ws://x/live/ws", token: "t" },
+    }));
+
+    const opened = await handle.liveOpen("reachy", { model: "gpt-realtime-2" });
+    assert.equal(calls[0].method, "mobkit/live/open");
+    assert.deepEqual(calls[0].params, {
+      identity: "reachy",
+      model: "gpt-realtime-2",
+    });
+    assert.equal((opened.transport as Record<string, unknown>).type, "websocket");
+
+    setResponse(() => ({ open: true }));
+    await handle.liveStatus("reachy");
+    assert.equal(calls[1].method, "mobkit/live/status");
+
+    setResponse(() => ({ closed: true }));
+    await handle.liveClose("reachy");
+    assert.equal(calls[2].method, "mobkit/live/close");
+
+    setResponse(() => ({ refreshed: true }));
+    await handle.liveRefresh("reachy");
+    assert.equal(calls[3].method, "mobkit/live/refresh");
+  });
+});


### PR DESCRIPTION
Expose meerkat 0.7.25's live/* surface on mob member sessions through the gateway. Design of record: `docs/design/live-sessions.md`. Consumer shape: a LAN client (HomeCore's robot, a satellite process) opens a realtime audio/text channel to an **identity target**, converses, and the turns become durable member transcript.

## The five pieces (from the ask)

1. **RPC with identity targets** — `mobkit/live/{open,status,close,refresh,send_input,commit_input,interrupt}` on the stdin surface, resolving `{identity}` / `{member_id}` / `{session_id}` spellings (durable identities via the roster `agent_identity` label — the same canonicalization class as `/agents/{id}/events`). Off-state answers typed `-32050 live_unavailable`; capabilities advertise the methods only when attached.
2. **Transport on the existing listener** — meerkat-live's `live_ws_router` merges onto the gateway's HTTP app (no second port): clients reach `{base}/live/ws` directly or through the host's reverse proxy. `runtime_options.live = true | {public_base_url}` opt-in (default OFF, persistent mode only); `public_base_url` rewrites minted bootstrap URLs for proxied/LAN deployments. Tokens are machine-authority-backed, single-use, 60s TTL, channel-pinned.
3. **Tools through the callback bridge — free, verified** — the live tool dispatcher delegates to the session's `dispatch_external_tool_call`, i.e. the member's normal external-tool machinery. `CallbackToolDispatcher`, composed recorder tools, and gating apply to live turns unchanged.
4. **Live transcript → durable member transcript** — realtime transcript events commit into the ONE canonical session history through the same append-only save path as normal turns, so they ride `ContinuitySessionStoreAdapter` (including the Bug B-2 RebuildToAuthority fix). Lane semantics ported verbatim (display-text vs spoken-transcript, response_id-keyed drains, fail-closed delta identity).
5. **Realtime model** — the member's profile `model` decides (only `gpt-realtime-2` is realtime-capable in the shipped catalog); `mobkit/live/open` accepts a per-open `model` override. Credentials resolve **per open** through the same auth plumbing as text turns (env `OPENAI_API_KEY` works out of the box).

## Also in this PR

- **Fallout fix**: the `openai-realtime`/`live` feature unification enabled reqwest's `system-proxy`, putting a ~700ms one-time macOS proxy scan inside the FIRST HTTP-backed RPC's latency window (caught by the BigQuery timeout-propagation contract test). The BigQuery adapter now shares one process-wide client with per-request timeouts, and runtime bootstrap pre-warms the client stack.
- SDK methods both languages (`live_open`/`liveOpen`, status/close/refresh) with tests.
- rust-1.97 clippy fixes (toolchain moved mid-branch).

## Not in v1 (documented)

WebRTC, provider-native resume, console UI affordance, staged/archived-member recovery on open (an archived member surfaces as a typed error rather than silently resuming — fine while the bridge holds members live).

## Tests

`live_wiring` unit suite (turn-ledger keying, delta-identity fail-closed, token-admission mapping — 9); `gateway_live` integration (opt-in advertises + mounts `/live/ws` on the shared listener; off-state typed; unresolvable target typed); SDK suites both languages; full crate suite green (two isolated-pass load-class one-offs on 16-core local runs, consistent with the documented heavy-runtime family — CI's capped runners arbitrate).

Rides 0.7.31 (gated on meerkat 0.7.26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)