### PR TITLE
fix: Bug I mitigations — boot restore/retire race destroying durable sessions

### DIFF
--- a/docs/design/upstream-asks.md
+++ b/docs/design/upstream-asks.md
@@ -1,15 +1,18 @@
 # Meerkat upstream asks — work order
 
-## Current status (2026-07-10)
+## Current status (2026-07-11)
 
 This file is both the historical evidence record and the current upstream work
 queue. Historical problem statements remain below, but their status is
 authoritative only through the explicit status line under each ask.
 
-**Open work is intentionally limited to five actionable asks:**
+**Open actionable asks (31/32 are P0 — active continuity destruction in the field, Bug I):**
 
 | Ask | Current actionable residue |
 |---|---|
+| **31** | **P0 (Bug I).** Resume-provision rollback must be non-destructive: a failed resume spawn archives/retires the durable session it was resuming, permanently destroying the identity's continuity. Plus a revive affordance for already-retired sessions with intact snapshots. |
+| **32** | **P0 (Bug I racer).** A retire accepted as RetireAbsent must not cancel a subsequent spawn of the same id (or expose an awaitable retire-drain). Mobkit ships a drain-poll workaround; the fence belongs in the machine. |
+| **33** | SQLite writer contention under concurrent restores: the 5s busy_timeout is exceeded by multi-hundred-MB snapshot writes and lifecycle persists surface raw "database is locked" as spawn failures. Bounded SQLITE_BUSY retry for lifecycle persists and/or configurable busy_timeout. Related latent wall: a 366MB snapshot hit "string or blob too big". |
 | **10** | Add call-level tool authorization to executing transcript forks. Persisted/non-live transcript forking already works; that half of the original ask is closed. |
 | **14** | Add a typed member liveness/progress projection beyond lifecycle status: run-open/idle, in-flight work, last progress/event, and a machine-owned degraded/wedged classification. |
 | **27** | Make ordinary peer-send outcomes distinguish delivered/handed-off/queued from unreachable. Supervisor-rotation operation receipts do not close this general delivery ask. |
@@ -1505,3 +1508,118 @@ the full transcript, in the session-projection layer where
 user-content identity lane and exact-retry guards. mobkit stopgap (shipped
 0.7.32): the gateway clamps the projected seed at open time — correct but
 lossy; the principled summarize-then-seed belongs in core.
