### PR TITLE
feat: meerkat 0.7.27 (live images) + five field-reported live/schedule gaps

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,7 @@
 heavy-runtime = { max-threads = 2 }
 
 [[profile.default.overrides]]
-filter = 'package(meerkat-mobkit) & (binary(routing_delivery) + binary(list_runs) + binary(list_flows_run_flow) + binary(mob_events_cursor_persistence) + binary(mob_events_query_ledger) + binary(mob_events_streaming) + binary(access_control))'
+filter = 'package(meerkat-mobkit) & (binary(routing_delivery) + binary(list_runs) + binary(list_flows_run_flow) + binary(mob_events_cursor_persistence) + binary(mob_events_query_ledger) + binary(mob_events_streaming) + binary(access_control) + binary(unified_console))'
 test-group = 'heavy-runtime'
 retries = 2
 
@@ -37,6 +37,10 @@ retries = 2
 # run) — the same aggregate-load starvation family expressed as a crash
 # rather than a teardown timeout. Retries re-run in a fresh process near-alone;
 # a deterministic crash would still fail all three attempts.
+
+# `unified_console` joined 2026-07-10: its live-snapshot test SIG10-aborted
+# twice on loaded 16-core local full-suite runs (passes 1/1 isolated and in
+# its binary) — same aggregate-load crash family as access_control.
 
 # The console-aggregator burst test races a deliberately-slow backfill against
 # live frames; under peak suite load the burst window starves the same way the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,9 +1737,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f68a00835688ad901d10124f33f8695d86533c04c26eeb7e5f58a03c929471a"
