### PR TITLE
fix(examples): make MDM target E2E functional

### DIFF
--- a/examples/004-mdm-console-pack/README.md
+++ b/examples/004-mdm-console-pack/README.md
@@ -88,8 +88,13 @@ reachable from the targets:
 ```bash
 MDM_SUPERVISOR_BIND_ADDRESS=0.0.0.0:5790 \
 MDM_SUPERVISOR_ADVERTISED_ADDRESS=tcp://<console-reachable-host>:5790 \
+MDM_MEMBER_COMMS_ADDRESS=<console-reachable-ip>:0 \
 ./004-mdm-console-pack/scripts/start-console.sh
 ```
+
+`MDM_MEMBER_COMMS_ADDRESS` must name a concrete local interface, not
+`0.0.0.0`; each Hive/member runtime binds an ephemeral port on that interface
+and advertises the resolved TCP endpoint back to external targets.
 
 For a local-only demo, the default supervisor bridge is
 `tcp://127.0.0.1:5790`.
@@ -118,22 +123,32 @@ cd examples
 npm run mdm:smoke
 npm run mdm:browser-smoke
 npm run mdm:real-target-smoke
+npm run mdm:real-target-e2e
+npm run mdm:real-target-multi-e2e
 npm run mdm:local-target
 npm run mdm:console
 ```
 
 The empty-target smokes verify that the console boots without the old kennel
 path. `mdm:real-target-smoke` starts a disposable real `mdm_mob_target`, binds it
-as an external mob member, sends a queued mob turn to that target, and checks
-that the target process observed the peer turn. That is the release gate for the
-Meerkat bridge integration.
+as an external mob member, sends through the same console RPC used by the UI,
+and checks that the target process observed the peer turn. This deterministic
+lane does not require a provider response. `mdm:real-target-e2e` additionally
+requires configured provider credentials, sends the operator turn to the local
+hive, waits for the hive to query the wired target through peer comms, and
+fails unless target-side model/shell execution returns through the hive's
+tracked console terminal. Direct external-member delivery remains an
+ingress-acknowledged lane in Meerkat 0.8.2; the hive interaction is the
+supported terminal-owning MDM path.
+`mdm:real-target-multi-e2e` raises the same gate with two independent target
+processes and requires Hive's verified terminal summary to name both targets.
 
-The pack is pinned to the Meerkat 0.6.30 family. Re-apply and validate the pin
+The pack is pinned to Meerkat 0.8.2. Re-apply and validate the pin
 with:
 
 ```bash
 cd examples
-npm run mdm:upgrade-meerkat -- 0.6.30
+npm run mdm:upgrade-meerkat -- 0.8.2
 npm run mdm:real-target-smoke
 ```
 
@@ -142,6 +157,7 @@ with unrestricted shell tools enabled on the target side. The useful prompt is
 something like: "Ask every target what machine it is running on." The answer
 should come from target-side peer turns, not from roster labels.
 
-`mdm:real-target-smoke` passes on the published Meerkat 0.6.30 line. If it
+`mdm:real-target-smoke` and the credential-gated `mdm:real-target-e2e` pass on
+the published Meerkat 0.8.2 line. If either
 fails, treat that as a real bridge or MobKit regression rather than falling back
 to labels, demo model text, or static binding metadata.

--- a/examples/004-mdm-console-pack/run.ts
+++ b/examples/004-mdm-console-pack/run.ts
@@ -102,7 +102,10 @@ function defaultSupervisorAdvertisedAddress(bindAddress: string): string {
   return `tcp://${bindAddress}`;
 }
 
