### PR TITLE
chore: meerkat 0.7.28 pins (GPT-5.6, upstream seed window, endpoint-recovery fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,9 +1737,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7b8e7dc94f1711d21f40b9bb8a2bef28cbbc5fddfca922909569087ee411e"
+checksum = "09cb9715f8af9d027d2c849e1e73ba3293e01d9e016daf9b204c8aaecc11b9ba"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1778,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bfa3fa7d5ecae7d5ab29224d071f2e454d6552a483f3e92657cb1dcb154e22"
+checksum = "62c5c35bfdcd85a59f3ba9998e59f112a3465e13b7d09d3888b99f8cd7a5aaa9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1802,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5908e723f7a925c6d7896fef1d543bd5b5e36f68af1a80e2908d7997ca4b4db7"
+checksum = "0664fc31b64a921751d9adc8fb860967f0a39c4aee3528c0bf749d92a9c7760c"
 dependencies = [
  "async-trait",
  "axum",
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c408133021b53bd0a22db768942f94f0cc2327cfe66aba39ac68b8462f4d192"
+checksum = "8b1a46fcec3f436376e7f55755b6caa98fc949e2c50f1876087708fb11a0fe00"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afeec98c91db99f9b374322bd8c549bace28ba949f7ee143d1456257bbdcbfc"
+checksum = "f0958c5c7f4e7a1064dc92f796325e84c4afe12f7878587ad5fbe4d8c3005c09"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d29710610223824c7bb8ab4514606404f68ccbeb8ed5f159f40ebd9a9d7a53c"
+checksum = "b8cfe64585ac0ef577b83373a97eae61de9384d5b6e99dcb3dfd238f56d4febf"
 dependencies = [
  "async-trait",
  "base64",
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2496c3c0633fbad80b900e3d7836147c3fff99e672d20c4a297204dd530e8cdb"
+checksum = "d234e14e3382eb4d588fcbbcc10a6dd5fb0730a52fe487fed49ecb9fdb8d75b4"
 dependencies = [
  "base64",
  "chrono",
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7285c605d15406f427209878d577fe5ba96a523d65293a64ea54c28edf28101"
+checksum = "8d2c7fcee6f4eba909c44e1da945e2e5fc8316c7b521fdfd88b45db49c28a22a"
 dependencies = [
  "async-trait",
  "base64",
@@ -1947,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10df37da475915393f32fa6fddbdf6f9f1c84d3bf0be3a5d09574b47dd0d0da3"
+checksum = "9affb60deab85da8e77e88c301c1ce3d35243a3cd15ebc16280085acef09a51a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1971,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eed50146250fcd8cc948020d4792a7630d79770dc319277a27bb001798260e2"
+checksum = "186f956fb18c1102c7a533d51a39fe0e3b263cd72062fee4dc9de07ed12a5de0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cacec9ae7b21fa606923b3f64e7b2891761b2749684da6d454f7ada36affeb4"
+checksum = "3788aaae0524f3ae80621718f7e9f61458ea3b841f08a3a5d505d3b2ffb95328"
 dependencies = [
  "async-trait",
  "axum",
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0de464d932373d480e7d1ad66abdf414e9b0684623b8b16fb2af26f1c606d9"
+checksum = "f643fc1091e22dc55c44ce812029d0397679223c77bdaa24895980acdbecdb81"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df4791c667b4da429fbbfe667bb50c5128ec36cc669c5b7d63a8b0d8333497a"
+checksum = "afeb50de33de198ba473c4f73606059820963e2fabe1df1a71692d8fc16f942a"
 dependencies = [
  "quote",
  "syn",
@@ -2050,18 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a7060d61268be5a8eaa11189893f79e1af169c1aef8ca622322ebae927c1b6"
+checksum = "046bfc7947769bc15d8e4181f4e1243eb69f29611419dc84089d3c9adfd6f45c"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cedab6fc4f0ef4c22b827cd49075e6696aff65ae27469e2ad86fc3b9adcba316"
+checksum = "9a1d8dd2bb3436f20a775b7542e3db2841e9c7e7aa983cda1734caf822a4bc5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2070,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41316e0bb47539346b3670d98edefc88440c08b5b1267c58cb9e42ffc1ae433"
+checksum = "cea87e6e4f2d98201126724719757a9a33249a383f849bbf7088d2877520d0cf"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2083,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642740eaa0ad5b65d855388f152d97599222c3d5039681ddde7f12fdfc7a172d"
+checksum = "21ba4719f5ff0ca4fc30cd99443e92cfc49bf5a466603473e94ee06fe96ea82a"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dff1684a2fd6e716af79b377eb447c4744d2099dcdbc687efa6332df4bc5f4"
+checksum = "eb2aa345ade4386a5619fb3b9588758e1b0c037d07555a102932e674fd862d5c"
 dependencies = [
  "async-trait",
  "futures",
@@ -2121,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fabdab423d0cece18197780b62c0df5d36283017006fc5ad2736237c4d87979"
+checksum = "a63a2ede49a14c993e7ef8bbeb1653e82480b0db8bc4d5ec7c63e5c4e4421c8f"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366a41c0740e2bee488afd74b1898d95baf7afaf5b8719305ce82c09a3c3397"
+checksum = "c59cfa283dd5318f2618e9f9c39b6d67f53a0104c4dbeb8290a2c5a840b2952e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a6c0f4bf5f9fd43e6b593d8625c8536430b6a8806ae5db9c713b6488bcbd8a"
+checksum = "e670f86b15e8316dc10bbb064a69a2c683e2c6d139c491b00ad92be34772a416"
 dependencies = [
  "async-trait",
  "futures",
@@ -2260,18 +2260,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd23be9f011dd7d0af7e2a192dae5d3f08250ca3e1fc66f1cf1b211e949bc2b9"
+checksum = "9a8167f4135f4ed5b65ad942fa2714ed73801884b771ed51ab73d9a80b22b014"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1fd600ca94158495e7cd0d6d7c0d23d817a899d3848581c41ab3f63c66945a"
+checksum = "fe41705fc1ce90d14cb526e57e92cc6a7b04f74149753e7df5accb30e744c32a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2299,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c77889ee84c896a589231c0a0f4d06b753e774046221f4d2a54a113cd4440f0"
+checksum = "cc40d9dafab3b461d7799c141db06abb43a892fa9fd15c1685ba854fca37a03e"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2309,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62df6a8302b4f3c89639a645c8d93fd2ae9472634da73cc2b37bad70b1dde708"
+checksum = "dac15e124b69035bcee8c03bcdd9bd9fa865af146b0ba10cb5f600d57e51e70d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2337,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66362cffb821d009fdddd89bf12adae5b9c7a0196ffe3579accbee7233e0707"
+checksum = "9b6ac9804cb23fde2a3c8762a8bf83860b2a65a940e5a91cf84f5e8f1d477692"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2363,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042525012e093ef75c5ad4d034f6254f6cd6939c6b3783460b264d6fe52f23f9"
+checksum = "8fe8be796343e555ccaf753ee51bbb10123a5e09c60d61a7b5e154422f48a86f"
 dependencies = [
  "async-trait",
  "futures",
@@ -2389,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a47a72e9d9cea6a5c0c13dad979ebb929e683e0253a4e2f7db9dc3835f5d41"
+checksum = "943d9c4bc71d9470392ae1acf5e6a74608556f687346e5c7c9202ef2c32b335d"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2412,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a08414a9b322a315058238c827ca2eac7bc96f7bffee7546935b6b899afe19"
+checksum = "3407ea32d98e80c0a911b9bda2fe0311b0c87926e0eea98404754f37891acecb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2436,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6679dda0c195fc1610e09302c801174811fccefa619f5a269f7d51e6b941a23"
+checksum = "5903f0762451d79403a3caa72bf4869fdd52d0f816050f9f15a79851ec821524"
 dependencies = [
  "async-trait",
  "base64",
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e936d2b7ee38b4e15587e669373f76ab10cedd61632bdadc31d215dd910e32"
+checksum = "1f763a3ff223aaf1d0bcd507721673a2c43150c5dc9c46797c602712125d84eb"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/design/live-sessions.md
+++ b/docs/design/live-sessions.md
@@ -122,7 +122,9 @@ user-content identity lane, which also rides the open config
 committed images. The projection sink forwards the transcript apply outcome
 (0.7.27 API) so the host synthesizes the redacted image receipt only after
 durable reducer application. Only `gpt-realtime-2` accepts image input in
-the shipped catalog (capabilities carry `image_in`).
+the shipped catalog (capabilities carry `image_in`). As of meerkat 0.7.28
+the catalog default model is `gpt-5.6-sol` (GPT-5.6 Sol/Terra/Luna added;
+explicit GPT-5.5 pins stay honored) — realtime capability is unchanged.
 
 ## Field-reported additions (mobkit 0.7.32)
 

--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -1484,6 +1484,14 @@ resume-respawn when they diverge) — planned, not yet shipped.
 
 ## Ask 30 — live seed-window: bounded/summarized session projection for realtime opens — P2
 
+**SHIPPED in meerkat 0.7.28** (`live/open.seed_max_chars` — windowed
+projection preserving enabled root context, an affordable compaction
+summary, the identity/tombstone/rewrite-generation/canonical-image
+sidecars, with explicit degraded-continuity reporting). Mobkit adoption
+(0.7.33): `live_open_config_for_session` delegates to
+`realtime_projection_messages_with_window`; the 0.7.32 oldest-first clamp
+stopgap is DELETED — the `seed_max_chars` wire params are unchanged.
+
 Field (HomeCore robot, 2026-07-10): the realtime provider adapter enforces a
 65,536-token instruction cap, and `live/open` seeds the WHOLE projected
 session (system prompt + full transcript projection). Long-lived members

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,28 +48,28 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.7.27"
-meerkat-client = "=0.7.27"
-meerkat-contracts = "=0.7.27"
-meerkat-mob = "=0.7.27"
-meerkat-mob-mcp = "=0.7.27"
-meerkat-mcp = "=0.7.27"
-meerkat-models = "=0.7.27"
+meerkat-core = "=0.7.28"
+meerkat-client = "=0.7.28"
+meerkat-contracts = "=0.7.28"
+meerkat-mob = "=0.7.28"
+meerkat-mob-mcp = "=0.7.28"
+meerkat-mcp = "=0.7.28"
+meerkat-models = "=0.7.28"
 # meerkat 0.7 split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.7.27", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.7.28", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.7.27"
+meerkat-memory = "=0.7.28"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.7.27"
-meerkat-runtime = { version = "=0.7.27", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.7.27", features = ["session-store"] }
-meerkat-store = { version = "=0.7.27", features = ["sqlite"] }
-meerkat-tools = "=0.7.27"
+meerkat-live = "=0.7.28"
+meerkat-runtime = { version = "=0.7.28", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.7.28", features = ["session-store"] }
+meerkat-store = { version = "=0.7.28", features = ["sqlite"] }
+meerkat-tools = "=0.7.28"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -123,10 +123,10 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-comms = "=0.7.27"
-meerkat-schedule = "=0.7.27"
+meerkat-comms = "=0.7.28"
+meerkat-schedule = "=0.7.28"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.7.27", features = ["schema"] }
+meerkat-mob = { version = "=0.7.28", features = ["schema"] }

--- a/meerkat-mobkit/src/adaptive_layer_decision.schema.json
+++ b/meerkat-mobkit/src/adaptive_layer_decision.schema.json
@@ -646,6 +646,43 @@
       "description": "Opaque provider-native JSON body carried verbatim from caller to\nprovider. Used for pass-through sub-shapes (web search config,\nprovider-native custom compaction edits, OpenAI-compatible\n`chat_template_kwargs`/`thinking`/`reasoning` forwards) where the\nexact wire shape varies across downstream providers (Anthropic /\nDeepSeek / OpenRouter / custom proxies) and the runtime deliberately\ndoes not parse the body — it simply forwards it.",
       "type": "string"
     },
+    "OpenAiPromptCacheMode": {
+      "description": "Request-wide GPT-5.6 prompt-cache breakpoint policy.",
+      "enum": [
+        "implicit",
+        "explicit"
+      ],
+      "type": "string"
+    },
+    "OpenAiPromptCacheOptions": {
+      "additionalProperties": false,
+      "description": "GPT-5.6 request-wide prompt-cache controls.",
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OpenAiPromptCacheMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Automatic (`implicit`) or explicit-only cache breakpoint placement."
+        },
+        "ttl": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OpenAiPromptCacheTtl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Minimum cache lifetime. GPT-5.6 currently accepts only `30m`."
+        }
+      },
+      "type": "object"
+    },
     "OpenAiPromptCacheRetention": {
       "description": "Typed shape of OpenAI's prompt-cache retention hint.",
       "oneOf": [
@@ -660,6 +697,39 @@
           "type": "string"
         }
       ]
+    },
+    "OpenAiPromptCacheTtl": {
+      "description": "Minimum lifetime for GPT-5.6 prompt-cache entries.",
+      "enum": [
+        "30m"
+      ],
+      "type": "string"
+    },
+    "OpenAiReasoningContext": {
+      "description": "Which available reasoning items GPT-5.6 may render into the next sample.",
+      "enum": [
+        "auto",
+        "current_turn",
+        "all_turns"
+      ],
+      "type": "string"
+    },
+    "OpenAiReasoningMode": {
+      "description": "GPT-5.6 Responses execution mode.",
+      "enum": [
+        "standard",
+        "pro"
+      ],
+      "type": "string"
+    },
+    "OpenAiTextVerbosity": {
+      "description": "Default level of detail for OpenAI text output.",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "type": "string"
     },
     "OutputSchema": {
       "description": "Configuration for structured output extraction.\n\nWhen provided to an agent, the agent will perform an extraction turn after\ncompleting the agentic work, forcing the LLM to output validated JSON that\nconforms to the provided schema. [`RunResult::text`] remains the committed\nmain-turn output; extraction populates [`RunResult::structured_output`] on\nsuccess or [`RunResult::extraction_error`] on failure.",
@@ -1080,6 +1150,17 @@
                 "null"
               ]
             },
+            "prompt_cache_options": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/OpenAiPromptCacheOptions"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "GPT-5.6 request-wide prompt-cache policy and minimum TTL."
+            },
             "prompt_cache_retention": {
               "anyOf": [
                 {
@@ -1106,6 +1187,17 @@
               ],
               "description": "OpenAI-compatible endpoints (DeepSeek / OpenRouter / vLLM):\nfull `reasoning` body forwarded verbatim alongside\n`reasoning_effort`."
             },
+            "reasoning_context": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/OpenAiReasoningContext"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "GPT-5.6 persisted-reasoning context selection."
+            },
             "reasoning_effort": {
               "anyOf": [
                 {
@@ -1116,6 +1208,17 @@
                 }
               ],
               "description": "Reasoning-effort level for o-series and GPT-5 models."
+            },
+            "reasoning_mode": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/OpenAiReasoningMode"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "GPT-5.6 Responses execution mode (`standard` or `pro`)."
             },
             "seed": {
               "description": "Deterministic-sampling seed.",
@@ -1156,6 +1259,17 @@
                 "boolean",
                 "null"
               ]
+            },
+            "text_verbosity": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/OpenAiTextVerbosity"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Default GPT-5.6 text-output detail level."
             },
             "thinking": {
               "anyOf": [
@@ -1311,7 +1425,8 @@
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
       "type": "string"
     },

--- a/meerkat-mobkit/src/live_wiring.rs
+++ b/meerkat-mobkit/src/live_wiring.rs
@@ -1123,9 +1123,10 @@ async fn live_open_config_for_session<B: SessionAgentBuilder + 'static>(
     service: &PersistentSessionService<B>,
     session_id: &SessionId,
     turning_mode: RealtimeTurningMode,
+    seed_max_chars: Option<usize>,
 ) -> Result<RealtimeSessionOpenConfig, meerkat_core::SessionError> {
-    let session = service
-        .export_realtime_open_session_snapshot(session_id)
+    let (session, canonical_user_image_decoded_bytes) = service
+        .export_realtime_open_session_snapshot_with_image_usage(session_id)
         .await?;
     let llm_identity = service.live_session_llm_identity(session_id).await?;
     let visible_tools = service.live_visible_tool_defs(session_id).await?;
@@ -1137,22 +1138,60 @@ async fn live_open_config_for_session<B: SessionAgentBuilder + 'static>(
             err.to_string(),
         ))
     })?;
