### PR TITLE
perf(identity-first): parallelize member restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Identity-first bootstrap restores up to four durable members concurrently
+  instead of serially, with bounded fan-out and per-member restore timing logs
+  for slow resumes. This prevents large full-history rosters from accumulating
+  every member's resume latency inside `mobkit/init`.
+
 ## [0.7.31] - 2026-07-09
 
 ### Added

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -5,6 +5,9 @@
 //! not continuity truth), and REQ-33 (identity-keyed reconciliation).
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
+
+use futures::{StreamExt, stream};
 
 use super::contracts::{AgentCustomizer, TopologyProvider};
 use super::runtime::{IdentityRuntime, IdentityRuntimeError};
@@ -14,6 +17,25 @@ use super::types::{
     ContinuityResolveState, DurableAgentSpec, IdentityLifecycleState, LeaseAcquireResult,
     LeaseGrant, ManagedPeerEdge, SessionSnapshot, TopologyContext,
 };
+
+pub(crate) const IDENTITY_RESTORE_CONCURRENCY: usize = 4;
+
+fn trace_identity_restore_completed(identity: &AgentIdentity, started_at: Instant) {
+    let elapsed = started_at.elapsed();
+    if elapsed >= Duration::from_secs(1) {
+        tracing::info!(
+            %identity,
+            elapsed_ms = elapsed.as_millis(),
+            "identity restore completed"
+        );
+    } else {
+        tracing::debug!(
+            %identity,
+            elapsed_ms = elapsed.as_millis(),
+            "identity restore completed"
+        );
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Restore flow result
@@ -270,14 +292,12 @@ pub async fn restore_flow(
     let topology_context = TopologyContext {
         roster: roster.to_vec(),
     };
-    let mut activated_identities = BTreeSet::new();
     let managed_edges = if let Some(tp) = topology_provider {
         match tp.compute_edges(&identities, &topology_context).await {
             Ok(edges) => edges,
             Err(e) => {
                 let cleanup_error =
-                    release_unactivated_restore_grants(runtime, &grants, &activated_identities)
-                        .await;
+                    release_unactivated_restore_grants(runtime, &grants, &BTreeSet::new()).await;
                 return Err(IdentityRuntimeError::Internal(append_cleanup_error(
                     format!("topology: {e}"),
                     cleanup_error,
@@ -288,10 +308,32 @@ pub async fn restore_flow(
         Vec::new()
     };
 
-    // Steps 5-11: per-identity processing
-    let mut outcomes = BTreeMap::new();
-    for spec in roster {
-        let identity = &spec.identity;
+    // Steps 5-11: per-identity processing. Session restoration is dominated by
+    // independent history loading and agent construction, so keep a small
+    // bounded set in flight instead of making large durable rosters pay the
+    // full sum of every member's resume latency.
+    tracing::info!(
+        member_count = roster.len(),
+        concurrency = IDENTITY_RESTORE_CONCURRENCY,
+        "starting identity restore"
+    );
+    let restore_started_at = Instant::now();
+    let restore_results = stream::iter(roster.iter().cloned().enumerate())
+        .map(|(index, spec)| {
+            let resolve_state = resolved.get(&spec.identity).cloned();
+            let grant = grants.get(&spec.identity).cloned();
+            let identities = identities.clone();
+            let managed_edges = managed_edges.clone();
+            async move {
+                let member_started_at = Instant::now();
+                let mut grants = BTreeMap::new();
+                if let Some(grant) = grant {
+                    grants.insert(spec.identity.clone(), grant);
+                }
+                let mut activated_identities = BTreeSet::new();
+                let mut outcomes = BTreeMap::new();
+                let spec = &spec;
+                let identity = &spec.identity;
 
         // If this identity is already registered and in Active state
         // (from a previous restore_flow call), skip bridge operations — the
@@ -320,7 +362,7 @@ pub async fn restore_flow(
             activated_identities.insert(identity.clone());
         }
 
-        let persisted_resolve_state = resolved.get(identity).ok_or_else(|| {
+        let persisted_resolve_state = resolve_state.as_ref().ok_or_else(|| {
             IdentityRuntimeError::Internal(format!(
                 "resolve_many did not return state for {identity}"
             ))
@@ -851,9 +893,22 @@ pub async fn restore_flow(
                                     detail: err.to_string(),
                                 }),
                             );
-                            // Not added to activated_identities: the final
-                            // cleanup releases this identity's lease grant.
-                            continue;
+                            // Not added to activated_identities: release this
+                            // identity's lease grant before completing its
+                            // independently scheduled restore task.
+                            if let Some(cleanup_error) = release_unactivated_restore_grants(
+                                runtime,
+                                &grants,
+                                &activated_identities,
+                            )
+                            .await
+                            {
+                                return Err(IdentityRuntimeError::Internal(format!(
+                                    "restore cleanup failed: {cleanup_error}"
+                                )));
+                            }
+                            trace_identity_restore_completed(identity, member_started_at);
+                            return Ok((index, outcomes));
                         }
                     };
                     record.session_id = resumed_session_id;
@@ -1104,18 +1159,41 @@ pub async fn restore_flow(
 
             // Step 11: Broken → fail loudly (REQ-13)
             ContinuityResolveState::Broken { failure } => {
-                outcomes.insert(identity.clone(), RestoreOutcome::Broken(failure.clone()));
+                outcomes.insert(identity.clone(), RestoreOutcome::Broken(failure));
             }
         }
-    }
+                if let Some(cleanup_error) =
+                    release_unactivated_restore_grants(runtime, &grants, &activated_identities)
+                        .await
+                {
+                    return Err(IdentityRuntimeError::Internal(format!(
+                        "restore cleanup failed: {cleanup_error}"
+                    )));
+                }
 
-    if let Some(cleanup_error) =
-        release_unactivated_restore_grants(runtime, &grants, &activated_identities).await
-    {
-        return Err(IdentityRuntimeError::Internal(format!(
-            "restore cleanup failed: {cleanup_error}"
-        )));
+                trace_identity_restore_completed(identity, member_started_at);
+                Ok((index, outcomes))
+            }
+        })
+        .buffer_unordered(IDENTITY_RESTORE_CONCURRENCY)
+        .collect::<Vec<Result<(usize, BTreeMap<AgentIdentity, RestoreOutcome>), _>>>()
+        .await;
+
+    let mut ordered_results = Vec::with_capacity(restore_results.len());
+    for result in restore_results {
+        ordered_results.push(result?);
     }
+    ordered_results.sort_by_key(|(index, _)| *index);
+
+    let mut outcomes = BTreeMap::new();
+    for (_, member_outcomes) in ordered_results {
+        outcomes.extend(member_outcomes);
+    }
+    tracing::info!(
+        member_count = roster.len(),
+        elapsed_ms = restore_started_at.elapsed().as_millis(),
+        "identity restore completed"
+    );
 
     if let Err(err) = runtime.reconcile_managed_peer_edges(&managed_edges).await {
         tracing::warn!(

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -4410,6 +4410,7 @@ pub async fn wire_cross_mob_by_identity(
 mod reset_reprofile_tests {
     use super::*;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 
     use super::super::bridge::{BridgeError, MemberInspection, ResumeSessionOutcome};
@@ -4447,6 +4448,9 @@ mod reset_reprofile_tests {
     #[derive(Default)]
     struct RecordingBridge {
         create_profiles: AsyncMutex<Vec<String>>,
+        create_delay: Duration,
+        creates_in_flight: AtomicUsize,
+        max_creates_in_flight: AtomicUsize,
         retired_runtime_ids: AsyncMutex<Vec<String>>,
         hanging_retire_runtime_ids: AsyncMutex<BTreeSet<String>>,
         failing_unregister_session_ids: AsyncMutex<BTreeSet<String>>,
@@ -4455,6 +4459,10 @@ mod reset_reprofile_tests {
     impl RecordingBridge {
         async fn create_profiles(&self) -> Vec<String> {
             self.create_profiles.lock().await.clone()
+        }
+
+        fn max_creates_in_flight(&self) -> usize {
+            self.max_creates_in_flight.load(Ordering::SeqCst)
         }
 
         async fn retired_runtime_ids(&self) -> Vec<String> {
@@ -4486,6 +4494,11 @@ mod reset_reprofile_tests {
             _draft: &AgentBuildDraft,
             session_id: &SessionId,
         ) -> Result<SessionId, BridgeError> {
+            let in_flight = self.creates_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_creates_in_flight
+                .fetch_max(in_flight, Ordering::SeqCst);
+            tokio::time::sleep(self.create_delay).await;
+            self.creates_in_flight.fetch_sub(1, Ordering::SeqCst);
             self.create_profiles
                 .lock()
                 .await
@@ -4582,6 +4595,46 @@ mod reset_reprofile_tests {
             backend: None,
             binding: None,
         }
+    }
+
+    #[tokio::test]
+    async fn restore_flow_bounds_parallel_member_creation() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let specs = (0..8)
+            .map(|index| {
+                Ok(durable_spec(
+                    AgentIdentity::parse(&format!("domain:restore-{index}"))?,
+                    "domain",
+                ))
+            })
+            .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
+        let bridge = Arc::new(RecordingBridge {
+            create_delay: Duration::from_millis(25),
+            ..RecordingBridge::default()
+        });
+        let runtime = IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(LocalContinuityStore::in_memory()?),
+            lease_provider: Arc::new(LocalLeaseProvider::new()),
+            runtime_instance_id: "parallel-restore-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge.clone()),
+            default_timeout: None,
+        });
+
+        let result = super::super::orchestrator::restore_flow(&runtime, &specs, None, None).await?;
+
+        assert_eq!(result.outcomes.len(), specs.len());
+        assert!(
+            bridge.max_creates_in_flight() > 1,
+            "member creation should no longer be serial"
+        );
+        assert!(
+            bridge.max_creates_in_flight()
+                <= super::super::orchestrator::IDENTITY_RESTORE_CONCURRENCY,
+            "restore concurrency must remain bounded"
+        );
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- restore identity-first roster members with bounded concurrency of four instead of serially
- preserve per-identity lease cleanup and durable-session failure semantics
- emit aggregate and slow-member restore timing logs during `mobkit/init`
- add regression coverage proving restore work is concurrent but bounded

## Motivation

HomeCore now restores 16 members with large durable histories. Serial member resume pushed `mobkit/init` beyond the 300-second SDK transport timeout, causing launchd to repeatedly restart the service. Raising `HOMECORE_RPC_TIMEOUT_SECS` to 900 avoids the immediate boot loop, but does not address the accumulated per-member startup latency.

This change removes the serial bottleneck while retaining a conservative concurrency cap to avoid an unbounded startup burst.

## Validation

- `cargo test -p meerkat-mobkit --lib identity_first::runtime::reset_reprofile_tests -- --nocapture`
- `cargo test -p meerkat-mobkit --test identity_first_runtime restore -- --nocapture`
- `cargo test -p meerkat-mobkit --test identity_first_cold_restart_continuity -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p meerkat-mobkit --all-targets -- -D warnings`
- `cargo check -p meerkat-mobkit`
- repository pre-push formatting, clippy, and workspace unit gates

The raw `cargo test -p meerkat-mobkit --lib` invocation still exhausts the local process file-descriptor limit (`Too many open files`) across unrelated runtime-heavy tests; the repository's pre-push workspace unit gate passes.
