### PR TITLE
Support semantic sidebar item groups

### DIFF
--- a/packages/console-components/src/index.ts
+++ b/packages/console-components/src/index.ts
@@ -43,6 +43,7 @@ export type {
   ConsoleSidebarItemTrailingRenderArgs,
   ConsoleSidebarSectionContainerRenderArgs,
   ConsoleSidebarSectionHeaderRenderArgs,
+  ConsoleSidebarSectionItemsRenderArgs,
 } from "./sidebar/console-sidebar";
 export type { ConsoleWorkbenchProps } from "./workbench/console-workbench";
 export { ConsoleComposer } from "./composer/console-composer";

--- a/packages/console-components/src/sidebar/console-sidebar.test.tsx
+++ b/packages/console-components/src/sidebar/console-sidebar.test.tsx
@@ -96,6 +96,8 @@ describe("ConsoleSidebar", () => {
     expect(onSelectItem).toHaveBeenCalled();
 
     expect(screen.getByText("archive:thread-1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Extract the console sidebar" }))
+      .toBeInTheDocument();
   });
 
   test("emits optional item drag and drop callbacks", () => {
@@ -143,5 +145,58 @@ describe("ConsoleSidebar", () => {
 
     expect(onItemDragStart).toHaveBeenCalled();
     expect(onItemDrop).toHaveBeenCalled();
+  });
+
+  test("lets consumers add semantic item groups without rebuilding interactive rows", () => {
+    const onSelectItem = vi.fn();
+
+    render(
+      <ConsoleSidebar
+        onSelectItem={onSelectItem}
+        renderSectionItems={({ section, defaultItems }) => {
+          const agents = defaultItems.filter((_row, index) => section.items[index]?.id.startsWith("agent:"));
+          const threads = defaultItems.filter((_row, index) => !section.items[index]?.id.startsWith("agent:"));
+          return (
+            <>
+              <div aria-labelledby="agents-heading" role="group">
+                <h3 id="agents-heading">Agents</h3>
+                {agents}
+              </div>
+              <div aria-labelledby="threads-heading" role="group">
+                <h3 id="threads-heading">Threads</h3>
+                {threads}
+              </div>
+            </>
+          );
+        }}
+        viewState={{
+          blocks: [{
+            id: "projects",
+            kind: "list",
+            sections: [{
+              id: "workspace",
+              title: "workspace",
+              items: [
+                { id: "agent:desktop", title: "Desktop UI" },
+                { id: "thread-1", title: "Polish the sidebar" },
+              ],
+            }],
+          }],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("group", { name: "Agents" })).toContainElement(
+      screen.getByRole("button", { name: "Desktop UI" }),
+    );
+    expect(screen.getByRole("group", { name: "Threads" })).toContainElement(
+      screen.getByRole("button", { name: "Polish the sidebar" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Desktop UI" }));
+    expect(onSelectItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "projects" }),
+      expect.objectContaining({ id: "workspace" }),
+      expect.objectContaining({ id: "agent:desktop" }),
+    );
   });
 });

--- a/packages/console-components/src/sidebar/console-sidebar.tsx
+++ b/packages/console-components/src/sidebar/console-sidebar.tsx
@@ -32,6 +32,17 @@ export type ConsoleSidebarSectionContainerRenderArgs = {
   defaultSection: ReactNode;
 };
 
+export type ConsoleSidebarSectionItemsRenderArgs = {
+  block: ConsoleSidebarBlock;
+  section: ConsoleSidebarSection;
+  /**
+   * Fully wired row nodes in the same order as `section.items`.
+   * Consumers may group or annotate them without reimplementing row
+   * interaction, drag-and-drop, actions, or keyboard behavior.
+   */
+  defaultItems: ReactNode[];
+};
+
 export type ConsoleSidebarItemTrailingRenderArgs = {
   block: ConsoleSidebarBlock;
   section: ConsoleSidebarSection;
@@ -69,6 +80,7 @@ export type ConsoleSidebarProps = {
   getActionButtonProps?: (scope: ConsoleSidebarActionButtonScope) => SidebarActionButtonProps;
   renderSectionHeader?: (args: ConsoleSidebarSectionHeaderRenderArgs) => ReactNode;
   renderSectionContainer?: (args: ConsoleSidebarSectionContainerRenderArgs) => ReactNode;
+  renderSectionItems?: (args: ConsoleSidebarSectionItemsRenderArgs) => ReactNode;
   renderItemTrailing?: (args: ConsoleSidebarItemTrailingRenderArgs) => ReactNode;
   onBlockAction?: (block: ConsoleSidebarBlock, action: ConsoleSidebarAction) => void;
   onSelectSection?: (block: ConsoleSidebarBlock, section: ConsoleSidebarSection) => void;
@@ -396,6 +408,7 @@ function SidebarRow({
 
   return (
     <div
+      aria-label={item.title}
       className={clsx(
         "cc-sidebar-row",
         "thread-row",
@@ -501,6 +514,7 @@ function ListBlock({
   getActionButtonProps,
   renderSectionHeader,
   renderSectionContainer,
+  renderSectionItems,
   renderItemTrailing,
   onBlockAction,
   onSelectSection,
@@ -519,6 +533,7 @@ function ListBlock({
   getActionButtonProps?: (scope: ConsoleSidebarActionButtonScope) => SidebarActionButtonProps;
   renderSectionHeader?: (args: ConsoleSidebarSectionHeaderRenderArgs) => ReactNode;
   renderSectionContainer?: (args: ConsoleSidebarSectionContainerRenderArgs) => ReactNode;
+  renderSectionItems?: (args: ConsoleSidebarSectionItemsRenderArgs) => ReactNode;
   renderItemTrailing?: (args: ConsoleSidebarItemTrailingRenderArgs) => ReactNode;
   onBlockAction?: (block: ConsoleSidebarBlock, action: ConsoleSidebarAction) => void;
   onSelectSection?: (block: ConsoleSidebarBlock, section: ConsoleSidebarSection) => void;
@@ -585,29 +600,32 @@ function ListBlock({
           const header = renderSectionHeader
             ? renderSectionHeader({ block, section, defaultHeader })
             : defaultHeader;
+          const defaultItems = section.items.map((item) => (
+            <SidebarRow
+              Icon={Icon}
+              block={block}
+              getActionButtonProps={getActionButtonProps}
+              item={item}
+              isItemDraggable={isItemDraggable}
+              isItemDropTarget={isItemDropTarget}
+              key={item.id}
+              onItemAction={onItemAction}
+              onItemContextMenu={onItemContextMenu}
+              onItemDragEnd={onItemDragEnd}
+              onItemDragStart={onItemDragStart}
+              onItemDrop={onItemDrop}
+              onSelectItem={onSelectItem}
+              section={section}
+              trailingContent={renderItemTrailing?.({ block, section, item })}
+            />
+          ));
           const defaultSection = (
             <section className={clsx("cc-sidebar-section", hasVisibleSectionHeader(section) && "has-header")} key={section.id}>
               {header}
               <div className="cc-sidebar-section__rows">
-                {section.items.map((item) => (
-                  <SidebarRow
-                    Icon={Icon}
-                    block={block}
-                    getActionButtonProps={getActionButtonProps}
-                    item={item}
-                    isItemDraggable={isItemDraggable}
-                    isItemDropTarget={isItemDropTarget}
-                    key={item.id}
-                    onItemAction={onItemAction}
-                    onItemContextMenu={onItemContextMenu}
-                    onItemDragEnd={onItemDragEnd}
-                    onItemDragStart={onItemDragStart}
-                    onItemDrop={onItemDrop}
-                    onSelectItem={onSelectItem}
-                    section={section}
-                    trailingContent={renderItemTrailing?.({ block, section, item })}
-                  />
-                ))}
+                {renderSectionItems
+                  ? renderSectionItems({ block, section, defaultItems })
+                  : defaultItems}
               </div>
             </section>
           );
@@ -632,6 +650,7 @@ export function ConsoleSidebar({
   getActionButtonProps,
   renderSectionHeader,
   renderSectionContainer,
+  renderSectionItems,
   renderItemTrailing,
   onBlockAction,
   onSelectSection,
@@ -678,6 +697,7 @@ export function ConsoleSidebar({
             renderItemTrailing={renderItemTrailing}
             renderSectionHeader={renderSectionHeader}
             renderSectionContainer={renderSectionContainer}
+            renderSectionItems={renderSectionItems}
           />
         )
       ))}


### PR DESCRIPTION
## Summary
- expose a `renderSectionItems` hook that preserves MobKit-owned interactive rows
- let consumers add semantic subgroups such as Agents and Threads
- add accessible row labels and focused interaction coverage

## Validation
- console sidebar tests: 4/4
- consuming app TypeScript check
- pre-push hooks