+checksum = "f0b7b8e7dc94f1711d21f40b9bb8a2bef28cbbc5fddfca922909569087ee411e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1778,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e969f9ad7fe855df962fdc650b51656a04919c3fd19da2d436a191d61411763"
+checksum = "a1bfa3fa7d5ecae7d5ab29224d071f2e454d6552a483f3e92657cb1dcb154e22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1802,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367fc84dd6abdb8bf60e0b434b19771c9bc164cd22f784a1200dade2d826789"
+checksum = "5908e723f7a925c6d7896fef1d543bd5b5e36f68af1a80e2908d7997ca4b4db7"
 dependencies = [
  "async-trait",
  "axum",
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ee1a769e96c13ddf14207cd27321425e4c3ab3296b85077d201fc2465739de"
+checksum = "5c408133021b53bd0a22db768942f94f0cc2327cfe66aba39ac68b8462f4d192"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec15bd12b1aa0a73566d4e066c0ed36ef32f10ed484dcd6ba722dd6965841c3"
+checksum = "4afeec98c91db99f9b374322bd8c549bace28ba949f7ee143d1456257bbdcbfc"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2790425719362a3275c368e90ddd2e972498e966346328eaac0ec64edcb9ab"
+checksum = "5d29710610223824c7bb8ab4514606404f68ccbeb8ed5f159f40ebd9a9d7a53c"
 dependencies = [
  "async-trait",
  "base64",
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f512dac276b29c24424a9ad1a10064c63a9c3bbed3aa411a6092e1247c024536"
+checksum = "2496c3c0633fbad80b900e3d7836147c3fff99e672d20c4a297204dd530e8cdb"
 dependencies = [
  "base64",
  "chrono",
@@ -1911,13 +1911,14 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1c5e2592548cc72374e794b5036d06c882ad7efdec45e5b03087c45ddd75fb"
+checksum = "e7285c605d15406f427209878d577fe5ba96a523d65293a64ea54c28edf28101"
 dependencies = [
  "async-trait",
  "base64",
@@ -1946,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4b077f48906868307ab4f75a6fb452884834c59f276982484c84f50e8c22b9"
+checksum = "10df37da475915393f32fa6fddbdf6f9f1c84d3bf0be3a5d09574b47dd0d0da3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1970,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d141ef1f5fe58beaf0213fa17af24f8a067876f028bbc7b987ab073e2f8c1b"
+checksum = "6eed50146250fcd8cc948020d4792a7630d79770dc319277a27bb001798260e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1993,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b35b36a4a9646afbc918364e5090195aba5fa22440a3ad9d350be3aba2d150"
+checksum = "1cacec9ae7b21fa606923b3f64e7b2891761b2749684da6d454f7ada36affeb4"
 dependencies = [
  "async-trait",
  "axum",
@@ -2013,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0320f0d04a4060392aa907490dd5290cca8b3c2ec03d4820d7bb963931a4fd"
+checksum = "6d0de464d932373d480e7d1ad66abdf414e9b0684623b8b16fb2af26f1c606d9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2039,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fe9af0a5ebb8dbbe1ef2732671e768ff75db27f950446ec60696329a59dbc"
+checksum = "9df4791c667b4da429fbbfe667bb50c5128ec36cc669c5b7d63a8b0d8333497a"
 dependencies = [
  "quote",
  "syn",
@@ -2049,18 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36292611abd687f1b410741371edea698bee55b140b5710fdf95b176efac62c"
+checksum = "05a7060d61268be5a8eaa11189893f79e1af169c1aef8ca622322ebae927c1b6"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5f14d167433106c2246beef1ba2cd4e9c745d9c0122cff39bdc4ed25b1f74c"
+checksum = "cedab6fc4f0ef4c22b827cd49075e6696aff65ae27469e2ad86fc3b9adcba316"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2069,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1e5eb4e3bb4b07f84240e061d4004e5256d5ce46d0b401d0c7dec94d182f50"
+checksum = "a41316e0bb47539346b3670d98edefc88440c08b5b1267c58cb9e42ffc1ae433"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2082,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78a348250f85b27652fa48ebcbed227dd5c583c7fb591d5b056c46ab629f31c"
+checksum = "642740eaa0ad5b65d855388f152d97599222c3d5039681ddde7f12fdfc7a172d"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2095,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db0010cf175f547cf52574bd2c824b02416e40efced8473c8563edc4571f874"
+checksum = "03dff1684a2fd6e716af79b377eb447c4744d2099dcdbc687efa6332df4bc5f4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2120,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84468d8d88bf0db4efa87b01e4cf8ff37c773b8ba77a6a93af0a7f91100a996"
+checksum = "0fabdab423d0cece18197780b62c0df5d36283017006fc5ad2736237c4d87979"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2141,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f749ff889d8189f485e794bdbf3b6d9d78acb12c626e35a5ddff0950565b46"
+checksum = "f366a41c0740e2bee488afd74b1898d95baf7afaf5b8719305ce82c09a3c3397"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2179,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af49ef6e0bfc8e4d379631c7882e211571cd80142071ce53c97e704f88b7482"
+checksum = "96a6c0f4bf5f9fd43e6b593d8625c8536430b6a8806ae5db9c713b6488bcbd8a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2259,18 +2260,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7898691aa9e9dfb35c1762dd175eab2e029a347f3ef962d7851013f7675930e"
+checksum = "bd23be9f011dd7d0af7e2a192dae5d3f08250ca3e1fc66f1cf1b211e949bc2b9"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2ce8b562ade0ad867b3b96df79f29e7688ab89649ec1199c31588b46f06c43"
+checksum = "2e1fd600ca94158495e7cd0d6d7c0d23d817a899d3848581c41ab3f63c66945a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2288,6 +2289,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -2297,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac15542919794332922e0780dc80163cf0e00435f1c1dfdbd54ec9537ded37d4"
+checksum = "5c77889ee84c896a589231c0a0f4d06b753e774046221f4d2a54a113cd4440f0"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2307,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988ed6b718348f1e02efd78826ce6df1302eb481c00b9a8986dbb726c63106d6"
+checksum = "62df6a8302b4f3c89639a645c8d93fd2ae9472634da73cc2b37bad70b1dde708"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2335,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804c8a1c4b3af1d6241b862bf57f43b882e4ede8c66a0c088c8e1c83645e371d"
+checksum = "c66362cffb821d009fdddd89bf12adae5b9c7a0196ffe3579accbee7233e0707"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2361,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682f361fad1d04d713f2735a91ee9c441ed8b5c892abc6b33c129a1d725b087"
+checksum = "042525012e093ef75c5ad4d034f6254f6cd6939c6b3783460b264d6fe52f23f9"
 dependencies = [
  "async-trait",
  "futures",
@@ -2387,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77494084bfe89eafe47e860a696b898ad17779210b40bae5e23eba223da50515"
+checksum = "32a47a72e9d9cea6a5c0c13dad979ebb929e683e0253a4e2f7db9dc3835f5d41"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2410,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8211383aea354e56695f942ace0049c2f2552ab6b4aee6a3135359c3ef9ce9"
+checksum = "03a08414a9b322a315058238c827ca2eac7bc96f7bffee7546935b6b899afe19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2434,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa4dab4e6f9ac7b9b70e0bdda36129ace77f583d363f3a5d377a7d96f4292bc"
+checksum = "e6679dda0c195fc1610e09302c801174811fccefa619f5a269f7d51e6b941a23"
 dependencies = [
  "async-trait",
  "base64",
@@ -2472,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.26"
+version = "0.7.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a06e262155e8b99d5580763e9781a50d56fdca15077c2d846061a93935af"
+checksum = "54e936d2b7ee38b4e15587e669373f76ab10cedd61632bdadc31d215dd910e32"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/design/live-sessions.md
+++ b/docs/design/live-sessions.md
@@ -86,7 +86,8 @@ New module `meerkat-mobkit/src/live_wiring.rs`:
 5. **RPC surface** (unified stdin + console): `mobkit/live/open`,
    `mobkit/live/status`, `mobkit/live/close`, `mobkit/live/refresh`,
    `mobkit/live/send_input`, `mobkit/live/commit_input`,
-   `mobkit/live/interrupt`. Params accept an IDENTITY TARGET —
+   `mobkit/live/interrupt`, `mobkit/live/truncate`. Params accept an
+   IDENTITY TARGET —
    `{identity: "reachy"}` or `{member_id}` or raw `{session_id}` —
    resolved via `resolve_bridge_session_id` + the roster `agent_identity`
    label fallback (the same canonicalization class as
@@ -105,6 +106,45 @@ New module `meerkat-mobkit/src/live_wiring.rs`:
    `mobkit/init` (default OFF). ABAC: live methods map to `agent.send` on
    the target member (console surface); stdin surface is host-trusted as
    usual.
+
+## Images (meerkat 0.7.27, mobkit 0.7.32)
+
+Still-image input rides the SAME transport and RPC surface: the wire chunk
+`{kind: "image", idempotency_key, mime, data}` flows through
+`mobkit/live/send_input` unchanged (the handler deserializes
+`LiveInputChunkWire`, which gained the exhaustive `Image` variant), and the
+SDKs add `live_send_input_image` / `liveSendInputImage` conveniences
+mirroring meerkat's SDK signatures. `idempotency_key` is caller-stable
+within the session — retries are exact-retry deduplicated by the runtime's
+user-content identity lane, which also rides the open config
+(`user_content_identities` / `user_content_tombstones` /
+`transcript_rewrite_generation`) so reopened channels do not replay
+committed images. The projection sink forwards the transcript apply outcome
+(0.7.27 API) so the host synthesizes the redacted image receipt only after
+durable reducer application. Only `gpt-realtime-2` accepts image input in
+the shipped catalog (capabilities carry `image_in`).
+
+## Field-reported additions (mobkit 0.7.32)
+
+- **Per-open instruction overlay**: `mobkit/live/open` accepts
+  `instructions` (string or array of strings). The overlay rides the
+  runtime system-context lane of the open projection
+  (`with_runtime_system_context`), NOT the typed `system_prompt` — the
+  prompt field is the projection of durable prompt truth (R10) and must not
+  be contaminated by per-open ephemera. The overlay never persists into the
+  durable transcript and is dropped by `live/refresh` (which re-projects
+  from the durable session) and on reopen.
+- **Seed clamp (upstream ask 30 STOPGAP)**: providers cap live instructions
+  at 65,536 tokens, so long member transcripts overflow the projected seed
+  at open. `runtime_options.live.seed_max_chars` (object form) sets a
+  gateway-wide serialized-char budget; per-open `seed_max_chars` overrides
+  it. Whole messages drop OLDEST-first; a projected root system message is
+  never dropped. Remove when meerkat ships a machine-owned seed-window
+  projection (ask 30).
+- **`mobkit/live/truncate`** (was deliberately unported in v1): barge-in
+  cleanup — truncate an assistant item at the client-tracked playback
+  cursor. Same machine-authority choreography as the sibling command
+  handlers; SDK conveniences `live_truncate` / `liveTruncate`.
 
 ## What we deliberately do NOT do in v1
 

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -1278,3 +1278,34 @@ LEAD a pre-addressed "conclude the objective" affordance (mirroring
 await "objective concluded" instead of inferring it from interaction
 completion + quiescence heuristics. mobkit would surface the conclusion as
 a typed console/RPC event.
+
+## Ask 29 — profile overrides freeze the whole tool surface across definition drift — P2
+
+Field (HomeCore Bug G′, 2026-07-10): the only reset-reprofiled member
+(domain:security, gen 8) has NO `meerkat_schedule_*` tools despite
+`[profiles.security.tools] schedule = true` — the agent improvised via its
+unrestricted shell, hand-writing schedule rows into `schedule.sqlite` that
+the driver fired into the wrong member.
+
+Mechanism (confirmed): a model-only reprofile forces mobkit to snapshot the
+WHOLE profile into `SpawnMemberSpec.override_profile` (there is no
+narrower override — handle.rs:1894). meerkat 0.7.25 M2 durably persists
+`effective_profile_override` and the revival path takes it VERBATIM over
+the current definition (actor.rs:5141, deliberately: "revival inputs must
+equal spawn-time inputs"). Net: the member's tool flags freeze at
+reset-time; definition edits (adding `schedule = true`) reach every
+ordinary member but never the reprofiled one. The 0.7.26 cold-revival
+epoch fix made revival work cold, which made the freeze bite every boot.
+
+Ask (either resolves it):
+- A FIELD-SCOPED override on `SpawnMemberSpec` (e.g. `model_override:
+  Option<String>`) so a reprofile pins only what it changed and the
+  definition stays authoritative for everything else (tools, skills,
+  peer_description) across drift; or
+- revival re-resolves the CURRENT definition profile and applies the
+  recorded override as a patch (requires knowing which fields were
+  overridden — same shape as the first option).
+
+mobkit interim: heal-on-divergence at identity-first restore (compare the
+replayed effective profile against the freshly-composed spec; retire +
+resume-respawn when they diverge) — planned, not yet shipped.

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -1481,3 +1481,19 @@ Ask (either resolves it):
 mobkit interim: heal-on-divergence at identity-first restore (compare the
 replayed effective profile against the freshly-composed spec; retire +
 resume-respawn when they diverge) — planned, not yet shipped.
+
+## Ask 30 — live seed-window: bounded/summarized session projection for realtime opens — P2
+
+Field (HomeCore robot, 2026-07-10): the realtime provider adapter enforces a
+65,536-token instruction cap, and `live/open` seeds the WHOLE projected
+session (system prompt + full transcript projection). Long-lived members
+with large durable histories cannot open a live channel at all once the
+projection exceeds the cap.
+
+Ask: a seed-window knob on the realtime open path — project a bounded
+suffix (and/or a compaction-style summary head) of the session instead of
+the full transcript, in the session-projection layer where
+`realtime_projection_messages` lives, so the bound composes with the
+user-content identity lane and exact-retry guards. mobkit stopgap (shipped
+0.7.32): the gateway clamps the projected seed at open time — correct but
+lossy; the principled summarize-then-seed belongs in core.

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -35,14 +35,14 @@ holds the original deep-dive evidence.
 
 ## Status ledger (verified against the meerkat CHANGELOG, 2026-07-10)
 
-**24 of 30 asks shipped; 6 open.**
+**25 of 30 asks shipped; 5 open.**
 
 | Asks | Status |
 |---|---|
 | 1–8 (agent-memory initiative) | shipped meerkat 0.7.12 |
 | 9 (taint surfaces), 10 (host runnables) | shipped meerkat 0.7.13 |
 | 11 (incremental session persistence) | shipped meerkat 0.7.25 |
-| 12 (compaction-archive singletons) | **OPEN** |
+| 12 (compaction-archive singletons) | shipped meerkat 0.6.30 (PR #747 — predates the tracker entry; see the section note) |
 | 13 (event-forwarder backoff/quarantine) | **OPEN** |
 | 14 (typed member health surface) | **OPEN** |
 | 15 (transcript interaction ids) | shipped meerkat 0.7.25 (residual: the classic-send external work door has no interaction param) |
@@ -606,6 +606,23 @@ persistence contract MobKit's memory providers will follow (memory writes
 must stay O(delta) — architecture §12 discipline).
 
 ## Ask 12 — Compaction-archive must not strand singletons
+
+**SHIPPED in meerkat 0.6.30 (PR #747) — predates this tracker entry; the
+tracker incorporated an older production report without recording that its
+original incident had already been fixed (maintainer annotation,
+2026-07-10).** Two layers: (1) root cause — a legitimately compacted
+runtime-authoritative session can replace a lagging, LONGER durable
+projection using the already-validated CAS/continuity proof instead of
+falling through to the rewrite-blind append-only guard; (2) defense in
+depth — even if archival fails for an unrelated reason, disposal removes
+the dead roster anchor so respawn/reset never leave an unreachable
+singleton stranded. Regression tests still on origin/main:
+`test_compacted_session_persists_when_durable_projection_lagged_across_compaction`,
+`test_archive_succeeds_for_compacted_session_with_lagging_durable_projection`.
+NOT the same bug as the later archive asks: 20/21 were created-but-never-run
+members with no runtime snapshot (ArchiveSession/NotFound), 21c was a
+runtime-loop self-deadlock during cleanup, and the 0.7.26 classic-store
+MonotonicityViolation fix addressed torn-shutdown projection rollback.
 
 **Title:** Fix retire-after-compaction stranding (`MonotonicityViolation` on
 ArchiveSession shrink-save, no fallback, ghost roster entry)

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -1,5 +1,26 @@
 # Meerkat upstream asks — work order
 
+## Current status (2026-07-10)
+
+This file is both the historical evidence record and the current upstream work
+queue. Historical problem statements remain below, but their status is
+authoritative only through the explicit status line under each ask.
+
+**Open work is intentionally limited to five actionable asks:**
+
+| Ask | Current actionable residue |
+|---|---|
+| **10** | Add call-level tool authorization to executing transcript forks. Persisted/non-live transcript forking already works; that half of the original ask is closed. |
+| **14** | Add a typed member liveness/progress projection beyond lifecycle status: run-open/idle, in-flight work, last progress/event, and a machine-owned degraded/wedged classification. |
+| **27** | Make ordinary peer-send outcomes distinguish delivered/handed-off/queued from unreachable. Supervisor-rotation operation receipts do not close this general delivery ask. |
+| **28** | Add durable kickoff objective-to-outcome correlation and an explicit conclude-objective affordance. Kickoff quiescence/teardown safety is not objective completion. |
+| **29** | Make profile overrides field-scoped, or reapply them as patches over the current definition during revival, so unrelated tool/profile fields do not freeze. |
+
+Everything else in this document is **closed, shipped, superseded, or retired
+as a separate upstream ask**. In particular, ask 12 was fixed before it was
+filed, and ask 13's operational incidents were closed by a MobKit-local
+forwarder fix plus later Meerkat member-scoped failure containment.
+
 > **Handed to the meerkat coding agent by Luka (2026-07-02).** Eight asks for
 > the meerkat repo, derived from the MobKit memory initiative
 > ([`agent-memory-architecture.md`](agent-memory-architecture.md) §13) and
@@ -33,33 +54,10 @@ holds the original deep-dive evidence.
 ---
 
 
-## Status ledger (verified against the meerkat CHANGELOG, 2026-07-10)
-
-**25 of 30 asks shipped; 5 open.**
-
-| Asks | Status |
-|---|---|
-| 1–8 (agent-memory initiative) | shipped meerkat 0.7.12 |
-| 9 (taint surfaces), 10 (host runnables) | shipped meerkat 0.7.13 |
-| 11 (incremental session persistence) | shipped meerkat 0.7.25 |
-| 12 (compaction-archive singletons) | shipped meerkat 0.6.30 (PR #747 — predates the tracker entry; see the section note) |
-| 13 (event-forwarder backoff/quarantine) | **OPEN** |
-| 14 (typed member health surface) | **OPEN** |
-| 15 (transcript interaction ids) | shipped meerkat 0.7.25 (residual: the classic-send external work door has no interaction param) |
-| 16–19 (schedule poisoned-row family) | shipped meerkat 0.7.19 |
-| 20, 21, 21b (never-ran/archive strands) | shipped meerkat 0.7.22 |
-| 21c (retire-archive mob deadlock) | shipped meerkat 0.7.22 |
-| 21d (identity-first worker archive-NotFound) | shipped meerkat 0.7.23 |
-| 22 (past-due one-shot regeneration) | shipped meerkat 0.7.20 |
-| 23–26 (workgraph break-glass/GC/uniqueness/reply seam) | shipped meerkat 0.7.25 |
-| 27 (unreachable-peer sends read as success) | **OPEN** |
-| 28 (kickoff-scoped objective conclusion) | **OPEN** |
-| 29 (profile overrides freeze tool surface — Bug G′) | **OPEN** |
-
-Keep this table current when filing or closing asks; per-ask sections below
-carry the detail and mobkit adoption notes.
-
 ## Ask 1 — Typed injected-context message class, excluded from compaction indexing
+
+**CLOSED — shipped in Meerkat 0.7.12 (#821).** Typed injected context is a
+separate transcript class and is excluded from semantic-memory indexing.
 
 **Title:** Add a typed injected-context message class that
 `indexable_content()` excludes from compaction indexing
@@ -132,6 +130,10 @@ and MobKit's separate-typed-message delivery — have landed.
 
 ## Ask 2 — `MemoryStore` lifecycle: delete/GC and lazy per-scope index loading
 
+**CLOSED — shipped in Meerkat 0.7.12 (#821).** `drop_scope`, paged scoped
+enumeration, and lazy HNSW scope loading close the lifecycle and rebuild-cost
+properties requested here.
+
 **Title:** `MemoryStore` needs delete/GC (per-scope drop) and lazy per-scope
 index loading
 
@@ -184,6 +186,9 @@ identity-keyed store even though the meerkat rows are stranded.
 
 ## Ask 3 — Compaction-summary indexing exemption
 
+**CLOSED — shipped in Meerkat 0.7.12 (#821).** Compaction summaries are
+excluded from semantic-memory indexing and the retained-turn budget.
+
 **Title:** Discarded compaction summaries should be excluded from compaction
 indexing
 
@@ -219,6 +224,10 @@ known defect rather than worked around.
 ---
 
 ## Ask 4 — LLM-curated compaction seam (host-supplied curator)
+
+**CLOSED — shipped in Meerkat 0.7.12 (#821).** `CompactionCurator` supplies
+the summary in place of the compactor's LLM call; transcript revision listing
+also exposes the current head requested by the implementation refinement.
 
 **Title:** Let a host-supplied curator produce the compaction summary
 
@@ -287,6 +296,10 @@ ideally a revision list) on `SessionService` or the history extension.
 ---
 
 ## Ask 5 — Comms envelope taint metadata + dispatch-time taint visibility
+
+**CLOSED — shipped across Meerkat 0.7.12–0.7.13 (#821, #824).** Signed sender
+taint, typed tool provenance, synchronous dispatch classification, and
+host-consumable peer-ingestion/outbound-taint surfaces close both halves.
 
 **Title:** Taint metadata on comms envelopes; tool-source taint visibility at
 dispatch time
@@ -357,6 +370,10 @@ LLM-authored write quarantines until steward/operator review).
 
 ## Ask 6 — Capability-gated tool authorization for fork-launched members
 
+**CLOSED for member spawn — shipped in Meerkat 0.7.12 (#821).**
+`SpawnMemberSpec.tool_access_policy` is enforced end to end. The distinct
+call-level transcript-fork residue is tracked narrowly as open ask 10.
+
 **Title:** Call-level tool authorization policy on fork/spawn launch modes, so
 a fork-launched member can be capability-contained without changing its tool
 list
@@ -415,6 +432,10 @@ and can consider an agentic steward gather phase; the seam is documented in
 
 ## Ask 7 — Internal-runnable schedule targets in meerkat-schedule
 
+**CLOSED — shipped in Meerkat 0.7.12, with runtime-host wiring completed in
+0.7.13 (#821, #824).** Host-runnable targets flow through the normal durable
+occurrence lifecycle.
+
 **Title:** Let `meerkat-schedule` target a host-registered runnable, not only
 mob members/sessions
 
@@ -451,6 +472,9 @@ the dream as a host runnable and deletes the loop.
 ---
 
 ## Ask 8 — `MemoryStore` enumeration API
+
+**CLOSED — shipped in Meerkat 0.7.12 (#821).** `enumerate_scoped` provides
+paged deterministic reads with source-range and indexed-time filters.
 
 **Title:** Add a scoped enumeration/read API to the `MemoryStore` trait
 (pairs with Ask 2's delete/GC)
@@ -517,6 +541,10 @@ the exact range and the approximation caveat comes out of `distiller.rs`.
 
 ## Ask 9 — Dispatch-time content-taint visibility + `ToolDef` provenance
 
+**CLOSED — shipped across Meerkat 0.7.12–0.7.13 (#821, #824).** Tool
+provenance is typed and the host receives synchronous/typed taint facts rather
+than relying on name parsing and a lagging observe-only signal.
+
 **Title:** Give hosts a synchronous taint signal at tool dispatch, and typed
 tool provenance (completes Ask 5)
 
@@ -550,6 +578,15 @@ compat.
 
 ## Ask 10 — Fork tool authorization + fork-from-persisted (completes Ask 6)
 
+**OPEN, NARROWED (2026-07-10) — call-level fork authorization only.** Current
+`PersistentSessionService` already resolves transcript-edit sources from the
+authoritative persisted session when no live source is available, so the
+fork-from-persisted half is closed (and appears to have predated this filing).
+The real residue is that `SessionForkAtRequest` and
+`SessionForkReplaceRequest` still carry no `tool_access_policy`. Keep the
+zero-tool detached MobKit Distiller until an executing fork can be granted a
+call-scoped policy without broadening its tool surface.
+
 **Title:** Call-level `tool_access_policy` on session fork, and forking a
 persisted (non-live) session
 
@@ -577,6 +614,10 @@ prompt-cache economics). On landing, extraction moves to a fork sharing the
 parent's cached prefix — material at OB3-scale multi-GB transcripts.
 
 ## Ask 11 — Incremental session persistence (`IncrementalSessionStore`)
+
+**CLOSED — shipped in Meerkat 0.7.25 (#857).** `IncrementalSessionStore`
+makes ordinary saves O(delta), and compaction commits a shrinking canonical
+head rather than growing a monolithic session blob.
 
 **Title:** Adopt OB3's incremental session persistence spec — O(delta) saves,
 compaction that shrinks the persisted head
@@ -606,6 +647,13 @@ persistence contract MobKit's memory providers will follow (memory writes
 must stay O(delta) — architecture §12 discipline).
 
 ## Ask 12 — Compaction-archive must not strand singletons
+
+**CLOSED BEFORE FILING — shipped in Meerkat 0.6.30 (#747).** The validated
+projection CAS now accepts a legitimate compacted shrink when the durable
+projection lags, and disposal removes dead roster anchors even if an unrelated
+archive error occurs. The exact persistence and full-archive regressions remain
+in the current Meerkat test suite. Asks 20/21/21c were later, different
+never-run/archive and cleanup-deadlock bugs; they do not reopen this ask.
 
 **SHIPPED in meerkat 0.6.30 (PR #747) — predates this tracker entry; the
 tracker incorporated an older production report without recording that its
@@ -646,6 +694,15 @@ meerkat's session archive path); hosts carry watchdogs + process restarts.
 
 ## Ask 13 — Event-forwarder backoff + per-member commit-failure quarantine
 
+**CLOSED AS AN OPERATIONAL INCIDENT (2026-07-10).** The forwarder hot-loop was
+fixed in MobKit (`9b55a063`): only active members are subscribed, failures use
+per-member exponential backoff capped at 30 seconds, and repeated failures do
+not flood WARN logs. Meerkat later made failed-batch resolution machine-total
+(#859) and session-scoped composition-dispatch failures degrade only the
+affected member instead of terminating the mob actor (#864). The originally
+suggested generic forwarder terminal-state API was never needed to restore the
+requested operational property and is retired rather than left open.
+
 **Title:** Stop dead-stream hot-loops and fleet-wide commit cascades
 
 **Problem statement.** (a) The agent-event forwarder retries dead streams at
@@ -665,6 +722,12 @@ failure — one member degrades, the fleet continues.
 app-level timeouts and runs its own wedge sentinel.
 
 ## Ask 14 — Typed member health/progress surface
+
+**OPEN (2026-07-10).** Lifecycle/member status and restart-durable terminal
+input status have improved, but they still do not provide the requested
+machine-owned run-open/idle, in-flight-work, last-progress/event, and
+degraded/wedged projection. Hosts still reconstruct this from events and
+watchdogs, so the abstraction remains worthwhile.
 
 **Title:** A per-member liveness/progress signal, so hosts stop
 reverse-engineering health from event streams
@@ -689,7 +752,15 @@ approximates from event recency.
 
 ## Ask 15 — Persist `interaction_id` in the transcript
 
-**SHIPPED in meerkat 0.7.25** (addendum included: `SubscribableInjector::inject_with_interaction_id` + `WorkSpec.interaction_id` thread host ids to runtime admission; `TranscriptMessageIdentity` persists onto committed messages). Mobkit adoption (0.7.30): identity-first console sends mint UUIDv5 interaction ids and thread them via `send_with_mode_and_interaction` → bridge `WorkSpec`; session-history backfill stamps `interaction_id`/`run_id` onto frames; console dedup treats UUID-form ids as authoritative twin identity. Residual: the CLASSIC console send path cannot thread (the external work door `external_turn_for_member` has no interaction parameter) — candidate follow-up ask.
+**CLOSED — shipped in Meerkat 0.7.25 (#856) and adopted in MobKit 0.7.30.**
+`SubscribableInjector::inject_with_interaction_id` + `WorkSpec.interaction_id`
+thread host ids to runtime admission; `TranscriptMessageIdentity` persists
+them onto committed messages. Identity-first console sends mint UUIDv5 ids,
+history backfill stamps `interaction_id`/`run_id`, and console dedup treats
+UUID-form ids as authoritative twin identity. The CLASSIC compatibility path
+cannot thread an id through `external_turn_for_member`; that limitation does
+not reopen the identity-first MobKit ask and should only become a new ask if a
+supported classic consumer requires it.
 
 
 **Title:** Give live and historical copies of the same assistant reply a
@@ -747,6 +818,9 @@ the transcript so backfill can stamp them.
 
 ## Ask 16 — `spawn_schedule_host` discards every driver tick error
 
+**CLOSED — shipped in Meerkat 0.7.19 (#842).** Tick failures are tracked,
+attributed, rate-limited, and recovery is reported.
+
 **Problem statement.** `meerkat/src/surface/schedule_host.rs` runs the firing
 loop as `let _ = driver.tick_once().await;` every 250 ms. When ticks fail
 persistently (see asks 17–19 for why they do), schedules silently stop firing
@@ -760,6 +834,9 @@ count consecutive failures in the report struct. A driver that cannot claim
 is an incident, not a no-op.
 
 ## Ask 17 — one poisoned row starves every schedule (all-or-nothing scans)
+
+**CLOSED — shipped in Meerkat 0.7.19 (#842).** Schedule and occurrence row
+faults are isolated while healthy neighbors continue claiming.
 
 **Problem statement.** `ScheduleDriver::tick_once` begins with
 `service.list()` — which fails wholesale on the FIRST schedule row whose
@@ -783,6 +860,9 @@ claims everything healthy.
 
 ## Ask 18 — Deleted schedule tombstones fail recovery and kill `list()`
 
+**CLOSED — shipped in Meerkat 0.7.19 (#842).** Legacy tombstones heal at the
+durable parse boundary and new invalid states remain fail-closed.
+
 **Problem statement.** Deleting a schedule persists a tombstone row whose
 recovered `ScheduleLifecycleMachine` state is then REJECTED on read:
 `RecoveredStateInvariantRejected { phase: Deleted, invariant:
@@ -802,6 +882,9 @@ Plus an upgrade-carry test: delete a schedule under version N, open under
 N+1, `list()` must succeed.
 
 ## Ask 19 — claim scan reads the whole store per tick
+
+**CLOSED — shipped in Meerkat 0.7.19 (#842).** SQL prefiltering bounds scans
+to active schedules and live, due/lease-expired occurrences.
 
 **Problem statement.** `claim_due_occurrences_impl` SELECTs and deserializes
 every occurrence (joined with its schedule) with no SQL predicate on phase or
@@ -833,6 +916,11 @@ reporter's, relayed verbatim-in-substance; ask 20 is mobkit's root-cause of
 the reporter's K1, which turned out to be upstream.
 
 ## Ask 20 — retire/respawn of a never-ran member fails ArchiveSession and strands it in `retiring` (reported as mobkit K1) — P0
+
+**CLOSED — converged across Meerkat 0.7.19–0.7.23 (#842, #843, #845, #847,
+#849).** The original K1 disposal path and the subsequently exposed
+never-run/session-authority residues now retire and respawn without a stranded
+roster anchor or registered-runtime leak.
 
 **Problem statement.** A session-bound mob member that has never run a turn
 has no runtime-store session snapshot (the machine commits at run
@@ -923,6 +1011,11 @@ query in meerkat-session/runtime deletes that code for every embedder.
 
 ## Ask 21 — owned-but-snapshotless sessions still strand on archive (ask-20 residue) — P1
 
+**CLOSED — shipped across Meerkat 0.7.20–0.7.23 (#843, #845, #847, #849).**
+Never-run durable sessions archive, cleanup no longer self-deadlocks, retry
+states converge, and terminal registered-runtime NotFound residue completes
+disposal.
+
 **Problem statement.** 0.7.19's ask-20 fix routes disposal on
 `session_known_to_archive_authority`, but that gate only reroutes sessions
 the authority does NOT own (`known=false`, host-adopted). A mob-CREATED
@@ -960,6 +1053,10 @@ that never ran, a narrow window in practice since workers receive kickoff
 messages at spawn.
 
 ## Ask 22 — past-due one-shot regenerates occurrences unboundedly (planning-cursor precision loss) — P0
+
+**CLOSED — shipped in Meerkat 0.7.20 (#843).** Trigger comparison and the
+machine planning cursor use one millisecond representation, with a monotonic
+planning guard preventing recurrence.
 
 **Field report (HomeCore on 0.7.25):** one one-shot with a fire time
 near/just-past now produced 223 misfired occurrences + 223 receipts in ~2
@@ -1035,6 +1132,10 @@ persistent test; the trace capture recipe is a `tracing_subscriber` init
 with `meerkat_mob=debug,meerkat_session=debug` in the test body.
 
 ## Ask 21c — 0.7.21's retire-completing archive arm deadlocks the whole mob (runtime-loop self-deadlock on the session mutation gate) — P0, blocks 0.7.21 adoption
+
+**CLOSED — shipped in Meerkat 0.7.22 (#847), with the identity-first 21d
+residue closed in 0.7.23 (#849).** Runtime-loop stop realization no longer
+runs executor cleanup while holding the session mutation gate.
 
 Verified against meerkat =0.7.21 with the mobkit K1 persistent repro
 (`meerkat-mobkit/tests/studio_k_asks.rs`,
@@ -1179,7 +1280,10 @@ agent-tool workers, OB3 worker plane after migration).
 
 ## Ask 23 — break-glass host reassignment for stuck bindings — P3 (reframed 2026-07-08)
 
-**SHIPPED in meerkat 0.7.25** (`WorkGraphService::break_glass_reassign_attention`, host API only, mandatory principal+reason, event-stream audited). Mobkit adoption (0.7.30): `mobkit/workgraph/attention/break_glass_reassign` on the CONSOLE surface only; principal = authenticated console principal.
+**CLOSED — shipped in Meerkat 0.7.25 (#854).**
+`WorkGraphService::break_glass_reassign_attention` is host-only, requires a
+principal and reason, and is event-stream audited. MobKit 0.7.30 exposes it on
+the authenticated console surface only.
 
 
 meerkat 0.7.23's `reassign_attention` requires the witness's
@@ -1210,7 +1314,10 @@ stays untouched.
 
 ## Ask 24 — filtered attention queries + terminal-binding GC — P2
 
-**SHIPPED in meerkat 0.7.25** (SQL-pushed status/target filters over indexed columns with NULL-tolerant migration; `prune_terminal_attention`; clause-3 metadata-only session read seam as `SessionStore::load_meta`). Mobkit adoption (0.7.30): `mobkit/workgraph/attention/prune` + SDK methods.
+**CLOSED — shipped in Meerkat 0.7.25 (#854, #856).** SQL-pushed filters,
+NULL-tolerant migration, `prune_terminal_attention`, and
+`SessionStore::load_meta` close all three clauses. MobKit 0.7.30 exposes prune
+through RPC and the SDKs.
 
 
 `SqliteWorkGraphStore::list_sqlite_attention` (0.7.23 store.rs:1576) runs
@@ -1236,7 +1343,11 @@ own ask candidate).
 
 ## Ask 25 — attention-binding uniqueness belongs in the service/store (or arbitrate like sessions) — P1
 
-**SHIPPED in meerkat 0.7.25** — BOTH halves: store-level transactional uniqueness with typed `Conflict` naming the occupant, AND newest-binding-wins arbitration for legacy duplicates (`MultipleActiveBindings` removed). Mobkit's admission demotes to defense-in-depth + session↔identity alias unification; sidecar-lock removal is the 0.7.31 follow-up.
+**CLOSED — shipped in Meerkat 0.7.25 (#854).** Both halves landed:
+transactional store-level uniqueness with a typed occupant conflict, and
+newest-binding-wins arbitration for legacy duplicates. MobKit's admission
+layer is defense in depth; its sidecar-lock cleanup is downstream maintenance,
+not an open upstream ask.
 
 
 `MultipleActiveBindings` is a HARD per-turn error (0.7.23
@@ -1265,7 +1376,9 @@ When either lands, mobkit's admission layer demotes to defense-in-depth.
 
 ## Ask 26 — structural reply affordance on comms deliveries — P2
 
-**SHIPPED in meerkat 0.7.25** (`PeerReplyCapability` in the dispatch context, pre-addressed `reply_to_peer` comms tool, batch-level minting via the canonical `TurnToolOverlay::compose`). No mobkit change needed: nothing strips the overlay, and the console renders the tool generically. Verified at the 0.7.25 pin bump.
+**CLOSED — shipped in Meerkat 0.7.25 (#856).** `PeerReplyCapability` in the
+dispatch context and the pre-addressed `reply_to_peer` tool provide the
+structural affordance. No MobKit change is required.
 
 
 Peer messages arrive framed as prose ("Peer message from <endpoint>...")
@@ -1281,6 +1394,11 @@ delivery), so "answer the peer" is an affordance rather than a prompt
 convention. mobkit interim: none (app-side relays).
 
 ## Ask 27 — peer sends to unreachable targets must not read as success — P2
+
+**OPEN (2026-07-10).** Ordinary comms still collapse successful no-ACK
+handoff and some unreachable paths into `acked: false`. Supervisor rotation's
+durable operation receipts are intentionally scoped to that lifecycle
+operation and do not make general peer delivery truthful.
 
 Field (HomeCore, mobkit 0.7.30 / meerkat 0.7.25, 2026-07-09): an agent's
 comms `send_message` to a peer whose runtime is not booted (or whose
@@ -1303,6 +1421,12 @@ mobkit interim: none (host-side relay).
 
 ## Ask 28 — kickoff-scoped objective→outcome correlation (reply-to-kickoff) — P2
 
+**OPEN (2026-07-10).** Interaction ids and peer-reply capabilities are
+available building blocks, but no durable objective id propagates across the
+delegated work, and the lead has no explicit conclude-objective affordance.
+Kickoff quiescence prevents premature teardown; it does not identify the final
+answer.
+
 Field (HomeCore): the kickoff send's interaction completes on the lead's
 FIRST turn — usually the delegation, often textless. The real outcome lands
 turns later under different interaction ids, so hosts reconstruct
@@ -1324,6 +1448,10 @@ completion + quiescence heuristics. mobkit would surface the conclusion as
 a typed console/RPC event.
 
 ## Ask 29 — profile overrides freeze the whole tool surface across definition drift — P2
+
+**OPEN (2026-07-10).** Neither a field-scoped override nor patch-over-current-
+definition revival exists. The MobKit heal-on-divergence mitigation is still
+planned rather than shipped, so the upstream ownership fix remains warranted.
 
 Field (HomeCore Bug G′, 2026-07-10): the only reset-reprofiled member
 (domain:security, gen 8) has NO `meerkat_schedule_*` tools despite

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -32,6 +32,33 @@ holds the original deep-dive evidence.
 
 ---
 
+
+## Status ledger (verified against the meerkat CHANGELOG, 2026-07-10)
+
+**24 of 30 asks shipped; 6 open.**
+
+| Asks | Status |
+|---|---|
+| 1–8 (agent-memory initiative) | shipped meerkat 0.7.12 |
+| 9 (taint surfaces), 10 (host runnables) | shipped meerkat 0.7.13 |
+| 11 (incremental session persistence) | shipped meerkat 0.7.25 |
+| 12 (compaction-archive singletons) | **OPEN** |
+| 13 (event-forwarder backoff/quarantine) | **OPEN** |
+| 14 (typed member health surface) | **OPEN** |
+| 15 (transcript interaction ids) | shipped meerkat 0.7.25 (residual: the classic-send external work door has no interaction param) |
+| 16–19 (schedule poisoned-row family) | shipped meerkat 0.7.19 |
+| 20, 21, 21b (never-ran/archive strands) | shipped meerkat 0.7.22 |
+| 21c (retire-archive mob deadlock) | shipped meerkat 0.7.22 |
+| 21d (identity-first worker archive-NotFound) | shipped meerkat 0.7.23 |
+| 22 (past-due one-shot regeneration) | shipped meerkat 0.7.20 |
+| 23–26 (workgraph break-glass/GC/uniqueness/reply seam) | shipped meerkat 0.7.25 |
+| 27 (unreachable-peer sends read as success) | **OPEN** |
+| 28 (kickoff-scoped objective conclusion) | **OPEN** |
+| 29 (profile overrides freeze tool surface — Bug G′) | **OPEN** |
+
+Keep this table current when filing or closing asks; per-ask sections below
+carry the detail and mobkit adoption notes.
+
 ## Ask 1 — Typed injected-context message class, excluded from compaction indexing
 
 **Title:** Add a typed injected-context message class that

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,28 +48,28 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.7.26"
-meerkat-client = "=0.7.26"
-meerkat-contracts = "=0.7.26"
-meerkat-mob = "=0.7.26"
-meerkat-mob-mcp = "=0.7.26"
-meerkat-mcp = "=0.7.26"
-meerkat-models = "=0.7.26"
+meerkat-core = "=0.7.27"
+meerkat-client = "=0.7.27"
+meerkat-contracts = "=0.7.27"
+meerkat-mob = "=0.7.27"
+meerkat-mob-mcp = "=0.7.27"
+meerkat-mcp = "=0.7.27"
+meerkat-models = "=0.7.27"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.7.26", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.7.27", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.7.26"
+meerkat-memory = "=0.7.27"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.7.26"
-meerkat-runtime = { version = "=0.7.26", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.7.26", features = ["session-store"] }
-meerkat-store = { version = "=0.7.26", features = ["sqlite"] }
-meerkat-tools = "=0.7.26"
+meerkat-live = "=0.7.27"
+meerkat-runtime = { version = "=0.7.27", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.7.27", features = ["session-store"] }
+meerkat-store = { version = "=0.7.27", features = ["sqlite"] }
+meerkat-tools = "=0.7.27"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -123,10 +123,10 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "=0.7.26"
-meerkat-schedule = "=0.7.26"
+meerkat-comms = "=0.7.27"
+meerkat-schedule = "=0.7.27"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.7.26", features = ["schema"] }
+meerkat-mob = { version = "=0.7.27", features = ["schema"] }

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -83,20 +83,29 @@ struct GatewayRuntimeOptions {
     workgraph: GatewayWorkgraphOption,
     /// Live (realtime) transport opt-in (default off). Persistent mode only.
     live: GatewayLiveOption,
+    /// SDK-registered deterministic schedule targets
+    /// (`runtime_options.host_runnables`): each name registers a schedule
+    /// host runnable whose fire forwards over the callback bridge as
+    /// `callback/schedule_fire`.
+    host_runnables: Vec<meerkat::HostRunnableName>,
 }
 
 /// `runtime_options.live` wire forms: `true` mounts the live WebSocket
 /// transport on the gateway's HTTP listener with bootstrap URLs derived from
-/// the loopback base; `{"public_base_url": "ws://192.168.0.123:8080"}`
+/// the loopback base; the object form
+/// `{"public_base_url": "ws://192.168.0.123:8080", "seed_max_chars": 200000}`
 /// additionally rewrites the minted bootstrap URLs for clients that reach
 /// the gateway through a proxy or a LAN address (the token/channel query
-/// parameters are appended to this base).
+/// parameters are appended to this base) and/or clamps the projected seed
+/// transcript at open time (upstream ask 30 stopgap; see
+/// `live_wiring::clamp_seed_messages_oldest_first`).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 enum GatewayLiveOption {
     #[default]
     Disabled,
     Enabled {
         public_base_url: Option<String>,
+        seed_max_chars: Option<usize>,
     },
 }
 
@@ -180,6 +189,7 @@ impl Default for GatewayRuntimeOptions {
             agent_memory: None,
             workgraph: GatewayWorkgraphOption::Enabled,
             live: GatewayLiveOption::Disabled,
+            host_runnables: Vec::new(),
         }
     }
 }
@@ -416,6 +426,128 @@ mod tests {
         assert_eq!(modules[0].args, Vec::<String>::new());
         assert_eq!(modules[0].restart_policy, RestartPolicy::Never);
         assert!(pre_spawn.is_empty());
+    }
+
+    #[test]
+    fn gateway_runtime_options_parse_host_runnables() {
+        let params = json!({
+            "runtime_options": {
+                "host_runnables": ["digest", "backup.rotate"]
+            }
+        });
+        let options = parse_gateway_runtime_options(&params, None).expect("runtime options");
+        assert_eq!(
+            options
+                .host_runnables
+                .iter()
+                .map(meerkat::HostRunnableName::as_str)
+                .collect::<Vec<_>>(),
+            vec!["digest", "backup.rotate"]
+        );
+    }
+
+    #[test]
+    fn gateway_runtime_options_reject_invalid_host_runnables() {
+        for (runtime_options, needle) in [
+            (json!({"host_runnables": "digest"}), "must be an array"),
+            (json!({"host_runnables": [7]}), "must be strings"),
+            (json!({"host_runnables": ["  "]}), "is invalid"),
+            (
+                json!({"host_runnables": ["digest", "digest"]}),
+                "duplicated",
+            ),
+            (
+                json!({"host_runnables": [
+                    meerkat_mobkit::schedule_wiring::STEWARD_DREAM_RUNNABLE
+                ]}),
+                "reserved",
+            ),
+        ] {
+            let params = json!({ "runtime_options": runtime_options });
+            let err = match parse_gateway_runtime_options(&params, None) {
+                Err(err) => err,
+                Ok(_) => panic!("expected rejection for {params}"),
+            };
+            assert!(err.contains(needle), "{err} should mention '{needle}'");
+        }
+    }
+
+    #[test]
+    fn gateway_runtime_options_parse_live_seed_max_chars() {
+        let params = json!({
+            "runtime_options": {
+                "live": { "seed_max_chars": 200000 }
+            }
+        });
+        let options = parse_gateway_runtime_options(&params, None).expect("runtime options");
+        assert_eq!(
+            options.live,
+            GatewayLiveOption::Enabled {
+                public_base_url: None,
+                seed_max_chars: Some(200_000),
+            }
+        );
+
+        let err = match parse_gateway_runtime_options(
+            &json!({"runtime_options": {"live": {"seed_max_chars": 0}}}),
+            None,
+        ) {
+            Err(err) => err,
+            Ok(_) => panic!("zero seed_max_chars must be rejected"),
+        };
+        assert!(err.contains("seed_max_chars"), "{err}");
+    }
+
+    fn test_callback_bridge() -> StdioCallbackBridge {
+        let (stdout_tx, _stdout_rx) = mpsc::channel::<String>(4);
+        StdioCallbackBridge::new(stdout_tx)
+    }
+
+    /// Fix 3: `register_tool(..., input_schema=...)` schemas cross the
+    /// `callback/build_agent` wire and land on the dispatcher's `ToolDef`s
+    /// (which is what `live_visible_tool_defs` and normal turns both read).
+    #[test]
+    fn callback_tool_dispatcher_defs_carry_wire_schemas() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        });
+        let specs = vec![
+            CallbackToolSpec::parse(&json!("legacy_name")).expect("legacy string spec"),
+            CallbackToolSpec::parse(&json!({
+                "name": "weather",
+                "description": "Look up the weather",
+                "input_schema": schema
+            }))
+            .expect("object spec"),
+        ];
+        let dispatcher =
+            CallbackToolDispatcher::new(test_callback_bridge(), "build-1".to_string(), specs);
+        let defs = AgentToolDispatcher::tools(&dispatcher);
+        assert_eq!(defs.len(), 2);
+        assert_eq!(defs[0].name.as_ref(), "legacy_name");
+        assert_eq!(defs[0].description, "Python callback tool");
+        assert_eq!(defs[0].input_schema, json!({"type": "object"}));
+        assert_eq!(defs[1].name.as_ref(), "weather");
+        assert_eq!(defs[1].description, "Look up the weather");
+        assert_eq!(defs[1].input_schema, schema);
+    }
+
+    #[test]
+    fn callback_tool_spec_rejects_malformed_wire_entries() {
+        for value in [
+            json!(7),
+            json!({"description": "no name"}),
+            json!({"name": ""}),
+            json!({"name": "x", "input_schema": "not-an-object"}),
+            json!({"name": "x", "description": 3}),
+        ] {
+            assert!(
+                CallbackToolSpec::parse(&value).is_err(),
+                "expected rejection for {value}"
+            );
+        }
     }
 
     #[test]
@@ -1744,6 +1876,7 @@ fn parse_gateway_runtime_options(
         "implicit_delegate_idle_sweep_interval_ms",
         "workgraph",
         "live",
+        "host_runnables",
     ];
     let unsupported = runtime_options
         .keys()
@@ -1847,16 +1980,30 @@ fn parse_gateway_runtime_options(
         parsed.live = match value {
             Value::Bool(true) => GatewayLiveOption::Enabled {
                 public_base_url: None,
+                seed_max_chars: None,
             },
             Value::Bool(false) => GatewayLiveOption::Disabled,
             Value::Object(map) => {
                 let enabled = map.get("enabled").and_then(Value::as_bool).unwrap_or(true);
+                let seed_max_chars = match map.get("seed_max_chars") {
+                    None | Some(Value::Null) => None,
+                    Some(value) => {
+                        let chars = value.as_u64().filter(|chars| *chars > 0).ok_or_else(|| {
+                            "runtime_options.live.seed_max_chars must be a positive integer"
+                                .to_string()
+                        })?;
+                        Some(usize::try_from(chars).map_err(|_| {
+                            "runtime_options.live.seed_max_chars is too large".to_string()
+                        })?)
+                    }
+                };
                 if enabled {
                     GatewayLiveOption::Enabled {
                         public_base_url: map
                             .get("public_base_url")
                             .and_then(Value::as_str)
                             .map(str::to_string),
+                        seed_max_chars,
                     }
                 } else {
                     GatewayLiveOption::Disabled
@@ -1864,11 +2011,38 @@ fn parse_gateway_runtime_options(
             }
             _ => {
                 return Err(
-                    "runtime_options.live must be a boolean or an object                      ({enabled?, public_base_url?})"
+                    "runtime_options.live must be a boolean or an object                      ({enabled?, public_base_url?, seed_max_chars?})"
                         .to_string(),
                 );
             }
         };
+    }
+    if let Some(value) = runtime_options.get("host_runnables") {
+        let entries = value.as_array().ok_or_else(|| {
+            "runtime_options.host_runnables must be an array of runnable names".to_string()
+        })?;
+        let mut names = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let text = entry.as_str().ok_or_else(|| {
+                "runtime_options.host_runnables entries must be strings".to_string()
+            })?;
+            let name = meerkat::HostRunnableName::parse(text).map_err(|err| {
+                format!("runtime_options.host_runnables entry '{text}' is invalid: {err}")
+            })?;
+            if name.as_str() == meerkat_mobkit::schedule_wiring::STEWARD_DREAM_RUNNABLE {
+                return Err(format!(
+                    "runtime_options.host_runnables entry '{text}' collides with the \
+                     reserved steward dream runnable"
+                ));
+            }
+            if names.contains(&name) {
+                return Err(format!(
+                    "runtime_options.host_runnables entry '{text}' is duplicated"
+                ));
+            }
+            names.push(name);
+        }
+        parsed.host_runnables = names;
     }
     if let Some(value) = runtime_options.get("demo_llm") {
         parsed.demo_llm = value
@@ -3034,11 +3208,70 @@ impl meerkat_mobkit::identity_first::gateway_bridges::CallbackBridge for StdioCa
     }
 }
 
+/// One SDK-registered callback tool as it crosses the `callback/build_agent`
+/// response wire: a bare name string (legacy shape) or
+/// `{name, description?, input_schema?}` so the agent — and the live
+/// projection's `live_visible_tool_defs` — see the real argument schema
+/// instead of the permissive `{"type": "object"}` placeholder.
+struct CallbackToolSpec {
+    name: String,
+    description: Option<String>,
+    input_schema: Option<Value>,
+}
+
+impl CallbackToolSpec {
+    fn parse(value: &Value) -> Result<Self, String> {
+        if let Some(name) = value.as_str() {
+            return Ok(Self {
+                name: name.to_string(),
+                description: None,
+                input_schema: None,
+            });
+        }
+        let Some(object) = value.as_object() else {
+            return Err(format!(
+                "tools entries must be strings or {{name, description?, input_schema?}} \
+                 objects, got: {value}"
+            ));
+        };
+        let name = object
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| format!("tool object requires a non-empty string name, got: {value}"))?
+            .to_string();
+        let description = match object.get("description") {
+            None | Some(Value::Null) => None,
+            Some(Value::String(text)) => Some(text.clone()),
+            Some(other) => {
+                return Err(format!(
+                    "tool '{name}' description must be a string, got: {other}"
+                ));
+            }
+        };
+        let input_schema = match object.get("input_schema") {
+            None | Some(Value::Null) => None,
+            Some(schema @ Value::Object(_)) => Some(schema.clone()),
+            Some(other) => {
+                return Err(format!(
+                    "tool '{name}' input_schema must be a JSON object, got: {other}"
+                ));
+            }
+        };
+        Ok(Self {
+            name,
+            description,
+            input_schema,
+        })
+    }
+}
+
 /// Tool dispatcher that routes tool calls to Python via the callback bridge.
 ///
-/// Created from tool name strings provided by `SessionBuildOptions.add_tools()`.
-/// When the agent calls a tool, `dispatch()` sends `callback/call_tool` to Python
-/// and returns the result.
+/// Created from the tool specs the SDK returned from `callback/build_agent`
+/// (`add_tools()` names or `register_tool()` name + description + schema).
+/// When the agent calls a tool, `dispatch()` sends `callback/call_tool` to
+/// Python and returns the result.
 struct CallbackToolDispatcher {
     bridge: StdioCallbackBridge,
     scope_id: String,
@@ -3046,14 +3279,18 @@ struct CallbackToolDispatcher {
 }
 
 impl CallbackToolDispatcher {
-    fn new(bridge: StdioCallbackBridge, scope_id: String, tool_names: Vec<String>) -> Self {
-        let tool_defs: Vec<Arc<ToolDef>> = tool_names
+    fn new(bridge: StdioCallbackBridge, scope_id: String, tools: Vec<CallbackToolSpec>) -> Self {
+        let tool_defs: Vec<Arc<ToolDef>> = tools
             .into_iter()
-            .map(|name| {
+            .map(|tool| {
                 Arc::new(ToolDef {
-                    name: name.into(),
-                    description: "Python callback tool".to_string(),
-                    input_schema: json!({"type": "object"}),
+                    name: tool.name.into(),
+                    description: tool
+                        .description
+                        .unwrap_or_else(|| "Python callback tool".to_string()),
+                    input_schema: tool
+                        .input_schema
+                        .unwrap_or_else(|| json!({"type": "object"})),
                     provenance: None,
                 })
             })
@@ -3302,21 +3539,20 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                 if let Some(tools) = result.get("tools") {
                     match tools.as_array() {
                         Some(arr) => {
-                            let mut tool_names = Vec::with_capacity(arr.len());
+                            let mut tool_specs = Vec::with_capacity(arr.len());
                             for v in arr {
-                                if let Some(name) = v.as_str() {
-                                    tool_names.push(name.to_string());
-                                } else {
-                                    return Err(SessionError::Agent(agent_tool_error(format!(
-                                        "callback/build_agent: tools must be strings, got: {v}"
-                                    ))));
-                                }
+                                let spec = CallbackToolSpec::parse(v).map_err(|reason| {
+                                    SessionError::Agent(agent_tool_error(format!(
+                                        "callback/build_agent: {reason}"
+                                    )))
+                                })?;
+                                tool_specs.push(spec);
                             }
-                            if !tool_names.is_empty() {
+                            if !tool_specs.is_empty() {
                                 let dispatcher = CallbackToolDispatcher::new(
                                     self.bridge.clone(),
                                     scope_id.clone(),
-                                    tool_names,
+                                    tool_specs,
                                 );
                                 let build = modified_req.build.get_or_insert_with(|| {
                                     meerkat_core::service::SessionBuildOptions::default()
@@ -4841,9 +5077,32 @@ external_addressable = true
         // the dream as a host runnable and find-or-create its cadence schedule
         // (idempotent across boots via the persistent store). The in-process
         // fallback loop is spawned only when there is no schedule host.
-        let runnable_host = meerkat_mobkit::schedule_wiring::steward_dream_runnable_host(
+        // SDK-registered runnables (`runtime_options.host_runnables`) compose
+        // into the same registry: their fires forward over the callback
+        // bridge as `callback/schedule_fire`, so apps get deterministic
+        // (non-LLM) schedule targets.
+        let callback_runnables = (!gateway_options.host_runnables.is_empty()).then(|| {
+            (
+                Arc::new(bridge.clone())
+                    as Arc<dyn meerkat_mobkit::identity_first::gateway_bridges::CallbackBridge>,
+                gateway_options.host_runnables.clone(),
+            )
+        });
+        let runnable_host = match meerkat_mobkit::schedule_wiring::gateway_runnable_host(
             agent_memory_steward.clone(),
-        );
+            callback_runnables,
+        ) {
+            Ok(host) => host,
+            Err(error) => {
+                // Structurally unreachable: names are deduplicated and the
+                // reserved steward name rejected at option parse time.
+                fail_init(
+                    &request_id,
+                    -32602,
+                    format!("failed to compose schedule host runnables: {error}"),
+                );
+            }
+        };
         if let Some(steward) = agent_memory_steward.as_ref()
             && let Err(error) = meerkat_mobkit::schedule_wiring::ensure_steward_dream_schedule(
                 &schedule_service,
@@ -4879,6 +5138,13 @@ external_addressable = true
             Some(watchdog),
         )
     } else {
+        if !gateway_options.host_runnables.is_empty() {
+            tracing::warn!(
+                "runtime_options.host_runnables is configured but this gateway runs no \
+                 schedule host (ephemeral mode, or schedule store unavailable): \
+                 host-runnable schedule targets will never fire"
+            );
+        }
         (None, None)
     };
 
@@ -4923,8 +5189,13 @@ external_addressable = true
             let ws_base_url = match &gateway_options.live {
                 GatewayLiveOption::Enabled {
                     public_base_url: Some(public),
+                    ..
                 } => public.trim_end_matches('/').to_string(),
                 _ => format!("ws://127.0.0.1:{port}"),
+            };
+            let live_seed_max_chars = match &gateway_options.live {
+                GatewayLiveOption::Enabled { seed_max_chars, .. } => *seed_max_chars,
+                GatewayLiveOption::Disabled => None,
             };
             let live_ctx = Arc::new(meerkat_mobkit::live_wiring::attach_live(
                 Arc::clone(&live_service),
@@ -4932,6 +5203,7 @@ external_addressable = true
                 &live_agent_factory,
                 meerkat::Config::default(),
                 ws_base_url,
+                live_seed_max_chars,
             ));
             let app = app.merge(meerkat_live::live_ws_router(Arc::clone(&live_ctx.ws_state)));
             let handler =

--- a/meerkat-mobkit/src/live_wiring.rs
+++ b/meerkat-mobkit/src/live_wiring.rs
@@ -2662,12 +2662,8 @@ mod tests {
         let oldest = user_message(&"a".repeat(400));
         let middle = user_message(&"b".repeat(400));
         let newest = user_message(&"c".repeat(400));
-        let mut config = test_open_config(vec![
-            system.clone(),
-            oldest.clone(),
-            middle.clone(),
-            newest.clone(),
-        ]);
+        let mut config =
+            test_open_config(vec![system.clone(), oldest, middle.clone(), newest.clone()]);
 
         // Budget for the system message + two newest user messages.
         let budget = serialized_message_chars(&system)

--- a/meerkat-mobkit/src/live_wiring.rs
+++ b/meerkat-mobkit/src/live_wiring.rs
@@ -57,16 +57,19 @@ use meerkat_client::realtime_session::{RealtimeSessionFactory, RealtimeSessionOp
 use meerkat_contracts::{
     LiveChannelParams, LiveCloseResult, LiveCommitInputParams, LiveCommitInputResult,
     LiveInterruptResult, LiveOpenResult, LiveOpenTransport, LiveRefreshResult, LiveSendInputParams,
-    LiveSendInputResult, LiveStatusResult, RealtimeCapabilities, RealtimeTurningMode,
-    WireLiveAdapterStatus, WireLiveDegradationReason,
+    LiveSendInputResult, LiveStatusResult, LiveTruncateParams, LiveTruncateResult,
+    RealtimeCapabilities, RealtimeTurningMode, WireLiveAdapterStatus, WireLiveDegradationReason,
 };
 use meerkat_core::live_adapter::{
     LiveAdapterCommand, LiveAdapterErrorCode, LiveAudioConfig, LiveChannelCapabilities,
     LiveContinuityMode, LiveProjectionSnapshot, LiveTransportBootstrap,
 };
 use meerkat_core::service::SessionService as _;
+use meerkat_core::session::SystemContextSource;
 use meerkat_core::types::{AssistantBlock, ContentInput, Message, SessionId, StopReason, Usage};
-use meerkat_core::{Config, ConfigError, RealtimeTranscriptEvent};
+use meerkat_core::{
+    Config, ConfigError, CoreRenderable, PendingSystemContextAppend, RealtimeTranscriptEvent,
+};
 use meerkat_live::{
     LiveAdapterHost, LiveAdapterHostError, LiveChannelCloseFeedback, LiveChannelCloseObservation,
     LiveChannelId, LiveChannelStatusFeedback, LiveChannelStatusObservation, LiveProjectionError,
@@ -796,15 +799,16 @@ impl<B: SessionAgentBuilder + 'static> LiveProjectionSink for GatewayLiveProject
         &self,
         session_id: &SessionId,
         event: &RealtimeTranscriptEvent,
-    ) -> Result<(), LiveProjectionError> {
+    ) -> Result<meerkat_core::RealtimeTranscriptApplyOutcome, LiveProjectionError> {
         // P1#2: forward provider-emitted realtime transcript events into the
         // same idempotent ordering / staging path used by deltas +
         // truncation; without this override `ItemObserved` /
-        // `AssistantTurnCompleted` etc. would be silently dropped.
+        // `AssistantTurnCompleted` etc. would be silently dropped. 0.7.27:
+        // the apply outcome flows back so the host synthesizes the redacted
+        // image receipt only AFTER durable reducer application.
         self.service
             .append_realtime_transcript_event(session_id, event.clone())
             .await
-            .map(|_outcome| ())
             .map_err(|err| session_error_to_projection(err, session_id))
     }
 }
@@ -870,6 +874,11 @@ pub struct GatewayLiveContext {
     pub ws_state: Arc<LiveWsState>,
     pub session_factory: Arc<dyn RealtimeSessionFactory>,
     pub ws_base_url: String,
+    /// Gateway-wide seed-projection clamp (`runtime_options.live.seed_max_chars`),
+    /// overridable per open. `None` = no clamp. Stopgap for upstream ask 30
+    /// (docs/design/upstream-asks.md): the provider caps live instructions at
+    /// 65,536 tokens and long member transcripts overflow the projected seed.
+    pub seed_max_chars: Option<usize>,
 }
 
 /// Compose the live stack for a persistent-mode gateway.
@@ -887,6 +896,7 @@ pub fn attach_live<B: SessionAgentBuilder + 'static>(
     factory: &AgentFactory,
     config: Config,
     ws_base_url: String,
+    seed_max_chars: Option<usize>,
 ) -> GatewayLiveContext {
     let sink = Arc::new(GatewayLiveProjectionSink::new(
         Arc::clone(&service),
@@ -910,14 +920,33 @@ pub fn attach_live<B: SessionAgentBuilder + 'static>(
         ws_state,
         session_factory,
         ws_base_url,
+        seed_max_chars,
     }
 }
 
 // ---------------------------------------------------------------------------
 // mobkit/live/* handlers — port of meerkat-rpc/src/handlers/live.rs
-// (websocket arms; webrtc and truncate deliberately not ported, per design
-// §"What we deliberately do NOT do in v1").
+// (websocket arms; webrtc deliberately not ported, per design §"What we
+// deliberately do NOT do in v1").
 // ---------------------------------------------------------------------------
+
+/// `instructions` on `mobkit/live/open` accepts a single string or an array
+/// of strings — both spell the same per-open overlay.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum LiveOpenInstructions {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl LiveOpenInstructions {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            Self::One(text) => vec![text],
+            Self::Many(items) => items,
+        }
+    }
+}
 
 /// The gateway-side params for `mobkit/live/open`. The member target
 /// (`identity` / `member_id` / `session_id`) is resolved by the CALLER
@@ -933,6 +962,17 @@ struct GatewayLiveOpenParams {
     /// not realtime-capable open the channel against this model instead.
     #[serde(default)]
     model: Option<String>,
+    /// Per-open ephemeral instruction overlay. Rides the runtime
+    /// system-context lane of the open projection, so it reaches the
+    /// provider's instructions channel without ever touching the member's
+    /// durable transcript or prompt truth. Dropped on `live/refresh` (the
+    /// refresh path re-projects from the durable session) and on reopen.
+    #[serde(default)]
+    instructions: Option<LiveOpenInstructions>,
+    /// Per-open override of the gateway-wide seed clamp
+    /// (`runtime_options.live.seed_max_chars`).
+    #[serde(default)]
+    seed_max_chars: Option<usize>,
 }
 
 fn live_success(rpc_id: Value, result: Value) -> JsonRpcResponse {
@@ -1062,6 +1102,7 @@ pub async fn handle_live_method<B: SessionAgentBuilder + 'static>(
         "mobkit/live/send_input" => handle_live_send_input(ctx, machine, params, rpc_id).await,
         "mobkit/live/commit_input" => handle_live_commit_input(ctx, machine, params, rpc_id).await,
         "mobkit/live/interrupt" => handle_live_interrupt(ctx, machine, params, rpc_id).await,
+        "mobkit/live/truncate" => handle_live_truncate(ctx, machine, params, rpc_id).await,
         other => live_error(
             rpc_id,
             METHOD_NOT_FOUND_CODE,
@@ -1088,12 +1129,23 @@ async fn live_open_config_for_session<B: SessionAgentBuilder + 'static>(
         .await?;
     let llm_identity = service.live_session_llm_identity(session_id).await?;
     let visible_tools = service.live_visible_tool_defs(session_id).await?;
+    // 0.7.27: exact-retry + live-rewrite guards ride the open config — the
+    // user-content identity lane and the transcript rewrite generation come
+    // from the exported snapshot, mirroring the facade orchestrator.
+    let transcript_rewrite_generation = session.transcript_rewrite_generation().map_err(|err| {
+        meerkat_core::SessionError::Agent(meerkat_core::error::AgentError::InternalError(
+            err.to_string(),
+        ))
+    })?;
     Ok(RealtimeSessionOpenConfig::new(
         turning_mode,
         llm_identity,
         visible_tools,
         realtime_projection_messages(&session)?,
     )
+    .with_user_content_identities(session.realtime_user_content_identities())
+    .with_user_content_tombstones(session.realtime_user_content_tombstones())
+    .with_transcript_rewrite_generation(transcript_rewrite_generation)
     .with_runtime_system_context(realtime_projection_runtime_system_context(&session)?)
     .with_system_prompt(match realtime_projection_root_system_message(&session)? {
         Some(Message::System(system)) => Some(system.content),
@@ -1101,6 +1153,84 @@ async fn live_open_config_for_session<B: SessionAgentBuilder + 'static>(
         // any other shape means no root system prompt to project.
         _ => None,
     }))
+}
+
+/// Provenance marker on the runtime system-context append carrying the
+/// per-open instruction overlay from `mobkit/live/open` `instructions`.
+const LIVE_OPEN_INSTRUCTIONS_SOURCE: &str = "mobkit/live/open#instructions";
+
+/// Fold the per-open instruction overlay into the open config's runtime
+/// system-context lane.
+///
+/// Lane choice: `runtime_system_context` (NOT `with_system_prompt`). The
+/// typed `system_prompt` field is the projection of the member's durable
+/// prompt truth (R10: single owner of live prompt truth), so baking a
+/// per-open overlay into it would misreport the member's prompt to the
+/// provider and to every snapshot consumer. The runtime system-context lane
+/// is exactly the typed carrier for runtime-authored ephemeral context:
+/// adapters fold it into the provider session as authoritative instructions,
+/// and because this append exists only on this open's projection it never
+/// persists into the durable transcript.
+fn apply_live_open_instruction_overlay(
+    open_config: &mut RealtimeSessionOpenConfig,
+    instructions: Vec<String>,
+) {
+    let joined = instructions
+        .iter()
+        .map(|instruction| instruction.trim())
+        .filter(|instruction| !instruction.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if joined.is_empty() {
+        return;
+    }
+    open_config
+        .runtime_system_context
+        .push(PendingSystemContextAppend {
+            content: CoreRenderable::text(joined),
+            source: Some(LIVE_OPEN_INSTRUCTIONS_SOURCE.to_string()),
+            idempotency_key: None,
+            source_kind: SystemContextSource::RuntimeSteer,
+            peer_response_terminal: None,
+            accepted_at: std::time::SystemTime::now(),
+        });
+}
+
+/// Serialized size of one projected seed message, as counted by the clamp.
+fn serialized_message_chars(message: &Message) -> usize {
+    serde_json::to_string(message).map_or(0, |text| text.len())
+}
+
+/// Clamp the projected seed transcript to `max_chars` total serialized
+/// length by dropping WHOLE messages oldest-first. A projected root system
+/// message at `seed_messages[0]` is never dropped — the system prompt is
+/// prompt truth, not seed history. Returns the number of dropped messages.
+///
+/// This is an explicit STOPGAP for upstream ask 30
+/// (docs/design/upstream-asks.md): providers cap live session instructions
+/// at 65,536 tokens and a long member transcript overflows the projected
+/// seed at open time. Remove once meerkat ships a machine-owned seed-window
+/// projection.
+fn clamp_seed_messages_oldest_first(
+    open_config: &mut RealtimeSessionOpenConfig,
+    max_chars: usize,
+) -> usize {
+    let head = usize::from(matches!(
+        open_config.seed_messages.first(),
+        Some(Message::System(_) | Message::SystemNotice(_))
+    ));
+    let mut total: usize = open_config
+        .seed_messages
+        .iter()
+        .map(serialized_message_chars)
+        .sum();
+    let mut dropped = 0usize;
+    while total > max_chars && open_config.seed_messages.len() > head {
+        let removed = open_config.seed_messages.remove(head);
+        total -= serialized_message_chars(&removed);
+        dropped += 1;
+    }
+    dropped
 }
 
 /// #176: project the factory's typed realtime audio policy into the typed
@@ -1150,6 +1280,9 @@ fn build_live_projection_snapshot(
         snapshot_version: 0,
         seed_messages: open_config.seed_messages.clone(),
         visible_tools: open_config.visible_tools.clone(),
+        user_content_identities: open_config.user_content_identities.clone(),
+        user_content_tombstones: open_config.user_content_tombstones.clone(),
+        transcript_rewrite_generation: open_config.transcript_rewrite_generation,
         // R10: the typed `system_prompt` field is the single owner of live
         // prompt truth — never re-derived from `seed_messages[0]` (the
         // history projector drops `Message::System`, so seed inference
@@ -1341,6 +1474,26 @@ async fn handle_live_open<B: SessionAgentBuilder + 'static>(
     // both gate — and the machine binds — the identity actually opened.
     if let Some(model) = parsed.model {
         open_config.llm_identity.model = model;
+    }
+    // Per-open ephemeral instruction overlay — runtime system-context lane
+    // (see apply_live_open_instruction_overlay for the lane rationale).
+    if let Some(instructions) = parsed.instructions {
+        apply_live_open_instruction_overlay(&mut open_config, instructions.into_vec());
+    }
+    // Seed clamp, upstream ask 30 stopgap: the per-open override beats the
+    // gateway-wide `runtime_options.live.seed_max_chars`; the projected
+    // system prompt is never touched.
+    if let Some(max_chars) = parsed.seed_max_chars.or(ctx.seed_max_chars) {
+        let dropped = clamp_seed_messages_oldest_first(&mut open_config, max_chars);
+        if dropped > 0 {
+            tracing::info!(
+                target: "meerkat_mobkit::live_wiring",
+                %session_id,
+                dropped,
+                max_chars,
+                "live open seed clamped oldest-first (upstream ask 30 stopgap)"
+            );
+        }
     }
 
     // B19 precheck runs BEFORE any channel infra is minted (the reference
@@ -1598,7 +1751,8 @@ fn live_command_result_from_machine_authority(
                 .map_err(|err| format!("failed to serialize LiveInterruptResult: {err}"))
         }
         LiveCommandPublicKind::TruncateAssistantOutput => {
-            Err("live/truncate is not surfaced by the mobkit gateway".to_string())
+            serde_json::to_value(LiveTruncateResult::truncated())
+                .map_err(|err| format!("failed to serialize LiveTruncateResult: {err}"))
         }
     }
 }
@@ -2306,6 +2460,74 @@ async fn handle_live_interrupt(
     }
 }
 
+/// A7: `mobkit/live/truncate` — truncate an assistant item at the given
+/// playback cursor. Port of the reference `handle_live_truncate`; maps to
+/// `LiveAdapterCommand::TruncateAssistantOutput` (no webrtc output-audio
+/// discard arm — the mobkit gateway mounts the WS transport only).
+async fn handle_live_truncate(
+    ctx: &GatewayLiveContext,
+    machine: &Arc<MeerkatMachine>,
+    params: &Value,
+    rpc_id: Value,
+) -> JsonRpcResponse {
+    let parsed: LiveTruncateParams = match parse_live_params(params, &rpc_id) {
+        Ok(p) => p,
+        Err(resp) => return *resp,
+    };
+    // Validate item_id is non-empty. content_index is `u32` and
+    // audio_played_ms is `u64`, so the type system already rejects negatives
+    // at deserialization (`>= 0` is satisfied by construction).
+    if parsed.item_id.is_empty() {
+        return live_error(rpc_id, INVALID_PARAMS_CODE, "item_id must be non-empty");
+    }
+
+    let channel_id = LiveChannelId::new(&parsed.channel_id);
+    let command_kind =
+        meerkat_runtime::meerkat_machine::dsl::LiveCommandPublicKind::TruncateAssistantOutput;
+    let Some(session_id) = machine.live_session_for_active_channel(&channel_id).await else {
+        return live_unbound_command_error_response(rpc_id, machine, &channel_id, command_kind)
+            .await;
+    };
+    let command = LiveAdapterCommand::TruncateAssistantOutput {
+        item_id: parsed.item_id.clone(),
+        content_index: parsed.content_index,
+        audio_played_ms: parsed.audio_played_ms,
+    };
+
+    match ctx.host.send_command_observed(&channel_id, command).await {
+        Ok(acceptance) => {
+            let authority = match machine
+                .resolve_live_command_result(&session_id, &acceptance)
+                .await
+            {
+                Ok(authority) => authority,
+                Err(error) => {
+                    return live_error(
+                        rpc_id,
+                        INTERNAL_ERROR_CODE,
+                        format!("live truncate authority rejected result: {error}"),
+                    );
+                }
+            };
+            match live_command_result_from_machine_authority(&authority, command_kind) {
+                Ok(value) => live_success(rpc_id, value),
+                Err(error) => live_error(rpc_id, INTERNAL_ERROR_CODE, error),
+            }
+        }
+        Err(err) => {
+            live_command_error_response(
+                rpc_id,
+                machine,
+                &session_id,
+                &channel_id,
+                command_kind,
+                &err,
+            )
+            .await
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -2317,6 +2539,181 @@ mod tests {
 
     fn other_session_id() -> SessionId {
         SessionId::parse("00000000-0000-0000-0000-000000000002").unwrap()
+    }
+
+    fn test_open_config(seed_messages: Vec<Message>) -> RealtimeSessionOpenConfig {
+        RealtimeSessionOpenConfig::new(
+            RealtimeTurningMode::ProviderManaged,
+            meerkat_core::SessionLlmIdentity {
+                model: "gpt-realtime-2".to_string(),
+                provider: meerkat_core::Provider::OpenAI,
+                self_hosted_server_id: None,
+                provider_params: None,
+                auth_binding: None,
+            },
+            Vec::new(),
+            seed_messages,
+        )
+        .with_system_prompt(Some("You are the member.".to_string()))
+    }
+
+    fn user_message(text: &str) -> Message {
+        Message::User(meerkat_core::types::UserMessage::text(text))
+    }
+
+    fn system_message(text: &str) -> Message {
+        Message::System(meerkat_core::types::SystemMessage::new(text))
+    }
+
+    #[test]
+    fn live_open_params_accept_string_and_array_instructions_and_seed_clamp() {
+        let one: GatewayLiveOpenParams = serde_json::from_value(serde_json::json!({
+            "identity": "reachy",
+            "instructions": "Speak Swedish.",
+            "seed_max_chars": 1000
+        }))
+        .expect("single-string instructions parse");
+        assert_eq!(
+            one.instructions.expect("instructions").into_vec(),
+            vec!["Speak Swedish.".to_string()]
+        );
+        assert_eq!(one.seed_max_chars, Some(1000));
+
+        let many: GatewayLiveOpenParams = serde_json::from_value(serde_json::json!({
+            "instructions": ["Speak Swedish.", "Keep replies short."]
+        }))
+        .expect("array instructions parse");
+        assert_eq!(
+            many.instructions.expect("instructions").into_vec(),
+            vec![
+                "Speak Swedish.".to_string(),
+                "Keep replies short.".to_string()
+            ]
+        );
+        assert_eq!(many.seed_max_chars, None);
+
+        let neither: GatewayLiveOpenParams =
+            serde_json::from_value(serde_json::json!({})).expect("empty params parse");
+        assert!(neither.instructions.is_none());
+        assert!(neither.seed_max_chars.is_none());
+
+        assert!(
+            serde_json::from_value::<GatewayLiveOpenParams>(
+                serde_json::json!({ "instructions": 7 })
+            )
+            .is_err(),
+            "non-string instructions must be rejected"
+        );
+    }
+
+    /// Fix 2 lane assertion: the per-open overlay lands ONLY on the runtime
+    /// system-context lane — the typed system prompt (durable prompt truth)
+    /// and the projected seed history stay byte-identical.
+    #[test]
+    fn instruction_overlay_rides_the_runtime_system_context_lane() {
+        let seed = vec![system_message("You are the member."), user_message("hello")];
+        let mut config = test_open_config(seed.clone());
+
+        apply_live_open_instruction_overlay(
+            &mut config,
+            vec![
+                "Speak Swedish.".to_string(),
+                "   ".to_string(),
+                "Keep replies short.".to_string(),
+            ],
+        );
+
+        assert_eq!(config.runtime_system_context.len(), 1);
+        let append = &config.runtime_system_context[0];
+        assert_eq!(
+            append.content.render_text(),
+            "Speak Swedish.\n\nKeep replies short."
+        );
+        assert_eq!(
+            append.source.as_deref(),
+            Some(LIVE_OPEN_INSTRUCTIONS_SOURCE)
+        );
+        assert!(
+            append.source_kind.is_runtime_steer(),
+            "overlay is a transient runtime steer"
+        );
+        assert_eq!(
+            config.system_prompt.as_deref(),
+            Some("You are the member."),
+            "the typed system prompt is not the overlay lane"
+        );
+        assert_eq!(config.seed_messages, seed, "seed history untouched");
+    }
+
+    #[test]
+    fn empty_or_whitespace_instructions_append_nothing() {
+        let mut config = test_open_config(Vec::new());
+        apply_live_open_instruction_overlay(&mut config, Vec::new());
+        apply_live_open_instruction_overlay(&mut config, vec!["  ".to_string(), String::new()]);
+        assert!(config.runtime_system_context.is_empty());
+    }
+
+    /// Fix 4 (upstream ask 30 stopgap): whole messages drop OLDEST-first, a
+    /// projected root system message never drops, and the surviving tail fits
+    /// the budget.
+    #[test]
+    fn seed_clamp_drops_oldest_first_and_never_touches_the_system_prompt() {
+        let system = system_message("You are the member.");
+        let oldest = user_message(&"a".repeat(400));
+        let middle = user_message(&"b".repeat(400));
+        let newest = user_message(&"c".repeat(400));
+        let mut config = test_open_config(vec![
+            system.clone(),
+            oldest.clone(),
+            middle.clone(),
+            newest.clone(),
+        ]);
+
+        // Budget for the system message + two newest user messages.
+        let budget = serialized_message_chars(&system)
+            + serialized_message_chars(&middle)
+            + serialized_message_chars(&newest);
+        let dropped = clamp_seed_messages_oldest_first(&mut config, budget);
+        assert_eq!(dropped, 1, "exactly the oldest user message drops");
+        assert_eq!(config.seed_messages, vec![system.clone(), middle, newest]);
+        assert!(
+            config
+                .seed_messages
+                .iter()
+                .map(serialized_message_chars)
+                .sum::<usize>()
+                <= budget
+        );
+
+        // A budget below even the system message still never drops it.
+        let dropped = clamp_seed_messages_oldest_first(&mut config, 1);
+        assert_eq!(dropped, 2, "both remaining user messages drop");
+        assert_eq!(config.seed_messages, vec![system]);
+        assert_eq!(
+            config.system_prompt.as_deref(),
+            Some("You are the member."),
+            "the typed system prompt field is never clamped"
+        );
+    }
+
+    #[test]
+    fn seed_clamp_without_a_root_system_message_drops_from_the_front() {
+        let oldest = user_message(&"a".repeat(400));
+        let newest = user_message(&"b".repeat(400));
+        let mut config = test_open_config(vec![oldest, newest.clone()]);
+        let budget = serialized_message_chars(&newest);
+        let dropped = clamp_seed_messages_oldest_first(&mut config, budget);
+        assert_eq!(dropped, 1);
+        assert_eq!(config.seed_messages, vec![newest]);
+    }
+
+    #[test]
+    fn seed_clamp_within_budget_is_a_no_op() {
+        let seed = vec![system_message("prompt"), user_message("hi")];
+        let mut config = test_open_config(seed.clone());
+        let dropped = clamp_seed_messages_oldest_first(&mut config, usize::MAX);
+        assert_eq!(dropped, 0);
+        assert_eq!(config.seed_messages, seed);
     }
 
     /// #301 port: the surface mapper routes through the canonical typed

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -1437,6 +1437,7 @@ async fn handle_unified_rpc_json_inner(
                     "mobkit/live/send_input",
                     "mobkit/live/commit_input",
                     "mobkit/live/interrupt",
+                    "mobkit/live/truncate",
                 ]);
             }
             if identity_ctx.is_some() {

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -46,11 +46,18 @@ use meerkat_mob_mcp::{MobMcpScheduleHost, MobMcpState};
 use meerkat_runtime::MeerkatMachine;
 use serde_json::{Map, Value};
 
+use crate::identity_first::gateway_bridges::CallbackBridge;
 use crate::memory::steward::StewardEngine;
 
 /// File name for the durable schedule store, kept beside the runtime DB so a
 /// gateway and a library-mode runtime pointed at the same dir share state.
 pub const SCHEDULE_STORE_FILE: &str = "schedule.sqlite";
+
+/// JSON-RPC callback method the gateway sends to the SDK host when a
+/// host-runnable schedule target registered via
+/// `runtime_options.host_runnables` fires. Params:
+/// `{runnable, occurrence: {schedule_id, occurrence_id, due_at, payload?}}`.
+pub const SCHEDULE_FIRE_CALLBACK_METHOD: &str = "callback/schedule_fire";
 
 /// Reserved host-runnable name for the memory steward's scheduled dream
 /// (§8.5 / upstream ask 7). Stable across boots: the find-or-create schedule
@@ -102,6 +109,118 @@ pub fn steward_dream_runnable_host(
         .register(name, Arc::new(StewardDreamRunnable { engine }))
         .expect("first registration into a fresh registry cannot duplicate");
     Some(Arc::new(registry))
+}
+
+/// A [`HostRunnable`] whose fire forwards over the SDK callback bridge as
+/// [`SCHEDULE_FIRE_CALLBACK_METHOD`], so the app process (Python/TypeScript)
+/// runs the occurrence deterministically — no LLM turn is involved.
+///
+/// A bridge error (handler raised, no handler registered for the name, host
+/// gone, callback timeout) is reported as a typed runnable FAILURE so the
+/// schedule store records the occurrence attempt as failed rather than
+/// silently completing. The app's JSON result is logged and dropped:
+/// upstream's `HostRunnableOutcome` deliberately carries no success payload
+/// (occurrence completion consumes no detail).
+struct CallbackHostRunnable {
+    bridge: Arc<dyn CallbackBridge>,
+}
+
+#[async_trait]
+impl HostRunnable for CallbackHostRunnable {
+    async fn run(
+        &self,
+        invocation: HostRunnableInvocation,
+    ) -> Result<HostRunnableOutcome, HostRunnableError> {
+        let mut occurrence = Map::new();
+        occurrence.insert(
+            "schedule_id".to_string(),
+            Value::String(invocation.schedule_id.to_string()),
+        );
+        occurrence.insert(
+            "occurrence_id".to_string(),
+            Value::String(invocation.occurrence_id.to_string()),
+        );
+        occurrence.insert(
+            "due_at".to_string(),
+            Value::String(invocation.trigger_time.to_rfc3339()),
+        );
+        if let Some(params) = invocation.params.as_deref() {
+            match serde_json::from_str::<Value>(params.get()) {
+                Ok(payload) => {
+                    occurrence.insert("payload".to_string(), payload);
+                }
+                Err(error) => {
+                    // The binding canonicalizes params at every ingress, so a
+                    // non-JSON payload here is store corruption — fail the
+                    // occurrence rather than firing with silently dropped params.
+                    return Err(HostRunnableError::Failed {
+                        detail: format!("host-runnable params are not valid JSON: {error}"),
+                    });
+                }
+            }
+        }
+        let params = serde_json::json!({
+            "runnable": invocation.runnable.as_str(),
+            "occurrence": Value::Object(occurrence),
+        });
+        match self
+            .bridge
+            .call(SCHEDULE_FIRE_CALLBACK_METHOD, params)
+            .await
+        {
+            Ok(result) => {
+                tracing::debug!(
+                    runnable = %invocation.runnable,
+                    occurrence_id = %invocation.occurrence_id,
+                    %result,
+                    "callback schedule fire completed"
+                );
+                Ok(HostRunnableOutcome::completed())
+            }
+            Err(detail) => Err(HostRunnableError::Failed { detail }),
+        }
+    }
+}
+
+/// Compose the gateway's schedule runnable host: the steward dream (when a
+/// steward engine is present) plus SDK-registered callback runnables
+/// (`runtime_options.host_runnables`), each forwarding its fire over the
+/// callback bridge as [`SCHEDULE_FIRE_CALLBACK_METHOD`].
+///
+/// `Ok(None)` when there is nothing to register (the schedule host then
+/// serves session/mob targets only). `Err` on a duplicate runnable name —
+/// including a callback runnable colliding with the reserved
+/// [`STEWARD_DREAM_RUNNABLE`] name.
+// The steward runnable name is a non-empty const, so its parse is infallible.
+#[allow(clippy::expect_used)]
+pub fn gateway_runnable_host(
+    steward: Option<Arc<StewardEngine>>,
+    callback_runnables: Option<(Arc<dyn CallbackBridge>, Vec<HostRunnableName>)>,
+) -> Result<Option<Arc<dyn ScheduleRunnableHost>>, String> {
+    let mut registry = HostRunnableRegistry::new();
+    let mut registered = false;
+    if let Some(engine) = steward {
+        let name = HostRunnableName::parse(STEWARD_DREAM_RUNNABLE)
+            .expect("STEWARD_DREAM_RUNNABLE is a non-empty runnable name");
+        registry
+            .register(name, Arc::new(StewardDreamRunnable { engine }))
+            .map_err(|error| error.to_string())?;
+        registered = true;
+    }
+    if let Some((bridge, names)) = callback_runnables {
+        for name in names {
+            registry
+                .register(
+                    name,
+                    Arc::new(CallbackHostRunnable {
+                        bridge: Arc::clone(&bridge),
+                    }),
+                )
+                .map_err(|error| error.to_string())?;
+            registered = true;
+        }
+    }
+    Ok(registered.then(|| Arc::new(registry) as Arc<dyn ScheduleRunnableHost>))
 }
 
 /// Find-or-create the durable schedule that drives the steward dream runnable
@@ -1318,6 +1437,212 @@ mod tests {
     #[test]
     fn steward_dream_runnable_host_is_none_without_a_steward() {
         assert!(steward_dream_runnable_host(None).is_none());
+    }
+
+    /// Records bridge calls and answers each with a scripted result, standing
+    /// in for the SDK host on the far side of the stdio callback bridge.
+    struct ScriptedCallbackBridge {
+        calls: std::sync::Mutex<Vec<(String, Value)>>,
+        result: Result<Value, String>,
+    }
+
+    impl ScriptedCallbackBridge {
+        fn new(result: Result<Value, String>) -> Arc<Self> {
+            Arc::new(Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                result,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl CallbackBridge for ScriptedCallbackBridge {
+        async fn call(&self, method: &str, params: Value) -> Result<Value, String> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push((method.to_string(), params));
+            self.result.clone()
+        }
+    }
+
+    fn runnable_name(value: &str) -> HostRunnableName {
+        HostRunnableName::parse(value).expect("valid runnable name")
+    }
+
+    fn callback_invocation(runnable: &str, params_json: Option<&str>) -> HostRunnableInvocation {
+        HostRunnableInvocation {
+            occurrence_id: meerkat::OccurrenceId::new(),
+            schedule_id: meerkat::ScheduleId::new(),
+            runnable: runnable_name(runnable),
+            trigger_time: chrono::Utc::now(),
+            params: params_json
+                .map(|text| RawValue::from_string(text.to_string()).expect("valid raw params")),
+        }
+    }
+
+    #[tokio::test]
+    async fn callback_runnable_fires_over_the_bridge_with_the_occurrence_shape() {
+        let bridge = ScriptedCallbackBridge::new(Ok(json!({"digest": "sent"})));
+        let host = gateway_runnable_host(
+            None,
+            Some((
+                Arc::clone(&bridge) as Arc<dyn CallbackBridge>,
+                vec![runnable_name("digest")],
+            )),
+        )
+        .expect("compose runnable host")
+        .expect("callback runnables registered");
+
+        assert_eq!(
+            host.probe_runnable(&runnable_name("digest")),
+            meerkat::RunnableProbe::Registered
+        );
+        assert_eq!(
+            host.probe_runnable(&runnable_name("unknown")),
+            meerkat::RunnableProbe::Unknown
+        );
+
+        let invocation = callback_invocation("digest", Some(r#"{"depth":3}"#));
+        let outcome = host
+            .run_occurrence(invocation.clone())
+            .await
+            .expect("bridge success completes the occurrence");
+        assert_eq!(outcome, HostRunnableOutcome::completed());
+
+        let calls = bridge.calls.lock().expect("calls lock");
+        assert_eq!(calls.len(), 1);
+        let (method, params) = &calls[0];
+        assert_eq!(method, SCHEDULE_FIRE_CALLBACK_METHOD);
+        assert_eq!(params["runnable"], json!("digest"));
+        let occurrence = params["occurrence"].as_object().expect("occurrence object");
+        assert_eq!(
+            occurrence["schedule_id"],
+            json!(invocation.schedule_id.to_string())
+        );
+        assert_eq!(
+            occurrence["occurrence_id"],
+            json!(invocation.occurrence_id.to_string())
+        );
+        assert_eq!(
+            occurrence["due_at"],
+            json!(invocation.trigger_time.to_rfc3339())
+        );
+        assert_eq!(occurrence["payload"], json!({"depth": 3}));
+    }
+
+    #[tokio::test]
+    async fn callback_runnable_omits_payload_when_the_binding_has_no_params() {
+        let bridge = ScriptedCallbackBridge::new(Ok(Value::Null));
+        let host = gateway_runnable_host(
+            None,
+            Some((
+                Arc::clone(&bridge) as Arc<dyn CallbackBridge>,
+                vec![runnable_name("digest")],
+            )),
+        )
+        .expect("compose runnable host")
+        .expect("callback runnables registered");
+
+        host.run_occurrence(callback_invocation("digest", None))
+            .await
+            .expect("fire without params");
+        let calls = bridge.calls.lock().expect("calls lock");
+        assert!(
+            calls[0].1["occurrence"].get("payload").is_none(),
+            "no payload key without binding params: {}",
+            calls[0].1
+        );
+    }
+
+    #[tokio::test]
+    async fn callback_runnable_maps_bridge_error_to_runnable_failure() {
+        let bridge = ScriptedCallbackBridge::new(Err("callback error: handler raised".to_string()));
+        let host = gateway_runnable_host(
+            None,
+            Some((
+                Arc::clone(&bridge) as Arc<dyn CallbackBridge>,
+                vec![runnable_name("digest")],
+            )),
+        )
+        .expect("compose runnable host")
+        .expect("callback runnables registered");
+
+        let error = host
+            .run_occurrence(callback_invocation("digest", None))
+            .await
+            .expect_err("bridge failure must fail the occurrence");
+        assert!(
+            matches!(&error, HostRunnableError::Failed { detail } if detail.contains("handler raised")),
+            "expected typed Failed with the bridge detail, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn gateway_runnable_host_is_none_with_nothing_to_register() {
+        assert!(
+            gateway_runnable_host(None, None)
+                .expect("empty composition is not an error")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn gateway_runnable_host_rejects_duplicate_callback_names() {
+        let bridge = ScriptedCallbackBridge::new(Ok(Value::Null));
+        let error = match gateway_runnable_host(
+            None,
+            Some((
+                bridge as Arc<dyn CallbackBridge>,
+                vec![runnable_name("digest"), runnable_name("digest")],
+            )),
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("duplicate names must be rejected"),
+        };
+        assert!(error.contains("digest"), "{error}");
+    }
+
+    /// The agent-facing schedule tools and any generic RPC pass-through
+    /// deserialize targets through `TargetBinding`'s serde — pin that the
+    /// host-runnable wire form is accepted and creation lands in the store.
+    #[tokio::test]
+    async fn schedule_creation_accepts_the_host_runnable_target_wire_form() {
+        let target: TargetBinding = serde_json::from_value(json!({
+            "target_kind": "host_runnable",
+            "runnable": "digest",
+            "params": {"depth": 3}
+        }))
+        .expect("host_runnable target wire form deserializes");
+        assert!(
+            matches!(&target, TargetBinding::HostRunnable(binding) if binding.runnable == runnable_name("digest")),
+            "expected host-runnable binding, got {target:?}"
+        );
+
+        let service = ScheduleService::new(Arc::new(MemoryScheduleStore::new()));
+        let created = service
+            .create(CreateScheduleRequest {
+                name: Some("sdk-digest".to_string()),
+                description: None,
+                trigger: TriggerSpec::Interval(IntervalTriggerSpec {
+                    start_at_utc: chrono::Utc::now() + chrono::Duration::seconds(60),
+                    every_seconds: 3600,
+                    end_at_utc: None,
+                }),
+                target,
+                misfire_policy: meerkat::MisfirePolicy::default(),
+                overlap_policy: meerkat::OverlapPolicy::default(),
+                missing_target_policy: meerkat::MissingTargetPolicy::default(),
+                labels: std::collections::BTreeMap::new(),
+                planning_horizon_days: None,
+                planning_horizon_occurrences: None,
+            })
+            .await
+            .expect("create schedule with host_runnable target");
+        assert!(
+            matches!(&created.target, TargetBinding::HostRunnable(_)),
+            "persisted schedule keeps the host-runnable target"
+        );
     }
 
     fn dream_target_count(schedules: &[meerkat::Schedule]) -> usize {

--- a/meerkat-mobkit/src/unified_runtime/mob_events.rs
+++ b/meerkat-mobkit/src/unified_runtime/mob_events.rs
@@ -430,7 +430,10 @@ fn event_kind_label(kind: &MobEventKind) -> &'static str {
         MobEventKind::MobReset => "mob_reset",
         MobEventKind::MemberSpawned(_) => "member_spawned",
         MobEventKind::MemberSessionBindingRecovered(_) => "member_session_binding_recovered",
+        MobEventKind::MemberRetirementStarted { .. } => "member_retirement_started",
         MobEventKind::MemberRetired { .. } => "member_retired",
+        MobEventKind::RemoteMemberRuntimeRetired { .. } => "remote_member_runtime_retired",
+        MobEventKind::RemoteMemberSupervisorRevoked { .. } => "remote_member_supervisor_revoked",
         MobEventKind::MemberReset { .. } => "member_reset",
         MobEventKind::MemberKickoffUpdated { .. } => "member_kickoff_updated",
         MobEventKind::MembersWired { .. } => "members_wired",
@@ -535,8 +538,11 @@ pub(crate) fn extract_structural_fields(
             None,
             Some(decode_member_id(event.agent_identity.as_str())),
         ),
-        MobEventKind::MemberRetired { agent_identity, .. }
-        | MobEventKind::MemberReset { agent_identity, .. } => {
+        MobEventKind::MemberRetirementStarted { agent_identity, .. }
+        | MobEventKind::MemberRetired { agent_identity, .. }
+        | MobEventKind::MemberReset { agent_identity, .. }
+        | MobEventKind::RemoteMemberRuntimeRetired { agent_identity, .. }
+        | MobEventKind::RemoteMemberSupervisorRevoked { agent_identity, .. } => {
             (None, None, Some(decode_member_id(agent_identity.as_str())))
         }
         MobEventKind::MemberKickoffUpdated { member, .. } => {

--- a/meerkat-mobkit/tests/gateway_live.rs
+++ b/meerkat-mobkit/tests/gateway_live.rs
@@ -163,6 +163,7 @@ fn live_opt_in_advertises_methods_and_mounts_the_ws_route() {
         "mobkit/live/status",
         "mobkit/live/close",
         "mobkit/live/refresh",
+        "mobkit/live/truncate",
     ] {
         assert!(methods.iter().any(|m| m == method), "missing {method}");
     }
@@ -186,6 +187,119 @@ fn live_opt_in_advertises_methods_and_mounts_the_ws_route() {
     assert!(
         response != 404,
         "live ws route must be mounted (got 404 from {url})"
+    );
+}
+
+/// Fix 5: `mobkit/live/truncate` is served (not method-not-found) and
+/// answers TYPED errors — invalid params for an empty item_id, and the
+/// machine-authority channel-not-found rejection for a channel that was
+/// never opened. A full truncate round-trip needs a live provider channel;
+/// the command mapping is covered by the shared
+/// `live_command_result_from_machine_authority` unit coverage.
+#[test]
+fn live_truncate_answers_typed_errors_without_a_channel() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+    gateway.send(init_params(&state_dir, json!(true)));
+    let init = gateway.wait_for_response("init", Duration::from_mins(1));
+    assert!(init["result"]["contract_version"].is_string(), "{init}");
+
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "truncate-empty-item",
+        "method": "mobkit/live/truncate",
+        "params": {
+            "channel_id": "chan-1",
+            "item_id": "",
+            "content_index": 0,
+            "audio_played_ms": 0
+        }
+    }));
+    let response = gateway.wait_for_response("truncate-empty-item", Duration::from_secs(15));
+    assert_eq!(response["error"]["code"], json!(-32602), "{response}");
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("item_id"),
+        "{response}"
+    );
+
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "truncate-unbound",
+        "method": "mobkit/live/truncate",
+        "params": {
+            "channel_id": "no-such-channel",
+            "item_id": "item_1",
+            "content_index": 0,
+            "audio_played_ms": 1200
+        }
+    }));
+    let response = gateway.wait_for_response("truncate-unbound", Duration::from_secs(15));
+    let error = response.get("error").expect("typed error, not a hang");
+    assert!(
+        error["message"]
+            .as_str()
+            .expect("error message")
+            .contains("no-such-channel"),
+        "unbound-channel rejection names the channel: {response}"
+    );
+}
+
+/// Fix 4 parse surface: `runtime_options.live.seed_max_chars` is accepted at
+/// init (object form) — a bad value fails init loudly.
+#[test]
+fn live_object_form_accepts_seed_max_chars() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+    gateway.send(init_params(&state_dir, json!({ "seed_max_chars": 200000 })));
+    let init = gateway.wait_for_response("init", Duration::from_mins(1));
+    assert!(init["result"]["contract_version"].is_string(), "{init}");
+}
+
+/// Fix 1 registration surface: `runtime_options.host_runnables` is accepted
+/// at init on a persistent gateway (the schedule host composes the callback
+/// runnables), and malformed values fail init loudly. The fire path
+/// (callback/schedule_fire over the bridge) is unit-tested in
+/// `schedule_wiring`; target-kind acceptance is pinned there too.
+#[test]
+fn init_accepts_host_runnables_and_rejects_duplicates() {
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "init",
+        "method": "mobkit/init",
+        "params": {
+            "persistent_state": state_dir.path(),
+            "mob_config": MOB_CONFIG,
+            "runtime_options": { "host_runnables": ["digest", "backup.rotate"] }
+        }
+    }));
+    let init = gateway.wait_for_response("init", Duration::from_mins(1));
+    assert!(init["result"]["contract_version"].is_string(), "{init}");
+    drop(gateway);
+
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let mut gateway = Gateway::start();
+    gateway.send(json!({
+        "jsonrpc": "2.0",
+        "id": "init",
+        "method": "mobkit/init",
+        "params": {
+            "persistent_state": state_dir.path(),
+            "mob_config": MOB_CONFIG,
+            "runtime_options": { "host_runnables": ["digest", "digest"] }
+        }
+    }));
+    let init = gateway.wait_for_response("init", Duration::from_mins(1));
+    assert!(
+        init["error"]["message"]
+            .as_str()
+            .expect("init error")
+            .contains("duplicated"),
+        "{init}"
     );
 }
 

--- a/sdk/python/meerkat_mobkit/agent_builder.py
+++ b/sdk/python/meerkat_mobkit/agent_builder.py
@@ -63,6 +63,9 @@ class CallbackDispatcher:
         self._roster_provider: Any | None = None
         self._topology_provider: Any | None = None
         self._agent_customizer: Any | None = None
+        # Host-runnable schedule-fire handlers, keyed by runnable name
+        # (callback/schedule_fire from runtime_options.host_runnables targets)
+        self._schedule_fire_handlers: dict[str, Any] = {}
 
     def register_builder(self, builder: SessionAgentBuilder) -> None:
         self._builder = builder
@@ -84,6 +87,21 @@ class CallbackDispatcher:
 
     def register_agent_customizer(self, provider: Any) -> None:
         self._agent_customizer = provider
+
+    def register_schedule_fire_handler(self, name: str, handler: Any) -> None:
+        """Register the handler for a named host runnable.
+
+        The gateway invokes it via ``callback/schedule_fire`` when a schedule
+        with a ``host_runnable`` target of that name fires. The handler
+        receives the occurrence dict (``schedule_id``, ``occurrence_id``,
+        ``due_at``, optional ``payload``); raising marks the occurrence
+        attempt failed in the durable schedule store.
+        """
+        if not isinstance(name, str) or not name.strip():
+            raise TypeError(f"runnable name must be a non-empty string, got {name!r}")
+        if not callable(handler):
+            raise TypeError(f"handler must be callable, got {type(handler).__name__}: {handler!r}")
+        self._schedule_fire_handlers[name] = handler
 
     def release_scope(self, scope_id: str) -> None:
         """Remove all tool handlers for a scope. Call when a session ends."""
@@ -165,6 +183,22 @@ class CallbackDispatcher:
             if isinstance(result, ToolResultContent):
                 return {"content_blocks": result.blocks}
             return {"content": result}
+
+        if method == "callback/schedule_fire":
+            runnable = params.get("runnable", "")
+            handler = self._schedule_fire_handlers.get(runnable)
+            if handler is None:
+                # The error crosses the bridge and fails the occurrence in the
+                # durable schedule store — never silently complete a fire the
+                # app has no handler for.
+                raise ValueError(
+                    f"no schedule-fire handler registered for runnable: {runnable}"
+                )
+            occurrence = params.get("occurrence", {})
+            result = handler(occurrence)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
 
         # ----- Identity-first provider routing (REQ-45) -----
         if method.startswith("callback/continuity_store/"):

--- a/sdk/python/meerkat_mobkit/builder.py
+++ b/sdk/python/meerkat_mobkit/builder.py
@@ -23,6 +23,7 @@ class MobKitBuilderConfig:
     workgraph_enabled: bool | str | None = None
     routing_config_path: str | None = None
     scheduling_files: list[str] = field(default_factory=list)
+    host_runnables: list[str] = field(default_factory=list)
     memory_config: Any | None = None
     agent_memory_config: Any | None = None
     auth_config: Any | None = None
@@ -142,6 +143,22 @@ class MobKitBuilder:
     def scheduling(self, *schedule_files: str) -> MobKitBuilder:
         """Set schedule config files (accepts multiple positional args)."""
         self._config.scheduling_files = list(schedule_files)
+        return self
+
+    def host_runnables(self, names: Sequence[str]) -> MobKitBuilder:
+        """Register named deterministic (non-LLM) schedule targets.
+
+        Wired into ``runtime_options.host_runnables``. Each name becomes a
+        schedule-host runnable: a durable schedule with target
+        ``{"target_kind": "host_runnable", "runnable": "<name>"}`` fires as
+        ``callback/schedule_fire`` into this process, dispatched to the
+        handler registered via :meth:`MobKitRuntime.on_schedule_fire`.
+        """
+        names = list(names)
+        for name in names:
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(f"host runnable names must be non-empty strings, got {name!r}")
+        self._config.host_runnables = names
         return self
 
     def memory(self, config: Any = None, *, stores: list[str] | None = None) -> MobKitBuilder:

--- a/sdk/python/meerkat_mobkit/models.py
+++ b/sdk/python/meerkat_mobkit/models.py
@@ -114,6 +114,9 @@ class SessionBuildOptions:
     resume_session_id: str | None = None
     _tools: list[str] = field(default_factory=list, repr=False)
     _tool_handlers: dict[str, Any] = field(default_factory=dict, repr=False)
+    # Per-tool wire metadata from register_tool(description=/input_schema=);
+    # tools without an entry cross the wire as bare name strings.
+    _tool_defs: dict[str, dict[str, Any]] = field(default_factory=dict, repr=False)
 
     def add_tools(self, tools: list[str]) -> None:
         """Declare tool names the agent can use."""
@@ -122,7 +125,14 @@ class SessionBuildOptions:
                 raise TypeError(f"tools must be strings, got {type(t).__name__}: {t!r}")
         self._tools.extend(tools)
 
-    def register_tool(self, name: str, handler: Any) -> None:
+    def register_tool(
+        self,
+        name: str,
+        handler: Any,
+        *,
+        description: str = "",
+        input_schema: dict[str, Any] | None = None,
+    ) -> None:
         """Register a callable tool with the agent.
 
         The handler is called when the agent invokes this tool. It receives
@@ -131,13 +141,27 @@ class SessionBuildOptions:
         Args:
             name: Tool name (string).
             handler: Async or sync callable ``(args: dict) -> Any``.
+            description: Human-readable tool description.
+            input_schema: JSON Schema for the tool arguments. When omitted
+                the gateway advertises the permissive ``{"type": "object"}``.
         """
         if not isinstance(name, str):
             raise TypeError(f"tool name must be a string, got {type(name).__name__}: {name!r}")
         if not callable(handler):
             raise TypeError(f"handler must be callable, got {type(handler).__name__}: {handler!r}")
+        if input_schema is not None and not isinstance(input_schema, dict):
+            raise TypeError(
+                f"input_schema must be a dict, got {type(input_schema).__name__}: {input_schema!r}"
+            )
         self._tools.append(name)
         self._tool_handlers[name] = handler
+        if description or input_schema is not None:
+            tool_def: dict[str, Any] = {"name": name}
+            if description:
+                tool_def["description"] = description
+            if input_schema is not None:
+                tool_def["input_schema"] = input_schema
+            self._tool_defs[name] = tool_def
 
     @property
     def tools(self) -> list[str]:
@@ -162,5 +186,10 @@ class SessionBuildOptions:
         if self.resume_session_id is not None:
             result["resume_session_id"] = self.resume_session_id
         if self._tools:
-            result["tools"] = self._tools
+            # Names with registered metadata cross as {name, description?,
+            # input_schema?} objects; everything else stays a bare string
+            # (backward-compatible with pre-0.7.30 gateways).
+            result["tools"] = [
+                self._tool_defs.get(name, name) for name in self._tools
+            ]
         return result

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -258,6 +258,19 @@ class MobKitRuntime:
             return
         await self._bootstrap()
 
+    def on_schedule_fire(self, name: str, handler: Any) -> None:
+        """Register the handler for a named host runnable.
+
+        Pairs with ``MobKitBuilder.host_runnables([...])``: when a durable
+        schedule with a ``host_runnable`` target of that name fires, the
+        gateway sends ``callback/schedule_fire`` and this handler runs with
+        the occurrence dict (``schedule_id``, ``occurrence_id``, ``due_at``,
+        optional ``payload``). Sync or async; raising fails the occurrence
+        attempt in the durable schedule store. Register before or after
+        :meth:`connect` — fires only start once a schedule targets the name.
+        """
+        self._dispatcher.register_schedule_fire_handler(name, handler)
+
     async def _bootstrap(self) -> None:
         if self._config.gateway_bin:
             self._transport = PersistentTransport(self._config.gateway_bin)
@@ -338,6 +351,8 @@ class MobKitRuntime:
             runtime_options["routing_config_path"] = self._config.routing_config_path
         if self._config.scheduling_files:
             runtime_options["scheduling_files"] = self._config.scheduling_files
+        if self._config.host_runnables:
+            runtime_options["host_runnables"] = list(self._config.host_runnables)
         if self._config.memory_config:
             runtime_options["memory_config"] = _serialize_config(self._config.memory_config)
         if self._config.agent_memory_config is not None:
@@ -1960,12 +1975,59 @@ class MobHandle:
         raw = await self._runtime._rpc("mobkit/live/close", params)
         return raw if isinstance(raw, dict) else {}
 
+    async def live_send_input_image(
+        self,
+        identity: str,
+        idempotency_key: str,
+        mime: str,
+        data_base64: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Send a still image into the member's open live channel (meerkat
+        0.7.27+).  ``idempotency_key`` must be caller-stable within the
+        session — retries with the same key are exact-retry deduplicated.
+        """
+        params: dict[str, Any] = {
+            "identity": identity,
+            "chunk": {
+                "kind": "image",
+                "idempotency_key": idempotency_key,
+                "mime": mime,
+                "data": data_base64,
+            },
+            **kwargs,
+        }
+        raw = await self._runtime._rpc("mobkit/live/send_input", params)
+        return raw if isinstance(raw, dict) else {}
+
     async def live_refresh(self, identity: str, **kwargs: Any) -> dict[str, Any]:
         """Push refreshed mutable config (instructions/tools/audio) into an
         open live channel without rebuilding the transport.  Model/provider
         swaps require close + reopen."""
         params: dict[str, Any] = {"identity": identity, **kwargs}
         raw = await self._runtime._rpc("mobkit/live/refresh", params)
+        return raw if isinstance(raw, dict) else {}
+
+    async def live_truncate(
+        self,
+        channel_id: str,
+        item_id: str,
+        content_index: int,
+        audio_played_ms: int,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Truncate an assistant item at the client-tracked playback cursor
+        (barge-in cleanup).  ``item_id``/``content_index`` are the
+        provider-side handle for the assistant item; ``audio_played_ms`` is
+        how much the client actually played."""
+        params: dict[str, Any] = {
+            "channel_id": channel_id,
+            "item_id": item_id,
+            "content_index": content_index,
+            "audio_played_ms": audio_played_ms,
+            **kwargs,
+        }
+        raw = await self._runtime._rpc("mobkit/live/truncate", params)
         return raw if isinstance(raw, dict) else {}
 
     # -----------------------------------------------------------------

--- a/sdk/python/tests/test_callback_tools.py
+++ b/sdk/python/tests/test_callback_tools.py
@@ -169,3 +169,72 @@ class TestRegisterToolValidation:
         opts = SessionBuildOptions()
         with pytest.raises(TypeError, match="handler must be callable"):
             opts.register_tool("bad", None)
+
+
+class _SchemaBuilder:
+    """Builder mixing legacy (name-only) and schema-carrying tools."""
+
+    WEATHER_SCHEMA = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+
+    async def build_agent(self, opts: SessionBuildOptions) -> None:
+        opts.register_tool("plain", lambda args: {"ok": True})
+        opts.register_tool(
+            "weather",
+            lambda args: {"temp_c": 21, "city": args["city"]},
+            description="Look up the weather",
+            input_schema=self.WEATHER_SCHEMA,
+        )
+
+
+class TestRegisterToolInputSchemaWire:
+    """Fix 3: register_tool(input_schema=...) crosses the callback/build_agent
+    response wire as {name, description?, input_schema?}; schema-less tools
+    stay bare strings (backward compatible)."""
+
+    @pytest.mark.asyncio
+    async def test_build_agent_wire_shape_carries_schema(self):
+        d = CallbackDispatcher()
+        d.register_builder(_SchemaBuilder())
+        result = await d.handle_callback(
+            "callback/build_agent", {"options": {"scope_id": "s1"}}
+        )
+        assert result["tools"] == [
+            "plain",
+            {
+                "name": "weather",
+                "description": "Look up the weather",
+                "input_schema": _SchemaBuilder.WEATHER_SCHEMA,
+            },
+        ]
+        # Handlers are captured for both shapes.
+        assert ("s1", "plain") in d._tool_handlers
+        assert ("s1", "weather") in d._tool_handlers
+
+    @pytest.mark.asyncio
+    async def test_schema_tool_still_dispatches(self):
+        d = CallbackDispatcher()
+        d.register_builder(_SchemaBuilder())
+        await d.handle_callback(
+            "callback/build_agent", {"options": {"scope_id": "s1"}}
+        )
+        result = await d.handle_callback(
+            "callback/call_tool",
+            {"scope_id": "s1", "tool": "weather", "arguments": {"city": "Stockholm"}},
+        )
+        assert result == {"content": {"temp_c": 21, "city": "Stockholm"}}
+
+    def test_description_only_emits_object_without_schema(self):
+        opts = SessionBuildOptions()
+        opts.register_tool("notify", lambda args: None, description="Send a note")
+        assert opts.to_dict()["tools"] == [
+            {"name": "notify", "description": "Send a note"}
+        ]
+
+    def test_non_dict_schema_raises(self):
+        opts = SessionBuildOptions()
+        with pytest.raises(TypeError, match="input_schema must be a dict"):
+            opts.register_tool("bad", lambda args: None, input_schema="nope")

--- a/sdk/python/tests/test_rpc_method_names.py
+++ b/sdk/python/tests/test_rpc_method_names.py
@@ -1583,3 +1583,40 @@ async def test_live_method_names_and_identity_param():
     ]
     assert calls[0][1] == {"identity": "reachy", "model": "gpt-realtime-2"}
     assert calls[1][1] == {"identity": "reachy"}
+
+
+@pytest.mark.asyncio
+async def test_live_truncate_wire_shape():
+    handle, calls = make_mock_mob_handle({
+        "mobkit/live/truncate": {"status": "truncated"},
+    })
+    result = await handle.live_truncate("chan-1", "item_1", 0, 1200)
+    assert result["status"] == "truncated"
+    assert calls[0][0] == "mobkit/live/truncate"
+    assert calls[0][1] == {
+        "channel_id": "chan-1",
+        "item_id": "item_1",
+        "content_index": 0,
+        "audio_played_ms": 1200,
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_send_input_image_wire_shape():
+    handle, calls = make_mock_mob_handle({
+        "mobkit/live/send_input": {"accepted": True},
+    })
+    result = await handle.live_send_input_image(
+        "reachy", "frame-0001", "image/jpeg", "aGVsbG8="
+    )
+    assert result["accepted"] is True
+    assert calls[0][0] == "mobkit/live/send_input"
+    assert calls[0][1] == {
+        "identity": "reachy",
+        "chunk": {
+            "kind": "image",
+            "idempotency_key": "frame-0001",
+            "mime": "image/jpeg",
+            "data": "aGVsbG8=",
+        },
+    }

--- a/sdk/python/tests/test_schedule_fire.py
+++ b/sdk/python/tests/test_schedule_fire.py
@@ -1,0 +1,98 @@
+"""Tests for host-runnable schedule fires (callback/schedule_fire).
+
+Fix 1 SDK seam: ``MobKitBuilder.host_runnables([...])`` rides
+``runtime_options.host_runnables`` at init, and incoming
+``callback/schedule_fire`` requests dispatch to handlers registered via
+``MobKitRuntime.on_schedule_fire(name, handler)``.
+"""
+import pytest
+
+from meerkat_mobkit.agent_builder import CallbackDispatcher
+from meerkat_mobkit.builder import MobKitBuilder
+from meerkat_mobkit.runtime import MobKitRuntime
+
+OCCURRENCE = {
+    "schedule_id": "sch-1",
+    "occurrence_id": "occ-1",
+    "due_at": "2026-07-10T07:00:00+00:00",
+    "payload": {"depth": 3},
+}
+
+
+class TestScheduleFireDispatch:
+    @pytest.mark.asyncio
+    async def test_sync_handler_receives_occurrence_and_returns_result(self):
+        d = CallbackDispatcher()
+        seen = []
+
+        def handler(occurrence):
+            seen.append(occurrence)
+            return {"digest": "sent"}
+
+        d.register_schedule_fire_handler("digest", handler)
+        result = await d.handle_callback(
+            "callback/schedule_fire",
+            {"runnable": "digest", "occurrence": OCCURRENCE},
+        )
+        assert result == {"digest": "sent"}
+        assert seen == [OCCURRENCE]
+
+    @pytest.mark.asyncio
+    async def test_async_handler_is_awaited(self):
+        d = CallbackDispatcher()
+
+        async def handler(occurrence):
+            return {"echo": occurrence["occurrence_id"]}
+
+        d.register_schedule_fire_handler("digest", handler)
+        result = await d.handle_callback(
+            "callback/schedule_fire",
+            {"runnable": "digest", "occurrence": OCCURRENCE},
+        )
+        assert result == {"echo": "occ-1"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_runnable_raises(self):
+        d = CallbackDispatcher()
+        with pytest.raises(ValueError, match="no schedule-fire handler"):
+            await d.handle_callback(
+                "callback/schedule_fire",
+                {"runnable": "nobody", "occurrence": OCCURRENCE},
+            )
+
+    def test_registration_validates_inputs(self):
+        d = CallbackDispatcher()
+        with pytest.raises(TypeError, match="non-empty string"):
+            d.register_schedule_fire_handler("", lambda o: None)
+        with pytest.raises(TypeError, match="handler must be callable"):
+            d.register_schedule_fire_handler("digest", "not_a_function")
+
+
+class TestRuntimeSeam:
+    @pytest.mark.asyncio
+    async def test_on_schedule_fire_registers_on_the_dispatcher(self):
+        runtime = MobKitRuntime(MobKitBuilder()._config)
+        runtime.on_schedule_fire("digest", lambda occurrence: {"ok": True})
+        result = await runtime._dispatcher.handle_callback(
+            "callback/schedule_fire",
+            {"runnable": "digest", "occurrence": OCCURRENCE},
+        )
+        assert result == {"ok": True}
+
+    def test_host_runnables_ride_init_params(self):
+        builder = MobKitBuilder().host_runnables(["digest", "backup.rotate"])
+        runtime = MobKitRuntime(builder._config)
+        params = runtime._build_init_params()
+        assert params["runtime_options"]["host_runnables"] == [
+            "digest",
+            "backup.rotate",
+        ]
+
+    def test_host_runnables_omitted_when_unset(self):
+        runtime = MobKitRuntime(MobKitBuilder()._config)
+        params = runtime._build_init_params()
+        assert "host_runnables" not in params["runtime_options"]
+
+    def test_host_runnables_rejects_empty_names(self):
+        with pytest.raises(ValueError, match="non-empty strings"):
+            MobKitBuilder().host_runnables(["digest", "  "])

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -115,6 +115,9 @@ export class SessionBuildOptions {
 
   private _tools: string[] = [];
   private _toolHandlers: Map<string, ToolHandler> = new Map();
+  // Per-tool wire metadata from registerTool options; tools without an
+  // entry cross the wire as bare name strings.
+  private _toolDefs: Map<string, Record<string, unknown>> = new Map();
 
   /** Declare tool names the agent can use. */
   addTools(tools: string[]): void {
@@ -128,8 +131,17 @@ export class SessionBuildOptions {
     this._tools.push(...tools);
   }
 
-  /** Register a callable tool with the agent. */
-  registerTool(name: string, handler: ToolHandler): void {
+  /**
+   * Register a callable tool with the agent.
+   *
+   * `options.inputSchema` is the JSON Schema for the tool arguments; when
+   * omitted the gateway advertises the permissive `{"type": "object"}`.
+   */
+  registerTool(
+    name: string,
+    handler: ToolHandler,
+    options?: { description?: string; inputSchema?: Record<string, unknown> },
+  ): void {
     if (typeof name !== "string") {
       throw new TypeError(
         `tool name must be a string, got ${typeof name}: ${String(name)}`,
@@ -142,6 +154,12 @@ export class SessionBuildOptions {
     }
     this._tools.push(name);
     this._toolHandlers.set(name, handler);
+    if (options?.description !== undefined || options?.inputSchema !== undefined) {
+      const def: Record<string, unknown> = { name };
+      if (options.description !== undefined) def.description = options.description;
+      if (options.inputSchema !== undefined) def.input_schema = options.inputSchema;
+      this._toolDefs.set(name, def);
+    }
   }
 
   get tools(): string[] {
@@ -163,7 +181,14 @@ export class SessionBuildOptions {
       result.labels = { ...this.labels };
     }
     if (this.profileName !== null) result.profile_name = this.profileName;
-    if (this._tools.length > 0) result.tools = [...this._tools];
+    if (this._tools.length > 0) {
+      // Names with registered metadata cross as {name, description?,
+      // input_schema?} objects; everything else stays a bare string
+      // (backward-compatible with pre-0.7.30 gateways).
+      result.tools = this._tools.map(
+        (name) => this._toolDefs.get(name) ?? name,
+      );
+    }
     return result;
   }
 }

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -2195,6 +2195,31 @@ export class MobHandle {
   }
 
   /**
+   * Send a still image into the member's open live channel (meerkat
+   * 0.7.27+). `idempotencyKey` must be caller-stable within the session —
+   * retries with the same key are exact-retry deduplicated.
+   */
+  async liveSendInputImage(
+    identity: string,
+    idempotencyKey: string,
+    mime: string,
+    dataBase64: string,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const raw = await this._runtime._rpc("mobkit/live/send_input", {
+      identity,
+      chunk: {
+        kind: "image",
+        idempotency_key: idempotencyKey,
+        mime,
+        data: dataBase64,
+      },
+      ...(options ?? {}),
+    });
+    return asWireRecord(raw);
+  }
+
+  /**
    * Push refreshed mutable config (instructions/tools/audio) into an open
    * live channel without rebuilding the transport. Model/provider swaps
    * require close + reopen.
@@ -2205,6 +2230,29 @@ export class MobHandle {
   ): Promise<Record<string, unknown>> {
     const raw = await this._runtime._rpc("mobkit/live/refresh", {
       identity,
+      ...(options ?? {}),
+    });
+    return asWireRecord(raw);
+  }
+
+  /**
+   * Truncate an assistant item at the client-tracked playback cursor
+   * (barge-in cleanup). `itemId`/`contentIndex` are the provider-side
+   * handle for the assistant item; `audioPlayedMs` is how much the client
+   * actually played.
+   */
+  async liveTruncate(
+    channelId: string,
+    itemId: string,
+    contentIndex: number,
+    audioPlayedMs: number,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const raw = await this._runtime._rpc("mobkit/live/truncate", {
+      channel_id: channelId,
+      item_id: itemId,
+      content_index: contentIndex,
+      audio_played_ms: audioPlayedMs,
       ...(options ?? {}),
     });
     return asWireRecord(raw);

--- a/sdk/typescript/tests/models.test.ts
+++ b/sdk/typescript/tests/models.test.ts
@@ -277,6 +277,28 @@ describe("SessionBuildOptions", () => {
           /handler must be callable/.test(err.message),
       );
     });
+
+    it("carries description + inputSchema onto the build_agent wire", () => {
+      const schema = {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      };
+      const opts = new SessionBuildOptions();
+      opts.registerTool("plain", () => "ok");
+      opts.registerTool("weather", () => "ok", {
+        description: "Look up the weather",
+        inputSchema: schema,
+      });
+      assert.deepEqual(opts.toDict().tools, [
+        "plain",
+        {
+          name: "weather",
+          description: "Look up the weather",
+          input_schema: schema,
+        },
+      ]);
+    });
   });
 
   describe("tools getter", () => {

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -2539,5 +2539,28 @@ describe("MobHandle live methods", () => {
     setResponse(() => ({ refreshed: true }));
     await handle.liveRefresh("reachy");
     assert.equal(calls[3].method, "mobkit/live/refresh");
+
+    setResponse(() => ({ accepted: true }));
+    await handle.liveSendInputImage("reachy", "frame-0001", "image/jpeg", "aGVsbG8=");
+    assert.equal(calls[4].method, "mobkit/live/send_input");
+    assert.deepEqual(calls[4].params, {
+      identity: "reachy",
+      chunk: {
+        kind: "image",
+        idempotency_key: "frame-0001",
+        mime: "image/jpeg",
+        data: "aGVsbG8=",
+      },
+    });
+
+    setResponse(() => ({ status: "truncated" }));
+    await handle.liveTruncate("chan-1", "item_1", 0, 1200);
+    assert.equal(calls[5].method, "mobkit/live/truncate");
+    assert.deepEqual(calls[5].params, {
+      channel_id: "chan-1",
+      item_id: "item_1",
+      content_index: 0,
+      audio_played_ms: 1200,
+    });
   });
 });


### PR DESCRIPTION
Two workstreams on one train (0.7.32):

## meerkat 0.7.27 adaptation — live images

Pins `=0.7.27`. Four breaking-surface fixes: the projection sink forwards the transcript apply outcome (redacted-receipt contract), the open config + snapshot carry the user-content identity lane (`user_content_identities`/`user_content_tombstones`/`transcript_rewrite_generation` from the exported session snapshot — reopened channels don't replay committed images), and the mob-event projection handles the three new retirement event kinds at both match sites. Image input rides the existing `mobkit/live/send_input` (the wire chunk enum grew `Image`); SDK conveniences `live_send_input_image`/`liveSendInputImage` both languages.

## Five field gaps (HomeCore robot)

1. **Deterministic schedule targets from the SDK** — `runtime_options.host_runnables` + `callback/schedule_fire` over the stdio bridge + Python `.host_runnables([...])`/`on_schedule_fire(name, handler)`; agents target them via the `host_runnable` target kind (wire acceptance pinned). Upstream `HostRunnableOutcome` is payload-less — app results logged and dropped (documented).
2. **Per-open instruction overlay** on `mobkit/live/open` — carried on the runtime-system-context lane, NOT the typed `system_prompt` (R10: single owner of durable prompt truth); per-open ephemeral, never persists, drops on refresh by construction.
3. **Real input schemas for callback tools** — `register_tool(..., input_schema=...)` crosses the build_agent wire into `CallbackToolDispatcher` ToolDefs (bare-string tools stay valid); live seeds and normal turns both see real schemas.
4. **Seed clamp stopgap** for the realtime 65,536-token cap — `runtime_options.live.seed_max_chars` + per-open override; whole-message oldest-first, root system message and typed prompt untouched. Explicit stopgap for **upstream ask 30** (filed).
5. **`mobkit/live/truncate`** — handler port + capabilities + SDK methods.

Also on the branch: upstream ask 29 (Bug G′) + ask 30 filings, the maintainer's authoritative asks-tracker curation, `unified_console` joins the heavy-runtime nextest family (second isolated-pass SIG10 on loaded local runs).

Tests: full workspace suite green under the CI exclusion set; Python 592; TS 602; new coverage for every gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)