### PR TITLE
fix(release): upgrade MobKit to Meerkat 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-22
+
+### Changed
+
+- Pinned the complete Meerkat dependency family to the public `0.8.2` crate
+  set. MobKit composes Meerkat's concrete `retire` authority for explicit
+  member deletion but does not duplicate the still-unsupported generated
+  `EnsureSessionAuthority` and `ReleaseSessionAuthority` actuators. Those
+  generic recovery observations remain explicitly repair-blocked upstream.
+
+### Fixed
+
+- Snapshot coherence now treats a snapshot's fence as historical write
+  provenance while requiring the presented fence to equal current write
+  authority. Cross-identity and cross-generation snapshot replacement is
+  rejected, and embedded session IDs must match their durable key.
+- The continuity session adapter remains a strict projection store: it no
+  longer runs a second transcript-recovery classifier or fabricates an empty
+  session when durable bytes are missing. Authoritative projection CAS checks
+  only the visible durable row.
+- Identity registration now rejects conflicting owners, generations, and
+  regressing fencing epochs, and ambiguous lost acknowledgements never rewind
+  checkpoint allocation.
+
 ## [0.8.0] - 2026-07-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df9102a1b56a795eeab974e281bbd820de9725436692fb973042e2afa99af9d"
+checksum = "d44eacea55fb4b7b2f18ea297fbc7e76bc7281ec579c6e682b33bd053a7545b0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6ab13072fe6594fa0d02c0ab3e1080b315a64016b262ecea76c48862d24fbc"
+checksum = "c4aa47243785c757c44db60583e1c957ca978c00eb3a93222fab12996ec03634"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4054867d00ff0abc02f0d3fe40040150bff301c56339a4d07c4b5b753f0d3e56"
+checksum = "9f2998a0b3d3738110b34bd361e95e6e5619b45e12e90ffa4736fc5a867edcfe"
 dependencies = [
  "async-trait",
  "axum",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce865fc6e0077eb3127ae3808ce7c1adc6da80e883fac396533e6443ab1b5249"
+checksum = "15c4f56d5f9438a36c183b41040f81a083e7bb587b54488c8ee16b3a6f47f282"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1858,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a276ff82f785b5e99e46806b228e3c34abb374965dfe984d4924748e35450"
+checksum = "fe9a61acea22d60c2a3dcc32b3cf937ac7ddfcb8501e3a3ec8337b736598291a"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaac4ee33e35072c8f492f87c73b7b929adc6d3a26e4a3ccad4fffa4485c470f"
+checksum = "89888edf729f25867a0a8c9c96d2a76f4e5a7d8e5d164326baf04801ee4dc827"
 dependencies = [
  "async-trait",
  "base64",
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e70966d707d85504698322541256b3d91d75f2b82d550423a16c577948fef8"
+checksum = "474629897f683206d1223d4259660f23f27e9597424689b11feed5350421f75a"
 dependencies = [
  "base64",
  "chrono",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170ad6e7fc8a526d60dffc1628a0c212b578582cf17cae23173a29b296e4958e"
+checksum = "9ad1e702c41cb3bbb16aabfa01cb9e07ebbc67dd2ac9557fa47aef7a27ee5bd4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe23902d50fed501724aa2729d09df71a3902e799e264ba09ae4aa6513034b4"
+checksum = "64729abfb656dc5f572925866db2edcd33e687a09629c213c5ca34603ebe26c0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f07d51937cb0322e0b31b610e33c1a0c04f1866f4f966230afe5ee7d1fd5fe"
+checksum = "addb0c5fb60c0ee82425d5e7f2c7bf767d9c63c271240f3d640e3f2f57a1a68c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2009,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f4e4a6c47d7159340408519fb216b457efddd7ad9f1fcc737b6c12d01b6ee0"
+checksum = "e26653da25bdd5d509395bea8b9b8597b3f7fe6be532190bed5f1c425e213c25"
 dependencies = [
  "async-trait",
  "axum",
@@ -2029,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee4f6b06c3e750839b2451d72815b33d17a9bd51cb196159b62a4bfbbd1a11a"
+checksum = "23549f2229cf0ac7cf882f5f632972122711dd97d4456edad7dd8b643fe160b4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2055,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3efdce5dd820374dd3974142b8774ccb49a488152d124e455b90c65a83c62"
+checksum = "6b368f20ef7fac37ca17d12b13fc20a680c9cf0de7ab20959a573d6ec3a9b7e4"
 dependencies = [
  "quote",
  "syn",
@@ -2065,18 +2065,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa836f7df13403463f620a7c35d1606829fe61b82d6f60448599c3615716e35f"
+checksum = "0e76f228869b07be94a5835484bb54b8a0a8118b79cad85ab4c1e5779111cdb8"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054bf9f3f5d9c50bc1fde1b63357aed78bcf52169f47316432707be0e92b93ee"
+checksum = "4d5646da1777188d2b7bf5b4a93398d2e266ce119909c6dda27543c9af6ba1b5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2c96655f581feab7a2e21003cb5a622826aced7471df49e63b9c1fec217811"
+checksum = "d5405a065a4a6c1b01901dd36311371f69f6c8d5469013c0765983a0d25b303c"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2957db79d5e136a52580a00b814c2896708627532ae35b26aa6ea823b05f08b8"
+checksum = "0e945d82bbf145644cfb550a098ee4c1a9de075d60f89386e52ad593a6963eef"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2112,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3099b2a8c294645acdd1ef37a5e5e2492cd905ea7763e8d49b4a4302eda939b"
+checksum = "77df281749c422d9c2444d9517598698cb10f52b94b156a53580416b872a93d6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5472fb95b48234190442014e8706699279f156b14a6a1bfc4e2869e741ddfdcd"
+checksum = "bcc734a416677fd44a0d7c54203c5cb845e631b3ac8b4472682e45820c499d15"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3172b09fb61353602a64aa3ddba46fcc7b4bfb757b620edab5e0d538d537e159"
+checksum = "76b3f6fd80944b3e4c2ef974b9c5be523af3637a9ff8ed3dd5b733950ea6edff"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208165d87d1addc0272a4159186472378c2d02edffb12f9deabc593b24bb54aa"
+checksum = "2271b9e9f5e0632e84f552d896be8e1ca3a3c602277c1354c835b6b57b7160be"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2281,18 +2281,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57730bba18db3954204e564d945ef3d8e12b50faaa96dffc3b4e7892defd7869"
+checksum = "08f7bc112da45537c1a227d91bf41556cc8ff85dfdedf82815028ed961e312d8"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7818f4628de8db757b2566ec5fa3fcbb1683b8a012a820fbe2245428974330"
+checksum = "22cc5e69b9f5283bd6b2707f22fb94684178afbf3d1f847c3ca665a4c034ac6d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2320,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180205e238ba07863c6cc63af266304eb032a753f2d70349c9ef7e75a56830e3"
+checksum = "1c4919eb11f8aaa29ead6f00f49bc738de77ec8727d0302f0c8d06481c688406"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06843247734c388ba392f0e10e439afb82618c2d2aeb47a95b547d6351ff8ee2"
+checksum = "d3191437b3ab2e267767083dc87af4eb149955e14793d41c180e720cc0419574"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ec2a86c8a5f274ad015eacd94160a5c335778733664701c0b35f0d04960489"
+checksum = "6c420cf45f064f85b4454b38086e576396ed0e6c57567adceaa8ef7ae9d8885b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523ced0b5f8b790293844e2b4203b9f98dfbdcd1c0561f1d1cc996e51e236bdb"
+checksum = "444da72dcd50b7b46b44457d396313c423d031125680f822f39fee017e6d2eb3"
 dependencies = [
  "async-trait",
  "futures",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539453bdb93599d9f172e650810206ef8dd6578daf84ea017a8c891f68e9922a"
+checksum = "de8e5ff91f4db9b4b74eb569666e5c041598b474a37353843c332f58102f6c41"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2434,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e724c3e56d24b51126c1792c67b255312cfbfb4515ed2163e26b7c2cc55e6b"
+checksum = "70d288c4102b76121ef2d4ae53e195dfbce297661e9b833e5e04fe10a6ec9287"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf6bf44325291d3739760035eeddb621133a3f033660b4ace25d5bc04d16d32"
+checksum = "35f058444e903a38a86bb541d23e8c82e9aae793eaff0a6bae8e3b55e0cd4b2f"
 dependencies = [
  "async-trait",
  "base64",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60faad63b461bc3a7a42814c2bacd7772918beba6856d6d965c4c725f72336c0"
+checksum = "c7c47fc4ec0b0fb3c54c0f354dd0aea78545f0f063ba3d9125ac0b62c8e2928f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "meerkat_mobkit",
-    version = "0.8.0",
+    version = "0.8.1",
 )
 
 bazel_dep(name = "rules_rust", version = "0.70.0")

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,7 +9,7 @@ description: "Bootstrap a MobKit runtime with modules and a Meerkat mob. Single 
   <Tab title="Rust crate">
     ```toml Cargo.toml
     [dependencies]
-    meerkat-mobkit = "0.8.0"
+    meerkat-mobkit = "0.8.1"
     tokio = { version = "1", features = ["full"] }
     ```
   </Tab>

--- a/docs/sdks/rust.mdx
+++ b/docs/sdks/rust.mdx
@@ -10,7 +10,7 @@ The Rust crate `meerkat-mobkit` is the primary interface for MobKit. All other i
 
 ```toml Cargo.toml
 [dependencies]
-meerkat-mobkit = "0.8.0"
+meerkat-mobkit = "0.8.1"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -53,7 +53,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -97,7 +97,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -148,7 +148,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -189,7 +189,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "distiller-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -230,7 +230,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -271,7 +271,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "hygienist-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -312,7 +312,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -353,7 +353,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -394,7 +394,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -435,7 +435,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -476,7 +476,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "selector-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -517,7 +517,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "steward-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -570,7 +570,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -633,7 +633,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "agent_events_identity_resolution",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -696,7 +696,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -764,7 +764,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -828,7 +828,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -891,7 +891,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -954,7 +954,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "classic_agent_memory",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1017,7 +1017,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1079,7 +1079,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1142,7 +1142,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1207,7 +1207,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1270,7 +1270,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1333,7 +1333,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1396,7 +1396,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1459,7 +1459,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1522,7 +1522,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "distiller_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1588,7 +1588,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1651,7 +1651,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1717,7 +1717,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "edge_wiring_reconcile",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1780,7 +1780,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1845,7 +1845,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1908,7 +1908,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "gateway_concurrent_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1971,7 +1971,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2034,7 +2034,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "gateway_live",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2096,7 +2096,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2161,7 +2161,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2228,7 +2228,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2293,7 +2293,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2356,7 +2356,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2419,7 +2419,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "hygienist_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2485,7 +2485,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2548,7 +2548,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2611,7 +2611,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2674,7 +2674,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_cold_restart_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2737,7 +2737,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2800,7 +2800,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2862,7 +2862,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2928,7 +2928,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2994,7 +2994,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_respawn_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3057,7 +3057,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3123,7 +3123,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3186,7 +3186,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3249,7 +3249,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3312,7 +3312,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3375,7 +3375,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3438,7 +3438,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3501,7 +3501,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3564,7 +3564,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3627,7 +3627,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3694,7 +3694,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "memory_comms_taint_contract",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3757,7 +3757,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3820,7 +3820,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3883,7 +3883,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3946,7 +3946,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4009,7 +4009,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4072,7 +4072,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4135,7 +4135,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4198,7 +4198,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "mobkit_gateway_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4265,7 +4265,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4328,7 +4328,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4394,7 +4394,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4460,7 +4460,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4523,7 +4523,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4586,7 +4586,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4649,7 +4649,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "schedule_store_text_carry",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4712,7 +4712,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4778,7 +4778,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4844,7 +4844,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "selector_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4911,7 +4911,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4974,7 +4974,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5037,7 +5037,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5100,7 +5100,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "steward_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5166,7 +5166,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "studio_k_asks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5229,7 +5229,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5295,7 +5295,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5358,7 +5358,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "topology_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5423,7 +5423,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5486,7 +5486,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5553,7 +5553,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "workgraph_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5615,7 +5615,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.0",
+        "CARGO_PKG_VERSION": "0.8.1",
         "CARGO_BIN_NAME": "workgraph_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,29 +48,29 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.8.1"
-meerkat-client = "=0.8.1"
-meerkat-comms = "=0.8.1"
-meerkat-contracts = "=0.8.1"
-meerkat-mob = "=0.8.1"
-meerkat-mob-mcp = "=0.8.1"
-meerkat-mcp = "=0.8.1"
-meerkat-models = "=0.8.1"
+meerkat-core = "=0.8.2"
+meerkat-client = "=0.8.2"
+meerkat-comms = "=0.8.2"
+meerkat-contracts = "=0.8.2"
+meerkat-mob = "=0.8.2"
+meerkat-mob-mcp = "=0.8.2"
+meerkat-mcp = "=0.8.2"
+meerkat-models = "=0.8.2"
 # Meerkat split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.8.1", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.8.2", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.8.1"
+meerkat-memory = "=0.8.2"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.8.1"
-meerkat-runtime = { version = "=0.8.1", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.8.1", features = ["session-store"] }
-meerkat-store = { version = "=0.8.1", features = ["sqlite"] }
-meerkat-tools = "=0.8.1"
+meerkat-live = "=0.8.2"
+meerkat-runtime = { version = "=0.8.2", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.8.2", features = ["session-store"] }
+meerkat-store = { version = "=0.8.2", features = ["sqlite"] }
+meerkat-tools = "=0.8.2"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -124,9 +124,9 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-schedule = "=0.8.1"
+meerkat-schedule = "=0.8.2"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.8.1", features = ["schema"] }
+meerkat-mob = { version = "=0.8.2", features = ["schema"] }

--- a/meerkat-mobkit/src/identity_first/adapters.rs
+++ b/meerkat-mobkit/src/identity_first/adapters.rs
@@ -202,7 +202,7 @@ impl TopologyProvider for EdgeDiscoveryTopologyAdapter {
 // ---------------------------------------------------------------------------
 
 /// Runtime state for a session, used by the adapter to resolve identity/fencing.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SessionRuntimeState {
     pub identity: AgentIdentity,
     pub generation: super::types::ContinuityGeneration,
@@ -306,6 +306,20 @@ impl ContinuitySessionStoreAdapter {
         let _guard = self.lock_session(session_id).await;
         let session_key = session_id.to_string();
         let checkpoint_version = state.checkpoint_version.get();
+        if let Some(existing) = self.lookup_session(&session_key) {
+            if existing.identity != state.identity || existing.generation != state.generation {
+                return Err(meerkat_store::SessionStoreError::Internal(format!(
+                    "session ownership conflict for {session_id}: registered owner {}/generation {} cannot be replaced by {}/generation {}",
+                    existing.identity, existing.generation, state.identity, state.generation
+                )));
+            }
+            if state.fencing_token < existing.fencing_token {
+                return Err(meerkat_store::SessionStoreError::Internal(format!(
+                    "session ownership conflict for {session_id}: fencing token {} cannot regress to {}",
+                    existing.fencing_token, state.fencing_token
+                )));
+            }
+        }
         let was_unregistered = self
             .unregistered_sessions
             .lock()
@@ -328,7 +342,7 @@ impl ContinuitySessionStoreAdapter {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             registry.insert(session_key.clone(), state.clone())
         };
-        let previous_version = {
+        {
             let mut versions = self
                 .versions
                 .lock()
@@ -336,10 +350,8 @@ impl ContinuitySessionStoreAdapter {
             let counter = versions
                 .entry(session_key.clone())
                 .or_insert_with(|| AtomicU64::new(checkpoint_version));
-            let previous_version = counter.load(Ordering::Relaxed);
             counter.fetch_max(checkpoint_version, Ordering::Relaxed);
-            previous_version
-        };
+        }
 
         let pending = {
             let pending = self
@@ -360,11 +372,10 @@ impl ContinuitySessionStoreAdapter {
                     effective_checkpoint_version = version;
                 }
                 Err(err) => {
-                    self.restore_registration_state(
-                        session_id,
-                        previous_registry,
-                        previous_version,
-                    );
+                    // The provider may have committed the attempted version
+                    // and lost only its acknowledgement. Restore registry and
+                    // marker state, but never rewind the monotonic allocator.
+                    self.restore_registration_state(session_id, previous_registry);
                     if was_unregistered {
                         self.unregistered_sessions
                             .lock()
@@ -550,7 +561,6 @@ impl ContinuitySessionStoreAdapter {
         &self,
         session_id: &meerkat_core::types::SessionId,
         previous_registry: Option<SessionRuntimeState>,
-        previous_version: u64,
     ) {
         let key = session_id.to_string();
         {
@@ -560,24 +570,12 @@ impl ContinuitySessionStoreAdapter {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             match previous_registry {
                 Some(state) => {
-                    registry.insert(key.clone(), state);
+                    registry.insert(key, state);
                 }
                 None => {
                     registry.remove(&key);
                 }
             }
-        }
-        let mut versions = self
-            .versions
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if previous_version == 0 {
-            versions.remove(&key);
-        } else {
-            versions
-                .entry(key)
-                .or_insert_with(|| AtomicU64::new(previous_version))
-                .store(previous_version, Ordering::Relaxed);
         }
     }
 
@@ -616,6 +614,12 @@ impl ContinuitySessionStoreAdapter {
             Some(snap) => {
                 let session: meerkat_core::Session = serde_json::from_slice(&snap.data)
                     .map_err(|e| meerkat_store::SessionStoreError::Serialization(e.to_string()))?;
+                if session.id() != id {
+                    return Err(meerkat_store::SessionStoreError::Serialization(format!(
+                        "continuity snapshot key {id} contains session {}",
+                        session.id()
+                    )));
+                }
                 Ok(Some(session))
             }
             None => Ok(None),
@@ -667,63 +671,6 @@ impl ContinuitySessionStoreAdapter {
             })?;
         Ok(checkpoint_version)
     }
-}
-
-/// Mirror of meerkat-session's `runtime_projection_rollback_authorized`
-/// (persistent.rs, meerkat 0.7.24 write-half of the torn-shutdown fix): two
-/// pure observations — the persisted row is a faithful continuation of the
-/// incoming authority transcript (the same run-boundary proof the save guard
-/// uses), and the row carries the intra-turn checkpointer's typed provenance
-/// stamp — drive the canonical `SessionDocumentMachine`, which owns the
-/// disposition. `RebuildToAuthority` (both observations true) authorizes the
-/// save to converge the row back onto committed truth, discarding the
-/// unacknowledged tail; an unstamped row or a genuine content fork resolves
-/// `RejectDivergent` and the caller keeps failing closed.
-fn runtime_projection_rollback_authorized(
-    session: &meerkat_core::Session,
-    previous: &meerkat_core::Session,
-) -> Result<bool, meerkat_store::SessionStoreError> {
-    use meerkat_core::session_document::{
-        SessionDocumentEffect, SessionDocumentKey, SessionDocumentMachineAuthority,
-    };
-
-    let row_continues_authority =
-        meerkat_core::session_store::run_boundary_snapshot_save_guard(previous, Some(session))
-            .is_ok();
-    let row_is_runtime_checkpoint = previous.has_runtime_checkpoint_provenance();
-    let mut authority = SessionDocumentMachineAuthority::new();
-    let effects = authority
-        .resolve_runtime_projection_rollback(
-            SessionDocumentKey::new(session.id().to_string()),
-            row_continues_authority,
-            row_is_runtime_checkpoint,
-        )
-        .map_err(|err| {
-            meerkat_store::SessionStoreError::Internal(format!(
-                "session document authority rejected runtime-projection rollback resolution \
-                 for session {}: {err}",
-                session.id()
-            ))
-        })?;
-    let disposition = effects
-        .iter()
-        .find_map(|effect| match effect {
-            SessionDocumentEffect::RuntimeProjectionRollbackResolved { disposition } => {
-                Some(*disposition)
-            }
-            _ => None,
-        })
-        .ok_or_else(|| {
-            meerkat_store::SessionStoreError::Internal(format!(
-                "session document authority returned no runtime-projection rollback \
-                 disposition for session {}",
-                session.id()
-            ))
-        })?;
-    Ok(matches!(
-        disposition,
-        meerkat_core::generated::session_document::RuntimeProjectionRollbackDisposition::RebuildToAuthority
-    ))
 }
 
 #[async_trait]
@@ -780,36 +727,11 @@ impl meerkat::SessionStore for ContinuitySessionStoreAdapter {
         }
 
         let previous = self.load_previous_session_for_save(session.id()).await?;
-        if let Err(save_error) =
-            meerkat_core::session_store::append_only_save_guard(session, previous.as_ref())
-        {
-            // Bug B-2 (HomeCore, 2026-07-09): the torn-shutdown save wedge.
-            // The intra-turn checkpointer can leave the continuity head
-            // carrying stamped mid-turn content the machine never
-            // acknowledged; after restart, the resume's first save of the
-            // (shorter) committed authority trips the append-only guard and
-            // the identity degrades forever. meerkat 0.7.24 fixed this in
-            // meerkat-session's projection-save shell
-            // (`runtime_projection_rollback_authorized`), but this adapter
-            // calls the raw guard — mirror the same machine-owned
-            // disposition here. `RebuildToAuthority` requires BOTH
-            // observations (stamped head + faithful continuation of the
-            // incoming authority); anything else keeps failing closed with
-            // the original guard error.
-            let rollback_authorized = match previous.as_ref() {
-                Some(previous) => runtime_projection_rollback_authorized(session, previous)?,
-                None => false,
-            };
-            if !rollback_authorized {
-                return Err(save_error);
-            }
-            tracing::warn!(
-                session_id = %session.id(),
-                error = %save_error,
-                "continuity head carried uncommitted intra-turn checkpoint residue; \
-                 rebuilding the row to committed authority (RebuildToAuthority)"
-            );
-        }
+        // Meerkat 0.8.2's PersistentSessionService owns projection rollback
+        // and invokes the authoritative-projection CAS seam when its generated
+        // classifier permits repair. This adapter remains a strict store; it
+        // must not run a second recovery classifier.
+        meerkat_core::session_store::append_only_save_guard(session, previous.as_ref())?;
         let snapshot = Arc::try_unwrap(snapshot).unwrap_or_else(|snapshot| (*snapshot).clone());
         let data = snapshot.data;
 
@@ -912,6 +834,9 @@ impl meerkat::SessionStore for ContinuitySessionStoreAdapter {
             return Ok(());
         }
         self.ensure_session_mutation_allowed(session.id())?;
+        // This is a compare-and-set against the visible durable projection.
+        // Pre-registration pending bytes are not a durable current revision
+        // and must not influence the expected `None`/revision predicate.
         let previous = self.load_persisted_session(session.id()).await?;
         meerkat_core::session_store::authoritative_projection_current_revision_guard(
             session,
@@ -942,16 +867,14 @@ impl meerkat::SessionStore for ContinuitySessionStoreAdapter {
         &self,
         id: &meerkat_core::types::SessionId,
     ) -> Result<Option<meerkat_core::Session>, meerkat_store::SessionStoreError> {
+        let _guard = self.lock_session(id).await;
         if self.session_was_superseded(id) {
             return Ok(None);
         }
-        match self.load_persisted_session(id).await? {
-            Some(session) => Ok(Some(session)),
-            None if self.lookup_session(&id.to_string()).is_some() => {
-                Ok(Some(meerkat_core::Session::with_id(id.clone())))
-            }
-            None => Ok(None),
-        }
+        // Registration is observed realization state, not transcript history.
+        // Missing durable bytes stay missing so upstream can classify them;
+        // never synthesize an empty session.
+        self.load_persisted_session(id).await
     }
 
     async fn list(
@@ -1184,6 +1107,7 @@ mod tests {
     struct FailSaveContinuityStore {
         inner: Arc<LocalContinuityStore>,
         fail_save: AtomicBool,
+        commit_then_fail_save: AtomicBool,
         fail_delete_once: AtomicBool,
         block_next_save: AtomicBool,
         save_entered: tokio::sync::Semaphore,
@@ -1195,6 +1119,7 @@ mod tests {
             Self {
                 inner,
                 fail_save: AtomicBool::new(false),
+                commit_then_fail_save: AtomicBool::new(false),
                 fail_delete_once: AtomicBool::new(false),
                 block_next_save: AtomicBool::new(false),
                 save_entered: tokio::sync::Semaphore::new(0),
@@ -1204,6 +1129,11 @@ mod tests {
 
         fn fail_saves(&self, fail: bool) {
             self.fail_save.store(fail, AtomicOrdering::SeqCst);
+        }
+
+        fn commit_then_fail_next_save(&self) {
+            self.commit_then_fail_save
+                .store(true, AtomicOrdering::SeqCst);
         }
 
         fn fail_next_delete(&self) {
@@ -1306,7 +1236,16 @@ mod tests {
                     fencing_token,
                     snapshot,
                 )
-                .await
+                .await?;
+            if self
+                .commit_then_fail_save
+                .swap(false, AtomicOrdering::SeqCst)
+            {
+                return Err(ContinuityStoreError::Io(
+                    "synthetic lost save acknowledgement".to_string(),
+                ));
+            }
+            Ok(())
         }
 
         async fn upsert_continuity_record(
@@ -2141,6 +2080,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn continuity_session_store_adapter_lost_ack_consumes_checkpoint_version() {
+        let inner = Arc::new(LocalContinuityStore::in_memory().expect("store"));
+        let fail_store = Arc::new(FailSaveContinuityStore::new(inner.clone()));
+        let adapter = ContinuitySessionStoreAdapter::new(fail_store.clone());
+        let session = meerkat_core::Session::new();
+        let identity = AgentIdentity::parse("agent:lost-ack").expect("identity");
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:agent:lost-ack:0").expect("runtime id"),
+            session_id: session.id().clone(),
+            generation: ContinuityGeneration::new(0),
+            checkpoint_version: CheckpointVersion::new(0),
+        };
+        let fencing_token = FencingToken::new(23);
+        inner
+            .upsert_continuity_record(&record, fencing_token)
+            .await
+            .expect("seed record");
+        meerkat::SessionStore::save(&adapter, &session)
+            .await
+            .expect("queue pre-registration snapshot");
+
+        let state = SessionRuntimeState {
+            identity: identity.clone(),
+            generation: record.generation,
+            fencing_token,
+            checkpoint_version: record.checkpoint_version,
+        };
+        fail_store.commit_then_fail_next_save();
+        adapter
+            .register_session(session.id(), state.clone())
+            .await
+            .expect_err("first flush commits version 1 but loses its acknowledgement");
+
+        let effective = adapter
+            .register_session(session.id(), state)
+            .await
+            .expect("retry must allocate a fresh checkpoint version");
+        assert_eq!(effective, CheckpointVersion::new(2));
+        let resolved = inner
+            .resolve_many(std::slice::from_ref(&identity))
+            .await
+            .expect("resolve");
+        let ContinuityResolveState::Ready { record } = resolved.get(&identity).expect("record")
+        else {
+            panic!("expected ready record");
+        };
+        assert_eq!(record.checkpoint_version, CheckpointVersion::new(2));
+    }
+
+    #[tokio::test]
+    async fn continuity_session_store_adapter_rejects_owner_generation_and_fence_regression() {
+        let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
+        let adapter = ContinuitySessionStoreAdapter::new(store);
+        let session = meerkat_core::Session::new();
+        let first = SessionRuntimeState {
+            identity: AgentIdentity::parse("agent:owner-a").expect("identity"),
+            generation: ContinuityGeneration::new(4),
+            fencing_token: FencingToken::new(10),
+            checkpoint_version: CheckpointVersion::new(7),
+        };
+        adapter
+            .register_session(session.id(), first.clone())
+            .await
+            .expect("initial registration");
+
+        let foreign_owner = SessionRuntimeState {
+            identity: AgentIdentity::parse("agent:owner-b").expect("identity"),
+            ..first.clone()
+        };
+        adapter
+            .register_session(session.id(), foreign_owner)
+            .await
+            .expect_err("a session id cannot be rebound to another identity");
+
+        let foreign_generation = SessionRuntimeState {
+            generation: ContinuityGeneration::new(5),
+            ..first.clone()
+        };
+        adapter
+            .register_session(session.id(), foreign_generation)
+            .await
+            .expect_err("a session id cannot be rebound to another generation");
+
+        let greater = SessionRuntimeState {
+            fencing_token: FencingToken::new(11),
+            ..first.clone()
+        };
+        adapter
+            .register_session(session.id(), greater.clone())
+            .await
+            .expect("a monotonic fence may replace the prior write authority");
+        adapter
+            .suspend_session(session.id())
+            .await
+            .expect("suspend replacement authority");
+
+        let regressed = SessionRuntimeState {
+            fencing_token: FencingToken::new(9),
+            ..first.clone()
+        };
+        adapter
+            .register_session(session.id(), regressed)
+            .await
+            .expect_err("suspension must never authorize fence regression");
+        adapter
+            .register_session(session.id(), greater.clone())
+            .await
+            .expect("the same current fence resumes suspended persistence");
+        assert_eq!(
+            adapter.lookup_session(&session.id().to_string()),
+            Some(greater),
+            "rejected registrations must not replace the owner"
+        );
+    }
+
+    #[tokio::test]
     async fn continuity_session_store_adapter_delete_if_current_revision_removes_matching_snapshot()
     {
         let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
@@ -2274,13 +2330,12 @@ mod tests {
         );
     }
 
-    /// Bug B-2 (HomeCore field wedge): a torn shutdown leaves the continuity
-    /// head carrying the intra-turn checkpointer's STAMPED mid-turn content;
-    /// the resume's first save of the shorter committed authority must
-    /// converge the row back onto authority (`RebuildToAuthority`), not
-    /// wedge on `MonotonicityViolation` forever.
+    /// Projection rollback is owned by Meerkat's PersistentSessionService.
+    /// The raw store adapter remains append-only and must not independently
+    /// reinterpret a stamped longer row as permission to fabricate rollback.
     #[tokio::test]
-    async fn save_rebuilds_stamped_checkpoint_residue_to_authority() {
+    #[allow(deprecated)] // Exercises compatibility with legacy stamped rows.
+    async fn raw_save_rejects_stamped_checkpoint_residue_rollback() {
         let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
         let adapter = ContinuitySessionStoreAdapter::new(store.clone());
         let mut authority = meerkat_core::Session::new();
@@ -2323,25 +2378,32 @@ mod tests {
         let mut stamped_head = authority.clone();
         stamped_head
             .append_external_user_content(meerkat_core::ContentInput::Text("mid-turn".to_string()));
-        stamped_head.set_runtime_checkpoint_provenance();
+        stamped_head
+            .set_runtime_checkpoint_provenance()
+            .expect("stamp legacy runtime checkpoint provenance");
         meerkat::SessionStore::save(&adapter, &stamped_head)
             .await
             .expect("checkpointer save of the stamped head");
 
-        // Restart: the read source served the runtime snapshot (authority);
-        // the resume's first save of that shorter content used to trip
-        // MonotonicityViolation and wedge the identity.
-        meerkat::SessionStore::save(&adapter, &authority)
+        // The authoritative Meerkat service may classify and drive this
+        // repair through its CAS seam. A direct adapter call may not.
+        let error = meerkat::SessionStore::save(&adapter, &authority)
             .await
-            .expect("authority save must rebuild the stamped residue, not wedge");
+            .expect_err("raw save must reject transcript rollback");
+        assert!(
+            error.to_string().contains("transcript")
+                || error.to_string().contains("monotonicity")
+                || error.to_string().contains("continuation"),
+            "unexpected rollback error: {error}"
+        );
         let loaded = meerkat::SessionStore::load(&adapter, authority.id())
             .await
             .expect("load")
             .expect("session");
         assert_eq!(
             loaded.messages().len(),
-            authority.messages().len(),
-            "row must be rebuilt to committed authority (tail discarded)"
+            stamped_head.messages().len(),
+            "rejected raw rollback must leave the durable stamped row unchanged"
         );
     }
 
@@ -2399,6 +2461,7 @@ mod tests {
     /// faithful continuation) resolves `RejectDivergent` — stamp alone never
     /// authorizes the rollback.
     #[tokio::test]
+    #[allow(deprecated)] // Exercises compatibility with legacy stamped rows.
     async fn save_keeps_rejecting_stamped_forked_heads() {
         let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
         let adapter = ContinuitySessionStoreAdapter::new(store.clone());
@@ -2432,7 +2495,9 @@ mod tests {
         let mut stamped_fork = base.clone();
         stamped_fork
             .append_external_user_content(meerkat_core::ContentInput::Text("forked".to_string()));
-        stamped_fork.set_runtime_checkpoint_provenance();
+        stamped_fork
+            .set_runtime_checkpoint_provenance()
+            .expect("stamp legacy runtime checkpoint provenance");
         meerkat::SessionStore::save(&adapter, &stamped_fork)
             .await
             .expect("seed the stamped head");
@@ -2652,8 +2717,9 @@ mod tests {
         assert!(
             meerkat::SessionStore::load(&adapter, session.id())
                 .await
-                .expect("synthetic load before delete")
-                .is_some()
+                .expect("load before delete")
+                .is_none(),
+            "registration alone must not fabricate a session document"
         );
 
         meerkat::SessionStore::delete(&adapter, session.id())
@@ -2666,6 +2732,100 @@ mod tests {
                 .is_none(),
             "delete must forget registry state when no persisted row exists"
         );
+    }
+
+    #[tokio::test]
+    async fn continuity_session_store_adapter_projection_cas_ignores_pending_bytes() {
+        let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
+        let adapter = ContinuitySessionStoreAdapter::new(store.clone());
+        let mut session = meerkat_core::Session::new();
+        session.set_metadata("projection", json!("first-pending"));
+        meerkat::SessionStore::save_authoritative_projection_if_current_revision(
+            &adapter, &session, None,
+        )
+        .await
+        .expect("first missing-row CAS");
+
+        session.set_metadata("projection", json!("latest-pending"));
+        meerkat::SessionStore::save_authoritative_projection_if_current_revision(
+            &adapter, &session, None,
+        )
+        .await
+        .expect("pending bytes are not a visible durable revision");
+
+        let identity = AgentIdentity::parse("agent:projection-pending").expect("identity");
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:agent:projection-pending:0")
+                .expect("runtime id"),
+            session_id: session.id().clone(),
+            generation: ContinuityGeneration::new(0),
+            checkpoint_version: CheckpointVersion::new(0),
+        };
+        let fencing_token = FencingToken::new(31);
+        store
+            .upsert_continuity_record(&record, fencing_token)
+            .await
+            .expect("seed record");
+        adapter
+            .register_session(
+                session.id(),
+                SessionRuntimeState {
+                    identity,
+                    generation: record.generation,
+                    fencing_token,
+                    checkpoint_version: record.checkpoint_version,
+                },
+            )
+            .await
+            .expect("flush latest pending projection");
+        let loaded = meerkat::SessionStore::load(&adapter, session.id())
+            .await
+            .expect("load")
+            .expect("snapshot");
+        assert_eq!(
+            loaded.metadata().get("projection"),
+            Some(&json!("latest-pending"))
+        );
+    }
+
+    #[tokio::test]
+    async fn continuity_session_store_adapter_rejects_snapshot_with_foreign_embedded_id() {
+        let store = Arc::new(LocalContinuityStore::in_memory().expect("store"));
+        let adapter = ContinuitySessionStoreAdapter::new(store.clone());
+        let requested = meerkat_core::Session::new();
+        let foreign = meerkat_core::Session::new();
+        let identity = AgentIdentity::parse("agent:foreign-snapshot-id").expect("identity");
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse("rt:agent:foreign-snapshot-id:0")
+                .expect("runtime id"),
+            session_id: requested.id().clone(),
+            generation: ContinuityGeneration::new(0),
+            checkpoint_version: CheckpointVersion::new(0),
+        };
+        let fencing_token = FencingToken::new(41);
+        store
+            .upsert_continuity_record(&record, fencing_token)
+            .await
+            .expect("seed record");
+        let bytes = serde_json::to_vec(&foreign).expect("serialize foreign session");
+        store
+            .save_session_snapshot(
+                &identity,
+                requested.id(),
+                record.generation,
+                CheckpointVersion::new(1),
+                fencing_token,
+                &SessionSnapshot { data: bytes },
+            )
+            .await
+            .expect("seed corrupt keyed snapshot");
+
+        let error = meerkat::SessionStore::load(&adapter, requested.id())
+            .await
+            .expect_err("embedded foreign session id must be explicit corruption");
+        assert!(error.to_string().contains("contains session"));
     }
 
     #[tokio::test]

--- a/meerkat-mobkit/src/identity_first/contracts.rs
+++ b/meerkat-mobkit/src/identity_first/contracts.rs
@@ -27,9 +27,12 @@ use crate::mob_handle_runtime::SessionCreatedContext;
 /// Candidate used by stores that can prove an exact, provenance-preserving
 /// snapshot no-op without returning and reparsing the durable document.
 ///
-/// A store may report a match only when both the bytes and every ownership/CAS
-/// field identify its current durable row. Implementations that cannot prove
-/// the complete predicate must use the trait's default `false` response.
+/// A store may report a match only when the bytes, identity, generation, and
+/// checkpoint revision identify its durable snapshot and the presented fence
+/// is current write authority. The snapshot's stored fence is historical
+/// provenance: it may precede the current lease epoch, but may never exceed
+/// it. Implementations that cannot prove the complete predicate must use the
+/// trait's default `false` response.
 #[derive(Debug, Clone)]
 pub struct SessionSnapshotMatchCandidate {
     pub identity: AgentIdentity,
@@ -72,8 +75,9 @@ pub trait ContinuityStore: Send + Sync {
     ) -> Result<Option<SessionSnapshot>, ContinuityStoreError>;
 
     /// Return `true` only when `candidate` is byte-for-byte identical to the
-    /// current durable row and its identity, generation, checkpoint version,
-    /// and fencing token all match.
+    /// current durable row and its identity, generation, and checkpoint
+    /// version match. `candidate.fencing_token` must equal current write
+    /// authority; the row's historical fence may be older but not newer.
     ///
     /// This additive capability lets adapters skip a full document load and
     /// parse for an already-durable save. The conservative default preserves

--- a/meerkat-mobkit/src/identity_first/local_store.rs
+++ b/meerkat-mobkit/src/identity_first/local_store.rs
@@ -385,12 +385,12 @@ impl ContinuityStore for LocalContinuityStore {
                              AND continuity.session_id = snapshot.session_id
                              AND continuity.generation = snapshot.generation
                              AND continuity.checkpoint_version = snapshot.checkpoint_version
-                             AND continuity.fencing_token = snapshot.fencing_token
                             WHERE snapshot.session_id = ?1
                               AND snapshot.identity = ?2
                               AND snapshot.generation = ?3
                               AND snapshot.checkpoint_version = ?4
-                              AND snapshot.fencing_token = ?5
+                              AND continuity.fencing_token = ?5
+                              AND snapshot.fencing_token <= ?5
                               AND snapshot.data = ?6
                         )",
                         rusqlite::params![
@@ -550,6 +550,26 @@ impl ContinuityStore for LocalContinuityStore {
                             current: CheckpointVersion::new(current_version),
                         });
                     }
+                }
+
+                let existing_snapshot_owner = tx
+                    .query_row(
+                        "SELECT identity, generation FROM session_snapshots WHERE session_id = ?1",
+                        rusqlite::params![session_id.to_string()],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, u64>(1)?)),
+                    )
+                    .optional()
+                    .map_err(|e| {
+                        ContinuityStoreError::Io(format!("query snapshot owner: {e}"))
+                    })?;
+                if let Some((snapshot_identity, snapshot_generation)) = existing_snapshot_owner
+                    && (snapshot_identity != identity.as_str()
+                        || snapshot_generation != generation.get())
+                {
+                    return Err(ContinuityStoreError::Corruption(format!(
+                        "session snapshot {session_id} is owned by {snapshot_identity}/generation \
+                         {snapshot_generation}, not {identity}/generation {generation}"
+                    )));
                 }
 
                 tx.execute(
@@ -1429,11 +1449,136 @@ mod tests {
             .unwrap();
         assert!(
             !store
-                .session_snapshot_matches_current(candidate)
+                .session_snapshot_matches_current(candidate.clone())
                 .await
                 .unwrap(),
-            "stale snapshot-row bytes must not mask a newer continuity head fence"
+            "a stale presented write fence must not match a newer continuity head"
         );
+        assert!(
+            store
+                .session_snapshot_matches_current(SessionSnapshotMatchCandidate {
+                    fencing_token: FencingToken::new(2),
+                    ..candidate
+                })
+                .await
+                .unwrap(),
+            "the historical row fence is provenance and may precede current write authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_save_rejects_another_identity_owning_the_session_id() {
+        let store = LocalContinuityStore::in_memory().expect("in-memory store");
+        let first = AgentIdentity::parse("agent:first-owner").unwrap();
+        let second = AgentIdentity::parse("agent:second-owner").unwrap();
+        let session_id = meerkat_core::types::SessionId::new();
+        store
+            .upsert_continuity_record(&record(&first, &session_id), FencingToken::new(1))
+            .await
+            .unwrap();
+        store
+            .save_session_snapshot(
+                &first,
+                &session_id,
+                ContinuityGeneration::new(0),
+                CheckpointVersion::new(1),
+                FencingToken::new(1),
+                &SessionSnapshot { data: vec![1] },
+            )
+            .await
+            .unwrap();
+        store
+            .upsert_continuity_record(&record(&second, &session_id), FencingToken::new(2))
+            .await
+            .unwrap();
+
+        let error = store
+            .save_session_snapshot(
+                &second,
+                &session_id,
+                ContinuityGeneration::new(0),
+                CheckpointVersion::new(1),
+                FencingToken::new(2),
+                &SessionSnapshot { data: vec![2] },
+            )
+            .await
+            .expect_err("a different identity must not overwrite the session row");
+        assert!(matches!(error, ContinuityStoreError::Corruption(_)));
+        assert_eq!(
+            store.load_session_snapshot(&session_id).await.unwrap(),
+            Some(SessionSnapshot { data: vec![1] })
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_save_rejects_same_identity_from_another_generation_atomically() {
+        let store = LocalContinuityStore::in_memory().expect("in-memory store");
+        let identity = AgentIdentity::parse("agent:generation-owner").unwrap();
+        let session_id = meerkat_core::types::SessionId::new();
+        store
+            .upsert_continuity_record(&record(&identity, &session_id), FencingToken::new(1))
+            .await
+            .unwrap();
+        store
+            .save_session_snapshot(
+                &identity,
+                &session_id,
+                ContinuityGeneration::new(0),
+                CheckpointVersion::new(1),
+                FencingToken::new(1),
+                &SessionSnapshot { data: vec![1] },
+            )
+            .await
+            .unwrap();
+
+        let identity_for_update = identity.clone();
+        store
+            .run_blocking("advance-test-generation", move |inner| {
+                inner.with_writer(|connection| {
+                    connection
+                        .execute(
+                            "UPDATE continuity_records
+                             SET generation = 1, checkpoint_version = 0, fencing_token = 2
+                             WHERE identity = ?1",
+                            rusqlite::params![identity_for_update.as_str()],
+                        )
+                        .map_err(|error| {
+                            ContinuityStoreError::Io(format!(
+                                "advance test continuity generation: {error}"
+                            ))
+                        })?;
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let error = store
+            .save_session_snapshot(
+                &identity,
+                &session_id,
+                ContinuityGeneration::new(1),
+                CheckpointVersion::new(1),
+                FencingToken::new(2),
+                &SessionSnapshot { data: vec![2] },
+            )
+            .await
+            .expect_err("a new generation must not overwrite the prior session row");
+        assert!(matches!(error, ContinuityStoreError::Corruption(_)));
+        assert_eq!(
+            store.load_session_snapshot(&session_id).await.unwrap(),
+            Some(SessionSnapshot { data: vec![1] }),
+            "failed cross-generation save must leave snapshot bytes unchanged"
+        );
+        let resolved = store
+            .resolve_many(std::slice::from_ref(&identity))
+            .await
+            .unwrap();
+        let ContinuityResolveState::Ready { record } = resolved.get(&identity).unwrap() else {
+            panic!("expected ready continuity head");
+        };
+        assert_eq!(record.generation, ContinuityGeneration::new(1));
+        assert_eq!(record.checkpoint_version, CheckpointVersion::new(0));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -1547,12 +1547,76 @@ impl meerkat_runtime::RuntimeStore for SessionStoreBackedRuntimeStore {
             .await
     }
 
+    async fn compare_and_swap_input_states_atomically_with_fence(
+        &self,
+        runtime_id: &meerkat_runtime::LogicalRuntimeId,
+        expected: &[StoredInputState],
+        replacements: &[InputStatePersistenceRecord],
+        write_fence: Arc<dyn meerkat_runtime::store::RuntimeStoreWriteFence>,
+    ) -> Result<
+        meerkat_runtime::store::FencedInputStateBatchCasOutcome,
+        meerkat_runtime::store::RuntimeStoreError,
+    > {
+        self.inner
+            .compare_and_swap_input_states_atomically_with_fence(
+                runtime_id,
+                expected,
+                replacements,
+                write_fence,
+            )
+            .await
+    }
+
     async fn load_input_state(
         &self,
         runtime_id: &meerkat_runtime::LogicalRuntimeId,
         input_id: &meerkat_core::lifecycle::InputId,
     ) -> Result<Option<StoredInputState>, meerkat_runtime::store::RuntimeStoreError> {
         self.inner.load_input_state(runtime_id, input_id).await
+    }
+
+    async fn observe_machine_lifecycle(
+        &self,
+        runtime_id: &meerkat_runtime::LogicalRuntimeId,
+    ) -> Result<
+        meerkat_runtime::store::MachineLifecycleObservation,
+        meerkat_runtime::store::RuntimeStoreError,
+    > {
+        self.inner.observe_machine_lifecycle(runtime_id).await
+    }
+
+    async fn compare_and_swap_machine_lifecycle(
+        &self,
+        runtime_id: &meerkat_runtime::LogicalRuntimeId,
+        expected: meerkat_runtime::store::MachineLifecycleExpectedVersion,
+        replacement: MachineLifecycleCommit,
+    ) -> Result<
+        meerkat_runtime::store::MachineLifecycleCasOutcome,
+        meerkat_runtime::store::RuntimeStoreError,
+    > {
+        self.inner
+            .compare_and_swap_machine_lifecycle(runtime_id, expected, replacement)
+            .await
+    }
+
+    async fn compare_and_swap_machine_lifecycle_with_fence(
+        &self,
+        runtime_id: &meerkat_runtime::LogicalRuntimeId,
+        expected: meerkat_runtime::store::MachineLifecycleExpectedVersion,
+        replacement: MachineLifecycleCommit,
+        write_fence: Arc<dyn meerkat_runtime::store::RuntimeStoreWriteFence>,
+    ) -> Result<
+        meerkat_runtime::store::FencedMachineLifecycleCasOutcome,
+        meerkat_runtime::store::RuntimeStoreError,
+    > {
+        self.inner
+            .compare_and_swap_machine_lifecycle_with_fence(
+                runtime_id,
+                expected,
+                replacement,
+                write_fence,
+            )
+            .await
     }
 
     async fn load_machine_lifecycle_record(

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -1366,7 +1366,6 @@ runtime_mode = "autonomous_host"
         )
         .expect("definition parses");
         let tmp = tempfile::tempdir().expect("temp dir");
-
         let builder = UnifiedRuntimeBuilder::default()
             .definition(definition)
             .persistent_state(tmp.path().join("state"))

--- a/meerkat-mobkit/tests/list_flows_run_flow.rs
+++ b/meerkat-mobkit/tests/list_flows_run_flow.rs
@@ -309,7 +309,6 @@ impl meerkat::LlmClient for HangingTestClient {
 #[tokio::test(flavor = "multi_thread")]
 async fn shutdown_quiesces_an_in_flight_flow_run() {
     let fixture = build_unified_runtime_with_flow_and_client(Arc::new(HangingTestClient)).await;
-
     let run_response = parse_json_rpc(
         &handle_unified_rpc_json(
             &fixture.runtime,

--- a/meerkat-mobkit/tests/swarm_integration.rs
+++ b/meerkat-mobkit/tests/swarm_integration.rs
@@ -185,6 +185,10 @@ impl MobSessionService for CheckpointerCancelProbeSessionService {
         self.inner.supports_persistent_sessions()
     }
 
+    fn runtime_adapter(&self) -> Option<Arc<meerkat_runtime::MeerkatMachine>> {
+        self.inner.runtime_adapter()
+    }
+
     async fn session_belongs_to_mob(&self, session_id: &SessionId, mob_id: &MobId) -> bool {
         self.inner.session_belongs_to_mob(session_id, mob_id).await
     }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.8.0"
+version = "0.8.1"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/python/tests/test_homecore_kitchen_sink.py
+++ b/sdk/python/tests/test_homecore_kitchen_sink.py
@@ -421,12 +421,13 @@ class TestHouseholdIncident:
                 )
             print("[Phase 5] All 7 actors restored with stable IDs")
 
-            # Wait for autonomous loops to restart after restore
-            await rt2.wait_until_ready([
-                "triage:main", "domain:school", "domain:calendar",
-                "gate:main", "identity:luka", "identity:louise",
-                "family-group:main",
-            ], timeout=30)
+            # A resumed member does not replay its one-time kickoff turn.
+            # Wait on the typed lifecycle readiness barrier rather than output
+            # previews, which may stay empty until fresh work is delivered.
+            startup = await rt2.wait_identity_bootstrap(
+                target="startup_ready", timeout=30
+            )
+            assert startup.startup_ready is True, startup.to_dict()
 
             # ASSERT conversational continuity via LLM content.
             # Luka received the school closure notice before shutdown.

--- a/sdk/python/tests/test_identity_first_homecore_e2e.py
+++ b/sdk/python/tests/test_identity_first_homecore_e2e.py
@@ -223,6 +223,34 @@ async def _boot_identity_runtime(
     return await builder.build()
 
 
+async def _wait_for_identity_convergence(runtime, *, timeout: float = 60.0):
+    """Wait through diagnostic Broken states until the roster converges.
+
+    Eager bootstrap is terminal once every identity has a classified outcome;
+    a retryable resume failure is therefore observable as ``Broken`` before
+    the runtime-owned repair supervisor's first backoff expires.  Recovery is
+    level-triggered, so restart tests must assert eventual convergence rather
+    than depend on whether the first observation won that race.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    status = await runtime.identity_bootstrap_status()
+    while not status.ready and loop.time() < deadline:
+        await asyncio.sleep(0.5)
+        status = await runtime.identity_bootstrap_status()
+    assert status.ready, status.to_dict()
+
+    # Active lifecycle is necessary but not sufficient: once the repair
+    # supervisor converges every identity, use the typed member-readiness
+    # barrier for the remaining time budget.
+    remaining = max(0.0, deadline - loop.time())
+    startup = await runtime.wait_identity_bootstrap(
+        target="startup_ready", timeout=remaining
+    )
+    assert startup.startup_ready is True, startup.to_dict()
+    return startup
+
+
 @pytest.fixture
 def mob_toml(tmp_path):
     p = tmp_path / "mob.toml"
@@ -639,7 +667,7 @@ class TestHC07ResetVsDelete:
 @_skip_no_binary
 class TestHC08PersistentRestart:
     @pytest.mark.asyncio
-    @pytest.mark.timeout(180)
+    @pytest.mark.timeout(360)
     async def test_session_and_continuity_preserved_across_restart(self, mob_toml, state_dir):
         roster = HomeCoreRoster(_DEFAULT_ROSTER)
         topology = HomeCoreTopology(_DEFAULT_EDGES)
@@ -678,6 +706,8 @@ class TestHC08PersistentRestart:
             after = await rt2.status("identity:luka")
             assert after.session_id == session_before
             assert after.agent_runtime_id == rt_id_before
+            await _wait_for_identity_convergence(rt2)
+            after = await rt2.status("identity:luka")
             assert after.state == "active"
 
             triage_after = await rt2.status("triage:main")
@@ -695,3 +725,27 @@ class TestHC08PersistentRestart:
             # was restored (not fresh-created).
         finally:
             await rt2.shutdown()
+
+        # Restart once more after the resumed runtime has committed another
+        # turn. This catches a latent same-base sibling fork that can look
+        # healthy during the first recovery but wedge the following restart.
+        rt3 = await _boot_identity_runtime(
+            state_dir, mob_toml, roster, topology, customizer
+        )
+        try:
+            after_second_restart = await rt3.status("identity:luka")
+            assert after_second_restart.session_id == session_before
+            assert after_second_restart.agent_runtime_id == rt_id_before
+            await _wait_for_identity_convergence(rt3)
+            after_second_restart = await rt3.status("identity:luka")
+            assert after_second_restart.state == "active"
+
+            triage_after_second_restart = await rt3.status("triage:main")
+            assert triage_after_second_restart.session_id == triage_session_before
+
+            await rt3.send(
+                "identity:luka",
+                "Confirm this session is still writable after the second restart.",
+            )
+        finally:
+            await rt3.shutdown()

--- a/sdk/python/tests/test_shutdown_real_gateway.py
+++ b/sdk/python/tests/test_shutdown_real_gateway.py
@@ -11,6 +11,7 @@ from meerkat_mobkit.identity_first_models import (
     IdentityBootstrapMode,
 )
 from meerkat_mobkit.identity_first_providers import (
+    ContinuityRecord,
     ContinuityResolveState,
     LeaseAcquireResult,
     LeaseGrant,
@@ -59,24 +60,73 @@ class _Roster:
 
 
 class _ContinuityStore:
+    def __init__(self):
+        self.records: dict[str, ContinuityRecord] = {}
+        self.snapshots: dict[str, object] = {}
+        self.fencing_tokens: dict[str, int] = {}
+
     async def resolve_many(self, identities):
         return {
-            identity: ContinuityResolveState(state="uninitialized")
+            identity: (
+                ContinuityResolveState(state="ready", record=self.records[identity])
+                if identity in self.records
+                else ContinuityResolveState(state="uninitialized")
+            )
             for identity in identities
         }
 
     async def load_session_snapshot(self, session_id):
-        del session_id
-        return None
+        return self.snapshots.get(session_id)
 
-    async def save_session_snapshot(self, *args):
-        del args
+    async def save_session_snapshot(
+        self,
+        identity,
+        session_id,
+        generation,
+        version,
+        fencing_token,
+        snapshot,
+    ):
+        record = self.records[identity]
+        assert record.session_id == session_id
+        assert record.generation == generation
+        assert self.fencing_tokens[identity] == fencing_token
+        self.snapshots[session_id] = snapshot
+        self.records[identity] = ContinuityRecord(
+            identity=record.identity,
+            agent_runtime_id=record.agent_runtime_id,
+            session_id=record.session_id,
+            generation=record.generation,
+            checkpoint_version=version,
+        )
 
-    async def upsert_continuity_record(self, *args):
-        del args
+    async def upsert_continuity_record(self, record, fencing_token):
+        self.records[record.identity] = record
+        self.fencing_tokens[record.identity] = fencing_token
 
-    async def delete_continuity_record(self, *args):
-        del args
+    async def delete_continuity_record(self, identity, fencing_token):
+        assert self.fencing_tokens.get(identity) == fencing_token
+        self.records.pop(identity, None)
+        self.fencing_tokens.pop(identity, None)
+
+    async def session_snapshot_matches_current(
+        self,
+        identity,
+        session_id,
+        generation,
+        checkpoint_version,
+        fencing_token,
+        snapshot,
+    ):
+        record = self.records.get(identity)
+        return (
+            record is not None
+            and record.session_id == session_id
+            and record.generation == generation
+            and record.checkpoint_version == checkpoint_version
+            and self.fencing_tokens.get(identity) == fencing_token
+            and self.snapshots.get(session_id) == snapshot
+        )
 
     async def delete_session_snapshot_if_current_revision(self, *args):
         del args

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump MobKit and SDKs to 0.8.1 with exact Meerkat 0.8.2 pins
- persist Meerkat mob/runtime stores and select create versus resume from durable state
- align continuity snapshot/fencing and lifecycle behavior with the supported 0.8.2 authority boundary
- keep unsupported generic session-authority obligations explicitly repair-blocked

## Validation
- repository pre-push hooks: fmt, clippy, workspace unit gate
- package all-target check
- version parity
- release verifier unit suite (21 tests)

Supersedes the relevant intent of #126, #159, and #160 without carrying forward their stale Meerkat APIs or unsafe partial-observation ownership logic.