### PR TITLE
Render typed system tasks as conversation cards

### DIFF
--- a/packages/console-components/src/conversation/conversation-message-view.test.tsx
+++ b/packages/console-components/src/conversation/conversation-message-view.test.tsx
@@ -54,6 +54,45 @@ describe("ConversationMessageView", () => {
     expect(screen.getByRole("img", { name: /uploaded receipt/i })).toBeInTheDocument();
   });
 
+  test("renders the exact initial-domain-study prompt in an accessible collapsible system card", () => {
+    const prompt = "Study the runtime domain.\n\nLearn every boundary, invariant, and workflow.";
+    const entry: ConversationTimelineEntry = {
+      id: "system-task-domain-study",
+      kind: "message",
+      variant: "plain",
+      identity: {
+        // Typed task metadata is authoritative even if a consumer's generic
+        // transcript adapter would otherwise present this entry as a user turn.
+        id: "user",
+        label: "You",
+        role: "user",
+        presentation: "user",
+        showLabel: false,
+      },
+      text: prompt,
+      taskKind: "domain_reconnaissance",
+      taskLabel: "Initial domain study",
+      taskId: "domain-study-runtime",
+      taskStatus: "running",
+      runId: "run-domain-study-runtime",
+    };
+
+    const { container } = render(<ConversationMessageView entry={entry} Icon={Icon} />);
+
+    const card = screen.getByRole("group", { name: "Initial domain study" });
+    expect(card).toBeInstanceOf(HTMLDetailsElement);
+    expect(card).not.toHaveAttribute("open");
+    expect(card).toHaveClass("cc-message--system-task", "cc-message--system");
+    expect(card).not.toHaveClass("cc-message--user");
+    expect(screen.queryByRole("button", { name: /copy message/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Initial domain study", { selector: "summary span" })).toBeInTheDocument();
+    expect(screen.getByText("Domain reconnaissance · Running", { exact: false })).toBeInTheDocument();
+    expect(container.querySelector(".cc-rich-thinking__body")?.textContent).toBe(prompt);
+
+    fireEvent.click(screen.getByText("Initial domain study", { selector: "summary span" }));
+    expect(card).toHaveAttribute("open");
+  });
+
   test("labels single outgoing peer tools with the concrete tool name", () => {
     const entry: ConversationTimelineEntry = {
       id: "peer-tool-1",

--- a/packages/console-components/src/conversation/conversation-message-view.tsx
+++ b/packages/console-components/src/conversation/conversation-message-view.tsx
@@ -14,6 +14,8 @@ import { WorkGraphCard, type WorkGraphCardActions } from "./work-graph-card";
 import { CopyButton } from "../copy-button";
 import type { IconRenderer } from "../shared";
 
+const SYSTEM_TASK_PROMPT_STYLE = { whiteSpace: "pre-wrap" } as const;
+
 function renderMultilineText(text: string) {
   return text.split("\n").map((line, index) => (
     <Fragment key={`${line}-${index}`}>
@@ -21,6 +23,14 @@ function renderMultilineText(text: string) {
       {line}
     </Fragment>
   ));
+}
+
+function humanizeSystemTaskMetadata(value: string | null | undefined) {
+  const normalized = String(value || "").trim().replace(/[_-]+/gu, " ");
+  if (!normalized) {
+    return "";
+  }
+  return `${normalized[0]?.toUpperCase() || ""}${normalized.slice(1)}`;
 }
 
 type ConversationMessageViewProps = {
@@ -71,6 +81,42 @@ export function ConversationMessageView({
 
   if (entry.kind === "summary") {
     return <SummaryCard entry={entry} />;
+  }
+
+  if (entry.taskKind || entry.taskLabel) {
+    const taskLabel = entry.taskLabel?.trim() || "System task";
+    const taskMetadata = [
+      humanizeSystemTaskMetadata(entry.taskKind),
+      humanizeSystemTaskMetadata(entry.taskStatus),
+    ].filter(Boolean).join(" · ");
+    const systemTaskClassName = [
+      "cc-message",
+      "cc-message--assistant",
+      "cc-message--system",
+      "cc-message--system-task",
+      "cc-summary-card",
+      "cc-rich-thinking",
+    ].join(" ");
+    return (
+      <details
+        aria-label={taskLabel}
+        className={systemTaskClassName}
+        data-task-kind={entry.taskKind}
+        data-task-status={entry.taskStatus}
+      >
+        <summary className="cc-rich-thinking__label">
+          <span className="cc-summary-card__title">{taskLabel}</span>
+          {taskMetadata ? (
+            <span className="cc-message-group__identity-meta"> · {taskMetadata}</span>
+          ) : null}
+        </summary>
+        <div className="cc-rich-thinking__body">
+          <p className="cc-rich-paragraph" style={SYSTEM_TASK_PROMPT_STYLE}>
+            {entry.text || ""}
+          </p>
+        </div>
+      </details>
+    );
   }
 
   if (entry.variant === "meta") {

--- a/packages/console-core/src/conversation.test.ts
+++ b/packages/console-core/src/conversation.test.ts
@@ -81,6 +81,32 @@ describe("conversation grouping", () => {
   });
 });
 
+describe("system task entries", () => {
+  test("preserves the exact task prompt for transcript copy and accessibility surfaces", () => {
+    const prompt = "Study the assigned domain.\n\nLearn every boundary and invariant.";
+    const entry: ConversationTimelineEntry = {
+      id: "system-task-domain-study",
+      kind: "message",
+      variant: "plain",
+      identity: {
+        id: "system-task-domain-study",
+        label: "Initial domain study",
+        role: "system",
+        presentation: "system",
+      },
+      text: prompt,
+      taskKind: "domain_reconnaissance",
+      taskLabel: "Initial domain study",
+      taskId: "domain-study-runtime",
+      taskStatus: "running",
+      runId: "run-domain-study-runtime",
+    };
+
+    expect(conversationEntryText(entry)).toBe(prompt);
+    expect(conversationIdentityGroupKey(entry.identity)).toBe("system-task-domain-study:system:label");
+  });
+});
+
 describe("flow run entries", () => {
   test("preserves an honest stopped state in the shared conversation model", () => {
     const entry: ConversationTimelineEntry = {

--- a/packages/console-core/src/conversation.ts
+++ b/packages/console-core/src/conversation.ts
@@ -56,6 +56,16 @@ export interface ConversationMessageEntry extends ConversationTimelineEntryBase 
   text?: string;
   blocks?: ConversationRichBlock[];
   richStyle?: "default" | "streaming";
+  /**
+   * Typed host-task metadata. System tasks stay distinct from operator turns
+   * all the way through the shared renderer instead of masquerading as user
+   * messages.
+   */
+  taskKind?: string;
+  taskLabel?: string;
+  taskId?: string;
+  taskStatus?: string;
+  runId?: string | null;
 }
 
 export interface ConversationSummaryFile {


### PR DESCRIPTION
## What changed

- carry structured host-task metadata on shared conversation message entries
- render those entries as collapsed, native `details`/`summary` system cards instead of user bubbles
- preserve the exact multiline assignment prompt while presenting readable task kind and status metadata
- cover transcript text preservation, keyboard-accessible expansion, and fail-safe system presentation even when a consumer supplies a user identity

## Why

Project-agent onboarding is a host-authored assignment, not an operator chat turn. The shared conversation contract previously had no structured task fields, so consumers could only project that assignment as an ordinary user message. This change gives host tasks a typed path through console-core and a distinct accessible presentation in console-components.

## Validation

- focused Vitest: 16 passed
- focused strict TypeScript check: passed
- `npm --prefix console run components:reuse --silent`: 21 passed
- `npm --prefix console run phase0:types --silent`: 375 passed
- `npm --prefix console run headless:transport --silent`: 16 passed
- `npm --prefix console run smoke --silent`: passed
- `npm --prefix console run embedded:freshness --silent`: passed
- `git diff --check`: passed
