### PR TITLE
Add scrollable conversation tail slot

### DIFF
--- a/packages/console-components/src/conversation/conversation-pane.test.tsx
+++ b/packages/console-components/src/conversation/conversation-pane.test.tsx
@@ -15,6 +15,33 @@ function Icon({ name }: { name: string; className?: string }) {
 }
 
 describe("ConversationPane", () => {
+  test("renders the scroll tail inside the scrolling body and keeps it out of the footer", () => {
+    const viewState: ConversationViewState = {
+      conversationId: "thread-scroll-tail",
+      entries: [],
+      groups: [],
+      turnDiff: null,
+      emptyState: null,
+    };
+
+    render(
+      <ConversationPane
+        footer={<div data-testid="pane-footer-content">Footer</div>}
+        scrollTail={<div data-testid="pane-scroll-tail">Scroll tail</div>}
+        viewState={viewState}
+      />,
+    );
+
+    const scrollTail = screen.getByTestId("pane-scroll-tail");
+    const scrollContainer = scrollTail.closest(".cc-conversation-pane__scroll");
+    const body = scrollTail.closest(".cc-conversation-pane__body");
+    const footer = screen.getByTestId("pane-footer-content").closest(".cc-conversation-pane__footer");
+
+    expect(scrollContainer).toContainElement(scrollTail);
+    expect(body?.lastElementChild).toBe(scrollTail);
+    expect(footer).not.toContainElement(scrollTail);
+  });
+
   test("restores the specific flow-run card that was clicked", () => {
     const releaseCrew: ConversationFlowRunEntry = {
       id: "flow-run:release-crew",

--- a/packages/console-components/src/conversation/conversation-pane.tsx
+++ b/packages/console-components/src/conversation/conversation-pane.tsx
@@ -24,6 +24,7 @@ export type ConversationPaneProps = {
   viewState: ConversationViewState;
   Icon?: IconRenderer | null;
   footer?: ReactNode;
+  scrollTail?: ReactNode;
   className?: string;
   scrollClassName?: string;
   bodyClassName?: string;
@@ -52,6 +53,7 @@ export function ConversationPane({
   viewState,
   Icon,
   footer = null,
+  scrollTail = null,
   className,
   scrollClassName,
   bodyClassName,
@@ -281,6 +283,7 @@ export function ConversationPane({
               viewState={viewState}
             />
           )}
+          {scrollTail}
         </div>
       </section>
       {footer ? <div className="cc-conversation-pane__footer">{footer}</div> : null}


### PR DESCRIPTION
## What changed

- adds an optional `scrollTail` slot to `ConversationPane`
- renders the slot after transcript content inside the pane's scroll body
- leaves the existing fixed `footer` contract unchanged
- adds a focused DOM ownership regression test

## Why

Large interactive transcript content (such as a six-item project-agent proposal) must participate in the conversation's single scroll surface. Mounting it as fixed footer chrome starves the transcript, creates nested scrolling, and can leave an overflow-hidden ancestor programmatically displaced after checkbox focus.

## Validation

- focused ConversationPane tests: 4/4 passed
- consuming meerkat-app desktop typecheck passed
- `git diff --check` passed