-    Ok(RealtimeSessionOpenConfig::new(
-        turning_mode,
-        llm_identity,
-        visible_tools,
-        realtime_projection_messages(&session)?,
+    // 0.7.28: seed bounding is upstream-owned (`live/open.seed_max_chars`,
+    // upstream ask 30 SHIPPED) — the windowed projection preserves the
+    // enabled root context, an affordable compaction summary, and the
+    // identity/tombstone/rewrite-generation/canonical-image sidecars, and
+    // reports degraded continuity explicitly. This replaced mobkit's
+    // oldest-first clamp stopgap.
+    let seed_projection = match seed_max_chars {
+        Some(max_chars) => {
+            let window =
+                meerkat::session_runtime::live_orchestration::LiveSeedWindow::new(max_chars)
+                    .map_err(|err| {
+                        meerkat_core::SessionError::Agent(
+                            meerkat_core::error::AgentError::InternalError(err.to_string()),
+                        )
+                    })?;
+            let projection =
+                meerkat::session_runtime::live_orchestration::realtime_projection_messages_with_window(
+                    &session, window,
+                )
+                .map_err(|err| {
+                    meerkat_core::SessionError::Agent(
+                        meerkat_core::error::AgentError::InternalError(err.to_string()),
+                    )
+                })?;
+            if !matches!(
+                projection.status,
+                meerkat::session_runtime::live_orchestration::LiveSeedProjectionStatus::Complete
+            ) {
+                tracing::info!(
+                    target: "meerkat_mobkit::live_wiring",
+                    %session_id,
+                    max_chars,
+                    status = ?projection.status,
+                    "live open seed windowed (upstream seed_max_chars)"
+                );
+            }
+            projection.messages
+        }
+        None => realtime_projection_messages(&session)?,
+    };
+    Ok(
+        RealtimeSessionOpenConfig::new(turning_mode, llm_identity, visible_tools, seed_projection)
+            .with_user_content_identities(session.realtime_user_content_identities())
+            .with_user_content_tombstones(session.realtime_user_content_tombstones())
+            .with_canonical_user_image_decoded_bytes(canonical_user_image_decoded_bytes)
+            .with_transcript_rewrite_generation(transcript_rewrite_generation)
+            .with_runtime_system_context(realtime_projection_runtime_system_context(&session)?)
+            .with_system_prompt(match realtime_projection_root_system_message(&session)? {
+                Some(Message::System(system)) => Some(system.content),
+                // The projector only ever yields `Message::System` (or `None`);
+                // any other shape means no root system prompt to project.
+                _ => None,
+            }),
     )
-    .with_user_content_identities(session.realtime_user_content_identities())
-    .with_user_content_tombstones(session.realtime_user_content_tombstones())
-    .with_transcript_rewrite_generation(transcript_rewrite_generation)
-    .with_runtime_system_context(realtime_projection_runtime_system_context(&session)?)
-    .with_system_prompt(match realtime_projection_root_system_message(&session)? {
-        Some(Message::System(system)) => Some(system.content),
-        // The projector only ever yields `Message::System` (or `None`);
-        // any other shape means no root system prompt to project.
-        _ => None,
-    }))
 }
 
 /// Provenance marker on the runtime system-context append carrying the
