### PR TITLE
test: drain mobkit_gateway stderr concurrently (kernel pipe-pressure deadlock)

### DIFF
--- a/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
+++ b/meerkat-mobkit/tests/mobkit_gateway_bootstrap.rs
@@ -278,6 +278,22 @@ fn mobkit_gateway_emits_tracing_on_stderr() {
     writeln!(stdin, "{}", serde_json::to_string(&init).unwrap()).expect("write init");
     stdin.flush().expect("flush");
 
+    // Drain stderr CONCURRENTLY from spawn. Leaving the pipe unread until
+    // after init deadlocks under kernel pipe-buffer pressure: when the
+    // machine-wide pipe pool is exhausted (macOS degrades fresh pipes to
+    // 512-byte buffers; observed with ~1.5k pipes leaked by a co-located
+    // agent), the gateway's ~576 bytes of bootstrap tracing overflow the
+    // buffer and its 4th stderr write blocks BEFORE the init response is
+    // printed — the test then times out on stdout with an almost-empty pipe.
+    let stderr_pipe = child.stderr.take().expect("stderr");
+    let stderr_drain = std::thread::spawn(move || {
+        let mut buffer = Vec::new();
+        use std::io::Read;
+        let mut reader = stderr_pipe;
+        let _ = reader.read_to_end(&mut buffer);
+        buffer
+    });
+
     // Wait for the init response so bootstrap tracing has happened.
     let stdout = child.stdout.take().expect("stdout");
     let (tx, rx) = mpsc::channel();
@@ -293,8 +309,9 @@ fn mobkit_gateway_emits_tracing_on_stderr() {
 
     let _ = stdin;
     let _ = child.kill();
-    let output = child.wait_with_output().expect("gateway output");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let _ = child.wait().expect("gateway exit");
+    let stderr_bytes = stderr_drain.join().expect("stderr drain thread");
+    let stderr = String::from_utf8_lossy(&stderr_bytes);
     assert!(
         stderr.contains("INFO") || stderr.contains("WARN"),
         "mobkit_gateway must emit tracing on stderr (RUST_LOG=info); \


### PR DESCRIPTION
`mobkit_gateway_emits_tracing_on_stderr` piped the gateway's stderr and left it unread until after the init response. Under machine-wide kernel pipe-buffer pressure, macOS degrades fresh pipes to **512-byte** buffers (observed live: a co-located agent holding ~1.5k pipes exhausted the pool; `os.pipe()` capacity measured at 512B). The gateway's ~576 bytes of bootstrap tracing then overflow the buffer and its 4th stderr `write(2)` blocks BEFORE `print_json_line(init_response)` — the test times out on stdout with an almost-empty stderr pipe.

Diagnosed with: thread sample showing `StderrRaw::write_all → write(2)` kernel-blocked with only 384 bytes buffered; drained-pipe control answering init instantly; fd-combination bisection isolating stderr-as-pipe; direct pipe-capacity measurement.

Fix: drain stderr concurrently from spawn into a buffer (join after kill), assert on the collected bytes. Verified 7/7 green under the exact live pipe pressure that failed the old shape deterministically; fails-closed semantics unchanged (the assert still checks INFO/WARN presence).

Not a product bug — gateway behavior is correct; this is test-harness robustness. Pre-existing (reproduces at v0.7.38); unrelated to PRs #281-290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)