### PR TITLE
fix: release the member's grant on the missing-resolve-state path (#265 fixup)

### DIFF
--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -362,11 +362,19 @@ pub async fn restore_flow(
             activated_identities.insert(identity.clone());
         }
 
-        let persisted_resolve_state = resolve_state.as_ref().ok_or_else(|| {
-            IdentityRuntimeError::Internal(format!(
-                "resolve_many did not return state for {identity}"
-            ))
-        })?;
+        let Some(persisted_resolve_state) = resolve_state.as_ref() else {
+            // Internal-invariant path (resolve_many answered every roster
+            // identity two steps ago), but keep it symmetric with every
+            // sibling error path in this task: release THIS member's grant
+            // before failing — under the parallel restore there is no final
+            // whole-roster cleanup to catch a skipped release (#265 fixup).
+            let cleanup_error =
+                release_unactivated_restore_grants(runtime, &grants, &activated_identities).await;
+            return Err(IdentityRuntimeError::Internal(append_cleanup_error(
+                format!("resolve_many did not return state for {identity}"),
+                cleanup_error,
+            )));
+        };
         let resolve_state = if !already_active && durable_spec_uses_external_binding(spec) {
             ContinuityResolveState::Uninitialized
         } else {


### PR DESCRIPTION
Review follow-up to #265 (parallel member restore, merged): every intra-task error path releases the member's own lease grant before failing — except the `persisted_resolve_state` internal-invariant check, which `?`-returned without cleanup. Under the serial flow the final whole-roster release caught it; under the parallel flow each task owns its cleanup, so the skipped release would leak the lease until expiry. Made symmetric with every sibling path.

(Also noted in review, no change needed: on one member's hard error the other members now complete their restores rather than never starting — partial progress is preserved and retry handles already-active members.)

Restore/reset suites green (37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)