@@ -1199,38 +1238,6 @@ fn apply_live_open_instruction_overlay(
 /// Serialized size of one projected seed message, as counted by the clamp.
 fn serialized_message_chars(message: &Message) -> usize {
     serde_json::to_string(message).map_or(0, |text| text.len())
-}
-
-/// Clamp the projected seed transcript to `max_chars` total serialized
-/// length by dropping WHOLE messages oldest-first. A projected root system
-/// message at `seed_messages[0]` is never dropped — the system prompt is
-/// prompt truth, not seed history. Returns the number of dropped messages.
-///
-/// This is an explicit STOPGAP for upstream ask 30
-/// (docs/design/upstream-asks.md): providers cap live session instructions
-/// at 65,536 tokens and a long member transcript overflows the projected
-/// seed at open time. Remove once meerkat ships a machine-owned seed-window
-/// projection.
-fn clamp_seed_messages_oldest_first(
-    open_config: &mut RealtimeSessionOpenConfig,
-    max_chars: usize,
-) -> usize {
-    let head = usize::from(matches!(
-        open_config.seed_messages.first(),
-        Some(Message::System(_) | Message::SystemNotice(_))
-    ));
-    let mut total: usize = open_config
-        .seed_messages
-        .iter()
-        .map(serialized_message_chars)
-        .sum();
-    let mut dropped = 0usize;
-    while total > max_chars && open_config.seed_messages.len() > head {
-        let removed = open_config.seed_messages.remove(head);
-        total -= serialized_message_chars(&removed);
-        dropped += 1;
-    }
-    dropped
 }
 
 /// #176: project the factory's typed realtime audio policy into the typed
@@ -1283,6 +1290,7 @@ fn build_live_projection_snapshot(
         user_content_identities: open_config.user_content_identities.clone(),
         user_content_tombstones: open_config.user_content_tombstones.clone(),
         transcript_rewrite_generation: open_config.transcript_rewrite_generation,
+        canonical_user_image_decoded_bytes: open_config.canonical_user_image_decoded_bytes,
         // R10: the typed `system_prompt` field is the single owner of live
         // prompt truth — never re-derived from `seed_messages[0]` (the
         // history projector drops `Message::System`, so seed inference
@@ -1450,8 +1458,13 @@ async fn handle_live_open<B: SessionAgentBuilder + 'static>(
     let turning_mode = parsed
         .turning_mode
         .unwrap_or(RealtimeTurningMode::ProviderManaged);
+    // The per-open seed_max_chars override beats the gateway-wide
+    // `runtime_options.live.seed_max_chars`; windowing is upstream-owned
+    // (0.7.28, ask 30 SHIPPED).
+    let seed_max_chars = parsed.seed_max_chars.or(ctx.seed_max_chars);
     let mut open_config =
-        match live_open_config_for_session(service, session_id, turning_mode).await {
+        match live_open_config_for_session(service, session_id, turning_mode, seed_max_chars).await
+        {
             Ok(config) => config,
             Err(meerkat_core::SessionError::NotFound { .. }) => {
                 return live_error(
@@ -1479,21 +1492,6 @@ async fn handle_live_open<B: SessionAgentBuilder + 'static>(
     // (see apply_live_open_instruction_overlay for the lane rationale).
     if let Some(instructions) = parsed.instructions {
         apply_live_open_instruction_overlay(&mut open_config, instructions.into_vec());
-    }
-    // Seed clamp, upstream ask 30 stopgap: the per-open override beats the
-    // gateway-wide `runtime_options.live.seed_max_chars`; the projected
-    // system prompt is never touched.
-    if let Some(max_chars) = parsed.seed_max_chars.or(ctx.seed_max_chars) {
-        let dropped = clamp_seed_messages_oldest_first(&mut open_config, max_chars);
-        if dropped > 0 {
-            tracing::info!(
-                target: "meerkat_mobkit::live_wiring",
-                %session_id,
-                dropped,
-                max_chars,
-                "live open seed clamped oldest-first (upstream ask 30 stopgap)"
-            );
-        }
     }
 
     // B19 precheck runs BEFORE any channel infra is minted (the reference
@@ -2195,10 +2193,13 @@ async fn handle_live_refresh<B: SessionAgentBuilder + 'static>(
         .await;
     };
 
+    // Refresh re-projects from the durable session; the gateway-wide seed
+    // window applies (there is no per-refresh override on the wire).
     let open_config = match live_open_config_for_session(
         service,
         &session_id,
         RealtimeTurningMode::ProviderManaged,
+        ctx.seed_max_chars,
     )
     .await
     {
@@ -2565,47 +2566,6 @@ mod tests {
         Message::System(meerkat_core::types::SystemMessage::new(text))
     }
 
-    #[test]
-    fn live_open_params_accept_string_and_array_instructions_and_seed_clamp() {
-        let one: GatewayLiveOpenParams = serde_json::from_value(serde_json::json!({
-            "identity": "reachy",
-            "instructions": "Speak Swedish.",
-            "seed_max_chars": 1000
-        }))
-        .expect("single-string instructions parse");
-        assert_eq!(
-            one.instructions.expect("instructions").into_vec(),
-            vec!["Speak Swedish.".to_string()]
-        );
-        assert_eq!(one.seed_max_chars, Some(1000));
-
-        let many: GatewayLiveOpenParams = serde_json::from_value(serde_json::json!({
-            "instructions": ["Speak Swedish.", "Keep replies short."]
-        }))
-        .expect("array instructions parse");
-        assert_eq!(
-            many.instructions.expect("instructions").into_vec(),
-            vec![
-                "Speak Swedish.".to_string(),
-                "Keep replies short.".to_string()
-            ]
-        );
-        assert_eq!(many.seed_max_chars, None);
-
-        let neither: GatewayLiveOpenParams =
-            serde_json::from_value(serde_json::json!({})).expect("empty params parse");
-        assert!(neither.instructions.is_none());
-        assert!(neither.seed_max_chars.is_none());
-
-        assert!(
-            serde_json::from_value::<GatewayLiveOpenParams>(
-                serde_json::json!({ "instructions": 7 })
-            )
-            .is_err(),
-            "non-string instructions must be rejected"
-        );
-    }
-
     /// Fix 2 lane assertion: the per-open overlay lands ONLY on the runtime
     /// system-context lane — the typed system prompt (durable prompt truth)
     /// and the projected seed history stay byte-identical.
@@ -2656,61 +2616,6 @@ mod tests {
     /// Fix 4 (upstream ask 30 stopgap): whole messages drop OLDEST-first, a
     /// projected root system message never drops, and the surviving tail fits
     /// the budget.
-    #[test]
-    fn seed_clamp_drops_oldest_first_and_never_touches_the_system_prompt() {
-        let system = system_message("You are the member.");
-        let oldest = user_message(&"a".repeat(400));
-        let middle = user_message(&"b".repeat(400));
-        let newest = user_message(&"c".repeat(400));
-        let mut config =
-            test_open_config(vec![system.clone(), oldest, middle.clone(), newest.clone()]);
-
-        // Budget for the system message + two newest user messages.
-        let budget = serialized_message_chars(&system)
-            + serialized_message_chars(&middle)
-            + serialized_message_chars(&newest);
-        let dropped = clamp_seed_messages_oldest_first(&mut config, budget);
-        assert_eq!(dropped, 1, "exactly the oldest user message drops");
-        assert_eq!(config.seed_messages, vec![system.clone(), middle, newest]);
-        assert!(
-            config
-                .seed_messages
-                .iter()
-                .map(serialized_message_chars)
-                .sum::<usize>()
-                <= budget
-        );
-
-        // A budget below even the system message still never drops it.
-        let dropped = clamp_seed_messages_oldest_first(&mut config, 1);
-        assert_eq!(dropped, 2, "both remaining user messages drop");
-        assert_eq!(config.seed_messages, vec![system]);
-        assert_eq!(
-            config.system_prompt.as_deref(),
-            Some("You are the member."),
-            "the typed system prompt field is never clamped"
-        );
-    }
-
-    #[test]
-    fn seed_clamp_without_a_root_system_message_drops_from_the_front() {
-        let oldest = user_message(&"a".repeat(400));
-        let newest = user_message(&"b".repeat(400));
-        let mut config = test_open_config(vec![oldest, newest.clone()]);
-        let budget = serialized_message_chars(&newest);
-        let dropped = clamp_seed_messages_oldest_first(&mut config, budget);
-        assert_eq!(dropped, 1);
-        assert_eq!(config.seed_messages, vec![newest]);
-    }
-
-    #[test]
-    fn seed_clamp_within_budget_is_a_no_op() {
-        let seed = vec![system_message("prompt"), user_message("hi")];
-        let mut config = test_open_config(seed.clone());
-        let dropped = clamp_seed_messages_oldest_first(&mut config, usize::MAX);
-        assert_eq!(dropped, 0);
-        assert_eq!(config.seed_messages, seed);
-    }
 
     /// #301 port: the surface mapper routes through the canonical typed
     /// owner so distinct `SessionError` variants land in distinct typed

--- a/meerkat-mobkit/src/live_wiring.rs
+++ b/meerkat-mobkit/src/live_wiring.rs
@@ -1235,11 +1235,6 @@ fn apply_live_open_instruction_overlay(
         });
 }
 
-/// Serialized size of one projected seed message, as counted by the clamp.
-fn serialized_message_chars(message: &Message) -> usize {
-    serde_json::to_string(message).map_or(0, |text| text.len())
-}
-
 /// #176: project the factory's typed realtime audio policy into the typed
 /// [`LiveAudioConfig`] the snapshot carries. `None` when the factory does
 /// not advertise both directions of audio, so the caller fails closed
@@ -2612,10 +2607,6 @@ mod tests {
         apply_live_open_instruction_overlay(&mut config, vec!["  ".to_string(), String::new()]);
         assert!(config.runtime_system_context.is_empty());
     }
-
-    /// Fix 4 (upstream ask 30 stopgap): whole messages drop OLDEST-first, a
-    /// projected root system message never drops, and the surviving tail fits
-    /// the budget.
 
     /// #301 port: the surface mapper routes through the canonical typed
     /// owner so distinct `SessionError` variants land in distinct typed


### PR DESCRIPTION
Pins `=0.7.27` → `=0.7.28`. One compile break (image-budget sidecar), one schema regen, one stopgap retired:

- **GPT-5.6** (Sol/Terra/Luna) in the catalog; `gpt-5.6-sol` is the new provider/catalog default — explicit 5.5 pins honored, realtime capability unchanged (docs noted).
- **Upstream ask 30 shipped and adopted**: `seed_max_chars` now delegates to meerkat's windowed projection (root context + compaction summary + sidecars preserved, explicit degraded-continuity); mobkit's 0.7.32 oldest-first clamp is deleted. Wire params unchanged — strictly better behavior for existing callers.
- Open config + snapshot carry `canonical_user_image_decoded_bytes` (image budget) from the with-image-usage export.
- Bundled adaptive layer-decision schema regenerated (new OpenAI responses params).
- Endpoint-recovery fixes ride along (cold-restart peer-endpoint replay, fail-closed drift/reuse handling).

Full suite 1660/1660, clippy clean. Last stop before 0.7.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)