+
+## Ask 31 — resume-provision rollback destroys the durable session it was resuming — P0
+
+**OPEN (filed 2026-07-11, Bug I).** The single most destructive defect of the
+HomeCore saga: on 0.7.33 boots, 1-2 slow-restoring eternal identities per boot
+were terminally retired by their own failed resume, and repair boots re-rolled
+the race instead of converging (14/16 when the operator stopped repairing).
+
+Mechanism (code-verified in meerkat-mob 0.7.28):
+
+1. A resume spawn fails at a LATE stage — in the field, supervisor-trust
+   lifecycle persists failing with `SQLite error: database is locked` under
+   concurrent restores (ask 33), or a spawn canceled by a queued retire
+   (ask 32).
+2. `MobActor::finalize_spawn_from_pending` (actor.rs:10838 and the sibling
+   arms at 10789/10880/10938) compensates via `provision.rollback()`.
+3. `PendingProvision::rollback` (provision_guard.rs:56) calls
+   `provisioner.retire_member(&member_ref)` — "archiving the session" per its
+   own doc comment.
+4. `SessionBackend::retire_runtime_before_archive` (provisioner.rs:685)
+   durably persists `runtime_state=retired` with the binding nulled.
+5. Retire is terminal by design: every subsequent resume fails with
+   `missing durable session snapshot` (actor.rs:9544). The identity's entire
+   transcript is unreachable forever.
+
+Forensic confirmation (HomeCore server, store
+`data/mobkit_state/5f68197796d9.damaged-bug-i/runtime.sqlite`): victims'
+`runtime_states` rows read `{"record_version":2,"runtime_state":"retired",
+"binding":{"agent_runtime_id":null,...}}` while their multi-hundred-MB
+snapshots sit intact alongside. Gateway stderr shows the full chain, including
+`archive compensation failed` arms where even the destruction itself hit the
+locked store.
+
+The rollback semantics are correct for a FRESH spawn (the provisioned session
+is garbage without its member). They are catastrophic for a RESUME: the
+provisioned session is the only copy of an eternal identity's history, and the
+mobkit bridge's rejection contract ("durable session preserved, identity
+degraded pending reconcile retry") is silently violated — the bridge REFUSES
+fresh-spawn fallback precisely because it assumes the session survived.
+
+Ask (both halves):
+- **Non-destructive resume rollback**: `PendingProvision` (or the provision
+  request) must distinguish provision-of-fresh-session from
+  provision-of-resumed-durable-session; rollback of a resume returns the
+  session to its pre-resume durable state (idle, binding intact or cleanly
+  cleared) and NEVER archives/retires it.
+- **Revive affordance**: an authority-level operation to return a
+  retired-with-intact-snapshot session to `idle` (the manual row-copy repair,
+  made legitimate). Without it, every past and future victim needs hand
+  surgery on `runtime.sqlite`.
+
+mobkit interim (0.7.34): post-rejection verification probes the session store
+and logs continuity destruction explicitly instead of the false "durable
+session preserved"; restore concurrency knob + collision-retry drain reduce
+the two known triggers. mobkit CANNOT prevent the destruction — the rollback
+runs inside the spawn path.
+
+## Ask 32 — RetireAbsent leaves a queued retire that cancels the next spawn of the same id — P0
+
+**OPEN (filed 2026-07-11, Bug I secondary racer).** Field trace (2ms apart,
+two independent incidents captured):
+
+```
+WARN  resume_session hit a roster collision; retiring the stale member and retrying resume
+       error=mob member already exists: mk--rt_cfamily-group_cmain_c0
+WARN  meerkat_mob::runtime::actor: retire requested for unknown meerkat id; MobMachine accepted RetireAbsent
+ERROR resume rejected ... error=internal error: spawn canceled for 'mk--rt_cfamily-group_cmain_c0': retire command received
+```
+
+The colliding roster entry is a Broken residue of an earlier rejected resume
+(same boot); it exists in the MobMachine roster but has no live actor. The
+bridge retires it; `retire()` returns Ok when the command is ACCEPTED
+(MobMachine records RetireAbsent), but the command is still queued when the
+resume retry arrives, so the retry spawn is canceled — and via ask 31 the
+cancel's rollback then archives the durable session (the family-group victim's
+next attempt logged `session not found`, then `missing durable session
+snapshot` forever).
+
+Ask: a retire resolved as RetireAbsent must be inert for later spawns of the
+same identity (it retired nothing; there is nothing to cancel), or the machine
+exposes an awaitable retire-drain so a caller can sequence
+retire-then-respawn without racing the command queue.
+
+mobkit interim (0.7.34): after a collision retire the bridge drain-polls the
+roster (bounded 2s) before retrying, and treats `spawn canceled ... retire
+command received` as retryable-once-after-drain. This narrows the window; it
+cannot close it (the queue is unobservable from the handle surface).
+
+## Ask 33 — SQLite writer contention under concurrent session restores — P1
+
+**OPEN (filed 2026-07-11, Bug I trigger).** meerkat-store sets
+`busy_timeout=5s` + WAL (sqlite_store.rs:24,113-114). A HomeCore boot restores
+16 identities with sessions up to 366MB; mobkit restores up to 4 concurrently
+(#265). Multi-hundred-MB snapshot writes hold the WAL writer lock past 5s, and
+every lifecycle persist that loses the wait surfaces raw `Store write failed:
+SQLite error: database is locked` — in the field this hit supervisor-trust
+revoke/install begin-lifecycle persists and recovery persists mid resume-spawn,
+which then fed the ask 31 destructive rollback. Slow-restoring members are
+victimized precisely in proportion to their restore duration.
+
+Ask:
+- lifecycle persists (small, critical, idempotent begin/commit rows) should
+  retry bounded on SQLITE_BUSY instead of failing the whole spawn; and/or
+- busy_timeout configurable per store open, sized for stores whose single
+  writes can take tens of seconds.
+
+Related latent wall, same store, observed 2026-07-10: domain:security's 366MB
+snapshot failed `runtime transcript rewrite snapshot persistence failed: Store
+write failed: string or blob too big` — the per-value size ceiling is being
+approached by real single-session stores; worth a deliberate position
+(chunking, streaming blob, or a documented limit) before it becomes Bug J.
+
+mobkit interim (0.7.34): `MOBKIT_IDENTITY_RESTORE_CONCURRENCY` env knob
+(clamped 1-16, default 4); `=1` serializes restores and removes mobkit's own
+contribution to writer contention.

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use meerkat_core::types::HandlingMode;
@@ -55,6 +56,17 @@ fn is_recoverable_bridge_respawn_cleanup_error(error: &str) -> bool {
 
 fn is_member_already_exists_error(error: &meerkat_mob::MobError) -> bool {
     matches!(error, meerkat_mob::MobError::MemberAlreadyExists(_))
+}
+
+/// A spawn canceled by a still-queued retire command for the same id. Reaches
+/// us stringified through the provisioning path; the meerkat wording is
+/// `spawn canceled for '<id>': retire command received` (actor.rs). This is
+/// the self-inflicted collision-retry race (Bug I secondary racer): our own
+/// collision retire, accepted as RetireAbsent, cancels the resume retry that
+/// follows it.
+fn is_spawn_canceled_by_pending_retire_error(error: &meerkat_mob::MobError) -> bool {
+    let text = error.to_string();
+    text.contains("spawn canceled") && text.contains("retire command received")
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -604,6 +616,71 @@ impl MobSessionBridge {
             .cloned()
     }
 
+    /// Wait for a collision retire to drain out of the mob actor before
+    /// retrying a resume. `MobHandle::retire` returning `Ok` only means the
+    /// command was accepted: when the colliding roster entry has no live
+    /// actor (a Broken residue from an earlier rejected resume), the retire
+    /// is recorded as RetireAbsent and its command can still be queued when
+    /// the retry spawn arrives, canceling it ("spawn canceled: retire command
+    /// received" — observed 2ms apart in the field, Bug I). Poll the roster
+    /// until the colliding entry is gone, then leave one settle tick for the
+    /// queued command itself.
+    async fn await_collision_retire_drain(&self, member_id: &MobAgentIdentity) {
+        const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(50);
+        const DRAIN_POLL_ATTEMPTS: usize = 40; // 2s bound
+        for _ in 0..DRAIN_POLL_ATTEMPTS {
+            match self.handle.get_member(member_id).await {
+                Ok(None) => break,
+                Ok(Some(_)) => tokio::time::sleep(DRAIN_POLL_INTERVAL).await,
+                // A faulted roster read cannot confirm the drain; fall
+                // through to the settle tick rather than spinning on it.
+                Err(_) => break,
+            }
+        }
+        tokio::time::sleep(DRAIN_POLL_INTERVAL).await;
+    }
+
+    /// After a rejected resume, verify the durable session actually survived.
+    /// meerkat's spawn rollback compensates late resume-spawn failures by
+    /// archiving the session it was resuming (`PendingProvision::rollback` →
+    /// `retire_member` → `retire_runtime_before_archive`), which durably
+    /// writes `runtime_state=retired` and makes every later resume fail with
+    /// "missing durable session snapshot" (Bug I). Until that is fixed
+    /// upstream (ask 31), the standard "durable session preserved" rejection
+    /// log can be false — probe the store and say so explicitly, so operators
+    /// see continuity destruction the moment it happens instead of on the
+    /// next boot.
+    async fn verify_durable_session_after_rejected_resume(
+        &self,
+        identity: &AgentIdentity,
+        session_id: &meerkat_core::types::SessionId,
+    ) {
+        let Some(store) = self.session_store.as_ref() else {
+            return;
+        };
+        match store.load_meta(session_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                tracing::error!(
+                    identity = %identity,
+                    session_id = %session_id,
+                    "durable session is GONE after the rejected resume: the spawn-failure \
+                     rollback archived/retired the continuity session (Bug I, upstream ask 31); \
+                     reconcile retries cannot recover this identity — the session must be \
+                     restored from a pre-damage store"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    identity = %identity,
+                    session_id = %session_id,
+                    %error,
+                    "could not verify durable session presence after the rejected resume"
+                );
+            }
+        }
+    }
+
     /// Resolve the inline definition profile backing `spec.profile`, used as
     /// the base when a draft model override must be projected into the typed
     /// `override_profile` spawn owner. Realm-ref bindings resolve to `None`.
@@ -1130,10 +1207,44 @@ impl SessionBridge for MobSessionBridge {
                         ));
                     }
                 }