-function writeRuntimeMobConfig(args: Args, stateDir: string): {
+function writeRuntimeMobConfig(
+  args: Args,
+  stateDir: string,
+): {
   path: string;
   bindAddress: string;
   advertisedAddress: string;
@@ -128,10 +131,14 @@ advertised_address = ${tomlString(advertisedAddress)}
 }
 
 function repoCargoEnv(): Record<string, string> {
-  const result = spawnSync(join(repoRoot, "scripts/repo-cargo"), ["--print-env"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    join(repoRoot, "scripts/repo-cargo"),
+    ["--print-env"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
   if (result.status !== 0) {
     throw new Error(`repo-cargo --print-env failed:\n${result.stderr}`);
   }
@@ -145,7 +152,8 @@ function repoCargoEnv(): Record<string, string> {
 }
 
 function ensureGatewayBin(skipBuild: boolean): string {
-  if (process.env.MOBKIT_RPC_GATEWAY_BIN) return process.env.MOBKIT_RPC_GATEWAY_BIN;
+  if (process.env.MOBKIT_RPC_GATEWAY_BIN)
+    return process.env.MOBKIT_RPC_GATEWAY_BIN;
   const env = repoCargoEnv();
   const gateway = join(env.CARGO_TARGET_DIR, "debug", "rpc_gateway");
   if (!skipBuild || !existsSync(gateway)) {
@@ -270,7 +278,8 @@ class MdmTopologyProvider implements TopologyProvider {
     const identities = new Set(targetIdentities);
     const edges: ManagedPeerEdge[] = [];
     const add = (a: string, b: string) => {
-      if (identities.has(a) && identities.has(b) && a !== b) edges.push({ a, b });
+      if (identities.has(a) && identities.has(b) && a !== b)
+        edges.push({ a, b });
     };
     for (const [a, b] of scenario.links) add(a, b);
     for (const target of this.targets) add("hive", target.id);
@@ -295,16 +304,160 @@ class MdmCustomizer implements AgentCustomizer {
 
 async function getConsoleTitle(baseUrl: string): Promise<string | undefined> {
   const response = await fetch(`${baseUrl}/console/experience`);
-  if (!response.ok) throw new Error(`/console/experience returned ${response.status}`);
+  if (!response.ok)
+    throw new Error(`/console/experience returned ${response.status}`);
   const experience = (await response.json()) as {
     console_config?: { title?: string };
   };
   return experience.console_config?.title;
 }
 
+let consoleRpcSequence = 0;
+
+async function consoleRpc<T>(
+  baseUrl: string,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  consoleRpcSequence += 1;
+  const response = await fetch(`${baseUrl}/console/rpc`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: `mdm-${consoleRpcSequence}`,
+      method,
+      params,
+    }),
+  });
+  if (!response.ok)
+    throw new Error(`${method} returned HTTP ${response.status}`);
+  const payload = (await response.json()) as {
+    result?: T;
+    error?: { code?: number; message?: string };
+  };
+  if (payload.error) {
+    throw new Error(
+      `${method} RPC error ${String(payload.error.code)}: ${payload.error.message ?? "unknown error"}`,
+    );
+  }
+  return payload.result as T;
+}
+
+async function waitForConsoleTerminal(
+  baseUrl: string,
+  targetId: string,
+  interactionId: string,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    const page = await consoleRpc<{
+      frames?: Array<{
+        interaction_id?: string;
+        kind?: string;
+        payload?: Record<string, unknown>;
+      }>;
+    }>(baseUrl, "mobkit/console/query_timeline", {
+      mode: "recent",
+      identity: targetId,
+      limit: 400,
+    });
+    const frames = page.frames ?? [];
+    const failed = frames.find(
+      (frame) =>
+        frame.interaction_id === interactionId &&
+        (frame.kind === "interaction_failed" ||
+          frame.kind === "message_delivery_failed"),
+    );
+    if (failed) {
+      // Delivery failure projection can append the pending-interaction
+      // terminal just before the typed error frame. Give that frame one poll
+      // interval to land, then report the complete correlated failure set.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const failurePage = await consoleRpc<{
+        frames?: Array<{
+          interaction_id?: string;
+          kind?: string;
+          payload?: Record<string, unknown>;
+        }>;
+      }>(baseUrl, "mobkit/console/query_timeline", {
+        mode: "recent",
+        identity: targetId,
+        limit: 400,
+      });
+      const correlated = (failurePage.frames ?? []).filter(
+        (frame) => frame.interaction_id === interactionId,
+      );
+      throw new Error(
+        `${targetId} interaction failed: ${JSON.stringify(correlated)}`,
+      );
+    }
+    const completed = frames.find(
+      (frame) =>
+        frame.interaction_id === interactionId &&
+        frame.kind === "interaction_complete",
+    );
+    if (completed) {
+      const terminal = completed.payload ?? {};
+      if (Object.keys(terminal).length === 0) {
+        throw new Error(`${targetId} returned an empty terminal response`);
+      }
+      return terminal;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(
+    `timed out waiting for ${targetId} terminal response (${interactionId})`,
+  );
+}
+
+async function waitForVerifiedHiveTerminal(
+  baseUrl: string,
+  targetIds: string[],
+  responseMarker: string,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + 180_000;
+  const incomplete =
+    /\b(no (?:real )?(?:peer )?repl(?:y|ies)|not contacted|not received|unknown|could not|couldn't|cannot|can't|missing|only|invalid|null|does not|still|follow-up|without)\b/i;
+  while (Date.now() < deadline) {
+    const page = await consoleRpc<{
+      frames?: Array<{
+        kind?: string;
+        payload?: Record<string, unknown>;
+      }>;
+    }>(baseUrl, "mobkit/console/query_timeline", {
+      mode: "recent",
+      identity: "hive",
+      limit: 400,
+    });
+    for (const frame of page.frames ?? []) {
+      if (frame.kind !== "interaction_complete") continue;
+      const payload = frame.payload ?? {};
+      const response =
+        typeof payload.result === "string"
+          ? payload.result
+          : JSON.stringify(payload.result);
+      const markerCount = response.split(responseMarker).length - 1;
+      if (
+        markerCount >= targetIds.length &&
+        targetIds.every((targetId) => response.includes(targetId)) &&
+        !incomplete.test(response)
+      ) {
+        return payload;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(
+    `timed out waiting for hive to publish verified target replies (${responseMarker})`,
+  );
+}
+
 async function runRealTargetSmoke(
   handle: MobHandle,
   targets: RemoteTargetBinding[],
+  baseUrl: string,
+  waitForTerminal: boolean,
 ): Promise<void> {
   if (targets.length === 0) {
     throw new Error("real target smoke requires at least one target binding");
@@ -327,13 +480,72 @@ async function runRealTargetSmoke(
       "Report hostname, OS/kernel, current user, and whether shell tools are available.",
       "Do not answer from roster labels or binding metadata.",
     ].join(" ");
-    const result = await handle.send(target.id, prompt, { handlingMode: "queue" });
-    if (!result.accepted) {
-      throw new Error(`real target smoke was not accepted by ${target.id}`);
+    const result = await consoleRpc<{
+      interaction_id: string;
+      session_id?: string;
+      status: string;
+    }>(baseUrl, "mobkit/console/send", {
+      identity: target.id,
+      content: prompt,
+      origin: "mdm-real-target-smoke",
+      idempotency_key: `mdm-real-target-smoke-${target.id}`,
+      handling_mode: "queue",
+    });
+    if (!result.interaction_id) {
+      throw new Error(
+        `real target smoke did not reserve an interaction for ${target.id}`,
+      );
     }
-    const sessionLabel = result.sessionId || "peer-only";
+    const sessionLabel = result.session_id || "peer-only";
     console.log(
-      `[mdm-real-target-smoke] ${target.id}: accepted session=${sessionLabel}`,
+      `[mdm-real-target-smoke] ${target.id}: accepted interaction=${result.interaction_id} session=${sessionLabel}`,
+    );
+  }
+
+  if (waitForTerminal) {
+    const targetList = targets.map((target) => target.id).join(", ");
+    const responseMarker = "MDM_E2E_TARGET_RESPONSE_OK";
+    const result = await consoleRpc<{
+      interaction_id: string;
+      session_id?: string;
+      status: string;
+    }>(baseUrl, "mobkit/console/send", {
+      identity: "hive",
+      content: [
+        `Contact these managed targets through peer comms: ${targetList}.`,
+        targets.length === 1
+          ? `This fixture has exactly one visible managed peer; its cryptographic route is the durable target ${targets[0].id}.`
+          : "Match each visible managed peer to the requested target before sending.",
+        "For each target, use the correlated send_request tool (not send_message) with the supported intent checksum_token and handling_mode queue.",
+        `Ask it to inspect its local host, report hostname, OS/kernel, current user, and whether shell tools are available, and include the exact marker ${responseMarker}.`,
+        "Wait for every correlated terminal response, then return a concise per-target summary preserving that marker.",
+        "Do not infer target facts from roster labels or binding metadata.",
+      ].join(" "),
+      origin: "mdm-real-target-e2e",
+      idempotency_key: `mdm-real-target-e2e-${targetList}`,
+      handling_mode: "queue",
+    });
+    if (!result.interaction_id) {
+      throw new Error("real target E2E did not reserve a hive interaction");
+    }
+    console.log(
+      `[mdm-real-target-e2e] hive: accepted interaction=${result.interaction_id}`,
+    );
+    const terminal = await waitForConsoleTerminal(
+      baseUrl,
+      "hive",
+      result.interaction_id,
+    );
+    const verifiedTerminal = await waitForVerifiedHiveTerminal(
+      baseUrl,
+      targets.map((target) => target.id),
+      responseMarker,
+    );
+    console.log(
+      `[mdm-real-target-e2e] hive: dispatch response=${JSON.stringify(terminal)}`,
+    );
+    console.log(
+      `[mdm-real-target-e2e] hive: verified target response=${JSON.stringify(verifiedTerminal)}`,
     );
   }
 }
@@ -342,10 +554,13 @@ async function main() {
   const args = parseArgs();
   const skipBuild = Boolean(args["skip-build"]);
   const smoke = Boolean(args.smoke);
-  const realTargetSmoke = Boolean(args["real-target-smoke"]);
+  const realTargetE2e = Boolean(args["real-target-e2e"]);
+  const realTargetSmoke = Boolean(args["real-target-smoke"]) || realTargetE2e;
   const wait = Boolean(args.wait) || Boolean(args["browser-smoke"]);
   const hiveKickoff = stringArg(args, "hive-kickoff");
-  const useDemoLlm = Boolean(args["demo-llm"]) || !process.env.OPENAI_API_KEY;
+  const useDemoLlm =
+    Boolean(args["demo-llm"]) ||
+    (!Boolean(args["real-llm"]) && !process.env.OPENAI_API_KEY);
   const targets = readTargetBindings(args);
   if (targets.length === 0 && !Boolean(args["allow-empty-targets"])) {
     throw new Error(
@@ -363,6 +578,7 @@ async function main() {
     .consoleConfig(join(configDir, "console.toml"))
     .consoleAuthRequired(false)
     .consoleFetchTimeoutMs(120_000)
+    .memberCommsTcp(process.env.MDM_MEMBER_COMMS_ADDRESS ?? "127.0.0.1:0")
     .persistentState(stateDir)
     .rosterProvider(new MdmRosterProvider(targets))
     .topologyProvider(new MdmTopologyProvider(targets))
@@ -379,9 +595,11 @@ async function main() {
       remote_topology: "mob-roster",
       supervisor_bridge: mobConfig.advertisedAddress,
     });
-    await handle.reconcileEdges();
+    const edgeReport = await handle.reconcileEdges();
+    console.log(`[mdm] topology: ${JSON.stringify(edgeReport)}`);
     const baseUrl = runtime.rustHttpBaseUrl;
-    if (!baseUrl) throw new Error("MobKit runtime did not expose an HTTP console URL");
+    if (!baseUrl)
+      throw new Error("MobKit runtime did not expose an HTTP console URL");
     console.log(`[mdm] console: ${baseUrl}/console`);
     console.log(`[mdm] remote-targets: ${targets.length}`);
     console.log(`[mdm] supervisor-bridge: ${mobConfig.advertisedAddress}`);
@@ -393,8 +611,9 @@ async function main() {
       }
     }
     if (realTargetSmoke) {
-      await runRealTargetSmoke(handle, targets);
+      await runRealTargetSmoke(handle, targets, baseUrl, realTargetE2e);
       console.log("[mdm-real-target-smoke] ok");
+      if (realTargetE2e) console.log("[mdm-real-target-e2e] ok");
     }
     if (smoke) {
       console.log("[mdm-smoke] ok");

--- a/examples/004-mdm-console-pack/scripts/real-target-smoke.sh
+++ b/examples/004-mdm-console-pack/scripts/real-target-smoke.sh
@@ -11,79 +11,121 @@ repo_root="$(cd "${examples_dir}/.." && pwd)"
 # directly (bypassing the workspace .cargo/config.toml [env] section).
 export RUST_MIN_STACK="${RUST_MIN_STACK:-33554432}"
 
-target_listen="${MDM_REAL_TARGET_SMOKE_LISTEN:-127.0.0.1:5807}"
-supervisor_bind="${MDM_REAL_TARGET_SMOKE_SUPERVISOR_BIND:-127.0.0.1:5808}"
+pick_loopback_port() {
+  node -e 'const net=require("node:net"); const s=net.createServer(); s.listen(0,"127.0.0.1",()=>{console.log(s.address().port);s.close();});'
+}
+
+supervisor_bind="${MDM_REAL_TARGET_SMOKE_SUPERVISOR_BIND:-127.0.0.1:$(pick_loopback_port)}"
+real_target_e2e="${MDM_REAL_TARGET_E2E:-0}"
+target_count="${MDM_REAL_TARGET_COUNT:-1}"
+if [[ ! "$target_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MDM_REAL_TARGET_COUNT must be a positive integer" >&2
+  exit 2
+fi
+if [[ "$target_count" -gt 1 && -n "${MDM_REAL_TARGET_SMOKE_LISTEN:-}" ]]; then
+  echo "MDM_REAL_TARGET_SMOKE_LISTEN is only valid with one target" >&2
+  exit 2
+fi
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/mdm-real-target-smoke.XXXXXX")"
-target_pid=""
+declare -a target_pids=()
+declare -a binding_files=()
+declare -a target_logs=()
 
 cleanup() {
-  if [[ -n "$target_pid" ]]; then
+  for target_pid in "${target_pids[@]}"; do
     kill "$target_pid" 2>/dev/null || true
     wait "$target_pid" 2>/dev/null || true
+  done
+  if [[ "${MDM_KEEP_TMP:-0}" == "1" ]]; then
+    echo "[mdm-real-target-smoke] retained state at ${tmp_dir}" >&2
+  else
+    rm -rf "$tmp_dir"
   fi
-  rm -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
-binding_file="${tmp_dir}/target.json"
-target_data_dir="${tmp_dir}/target-state"
+targets_file="${tmp_dir}/targets.json"
 
 cd "$repo_root"
 ./scripts/repo-cargo build -p meerkat-mobkit --example mdm_mob_target
 target_bin="$(./scripts/repo-cargo --print-env | awk -F= '$1 == "CARGO_TARGET_DIR" { print $2 }')/debug/examples/mdm_mob_target"
 
-"$target_bin" \
-  --id target-smoke \
-  --name target-smoke \
-  --listen "$target_listen" \
-  --data-dir "$target_data_dir" \
-  --binding-out "$binding_file" \
-  --model "${MDM_TARGET_MODEL:-gpt-5.5}" \
-  --provider "${MDM_TARGET_PROVIDER:-openai}" \
-  >"${tmp_dir}/target.log" 2>&1 &
-target_pid="$!"
-
-for _ in {1..120}; do
-  [[ -s "$binding_file" ]] && break
-  sleep 0.5
+for target_index in $(seq 1 "$target_count"); do
+  target_id="target-smoke-${target_index}"
+  target_listen="${MDM_REAL_TARGET_SMOKE_LISTEN:-127.0.0.1:$(pick_loopback_port)}"
+  binding_file="${tmp_dir}/${target_id}.json"
+  target_data_dir="${tmp_dir}/${target_id}-state"
+  target_log="${tmp_dir}/${target_id}.log"
+  "$target_bin" \
+    --id "$target_id" \
+    --name "$target_id" \
+    --listen "$target_listen" \
+    --data-dir "$target_data_dir" \
+    --binding-out "$binding_file" \
+    --model "${MDM_TARGET_MODEL:-gpt-5.5}" \
+    --provider "${MDM_TARGET_PROVIDER:-openai}" \
+    >"$target_log" 2>&1 &
+  target_pids+=("$!")
+  binding_files+=("$binding_file")
+  target_logs+=("$target_log")
 done
 
-if [[ ! -s "$binding_file" ]]; then
-  echo "[mdm-real-target-smoke] target did not write binding" >&2
-  tail -100 "${tmp_dir}/target.log" >&2 || true
-  exit 1
-fi
+for binding_file in "${binding_files[@]}"; do
+  for _ in {1..120}; do
+    [[ -s "$binding_file" ]] && break
+    sleep 0.5
+  done
+  if [[ ! -s "$binding_file" ]]; then
+    echo "[mdm-real-target-smoke] target did not write ${binding_file}" >&2
+    for target_log in "${target_logs[@]}"; do
+      tail -100 "$target_log" >&2 || true
+    done
+    exit 1
+  fi
+done
+node "${pack_dir}/scripts/merge-bindings.mjs" "$targets_file" "${binding_files[@]}" >/dev/null
 
 cd "$examples_dir"
+console_args=(
+  --targets "$targets_file"
+  --state-dir "${tmp_dir}/console-state"
+  --real-target-smoke
+  --smoke
+)
+if [[ "$real_target_e2e" == "1" ]]; then
+  console_args+=(--real-target-e2e --real-llm)
+else
+  console_args+=(--demo-llm)
+fi
 set +e
 MDM_SUPERVISOR_BIND_ADDRESS="$supervisor_bind" \
 MDM_SUPERVISOR_ADVERTISED_ADDRESS="tcp://${supervisor_bind}" \
 npx tsx 004-mdm-console-pack/run.ts \
-  --targets "$binding_file" \
-  --state-dir "${tmp_dir}/console-state" \
-  --real-target-smoke \
-  --smoke \
-  --demo-llm
-status=$?
+  "${console_args[@]}"
+run_status=$?
 set -e
 
-if [[ "$status" -ne 0 ]]; then
-  echo "[mdm-real-target-smoke] console bind failed; target log follows" >&2
-  tail -100 "${tmp_dir}/target.log" >&2 || true
-else
-  peer_seen=""
-  for _ in {1..60}; do
-    if grep -q "\\[mdm-target\\] peer turn accepted:" "${tmp_dir}/target.log"; then
-      peer_seen="yes"
-      break
-    fi
-    sleep 0.5
+if [[ "$run_status" -ne 0 ]]; then
+  echo "[mdm-real-target-smoke] console run failed; target logs follow" >&2
+  for target_log in "${target_logs[@]}"; do
+    tail -100 "$target_log" >&2 || true
   done
-  if [[ -z "$peer_seen" ]]; then
-    echo "[mdm-real-target-smoke] target never observed a peer turn; target log follows" >&2
-    tail -100 "${tmp_dir}/target.log" >&2 || true
-    exit 1
-  fi
+else
+  for target_log in "${target_logs[@]}"; do
+    peer_seen=""
+    for _ in {1..60}; do
+      if grep -q "\\[mdm-target\\] peer turn accepted:" "$target_log"; then
+        peer_seen="yes"
+        break
+      fi
+      sleep 0.5
+    done
+    if [[ -z "$peer_seen" ]]; then
+      echo "[mdm-real-target-smoke] a target never observed a peer turn: ${target_log}" >&2
+      tail -100 "$target_log" >&2 || true
+      exit 1
+    fi
+  done
 fi
 
-exit "$status"
+exit "$run_status"

--- a/examples/004-mdm-console-pack/target.rs
+++ b/examples/004-mdm-console-pack/target.rs
@@ -8,7 +8,8 @@ use meerkat::{AgentFactory, FactoryAgentBuilder, PersistenceBundle, PersistentSe
 use meerkat_core::lifecycle::RunId;
 use meerkat_core::lifecycle::core_executor::{
     CoreApplyOutput, CoreExecutor, CoreExecutorBoundaryHandle, CoreExecutorError,
-    CoreExecutorInterruptHandle,
+    CoreExecutorInterruptHandle, CoreExecutorPostStopCleanupHandle, CoreExecutorPublicationHandle,
+    CoreExecutorTurnFinalizationBoundaryHandle,
 };
 use meerkat_core::lifecycle::run_primitive::{
     ConversationContextAppend, RunApplyBoundary, RunPrimitive,
@@ -74,6 +75,55 @@ struct TargetCoreExecutor {
     session_id: SessionId,
 }
 
+struct TargetCorePostStopCleanupHandle {
+    service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
+    mob_state: Arc<MobMcpState>,
+    session_id: SessionId,
+}
+
+#[async_trait::async_trait]
+impl CoreExecutorPostStopCleanupHandle for TargetCorePostStopCleanupHandle {
+    async fn cleanup_after_runtime_stop_terminalized(&self) -> Result<(), CoreExecutorError> {
+        meerkat::surface::persistent_runtime_post_stop_cleanup_handle(
+            Arc::clone(&self.service),
+            self.session_id.clone(),
+        )
+        .cleanup_after_runtime_stop_terminalized()
+        .await?;
+        self.mob_state
+            .destroy_bridge_session_mobs(&self.session_id.to_string())
+            .await
+            .map_err(|error| {
+                CoreExecutorError::control_failed_runtime(format!(
+                    "failed to clean up target mobs for session {}: {error}",
+                    self.session_id
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn cleanup_after_runtime_stop_terminalized_under_turn_finalization_boundary(
+        &self,
+    ) -> Result<(), CoreExecutorError> {
+        meerkat::surface::persistent_runtime_post_stop_cleanup_handle(
+            Arc::clone(&self.service),
+            self.session_id.clone(),
+        )
+        .cleanup_after_runtime_stop_terminalized_under_turn_finalization_boundary()
+        .await?;
+        self.mob_state
+            .destroy_bridge_session_mobs(&self.session_id.to_string())
+            .await
+            .map_err(|error| {
+                CoreExecutorError::control_failed_runtime(format!(
+                    "failed to clean up target mobs for session {}: {error}",
+                    self.session_id
+                ))
+            })?;
+        Ok(())
+    }
+}
+
 impl TargetCoreExecutor {
     fn new(
         service: Arc<PersistentSessionService<FactoryAgentBuilder>>,
@@ -116,6 +166,16 @@ impl CoreExecutorBoundaryHandle for TargetCoreBoundaryHandle {
             })
             .map_err(|error| CoreExecutorError::control_failed_runtime(error.to_string()))
     }
+
+    async fn prepare_system_context_at_boundary(
+        &self,
+        expected_run_id: &RunId,
+        appends: Vec<PendingSystemContextAppend>,
+    ) -> Result<meerkat_core::CoreBoundaryStageOutput, meerkat_core::CoreBoundaryStageError> {
+        self.service
+            .prepare_live_system_context_boundary(&self.session_id, expected_run_id, appends)
+            .await
+    }
 }
 
 struct TargetCoreInterruptHandle {
@@ -154,6 +214,36 @@ impl CoreExecutor for TargetCoreExecutor {
         }))
     }
 
+    fn publication_handle(&self) -> Option<Arc<dyn CoreExecutorPublicationHandle>> {
+        Some(meerkat::surface::persistent_runtime_publication_handle(
+            Arc::clone(&self.service),
+            self.session_id.clone(),
+        ))
+    }
+
+    fn machine_managed_post_stop_unregister(&self) -> bool {
+        true
+    }
+
+    fn post_stop_cleanup_handle(&self) -> Option<Arc<dyn CoreExecutorPostStopCleanupHandle>> {
+        Some(Arc::new(TargetCorePostStopCleanupHandle {
+            service: Arc::clone(&self.service),
+            mob_state: Arc::clone(&self.mob_state),
+            session_id: self.session_id.clone(),
+        }))
+    }
+
+    fn turn_finalization_boundary_handle(
+        &self,
+    ) -> Option<Arc<dyn CoreExecutorTurnFinalizationBoundaryHandle>> {
+        Some(
+            meerkat::surface::persistent_runtime_turn_finalization_boundary_handle(
+                Arc::clone(&self.service),
+                self.session_id.clone(),
+            ),
+        )
+    }
+
     async fn apply(
         &mut self,
         run_id: RunId,
@@ -173,8 +263,12 @@ impl CoreExecutor for TargetCoreExecutor {
             }
             _ => Vec::new(),
         };
-        let prompt = primitive.extract_content_input();
-        let prompt_preview = match &prompt {
+        // Supervisor-bridge deliveries arrive as typed system notices. Their
+        // durable authorship stays in `typed_turn_appends`; only the preview
+        // uses the provider-facing projection so remote work is visible in
+        // diagnostics without flattening it into a fabricated user prompt.
+        let prompt_preview_input = primitive.model_projection_content_input();
+        let prompt_preview = match &prompt_preview_input {
             ContentInput::Text(text) => text.replace('\n', " "),
             ContentInput::Blocks(blocks) => format!("{} content blocks", blocks.len()),
         };
@@ -183,7 +277,7 @@ impl CoreExecutor for TargetCoreExecutor {
             prompt_preview.chars().take(160).collect::<String>()
         );
         let req = StartTurnRequest {
-            prompt,
+            prompt: primitive.extract_content_input(),
             injected_context: Vec::new(),
             system_prompt: None,
             event_tx: None,
@@ -196,7 +290,8 @@ impl CoreExecutor for TargetCoreExecutor {
                 metadata.and_then(|meta| meta.turn_tool_overlay.clone()),
                 pre_turn_context_appends,
                 metadata.cloned(),
-            ),
+            )
+            .with_typed_turn_appends(primitive.typed_turn_appends()),
         };
         let boundary = match &primitive {
             RunPrimitive::StagedInput(staged) => staged.boundary,
@@ -205,6 +300,56 @@ impl CoreExecutor for TargetCoreExecutor {
         let input_ids = primitive.contributing_input_ids().to_vec();
         self.service
             .apply_runtime_turn(&self.session_id, run_id, req, boundary, input_ids)
+            .await
+            .map_err(CoreExecutorError::apply_failed_from_session_error)
+    }
+
+    async fn reconcile_committed_compaction_projections(
+        &mut self,
+        intents: &[meerkat_core::CompactionProjectionIntent],
+    ) -> Result<(), CoreExecutorError> {
+        self.service
+            .reconcile_runtime_compaction_projections(&self.session_id, intents.to_vec())
+            .await
+            .map_err(|error| CoreExecutorError::Internal(error.to_string()))
+    }
+
+    async fn abort_uncommitted_compaction_projections(&mut self) -> Result<(), CoreExecutorError> {
+        self.service
+            .abort_uncommitted_compaction_projections(&self.session_id)
+            .await
+            .map_err(|error| CoreExecutorError::Internal(error.to_string()))
+    }
+
+    async fn abort_rejected_run_projections(&mut self) -> Result<(), CoreExecutorError> {
+        self.service
+            .abort_rejected_runtime_run_projections(&self.session_id)
+            .await
+            .map_err(|error| CoreExecutorError::Internal(error.to_string()))
+    }
+
+    async fn checkpoint_committed_session_snapshot(
+        &mut self,
+        session_snapshot: &[u8],
+    ) -> Result<(), CoreExecutorError> {
+        self.service
+            .checkpoint_committed_runtime_session_snapshot_under_runtime_turn_boundary(
+                &self.session_id,
+                session_snapshot,
+            )
+            .await
+            .map_err(CoreExecutorError::apply_failed_from_session_error)
+    }
+
+    async fn publish_interaction_terminals(
+        &mut self,
+        events: &[meerkat_core::AgentEvent],
+    ) -> Result<
+        Vec<meerkat_core::lifecycle::core_executor::CoreInteractionTerminalPublicationReceipt>,
+        CoreExecutorError,
+    > {
+        self.service
+            .publish_interaction_terminals_exact_batch(&self.session_id, events)
             .await
             .map_err(CoreExecutorError::apply_failed_from_session_error)
     }
@@ -224,22 +369,17 @@ impl CoreExecutor for TargetCoreExecutor {
     }
 
     async fn stop_runtime_executor(&mut self, _reason: String) -> Result<(), CoreExecutorError> {
-        let discard_result = self.service.discard_live_session(&self.session_id).await;
-        if let Err(error) = Box::pin(
-            self.mob_state
-                .destroy_bridge_session_mobs(&self.session_id.to_string()),
-        )
+        Ok(())
+    }
+
+    async fn cleanup_after_runtime_stop_terminalized(&mut self) -> Result<(), CoreExecutorError> {
+        TargetCorePostStopCleanupHandle {
+            service: Arc::clone(&self.service),
+            mob_state: Arc::clone(&self.mob_state),
+            session_id: self.session_id.clone(),
+        }
+        .cleanup_after_runtime_stop_terminalized()
         .await
-        {
-            eprintln!(
-                "[mdm-target] warning: cleanup mobs for session {}: {error}",
-                self.session_id
-            );
-        }
-        match discard_result {
-            Ok(()) | Err(SessionError::NotFound { .. }) => Ok(()),
-            Err(error) => Err(CoreExecutorError::control_failed_runtime(error.to_string())),
-        }
     }
 }
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,6 +11,8 @@
     "mdm:smoke": "tsx 004-mdm-console-pack/ts_smoke.ts",
     "mdm:browser-smoke": "node 004-mdm-console-pack/browser_smoke.cjs",
     "mdm:real-target-smoke": "004-mdm-console-pack/scripts/real-target-smoke.sh",
+    "mdm:real-target-e2e": "MDM_REAL_TARGET_E2E=1 004-mdm-console-pack/scripts/real-target-smoke.sh",
+    "mdm:real-target-multi-e2e": "MDM_REAL_TARGET_E2E=1 MDM_REAL_TARGET_COUNT=2 004-mdm-console-pack/scripts/real-target-smoke.sh",
     "mdm:upgrade-meerkat": "004-mdm-console-pack/scripts/use-meerkat-version.sh",
     "mdm:local-target": "004-mdm-console-pack/scripts/local-target.sh start",
     "mdm:console": "004-mdm-console-pack/scripts/start-console.sh",

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -82,6 +82,9 @@ struct GatewayRuntimeOptions {
     console_fetch_timeout_ms: Option<u64>,
     access: Option<meerkat_mobkit::AccessController>,
     demo_llm: bool,
+    /// Bind each locally hosted member to a signed loopback TCP endpoint so
+    /// peer-only external members in another process can return traffic.
+    member_comms_address: Option<String>,
     agent_memory: Option<GatewayAgentMemoryOptions>,
     /// WorkGraph service construction switch (default on). `false` disables
     /// the store, member tools, overlays, and the mobkit/workgraph/* RPCs.
@@ -192,12 +195,22 @@ impl Default for GatewayRuntimeOptions {
             console_fetch_timeout_ms: None,
             access: None,
             demo_llm: false,
+            member_comms_address: None,
             agent_memory: None,
             workgraph: GatewayWorkgraphOption::Enabled,
             live: GatewayLiveOption::Disabled,
             host_runnables: Vec::new(),
         }
     }
+}
+
+fn gateway_agent_config(options: &GatewayRuntimeOptions) -> Config {
+    let mut config = Config::default();
+    if let Some(address) = options.member_comms_address.as_ref() {
+        config.comms.mode = meerkat_core::CommsRuntimeMode::Tcp;
+        config.comms.address = Some(address.clone());
+    }
+    config
 }
 
 #[derive(Default)]
@@ -760,6 +773,22 @@ actions = ["agent.view"]
         let options = parse_gateway_runtime_options(&params, None).expect("runtime options");
 
         assert!(options.demo_llm);
+    }
+
+    #[test]
+    fn gateway_runtime_options_parse_member_comms_address() {
+        let params = json!({
+            "runtime_options": {
+                "member_comms_address": "127.0.0.1:0"
+            }
+        });
+
+        let options = parse_gateway_runtime_options(&params, None).expect("runtime options");
+
+        assert_eq!(options.member_comms_address.as_deref(), Some("127.0.0.1:0"));
+        let config = gateway_agent_config(&options);
+        assert_eq!(config.comms.mode, meerkat_core::CommsRuntimeMode::Tcp);
+        assert_eq!(config.comms.address.as_deref(), Some("127.0.0.1:0"));
     }
 
     #[test]
@@ -2170,6 +2199,7 @@ fn parse_gateway_runtime_options(
         "console_read_only",
         "console_fetch_timeout_ms",
         "demo_llm",
+        "member_comms_address",
         "max_sessions",
         "event_log",
         "agent_memory",
@@ -2352,6 +2382,21 @@ fn parse_gateway_runtime_options(
         parsed.demo_llm = value
             .as_bool()
             .ok_or_else(|| "runtime_options.demo_llm must be a boolean".to_string())?;
+    }
+    if let Some(value) = runtime_options.get("member_comms_address") {
+        let address = value.as_str().ok_or_else(|| {
+            "runtime_options.member_comms_address must be a socket address string".to_string()
+        })?;
+        let socket = address
+            .parse::<std::net::SocketAddr>()
+            .map_err(|error| format!("runtime_options.member_comms_address is invalid: {error}"))?;
+        if socket.ip().is_unspecified() {
+            return Err(
+                "runtime_options.member_comms_address must name a concrete interface; wildcard binds cannot be advertised to external peers"
+                    .to_string(),
+            );
+        }
+        parsed.member_comms_address = Some(address.to_string());
     }
     if let Some(value) = runtime_options.get("max_sessions") {
         let max_sessions = value
@@ -4531,7 +4576,8 @@ external_addressable = true
         // the builder consumes it.
         let live_agent_factory = factory.clone();
         let live_machine = Arc::clone(&adapter);
-        let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+        let mut inner_builder =
+            FactoryAgentBuilder::new(factory, gateway_agent_config(&gateway_options));
         inner_builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
             session_store.clone(),
         )));
@@ -4695,7 +4741,8 @@ external_addressable = true
         if image_generation {
             factory = factory.with_image_generation_machine(adapter.clone());
         }
-        let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+        let mut inner_builder =
+            FactoryAgentBuilder::new(factory, gateway_agent_config(&gateway_options));
         inner_builder.default_blob_store = Some(blob_store.clone());
         // No-persistent_state launches default to a memory-backed
         // workgraph (tools stay profile-gated, so nothing changes for
@@ -4763,7 +4810,8 @@ external_addressable = true
                 if image_generation {
                     factory = factory.with_image_generation_machine(adapter.clone());
                 }
-                let mut inner_builder = FactoryAgentBuilder::new(factory, Config::default());
+                let mut inner_builder =
+                    FactoryAgentBuilder::new(factory, gateway_agent_config(&gateway_options));
                 inner_builder.default_session_store = Some(Arc::new(
                     meerkat_store::StoreAdapter::new(session_store.clone()),
                 ));

--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -2393,12 +2393,35 @@ fn stale_durable_session_mismatch<'a>(
     live_records: &'a [ConsoleIdentityRecord],
 ) -> Option<&'a ConsoleIdentityRecord> {
     live_records.iter().find(|record| {
-        record.identity == durable.identity
-            && record.runtime_member_id == durable.runtime_member_id
+        live_record_realizes_durable_binding(durable, record)
             && durable.session_id.is_some()
             && record.session_id.is_some()
             && durable.session_id != record.session_id
     })
+}
+
+/// Whether a live roster row is the bridge-authorized realization of a
+/// durable identity binding.
+///
+/// Session-backed identities use their generated `rt:<identity>:<generation>`
+/// alias directly. External peer bindings are intentionally different: the
+/// Meerkat bridge gives the peer a stable durable roster name and records the
+/// durable owner in the runtime-authoritative `agent_identity` label. Raw
+/// member creation cannot supply that label, so accepting this exact mapping
+/// preserves stale-generation fencing without mistaking the external member
+/// for an unrelated raw alias.
+fn live_record_realizes_durable_binding(
+    durable: &ConsoleIdentityRecord,
+    live: &ConsoleIdentityRecord,
+) -> bool {
+    if live.identity != durable.identity {
+        return false;
+    }
+    if live.runtime_member_id == durable.runtime_member_id {
+        return true;
+    }
+    crate::member_comms_id::durable_identity_label(&live.labels)
+        .is_some_and(|identity| live.runtime_member_id == identity)
 }
 
 fn stale_durable_record_error(
@@ -2432,7 +2455,7 @@ fn stale_durable_record_error(
     }
     if matching_live
         .iter()
-        .any(|record| record.runtime_member_id == durable.runtime_member_id)
+        .any(|record| live_record_realizes_durable_binding(durable, record))
     {
         return None;
     }
@@ -4807,7 +4830,31 @@ async fn authoritative_durable_sendable_member_index(
             if !Box::pin(console_identity_record_visible(entry, &record)).await {
                 continue;
             }
-            bindings.insert((entry.runtime_key.clone(), runtime_id.as_str().to_string()));
+            let mut projected_member_ids = BTreeSet::new();
+            for index in sendable_indices {
+                let resolved = &matches[*index];
+                if resolved.entry.runtime_key != entry.runtime_key {
+                    continue;
+                }
+                let Some(live_record) = identity_record_for_resolved_member(resolved).await else {
+                    continue;
+                };
+                if live_record_realizes_durable_binding(&record, &live_record)
+                    && stale_durable_session_mismatch(&record, std::slice::from_ref(&live_record))
+                        .is_none()
+                {
+                    projected_member_ids.insert(live_record.runtime_member_id);
+                }
+            }
+            if projected_member_ids.is_empty() {
+                bindings.insert((entry.runtime_key.clone(), runtime_id.as_str().to_string()));
+            } else {
+                bindings.extend(
+                    projected_member_ids
+                        .into_iter()
+                        .map(|member_id| (entry.runtime_key.clone(), member_id)),
+                );
+            }
         }
     }
 
@@ -6223,6 +6270,42 @@ comms = true
             err.contains("session-durable") && err.contains("session-live"),
             "error should name both sessions: {err}"
         );
+    }
+
+    #[test]
+    fn stable_external_member_alias_realizes_generated_durable_binding() {
+        let mut durable = identity_record_for_test("target-smoke");
+        durable.runtime_member_id = "rt:target-smoke:0".to_string();
+
+        let mut live = durable.clone();
+        live.runtime_member_id = "target-smoke".to_string();
+        live.labels
+            .insert("agent_identity".to_string(), "target-smoke".to_string());
+
+        assert!(live_record_realizes_durable_binding(&durable, &live));
+        assert_eq!(
+            stale_durable_record_error("target-smoke", &durable, &[live]),
+            None,
+            "the bridge-owned stable alias must not be classified as a stale generated binding"
+        );
+    }
+
+    #[test]
+    fn stable_external_member_alias_still_fences_session_split_brain() {
+        let mut durable = identity_record_for_test("target-smoke");
+        durable.runtime_member_id = "rt:target-smoke:0".to_string();
+        durable.session_id = Some("session-durable".to_string());
+
+        let mut live = durable.clone();
+        live.runtime_member_id = "target-smoke".to_string();
+        live.session_id = Some("session-live".to_string());
+        live.labels
+            .insert("agent_identity".to_string(), "target-smoke".to_string());
+
+        let error = stale_durable_record_error("target-smoke", &durable, &[live])
+            .expect("stable aliases must not hide a session split-brain");
+        assert!(error.contains("session-durable"));
+        assert!(error.contains("session-live"));
     }
 
     async fn identity_runtime_for_test(

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -1016,11 +1016,10 @@ async fn console_send_identity_first(
                     .await;
                 if let Some(events) = console_events {
                     events
-                        .record_lifecycle(
+                        .record_interaction_failure(
                             identity.as_str(),
-                            "interaction_failed",
+                            accepted.interaction_id.as_str(),
                             json!({
-                                "interaction_id": accepted.interaction_id,
                                 "origin": request.origin,
                                 "error": err.to_string(),
                             }),
@@ -1090,11 +1089,10 @@ async fn console_send_identity_first(
                     .await;
                 if let Some(events) = dispatch_events {
                     events
-                        .record_lifecycle(
+                        .record_interaction_failure(
                             dispatch_identity.as_str(),
-                            "interaction_failed",
+                            dispatch_accepted.interaction_id.as_str(),
                             json!({
-                                "interaction_id": dispatch_accepted.interaction_id,
                                 "origin": dispatch_origin,
                                 "error": err.to_string(),
                             }),

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -1702,11 +1702,28 @@ impl SessionBridge for MobSessionBridge {
                 meerkat_mob::AgentIdentity::from(member_b.as_str()),
             ));
         }
-        self.handle
-            .wire_members_batch(member_edges)
-            .await
-            .map(|_| ())
-            .map_err(|e| BridgeError::Mob(e.to_string()))
+        match self.handle.wire_members_batch(member_edges.clone()).await {
+            Ok(_) => Ok(()),
+            Err(error)
+                if error
+                    .to_string()
+                    .contains("does not support legacy external (peer-only) members") =>
+            {
+                // Meerkat's dense batch operation is intentionally local-only.
+                // Its ordinary wire command is the generated reciprocal-trust
+                // authority for local↔peer-only edges, so retry the normalized
+                // edge set through that existing operation instead of
+                // fabricating an external-peer side channel.
+                for (member_a, member_b) in member_edges {
+                    self.handle
+                        .wire(member_a, member_b)
+                        .await
+                        .map_err(|error| BridgeError::Mob(error.to_string()))?;
+                }
+                Ok(())
+            }
+            Err(error) => Err(BridgeError::Mob(error.to_string())),
+        }
     }
 
     async fn current_member_wires(

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -50,6 +50,19 @@ fn durable_spec_uses_external_binding(spec: &DurableAgentSpec) -> bool {
         )
 }
 
+fn interaction_id_for_delivery<'a>(
+    spec: &DurableAgentSpec,
+    interaction_id: Option<&'a str>,
+) -> Option<&'a str> {
+    // Meerkat 0.8.2 deliberately rejects transcript interaction ids on
+    // remotely hosted / peer-only member turns: that metadata carrier is not
+    // representable on the wire path. MobKit still correlates the response
+    // through its pending-interaction ledger and the peer terminal event.
+    (!durable_spec_uses_external_binding(spec))
+        .then_some(interaction_id)
+        .flatten()
+}
+
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
@@ -5986,7 +5999,7 @@ impl IdentityRuntime {
         }
 
         let mut token = self.ensure_active_lease(identity).await?;
-        let (runtime_id, memory_session_key, memory_generation) = {
+        let (runtime_id, memory_session_key, memory_generation, bridge_interaction_id) = {
             let entries = self.entries.read().await;
             let entry = entries
                 .get(identity)
@@ -5999,6 +6012,7 @@ impl IdentityRuntime {
                 // Scopes the injector's cross-turn dedup + cumulative budget.
                 entry.continuity.as_ref().map(|c| c.session_id.to_string()),
                 entry.continuity.as_ref().map(|c| c.generation.get()),
+                interaction_id_for_delivery(&entry.spec, interaction_id),
             )
         };
         // Steer is latency-sensitive live operator input: it bypasses both
@@ -6046,7 +6060,7 @@ impl IdentityRuntime {
                     &content_to_deliver,
                     &injected_context,
                     handling_mode,
-                    interaction_id,
+                    bridge_interaction_id,
                 )
                 .await
                 .map_err(|e| IdentityRuntimeError::Internal(format!("bridge deliver: {e}")))?;
@@ -9042,6 +9056,25 @@ mod reset_reprofile_tests {
             backend: None,
             binding: None,
         }
+    }
+
+    #[test]
+    fn external_delivery_omits_unrepresentable_interaction_id_carrier()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identity = AgentIdentity::parse("target-smoke")?;
+        let mut external = durable_spec(identity.clone(), "target");
+        external.backend = Some(meerkat_mob::MobBackendKind::External);
+        assert_eq!(
+            interaction_id_for_delivery(&external, Some("interaction-1")),
+            None
+        );
+
+        let local = durable_spec(identity, "target");
+        assert_eq!(
+            interaction_id_for_delivery(&local, Some("interaction-1")),
+            Some("interaction-1")
+        );
+        Ok(())
     }
 
     async fn lazy_context_with_broken_retained_lease(

--- a/meerkat-mobkit/src/unified_runtime/console_events.rs
+++ b/meerkat-mobkit/src/unified_runtime/console_events.rs
@@ -351,6 +351,47 @@ impl ConsoleEventStore {
         self.append(identity, None, event_type, data).await;
     }
 
+    /// Terminalize one exact pending interaction without classifying the
+    /// failure itself as an identity lifecycle mutation.
+    pub(crate) async fn record_interaction_failure(
+        &self,
+        identity: &str,
+        interaction_id: &str,
+        data: Value,
+    ) {
+        {
+            let mut state = self.state.write().await;
+            if let Some(queue) = state.pending_by_identity.get_mut(identity) {
+                if let Some(position) = queue
+                    .iter()
+                    .position(|pending| pending.interaction_id == interaction_id)
+                {
+                    queue.remove(position);
+                }
+                if queue.is_empty() {
+                    state.pending_by_identity.remove(identity);
+                }
+            }
+            if state
+                .active_interaction_by_identity
+                .get(identity)
+                .is_some_and(|active| active == interaction_id)
+            {
+                state.active_interaction_by_identity.remove(identity);
+            }
+            state
+                .response_phase_by_identity
+                .insert(identity.to_string(), None);
+        }
+        self.append(
+            identity,
+            Some(interaction_id.to_string()),
+            "interaction_failed",
+            data,
+        )
+        .await;
+    }
+
     pub(crate) async fn project_unified_event(&self, event: &EventEnvelope<UnifiedEvent>) {
         let UnifiedEvent::Agent {
             agent_id,
@@ -864,6 +905,54 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(projected.len(), 1);
         assert_eq!(projected[0].interaction_id.as_deref(), Some("turn-1"));
+    }
+
+    #[tokio::test]
+    async fn exact_delivery_failure_preserves_error_and_other_pending_interactions() {
+        let store = ConsoleEventStore::new();
+        for interaction_id in ["turn-1", "turn-2"] {
+            store
+                .reserve_interaction_value(
+                    "worker",
+                    Some("rt:worker:1"),
+                    interaction_id,
+                    "console",
+                    json!({ "interaction": interaction_id }),
+                )
+                .await
+                .expect("reserve interaction");
+        }
+
+        store
+            .record_interaction_failure(
+                "worker",
+                "turn-1",
+                json!({ "error": "typed delivery failure" }),
+            )
+            .await;
+
+        let replay = store
+            .replay_all(None)
+            .await
+            .expect("all-events replay should succeed");
+        let failure = replay
+            .iter()
+            .find(|event| event.interaction_id.as_deref() == Some("turn-1"))
+            .expect("failed interaction should be projected");
+        assert_eq!(failure.event_type, "interaction_failed");
+        assert_eq!(failure.data["error"], "typed delivery failure");
+        assert!(
+            store
+                .state
+                .read()
+                .await
+                .pending_by_identity
+                .get("worker")
+                .is_some_and(|pending| pending
+                    .iter()
+                    .any(|entry| entry.interaction_id == "turn-2")),
+            "an unrelated queued interaction must remain pending"
+        );
     }
 
     #[tokio::test]

--- a/sdk/typescript/src/builder.ts
+++ b/sdk/typescript/src/builder.ts
@@ -106,6 +106,7 @@ export interface MobKitBuilderConfig {
   consoleReadOnly: boolean | null;
   consoleFetchTimeoutMs: number | null;
   demoLlm: boolean;
+  memberCommsAddress: string | null;
   gatingConfigPath: string | null;
   routingConfigPath: string | null;
   schedulingFiles: string[];
@@ -142,6 +143,7 @@ function defaultConfig(): MobKitBuilderConfig {
     consoleReadOnly: null,
     consoleFetchTimeoutMs: null,
     demoLlm: false,
+    memberCommsAddress: null,
     gatingConfigPath: null,
     routingConfigPath: null,
     schedulingFiles: [],
@@ -249,6 +251,21 @@ export class MobKitBuilder {
    */
   demoLlm(enabled = true): this {
     this._config.demoLlm = enabled;
+    return this;
+  }
+
+  /**
+   * Give locally hosted mob members signed TCP comms endpoints.
+   *
+   * External members run in another process and cannot reply to the default
+   * in-process endpoints. Each local member binds an ephemeral TCP port. Pass
+   * a concrete externally reachable interface address for cross-host peers.
+   */
+  memberCommsTcp(address = "127.0.0.1:0"): this {
+    if (!address.trim()) {
+      throw new Error("memberCommsTcp address must not be empty");
+    }
+    this._config.memberCommsAddress = address;
     return this;
   }
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -617,6 +617,9 @@ export class MobKitRuntime {
     if (this._config.demoLlm) {
       runtimeOptions.demo_llm = true;
     }
+    if (this._config.memberCommsAddress) {
+      runtimeOptions.member_comms_address = this._config.memberCommsAddress;
+    }
     if (this._config.implicitDelegateIdleRetireSecs !== undefined) {
       runtimeOptions.implicit_delegate_idle_retire_secs =
         this._config.implicitDelegateIdleRetireSecs;

--- a/sdk/typescript/tests/builder.test.ts
+++ b/sdk/typescript/tests/builder.test.ts
@@ -144,6 +144,16 @@ describe("MobKitBuilder chainable methods", () => {
     assert.equal(builder._config.demoLlm, false);
   });
 
+  it("memberCommsTcp() configures cross-process peer replies", () => {
+    const builder = MobKit.builder();
+    const result = builder.memberCommsTcp();
+    assert.equal(result, builder);
+    assert.equal(builder._config.memberCommsAddress, "127.0.0.1:0");
+    builder.memberCommsTcp("192.0.2.10:0");
+    assert.equal(builder._config.memberCommsAddress, "192.0.2.10:0");
+    assert.throws(() => builder.memberCommsTcp(""), /must not be empty/);
+  });
+
   it("maxSessions() sets maxSessions and returns this", () => {
     const builder = MobKit.builder();
     const result = builder.maxSessions(320);
@@ -277,6 +287,7 @@ describe("MobKitBuilder default config", () => {
     assert.equal(cfg.consoleReadOnly, null);
     assert.equal(cfg.consoleFetchTimeoutMs, null);
     assert.equal(cfg.demoLlm, false);
+    assert.equal(cfg.memberCommsAddress, null);
     assert.equal(cfg.gatingConfigPath, null);
     assert.equal(cfg.routingConfigPath, null);
     assert.deepEqual(cfg.schedulingFiles, []);
@@ -333,6 +344,7 @@ describe("MobKitBuilder method chaining", () => {
       .consoleReadOnly(true)
       .consoleFetchTimeoutMs(120_000)
       .demoLlm()
+      .memberCommsTcp()
       .gating("gating.toml")
       .routing("routing.toml")
       .scheduling("s1.toml")
@@ -349,6 +361,7 @@ describe("MobKitBuilder method chaining", () => {
     assert.equal(builder._config.consoleReadOnly, true);
     assert.equal(builder._config.consoleFetchTimeoutMs, 120_000);
     assert.equal(builder._config.demoLlm, true);
+    assert.equal(builder._config.memberCommsAddress, "127.0.0.1:0");
     assert.equal(builder._config.gatingConfigPath, "gating.toml");
     assert.equal(builder._config.workgraphEnabled, false);
     assert.equal(builder._config.routingConfigPath, "routing.toml");

--- a/sdk/typescript/tests/identity-first.test.ts
+++ b/sdk/typescript/tests/identity-first.test.ts
@@ -1171,6 +1171,7 @@ describe("Builder identity-first extensions (REQ-50)", () => {
       consoleReadOnly: null,
       consoleFetchTimeoutMs: null,
       demoLlm: false,
+      memberCommsAddress: null,
       gatingConfigPath: null,
       routingConfigPath: null,
       schedulingFiles: [],


### PR DESCRIPTION
## What

- make the MDM example target run with real Meerkat 0.8.2 session authority and peer ingress
- preserve stable identity/session correlation and safely handle external carrier wiring
- add configurable member-comms TCP advertisement for remote targets
- add single-target and multi-target real-model E2E harnesses and stricter completion verification

## Why

The shipped MDM example had never been exercised against independent remote target processes. Its target registration, authority, wiring, and console correlation paths were incomplete, so a nominally running example did not establish an actual end-to-end remote MDM flow.

## Impact

The example now supports the hive plus multiple independently hosted MDM targets. Operators can set `MDM_MEMBER_COMMS_ADDRESS` to a reachable address for cross-host target registration; local runs retain the ephemeral loopback default.

## Validation

- real single-target MDM E2E
- real two-target MDM E2E with both target responses required
- browser smoke
- Rust library tests: 1143 passed, 1 ignored
- RPC gateway tests: 50 passed
- TypeScript SDK tests: 622 passed
- TypeScript typecheck
- cargo fmt and clippy with warnings denied
- target example check and shell syntax check