+                // The retire is accepted, not necessarily drained: retrying
+                // immediately loses the race against our own queued retire
+                // command, which cancels the retry spawn (Bug I).
+                self.await_collision_retire_drain(&mid).await;
                 self.forget_runtime_member(runtime_id).await;
-                self.spawn_member_spec(spawn_spec).await.map_err(|error| {
-                    resume_rejected(identity, session_id, &error, "resume retry after collision")
-                })?;
+                match self.spawn_member_spec(spawn_spec.clone()).await {
+                    Ok(()) => {}
+                    Err(error) if is_spawn_canceled_by_pending_retire_error(&error) => {
+                        tracing::warn!(
+                            identity = %identity,
+                            session_id = %session_id,
+                            %error,
+                            "resume retry canceled by the still-queued collision retire; \
+                             draining again and retrying once more"
+                        );
+                        self.await_collision_retire_drain(&mid).await;
+                        if let Err(error) = self.spawn_member_spec(spawn_spec).await {
+                            self.verify_durable_session_after_rejected_resume(identity, session_id)
+                                .await;
+                            return Err(resume_rejected(
+                                identity,
+                                session_id,
+                                &error,
+                                "resume retry after collision",
+                            ));
+                        }
+                    }
+                    Err(error) => {
+                        self.verify_durable_session_after_rejected_resume(identity, session_id)
+                            .await;
+                        return Err(resume_rejected(
+                            identity,
+                            session_id,
+                            &error,
+                            "resume retry after collision",
+                        ));
+                    }
+                }
                 self.remember_runtime_member(runtime_id, &mid).await;
                 self.remember_runtime_session(runtime_id, session_id).await;
                 Ok(ResumeSessionOutcome::Resumed {
@@ -1146,12 +1257,16 @@ impl SessionBridge for MobSessionBridge {
             // would permanently abandon it (the HomeCore restart-loss bug).
             // Surface a typed rejection so the caller marks the identity
             // degraded and the next reconcile retries the resume.
-            Err(error) => Err(resume_rejected(
-                identity,
-                session_id,
-                &error,
-                "resume spawn",
-            )),
+            Err(error) => {
+                self.verify_durable_session_after_rejected_resume(identity, session_id)
+                    .await;
+                Err(resume_rejected(
+                    identity,
+                    session_id,
+                    &error,
+                    "resume spawn",
+                ))
+            }
         }
     }
 
@@ -1887,6 +2002,28 @@ mod tests {
             ),
             "ordinary respawn failures must still fail bridge repair"
         );
+    }
+
+    /// The Bug I secondary racer reaches the bridge stringified through the
+    /// provisioning path; match the exact meerkat actor.rs wording and nothing
+    /// broader (an operator-initiated retire canceling a spawn is legitimate).
+    #[test]
+    fn spawn_canceled_by_pending_retire_matches_field_wording() {
+        let canceled = meerkat_mob::MobError::Internal(
+            "internal error: spawn canceled for 'mk--rt_cfamily-group_cmain_c0': \
+             retire command received"
+                .to_string(),
+        );
+        assert!(is_spawn_canceled_by_pending_retire_error(&canceled));
+
+        let other_cancel = meerkat_mob::MobError::Internal(
+            "spawn canceled for 'mk--x': shutdown requested".to_string(),
+        );
+        assert!(!is_spawn_canceled_by_pending_retire_error(&other_cancel));
+
+        let unrelated =
+            meerkat_mob::MobError::Internal("retire command received out of band".to_string());
+        assert!(!is_spawn_canceled_by_pending_retire_error(&unrelated));
     }
 
     /// The persisted System message is authoritative on resume: even when the

--- a/meerkat-mobkit/src/identity_first/orchestrator.rs
+++ b/meerkat-mobkit/src/identity_first/orchestrator.rs
@@ -20,6 +20,55 @@ use super::types::{
 
 pub(crate) const IDENTITY_RESTORE_CONCURRENCY: usize = 4;
 
+/// Effective restore concurrency: `MOBKIT_IDENTITY_RESTORE_CONCURRENCY`
+/// overrides the default, clamped to [1, 16]. `1` serializes restores — the
+/// field mitigation for Bug I, where concurrent multi-hundred-MB session
+/// resumes against one SQLite store exceed the 5s writer busy_timeout and the
+/// resulting mid-spawn store failures feed meerkat's destructive resume
+/// rollback (upstream ask 31).
+pub(crate) fn identity_restore_concurrency() -> usize {
+    parse_identity_restore_concurrency(
+        std::env::var("MOBKIT_IDENTITY_RESTORE_CONCURRENCY")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn parse_identity_restore_concurrency(raw: Option<&str>) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .map(|value| value.clamp(1, 16))
+        .unwrap_or(IDENTITY_RESTORE_CONCURRENCY)
+}
+
+#[cfg(test)]
+mod restore_concurrency_tests {
+    use super::{IDENTITY_RESTORE_CONCURRENCY, parse_identity_restore_concurrency};
+
+    #[test]
+    fn defaults_when_unset_or_invalid() {
+        assert_eq!(
+            parse_identity_restore_concurrency(None),
+            IDENTITY_RESTORE_CONCURRENCY
+        );
+        assert_eq!(
+            parse_identity_restore_concurrency(Some("")),
+            IDENTITY_RESTORE_CONCURRENCY
+        );
+        assert_eq!(
+            parse_identity_restore_concurrency(Some("not-a-number")),
+            IDENTITY_RESTORE_CONCURRENCY
+        );
+    }
+
+    #[test]
+    fn parses_and_clamps() {
+        assert_eq!(parse_identity_restore_concurrency(Some("1")), 1);
+        assert_eq!(parse_identity_restore_concurrency(Some(" 8 ")), 8);
+        assert_eq!(parse_identity_restore_concurrency(Some("0")), 1);
+        assert_eq!(parse_identity_restore_concurrency(Some("64")), 16);
+    }
+}
+
 fn trace_identity_restore_completed(identity: &AgentIdentity, started_at: Instant) {
     let elapsed = started_at.elapsed();
     if elapsed >= Duration::from_secs(1) {
@@ -312,9 +361,10 @@ pub async fn restore_flow(
     // independent history loading and agent construction, so keep a small
     // bounded set in flight instead of making large durable rosters pay the
     // full sum of every member's resume latency.
+    let restore_concurrency = identity_restore_concurrency();
     tracing::info!(
         member_count = roster.len(),
-        concurrency = IDENTITY_RESTORE_CONCURRENCY,
+        concurrency = restore_concurrency,
         "starting identity restore"
     );
     let restore_started_at = Instant::now();
@@ -1183,7 +1233,7 @@ pub async fn restore_flow(
                 Ok((index, outcomes))
             }
         })
-        .buffer_unordered(IDENTITY_RESTORE_CONCURRENCY)
+        .buffer_unordered(restore_concurrency)
         .collect::<Vec<Result<(usize, BTreeMap<AgentIdentity, RestoreOutcome>), _>>>()
         .await;
 


### PR DESCRIPTION
## Bug I (HomeCore field report, 2026-07-11)

Every 0.7.33 boot, 1-2 slow-restoring eternal identities got \`spawn canceled: retire command received\` mid-restore; disposal durably wrote \`runtime_state=retired\`; retired sessions resume as \`missing durable session snapshot\` forever. Repair boots re-rolled the race and never converged (14/16 at stop).

## Root cause (code-verified, upstream)

1. **Trigger** — parallel identity restore (#265, concurrency 4) over one SQLite store: multi-hundred-MB snapshot writes exceed meerkat-store's 5s busy_timeout; supervisor-trust lifecycle persists fail mid resume-spawn with \`database is locked\`. → **ask 33**
2. **Destroyer** — meerkat-mob \`finalize_spawn_from_pending\` compensates any late spawn failure with \`PendingProvision::rollback\` → \`retire_member\` → \`retire_runtime_before_archive\`, durably retiring the session it was *resuming*. Correct for fresh spawns; destroys the only copy of an eternal identity's continuity on resumes. Forensics: victims' \`runtime_states\` rows show \`record_version:2, runtime_state:retired, binding null\` with intact snapshots alongside. → **ask 31 (P0)**
3. **Secondary racer** — bridge collision retry: retire of a Broken roster residue is accepted as RetireAbsent, and its still-queued command cancels the resume retry 2ms later, feeding (2). → **ask 32 (P0)**

## Mobkit mitigations (this PR — cannot prevent the upstream destruction)

- \`MOBKIT_IDENTITY_RESTORE_CONCURRENCY\` env knob (clamped 1-16, default 4 unchanged). \`=1\` is the immediate HomeCore mitigation: serializes restores, removing mobkit's contribution to writer contention.
- Collision-retry drain: bounded 2s roster-absence poll after the collision retire before retrying; \`spawn canceled: retire command received\` treated as retryable once after a second drain.
- Honest rejection contract: after any rejected resume, probe the session store (\`load_meta\`) and log **"durable session is GONE"** when the upstream rollback destroyed it, instead of the now-sometimes-false "durable session preserved".

Asks 31/32/33 filed in \`docs/design/upstream-asks.md\` with exact meerkat-mob 0.7.28 file:line pointers and forensic references.

## Tests

- Full gate: 1664/1664 (2 known contract_009 load flakes), clippy clean.
- New unit tests: concurrency knob parse/clamp; canceled-by-pending-retire matcher (exact field wording, rejects broader cancels).
- A deterministic red test for the drain race needs the upstream retire fence (ask 32) — the actor command queue is unobservable from the handle surface; noted in-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)