### PR TITLE
fix: repair identity-first flow and session failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44eacea55fb4b7b2f18ea297fbc7e76bc7281ec579c6e682b33bd053a7545b0"
+checksum = "c3f1d866b5323822e1f446f43afca772b77d6e47f7f4792ce3f581499643adb1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4aa47243785c757c44db60583e1c957ca978c00eb3a93222fab12996ec03634"
+checksum = "de610949d8fb7568fd7276ecbce20891697e6a2a4ce1975efacf2b25df11c419"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2998a0b3d3738110b34bd361e95e6e5619b45e12e90ffa4736fc5a867edcfe"
+checksum = "8942c19051ee06864bc972edcda1274abd69f15a7069e2736a2482ec147e4d6d"
 dependencies = [
  "async-trait",
  "axum",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4f56d5f9438a36c183b41040f81a083e7bb587b54488c8ee16b3a6f47f282"
+checksum = "a96be4b88f5086c2d1448fc44d4047ace4566c2a602692d93a3552cb2d3d546c"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1858,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9a61acea22d60c2a3dcc32b3cf937ac7ddfcb8501e3a3ec8337b736598291a"
+checksum = "d37e433ea5d7fb1b4068ef3b2938fa846b3068508ea279cb29cb21899f1b2d00"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89888edf729f25867a0a8c9c96d2a76f4e5a7d8e5d164326baf04801ee4dc827"
+checksum = "0f5004b12b6a01883664a95c3fd342f11309f6d5f4c81d39336715a0ff496b30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474629897f683206d1223d4259660f23f27e9597424689b11feed5350421f75a"
+checksum = "cba0b0dacd8b723f813c3055ec595e683f65b6b33303be58410db9594f3175a7"
 dependencies = [
  "base64",
  "chrono",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad1e702c41cb3bbb16aabfa01cb9e07ebbc67dd2ac9557fa47aef7a27ee5bd4"
+checksum = "ef13ac5de47a3c7887e333ee6b9840b5aade982541afb8e8411034d1f5a364fa"
 dependencies = [
  "async-trait",
  "base64",
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64729abfb656dc5f572925866db2edcd33e687a09629c213c5ca34603ebe26c0"
+checksum = "98c3e0e0a32f2554b2f8e414abeb348006bc85b5bc8b1b49234bbc6d5493b1ec"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addb0c5fb60c0ee82425d5e7f2c7bf767d9c63c271240f3d640e3f2f57a1a68c"
+checksum = "e54e24473ec0da8cb5a8bfde9594635275d23ea135965f8ee07fc50b0693e8c5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2009,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26653da25bdd5d509395bea8b9b8597b3f7fe6be532190bed5f1c425e213c25"
+checksum = "5fc4d5ea7a4007d526d7427b410339914e285f01489613a49e90281b67ab5e4b"
 dependencies = [
  "async-trait",
  "axum",
@@ -2029,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23549f2229cf0ac7cf882f5f632972122711dd97d4456edad7dd8b643fe160b4"
+checksum = "c352d13d8fe122668475b37268b9309ea808f39e4bce0a945a6e0fe58d7bbf22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2055,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b368f20ef7fac37ca17d12b13fc20a680c9cf0de7ab20959a573d6ec3a9b7e4"
+checksum = "a874230bfb7f6ed6670a95369809936d9ee9c70214efed0d49a252d213eb5485"
 dependencies = [
  "quote",
  "syn",
@@ -2065,18 +2065,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e76f228869b07be94a5835484bb54b8a0a8118b79cad85ab4c1e5779111cdb8"
+checksum = "04dc29bfd7ac1ec049149fd05e73b0a701831ba9ab7b66e2625a71080a09d673"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5646da1777188d2b7bf5b4a93398d2e266ce119909c6dda27543c9af6ba1b5"
+checksum = "03ae013755308fbec262f91ef9fa4bbd79d8cefb87e21224467306d7fa6d820b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5405a065a4a6c1b01901dd36311371f69f6c8d5469013c0765983a0d25b303c"
+checksum = "022245e9ea1e82f6d757488a820d1fe4c989715641fa7e38a39c71533eac85c7"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e945d82bbf145644cfb550a098ee4c1a9de075d60f89386e52ad593a6963eef"
+checksum = "85c56daca508b0b76e615c68f80bf5a786475c420073cd6afbdbdd622509b4d3"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2112,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77df281749c422d9c2444d9517598698cb10f52b94b156a53580416b872a93d6"
+checksum = "82ec13a42adb3776b800dcb0fea1e17dfcd78b2037a7c25a3067ab97e8bf9463"
 dependencies = [
  "async-trait",
  "futures",
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc734a416677fd44a0d7c54203c5cb845e631b3ac8b4472682e45820c499d15"
+checksum = "f3666597ad2ddac4ce2dbc6882df47886aff29cbfa35b9037942daa62a324e3b"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b3f6fd80944b3e4c2ef974b9c5be523af3637a9ff8ed3dd5b733950ea6edff"
+checksum = "21a1e588e77643dfb530a454db403e2ed706d63e5fe2cd1d18db06f59749c367"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2271b9e9f5e0632e84f552d896be8e1ca3a3c602277c1354c835b6b57b7160be"
+checksum = "fe40b4ca2a9462aaf255bc36d3c077c5df1cfe505b9220347bc327e24fac9e91"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2281,18 +2281,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f7bc112da45537c1a227d91bf41556cc8ff85dfdedf82815028ed961e312d8"
+checksum = "d0220b2ccad390da80a558fcfb3bbefb539255abfcd9523ca45cd7e8db6bd50e"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cc5e69b9f5283bd6b2707f22fb94684178afbf3d1f847c3ca665a4c034ac6d"
+checksum = "b28d08290b7a40677038f7d083e10a8eaef15d07554c5a8fc02a287ba3f599ed"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2320,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4919eb11f8aaa29ead6f00f49bc738de77ec8727d0302f0c8d06481c688406"
+checksum = "9aa8280519f71d2d6a4b2994bdd4f07b4df3197db00071ce984a9728b80a32d5"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3191437b3ab2e267767083dc87af4eb149955e14793d41c180e720cc0419574"
+checksum = "208cf917a2ef26db6ea5ad371bff45c6004ae1b495ea920197a7abe254e9255e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c420cf45f064f85b4454b38086e576396ed0e6c57567adceaa8ef7ae9d8885b"
+checksum = "8d261a84346ec988681d9449abdce318e818e633fcb8d5a8c2ddcbc5387ec1ec"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444da72dcd50b7b46b44457d396313c423d031125680f822f39fee017e6d2eb3"
+checksum = "c73a2dc0d7c65818429f039c8b81fbf1408194a486095e86cb07157fab5c9f84"
 dependencies = [
  "async-trait",
  "futures",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8e5ff91f4db9b4b74eb569666e5c041598b474a37353843c332f58102f6c41"
+checksum = "63b2cb113b40ca5308447d7aa52cf2a9af889b15e1e77b5e0bafda963aafee77"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2434,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d288c4102b76121ef2d4ae53e195dfbce297661e9b833e5e04fe10a6ec9287"
+checksum = "97885cbbbc3993c0d265ba6465d5891f07ae2445c77b9723b1ef7a8c24ea24c3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f058444e903a38a86bb541d23e8c82e9aae793eaff0a6bae8e3b55e0cd4b2f"
+checksum = "1cd25d56300fc768098b5b084d72bdbfbebf0165bd03f4e18c0fd91e3b387bea"
 dependencies = [
  "async-trait",
  "base64",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c47fc4ec0b0fb3c54c0f354dd0aea78545f0f063ba3d9125ac0b62c8e2928f"
+checksum = "1f98f990b8f8787c0d3145666d81856431296b1d1e64f37346ef00f7a5d1c1e3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/console/browser-e2e.cjs
+++ b/console/browser-e2e.cjs
@@ -64,7 +64,7 @@ function reservePort() {
   });
 }
 
-async function waitForHttpOk(url, timeoutMs = 120_000) {
+async function waitForHttpOk(url, timeoutMs = 300_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,29 +48,29 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.8.2"
-meerkat-client = "=0.8.2"
-meerkat-comms = "=0.8.2"
-meerkat-contracts = "=0.8.2"
-meerkat-mob = "=0.8.2"
-meerkat-mob-mcp = "=0.8.2"
-meerkat-mcp = "=0.8.2"
-meerkat-models = "=0.8.2"
+meerkat-core = "=0.8.3"
+meerkat-client = "=0.8.3"
+meerkat-comms = "=0.8.3"
+meerkat-contracts = "=0.8.3"
+meerkat-mob = "=0.8.3"
+meerkat-mob-mcp = "=0.8.3"
+meerkat-mcp = "=0.8.3"
+meerkat-models = "=0.8.3"
 # Meerkat split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.8.2", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.8.3", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.8.2"
+meerkat-memory = "=0.8.3"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.8.2"
-meerkat-runtime = { version = "=0.8.2", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.8.2", features = ["session-store"] }
-meerkat-store = { version = "=0.8.2", features = ["sqlite"] }
-meerkat-tools = "=0.8.2"
+meerkat-live = "=0.8.3"
+meerkat-runtime = { version = "=0.8.3", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.8.3", features = ["session-store"] }
+meerkat-store = { version = "=0.8.3", features = ["sqlite"] }
+meerkat-tools = "=0.8.3"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -124,9 +124,9 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-schedule = "=0.8.2"
+meerkat-schedule = "=0.8.3"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.8.2", features = ["schema"] }
+meerkat-mob = { version = "=0.8.3", features = ["schema"] }

--- a/meerkat-mobkit/src/identity_first/agent_memory.rs
+++ b/meerkat-mobkit/src/identity_first/agent_memory.rs
@@ -4,7 +4,7 @@
 //! boundary: callers provide a memory provider, and MobKit injects selected
 //! memories into the build draft during identity materialization.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -583,6 +583,10 @@ impl AgentMemoryProvider for MarkdownAgentMemoryStore {
 pub struct AgentMemoryCustomizer {
     inner: Option<Arc<dyn AgentCustomizer>>,
     coordinator: RecallCoordinator,
+    /// Explicit profile policy for bindings whose resolved tools declaration
+    /// is not available at the identity customizer boundary (notably
+    /// `RealmRef`). Explicit entries also allow per-profile overrides.
+    profile_memory_policy: BTreeMap<meerkat_mob::ProfileName, bool>,
 }
 
 /// Ambient per-turn memory injection plus inbound defanging. Thin caller
@@ -839,6 +843,7 @@ impl AgentMemoryCustomizer {
         Self {
             inner: None,
             coordinator: RecallCoordinator::new(provider, config),
+            profile_memory_policy: BTreeMap::new(),
         }
     }
 
@@ -850,7 +855,21 @@ impl AgentMemoryCustomizer {
         Self {
             inner,
             coordinator: RecallCoordinator::new(provider, config),
+            profile_memory_policy: BTreeMap::new(),
         }
+    }
+
+    /// Set the identity-first memory-tool policy for one durable profile.
+    ///
+    /// This is required for `RealmRef` profiles because the external profile
+    /// store is resolved later by Meerkat's spawn pipeline. Unresolved
+    /// references fail closed unless explicitly enabled here.
+    pub fn with_profile_memory_policy(
+        mut self,
+        policy: BTreeMap<meerkat_mob::ProfileName, bool>,
+    ) -> Self {
+        self.profile_memory_policy = policy;
+        self
     }
 
     /// Install the §7.2 provisional operator resolver on the build-time
@@ -875,22 +894,33 @@ impl AgentMemoryCustomizer {
     }
 }
 
-fn profile_enables_agent_memory(context: &AgentBuildContext, spec: &DurableAgentSpec) -> bool {
+fn profile_enables_agent_memory(
+    context: &AgentBuildContext,
+    spec: &DurableAgentSpec,
+    explicit_policy: &BTreeMap<meerkat_mob::ProfileName, bool>,
+) -> bool {
+    if let Some(enabled) = explicit_policy.get(&spec.profile) {
+        return *enabled;
+    }
     let Some(handle) = context.runtime_services.mob_handle() else {
         return true;
     };
-    definition_profile_enables_agent_memory(handle.definition(), &spec.profile)
+    definition_profile_enables_agent_memory(handle.definition(), &spec.profile, explicit_policy)
 }
 
 fn definition_profile_enables_agent_memory(
     definition: &meerkat_mob::MobDefinition,
     profile: &meerkat_mob::ProfileName,
+    explicit_policy: &BTreeMap<meerkat_mob::ProfileName, bool>,
 ) -> bool {
+    if let Some(enabled) = explicit_policy.get(profile) {
+        return *enabled;
+    }
     definition
         .profiles
         .get(profile)
         .and_then(|binding| binding.as_inline())
-        .is_none_or(|profile| profile.tools.memory)
+        .is_some_and(|profile| profile.tools.memory)
 }
 
 #[async_trait]
@@ -909,7 +939,7 @@ impl AgentCustomizer for AgentMemoryCustomizer {
         // Respect the same `profiles.<name>.tools.memory` declaration used by
         // Meerkat's native memory surface so a memory-disabled member receives
         // neither the MobKit recorder nor its behavioral/injection prompt.
-        if !profile_enables_agent_memory(context, spec) {
+        if !profile_enables_agent_memory(context, spec, &self.profile_memory_policy) {
             return Ok(());
         }
 
@@ -3337,7 +3367,7 @@ mod tests {
 
     #[test]
     fn profile_memory_policy_is_resolved_per_member_profile() -> Result<(), Box<dyn Error>> {
-        let definition = meerkat_mob::MobDefinition::from_toml(
+        let mut definition = meerkat_mob::MobDefinition::from_toml(
             r#"
 [mob]
 id = "profile-memory-policy"
@@ -3353,14 +3383,35 @@ model = "gpt-5.5"
 memory = false
 "#,
         )?;
+        let empty_policy = BTreeMap::new();
 
         assert!(definition_profile_enables_agent_memory(
             &definition,
-            &meerkat_mob::ProfileName::from("enabled")
+            &meerkat_mob::ProfileName::from("enabled"),
+            &empty_policy,
         ));
         assert!(!definition_profile_enables_agent_memory(
             &definition,
-            &meerkat_mob::ProfileName::from("disabled")
+            &meerkat_mob::ProfileName::from("disabled"),
+            &empty_policy,
+        ));
+
+        let realm_profile = meerkat_mob::ProfileName::from("realm-profile");
+        definition.profiles.insert(
+            realm_profile.clone(),
+            meerkat_mob::ProfileBinding::RealmRef {
+                realm_profile: "stored-profile".to_string(),
+            },
+        );
+        assert!(
+            !definition_profile_enables_agent_memory(&definition, &realm_profile, &empty_policy,),
+            "unresolved RealmRef memory policy must fail closed"
+        );
+        let explicit_policy = BTreeMap::from([(realm_profile.clone(), true)]);
+        assert!(definition_profile_enables_agent_memory(
+            &definition,
+            &realm_profile,
+            &explicit_policy,
         ));
         Ok(())
     }

--- a/meerkat-mobkit/src/identity_first/agent_memory.rs
+++ b/meerkat-mobkit/src/identity_first/agent_memory.rs
@@ -875,6 +875,24 @@ impl AgentMemoryCustomizer {
     }
 }
 
+fn profile_enables_agent_memory(context: &AgentBuildContext, spec: &DurableAgentSpec) -> bool {
+    let Some(handle) = context.runtime_services.mob_handle() else {
+        return true;
+    };
+    definition_profile_enables_agent_memory(handle.definition(), &spec.profile)
+}
+
+fn definition_profile_enables_agent_memory(
+    definition: &meerkat_mob::MobDefinition,
+    profile: &meerkat_mob::ProfileName,
+) -> bool {
+    definition
+        .profiles
+        .get(profile)
+        .and_then(|binding| binding.as_inline())
+        .is_none_or(|profile| profile.tools.memory)
+}
+
 #[async_trait]
 impl AgentCustomizer for AgentMemoryCustomizer {
     async fn customize_build(
@@ -885,6 +903,14 @@ impl AgentCustomizer for AgentMemoryCustomizer {
     ) -> Result<(), CustomizerError> {
         if let Some(inner) = self.inner.as_ref() {
             inner.customize_build(context, spec, draft).await?;
+        }
+
+        // The provider capability is global, but tool policy is profile-owned.
+        // Respect the same `profiles.<name>.tools.memory` declaration used by
+        // Meerkat's native memory surface so a memory-disabled member receives
+        // neither the MobKit recorder nor its behavioral/injection prompt.
+        if !profile_enables_agent_memory(context, spec) {
+            return Ok(());
         }
 
         let injection = self
@@ -3307,6 +3333,36 @@ mod tests {
             managed_edges: Vec::new(),
             runtime_services: Default::default(),
         })
+    }
+
+    #[test]
+    fn profile_memory_policy_is_resolved_per_member_profile() -> Result<(), Box<dyn Error>> {
+        let definition = meerkat_mob::MobDefinition::from_toml(
+            r#"
+[mob]
+id = "profile-memory-policy"
+
+[profiles.enabled]
+model = "gpt-5.5"
+[profiles.enabled.tools]
+memory = true
+
+[profiles.disabled]
+model = "gpt-5.5"
+[profiles.disabled.tools]
+memory = false
+"#,
+        )?;
+
+        assert!(definition_profile_enables_agent_memory(
+            &definition,
+            &meerkat_mob::ProfileName::from("enabled")
+        ));
+        assert!(!definition_profile_enables_agent_memory(
+            &definition,
+            &meerkat_mob::ProfileName::from("disabled")
+        ));
+        Ok(())
     }
 
     async fn recorder_dispatcher(

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -4994,6 +4994,7 @@ impl IdentityRuntime {
         &self,
         identity: &AgentIdentity,
         expected_runtime_id: &str,
+        expected_fencing_token: u64,
         detail: &str,
     ) -> Result<bool, IdentityRuntimeError> {
         let lifecycle_lock = self.lifecycle_lock_for(identity).await;
@@ -5007,7 +5008,11 @@ impl IdentityRuntime {
                 && entry
                     .continuity
                     .as_ref()
-                    .is_some_and(|record| record.agent_runtime_id.as_str() == expected_runtime_id);
+                    .is_some_and(|record| record.agent_runtime_id.as_str() == expected_runtime_id)
+                && entry
+                    .lease
+                    .as_ref()
+                    .is_some_and(|lease| lease.fencing_token.get() == expected_fencing_token);
             if is_current_active {
                 // Retain the exact live lease. Broken repair owns lower-plane
                 // cleanup and releases that grant before rematerializing.
@@ -9259,7 +9264,7 @@ mod reset_reprofile_tests {
 
         assert!(
             runtime
-                .mark_active_runtime_broken(&identity, &alias, "event stream closed")
+                .mark_active_runtime_broken(&identity, &alias, 7, "event stream closed")
                 .await?
         );
         assert_eq!(
@@ -9290,8 +9295,38 @@ mod reset_reprofile_tests {
                 .mark_active_runtime_broken(
                     &identity,
                     "rt:domain:replacement:stale",
+                    0,
                     "stale event stream closed",
                 )
+                .await?
+        );
+        assert_eq!(
+            runtime.status(&identity).await?.state,
+            IdentityLifecycleState::Active
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_fence_stream_loss_does_not_break_same_alias_replacement()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identity = AgentIdentity::parse("domain:replacement-fence")?;
+        let (runtime, alias) =
+            active_alias_runtime("replacement-fence-runtime", identity.as_str()).await?;
+        runtime
+            .update_lease(
+                &identity,
+                LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: FencingToken::new(8),
+                    ttl: Duration::from_secs(60),
+                },
+            )
+            .await?;
+
+        assert!(
+            !runtime
+                .mark_active_runtime_broken(&identity, &alias, 7, "old-fence event stream closed",)
                 .await?
         );
         assert_eq!(

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -9257,7 +9257,7 @@ mod reset_reprofile_tests {
                 LeaseGrant {
                     identity: identity.clone(),
                     fencing_token: FencingToken::new(7),
-                    ttl: Duration::from_secs(60),
+                    ttl: Duration::from_mins(1),
                 },
             )
             .await?;
@@ -9319,7 +9319,7 @@ mod reset_reprofile_tests {
                 LeaseGrant {
                     identity: identity.clone(),
                     fencing_token: FencingToken::new(8),
-                    ttl: Duration::from_secs(60),
+                    ttl: Duration::from_mins(1),
                 },
             )
             .await?;

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -4986,6 +4986,53 @@ impl IdentityRuntime {
         Ok(())
     }
 
+    /// Fail the exact active embodiment when its live session has been torn
+    /// down underneath the identity layer. A stale close notification from a
+    /// replaced generation is ignored, while the current embodiment becomes
+    /// `Broken` so the existing continuity repair supervisor can rebuild it.
+    pub(crate) async fn mark_active_runtime_broken(
+        &self,
+        identity: &AgentIdentity,
+        expected_runtime_id: &str,
+        detail: &str,
+    ) -> Result<bool, IdentityRuntimeError> {
+        let lifecycle_lock = self.lifecycle_lock_for(identity).await;
+        let _lifecycle_guard = lifecycle_lock.lock().await;
+        let changed = {
+            let mut entries = self.entries.write().await;
+            let entry = entries
+                .get_mut(identity)
+                .ok_or_else(|| IdentityRuntimeError::UnknownIdentity(identity.clone()))?;
+            let is_current_active = entry.state == IdentityLifecycleState::Active
+                && entry
+                    .continuity
+                    .as_ref()
+                    .is_some_and(|record| record.agent_runtime_id.as_str() == expected_runtime_id);
+            if is_current_active {
+                // Retain the exact live lease. Broken repair owns lower-plane
+                // cleanup and releases that grant before rematerializing.
+                entry.state = IdentityLifecycleState::Broken;
+            }
+            is_current_active
+        };
+        if changed {
+            self.mark_bootstrap_from_lifecycle(
+                identity,
+                IdentityLifecycleState::Broken,
+                Some(detail.to_string()),
+            );
+            self.emit_event(
+                identity,
+                IdentityEvent::StateChanged {
+                    identity: identity.clone(),
+                    new_state: IdentityLifecycleState::Broken,
+                },
+            )
+            .await;
+        }
+        Ok(changed)
+    }
+
     // -----------------------------------------------------------------------
     // Lease checking (INV-01, INV-02)
     // -----------------------------------------------------------------------
@@ -9191,6 +9238,67 @@ mod reset_reprofile_tests {
             .ok_or_else(|| {
                 format!("generated alias did not resolve to lifecycle target: {alias}").into()
             })
+    }
+
+    #[tokio::test]
+    async fn permanent_stream_loss_breaks_only_the_current_active_embodiment()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identity = AgentIdentity::parse("domain:stream-loss")?;
+        let (runtime, alias) =
+            active_alias_runtime("stream-loss-runtime", identity.as_str()).await?;
+        runtime
+            .update_lease(
+                &identity,
+                LeaseGrant {
+                    identity: identity.clone(),
+                    fencing_token: FencingToken::new(7),
+                    ttl: Duration::from_secs(60),
+                },
+            )
+            .await?;
+
+        assert!(
+            runtime
+                .mark_active_runtime_broken(&identity, &alias, "event stream closed")
+                .await?
+        );
+        assert_eq!(
+            runtime.status(&identity).await?.state,
+            IdentityLifecycleState::Broken
+        );
+        assert!(
+            runtime
+                .entries
+                .read()
+                .await
+                .get(&identity)
+                .and_then(|entry| entry.lease.as_ref())
+                .is_some(),
+            "repair must retain the exact live lease for fenced cleanup"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_stream_loss_does_not_break_replacement_embodiment()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identity = AgentIdentity::parse("domain:replacement")?;
+        let (runtime, _) = active_alias_runtime("replacement-runtime", identity.as_str()).await?;
+
+        assert!(
+            !runtime
+                .mark_active_runtime_broken(
+                    &identity,
+                    "rt:domain:replacement:stale",
+                    "stale event stream closed",
+                )
+                .await?
+        );
+        assert_eq!(
+            runtime.status(&identity).await?.state,
+            IdentityLifecycleState::Active
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -2591,18 +2591,6 @@ pub(super) async fn handle_run_flow(
     match flow_id_str {
         Some(fid) if !fid.is_empty() => {
             let flow_id = meerkat_mob::FlowId::from(fid);
-            if let Err(err) = runtime.materialize_identity_first_for_flow().await {
-                return JsonRpcResponse {
-                    jsonrpc: JSONRPC_VERSION.to_string(),
-                    id: response_id,
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32000,
-                        message: format!("identity-first flow materialization failed: {err}"),
-                        data: None,
-                    }),
-                };
-            }
             match Box::pin(runtime.mob_handle().run_flow(flow_id, flow_params)).await {
                 Ok(run_id) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -1,5 +1,6 @@
 //! Builder for constructing a configured UnifiedRuntime instance.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -69,6 +70,7 @@ pub struct UnifiedRuntimeBuilder {
     agent_customizer: Option<Arc<dyn AgentCustomizer>>,
     agent_memory_provider: Option<Arc<dyn AgentMemoryProvider>>,
     agent_memory_config: Option<AgentMemoryConfig>,
+    agent_memory_profile_policy: BTreeMap<meerkat_mob::ProfileName, bool>,
     agent_memory_from_persistent_state: bool,
     agent_memory_engines: Option<crate::memory_wiring::MemoryEnginesConfig>,
     identity_bootstrap_mode: IdentityBootstrapMode,
@@ -246,16 +248,34 @@ impl UnifiedRuntimeBuilder {
         self
     }
 
+    /// Override identity-first memory tooling for a specific durable profile.
+    ///
+    /// Inline profiles inherit `profiles.<name>.tools.memory` automatically.
+    /// Realm-referenced profiles are unresolved at the customizer boundary and
+    /// therefore fail closed unless explicitly enabled with this method.
+    pub fn agent_memory_for_profile(
+        mut self,
+        profile: impl Into<meerkat_mob::ProfileName>,
+        enabled: bool,
+    ) -> Self {
+        self.agent_memory_profile_policy
+            .insert(profile.into(), enabled);
+        self
+    }
+
     fn composed_agent_customizer(
         &self,
         memory_provider: Option<Arc<dyn AgentMemoryProvider>>,
     ) -> Option<Arc<dyn AgentCustomizer>> {
         match memory_provider {
-            Some(provider) => Some(Arc::new(AgentMemoryCustomizer::wrap(
-                self.agent_customizer.clone(),
-                provider,
-                self.agent_memory_config.clone().unwrap_or_default(),
-            ))),
+            Some(provider) => Some(Arc::new(
+                AgentMemoryCustomizer::wrap(
+                    self.agent_customizer.clone(),
+                    provider,
+                    self.agent_memory_config.clone().unwrap_or_default(),
+                )
+                .with_profile_memory_policy(self.agent_memory_profile_policy.clone()),
+            )),
             None => self.agent_customizer.clone(),
         }
     }

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -883,7 +883,7 @@ impl UnifiedRuntimeBuilder {
             (None, None)
         };
         // Set immutable outer fields by rebuilding the struct
-        let runtime = UnifiedRuntime {
+        let mut runtime = UnifiedRuntime {
             access_controller: self.access_controller,
             topology_controller,
             post_spawn_hook: self.post_spawn_hook,
@@ -1005,17 +1005,10 @@ impl UnifiedRuntimeBuilder {
         // memory-stack errors can return by ordinary drop without retaining
         // the runtime and its persistent controller locks.
         if let (Some(context), Some(roster_specs)) = (
-            runtime.identity_first_context.as_ref(),
+            runtime.identity_first_context.clone(),
             identity_roster_specs.as_ref(),
         ) {
-            runtime
-                .mob_runtime
-                .install_identity_runtime_authority(Arc::clone(&context.runtime));
-            *runtime
-                .implicit_delegate_identity_runtime
-                .write()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                Some(Arc::clone(&context.runtime));
+            runtime.install_identity_first_context_authority(Arc::clone(&context));
 
             // Identity bootstrap may now launch background warming; if it
             // fails, drive the fully assembled runtime through the same

--- a/meerkat-mobkit/src/unified_runtime/lifecycle.rs
+++ b/meerkat-mobkit/src/unified_runtime/lifecycle.rs
@@ -443,6 +443,9 @@ impl UnifiedRuntime {
                 let task = forwarder.task;
                 task.abort();
                 let _ = task.await;
+                let health_task = forwarder.identity_stream_health_task;
+                health_task.abort();
+                let _ = health_task.await;
             }
             None => {}
         }

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -236,10 +236,12 @@ impl UnifiedRuntime {
         // matching mob/run labels at projection time.
         let metadata_table = Arc::new(RuntimeMetadataTable::new());
         let mob_events_store = MobEventsStore::new().with_metadata_table(metadata_table.clone());
+        let identity_runtime_authority = Arc::new(std::sync::RwLock::new(None));
         let mob_event_ingress = Some(Self::create_event_ingress(
             mob_runtime.handle(),
             mob_runtime.agent_mob_mcp_state(),
             mob_events_store.clone(),
+            Arc::clone(&identity_runtime_authority),
         ));
         let mob_events_task = Self::spawn_mob_events_subscriber(
             mob_runtime.handle(),
@@ -285,7 +287,7 @@ impl UnifiedRuntime {
             mob_events: mob_events_store,
             mob_events_subscriber_task: tokio::sync::Mutex::new(mob_events_task),
             implicit_delegate_retirement_task: tokio::sync::Mutex::new(None),
-            implicit_delegate_identity_runtime: Arc::new(std::sync::RwLock::new(None)),
+            implicit_delegate_identity_runtime: identity_runtime_authority,
             identity_lease_renewal_task: tokio::sync::Mutex::new(None),
             identity_continuity_repair_task: tokio::sync::Mutex::new(None),
             agent_memory_observer_task: tokio::sync::Mutex::new(None),
@@ -683,6 +685,7 @@ impl UnifiedRuntime {
         &mut self,
         context: Arc<crate::identity_first::IdentityFirstRuntimeContext>,
     ) {
+        self.install_identity_first_flow_target_provisioner(&context.runtime);
         self.mob_runtime
             .install_identity_runtime_authority(Arc::clone(&context.runtime));
         *self
@@ -691,6 +694,34 @@ impl UnifiedRuntime {
             .unwrap_or_else(std::sync::PoisonError::into_inner) =
             Some(Arc::clone(&context.runtime));
         self.identity_first_context = Some(context);
+    }
+
+    pub(crate) fn install_identity_first_flow_target_provisioner(
+        &self,
+        runtime: &Arc<crate::identity_first::IdentityRuntime>,
+    ) {
+        let identity_runtime = Arc::downgrade(runtime);
+        self.mob_runtime
+            .handle()
+            .install_flow_target_provisioner(Arc::new(move || {
+                let identity_runtime = identity_runtime.clone();
+                Box::pin(async move {
+                    let runtime = identity_runtime.upgrade().ok_or_else(|| {
+                        MobError::Internal(
+                            "identity-first flow provisioner is no longer available".to_string(),
+                        )
+                    })?;
+                    runtime
+                        .materialize_all_required_tracked()
+                        .await
+                        .map(|_| ())
+                        .map_err(|error| {
+                            MobError::Internal(format!(
+                                "identity-first flow materialization failed: {error}"
+                            ))
+                        })
+                })
+            }));
     }
 
     fn start_identity_first_supervisors(&mut self) {
@@ -1047,6 +1078,9 @@ impl UnifiedRuntime {
         mob_handle: MobHandle,
         agent_mob_mcp_state: Option<Arc<meerkat_mob_mcp::MobMcpState>>,
         mob_events: MobEventsStore,
+        identity_runtime: Arc<
+            std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>,
+        >,
     ) -> MobEventIngress {
         // Keep forwarding bounded to avoid unbounded memory growth under sustained ingress.
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(256);
@@ -1055,6 +1089,7 @@ impl UnifiedRuntime {
             agent_mob_mcp_state,
             event_tx,
             mob_events,
+            identity_runtime,
         ));
         MobEventIngress::Forwarder(MobEventForwarder { event_rx, task })
     }
@@ -1092,8 +1127,9 @@ type TaggedAgentEventStream = BoxStream<'static, ForwardedAgentEvent>;
 /// forwarder. The forwarder reconciles every 250ms; without backoff a
 /// member that keeps failing `subscribe_agent_events` is retried 4×/s
 /// indefinitely and floods the log (observed: ~49k "failed to subscribe"
-/// warnings over 3.4h on a single wedged-retiring alias). We retry with
-/// exponential backoff and warn only on the first failure.
+/// warnings over 3.4h on a single wedged-retiring alias). We retry transient
+/// failures with exponential backoff and hand persistent loss to identity
+/// repair instead of suppressing the same dead session forever.
 struct SubscribeBackoff {
     next_attempt: tokio::time::Instant,
     consecutive_failures: u32,
@@ -1104,6 +1140,7 @@ struct SubscribeBackoff {
 /// `SUBSCRIBE_BACKOFF_MAX` instead of one per tick.
 const SUBSCRIBE_BACKOFF_BASE: Duration = Duration::from_millis(250);
 const SUBSCRIBE_BACKOFF_MAX: Duration = Duration::from_secs(30);
+const PERMANENT_STREAM_FAILURE_THRESHOLD: u32 = 4;
 
 fn subscribe_backoff_delay(consecutive_failures: u32) -> Duration {
     SUBSCRIBE_BACKOFF_BASE
@@ -1119,11 +1156,55 @@ fn forwarder_should_subscribe(status: MobMemberStatus) -> bool {
     matches!(status, MobMemberStatus::Active)
 }
 
+async fn trigger_identity_stream_repair(
+    primary_mob_id: &str,
+    tracked_key: &TrackedAgentEventStream,
+    identity_runtime: &Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
+    detail: &str,
+) {
+    let (mob_id, identity, runtime_id, _) = tracked_key;
+    if mob_id != primary_mob_id {
+        return;
+    }
+    let runtime_alias =
+        crate::member_comms_id::runtime_alias_str(runtime_id.identity.as_str()).into_owned();
+    let authority = identity_runtime
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let Some(authority) = authority else {
+        return;
+    };
+    let identity = match crate::identity_first::AgentIdentity::parse(identity.as_str()) {
+        Ok(identity) => identity,
+        Err(error) => {
+            tracing::warn!(
+                identity = %identity,
+                error = %error,
+                "mobkit agent event forwarder: roster identity cannot be mapped to identity authority"
+            );
+            return;
+        }
+    };
+    if let Err(error) = authority
+        .mark_active_runtime_broken(&identity, &runtime_alias, detail)
+        .await
+    {
+        tracing::warn!(
+            identity = %identity,
+            runtime_id = %runtime_id,
+            error = %error,
+            "mobkit agent event forwarder: failed to trigger identity repair after permanent stream loss"
+        );
+    }
+}
+
 async fn run_resilient_mob_agent_event_forwarder(
     handle: MobHandle,
     agent_mob_mcp_state: Option<Arc<meerkat_mob_mcp::MobMcpState>>,
     event_tx: Sender<EventEnvelope<UnifiedEvent>>,
     mob_events: MobEventsStore,
+    identity_runtime: Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
 ) {
     let mut streams: SelectAll<TaggedAgentEventStream> = SelectAll::new();
     let mut tracked = HashSet::new();
@@ -1138,6 +1219,7 @@ async fn run_resilient_mob_agent_event_forwarder(
         &mut tracked,
         &mut subscribe_failures,
         &mut streams,
+        &identity_runtime,
     ))
     .await;
 
@@ -1169,11 +1251,18 @@ async fn run_resilient_mob_agent_event_forwarder(
                     }
                     ForwardedAgentEvent::Closed(tracked_key) => {
                         tracked.remove(&tracked_key);
+                        subscribe_failures.remove(&tracked_key);
+                        trigger_identity_stream_repair(
+                            handle.mob_id().as_str(),
+                            &tracked_key,
+                            &identity_runtime,
+                            "live agent event stream closed permanently",
+                        ).await;
                     }
                 }
             }
             _ = reconcile_interval.tick() => {
-                Box::pin(reconcile_agent_event_streams(&handle, &agent_mob_mcp_state, &mut tracked, &mut subscribe_failures, &mut streams)).await;
+                Box::pin(reconcile_agent_event_streams(&handle, &agent_mob_mcp_state, &mut tracked, &mut subscribe_failures, &mut streams, &identity_runtime)).await;
             }
         }
     }
@@ -1185,10 +1274,11 @@ async fn reconcile_agent_event_streams(
     tracked: &mut HashSet<TrackedAgentEventStream>,
     subscribe_failures: &mut HashMap<TrackedAgentEventStream, SubscribeBackoff>,
     streams: &mut SelectAll<TaggedAgentEventStream>,
+    identity_runtime: &Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
 ) {
+    let primary_mob_id = handle.mob_id().to_string();
     let mut handles = vec![handle.clone()];
     if let Some(state) = agent_mob_mcp_state {
-        let primary_mob_id = handle.mob_id().to_string();
         handles.extend(
             Box::pin(state.mob_handles_snapshot())
                 .await
@@ -1293,7 +1383,10 @@ async fn reconcile_agent_event_streams(
                     // Usually a short-lived spawn/resume race while Meerkat
                     // finishes installing the session event injector. Retry
                     // with exponential backoff and warn only on the first
-                    // failure so a persistent failure can't flood the log.
+                    // failure. A bounded number of misses remains a spawn
+                    // race; persistent loss breaks the exact identity binding
+                    // and lets the continuity supervisor rebuild it.
+                    let repair_key = tracked_key.clone();
                     let backoff =
                         subscribe_failures
                             .entry(tracked_key)
@@ -1320,6 +1413,17 @@ async fn reconcile_agent_event_streams(
                     backoff.next_attempt =
                         now + subscribe_backoff_delay(backoff.consecutive_failures);
                     backoff.consecutive_failures = backoff.consecutive_failures.saturating_add(1);
+                    let stream_is_permanently_lost =
+                        backoff.consecutive_failures >= PERMANENT_STREAM_FAILURE_THRESHOLD;
+                    if stream_is_permanently_lost {
+                        trigger_identity_stream_repair(
+                            &primary_mob_id,
+                            &repair_key,
+                            identity_runtime,
+                            "live agent event stream remained unavailable after bounded retries",
+                        )
+                        .await;
+                    }
                 }
             }
         }
@@ -1553,6 +1657,7 @@ mod tests {
     /// most ~once per cap instead of 4×/s.
     #[test]
     fn subscribe_backoff_grows_and_caps() {
+        assert!(PERMANENT_STREAM_FAILURE_THRESHOLD > 1);
         assert_eq!(subscribe_backoff_delay(0), SUBSCRIBE_BACKOFF_BASE);
         assert_eq!(subscribe_backoff_delay(1), SUBSCRIBE_BACKOFF_BASE * 2);
         assert_eq!(subscribe_backoff_delay(3), SUBSCRIBE_BACKOFF_BASE * 8);

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -219,6 +219,7 @@ enum MobEventIngress {
 struct MobEventForwarder {
     event_rx: Receiver<EventEnvelope<UnifiedEvent>>,
     task: JoinHandle<()>,
+    identity_stream_health_task: JoinHandle<()>,
 }
 
 impl UnifiedRuntime {
@@ -1084,14 +1085,27 @@ impl UnifiedRuntime {
     ) -> MobEventIngress {
         // Keep forwarding bounded to avoid unbounded memory growth under sustained ingress.
         let (event_tx, event_rx) = tokio::sync::mpsc::channel(256);
+        // Identity lifecycle repair must remain live even when an embedding
+        // application does not drain the bounded console/event channel.
+        // A dedicated subscription monitor drains its streams independently
+        // and owns only permanent-loss detection; the ordinary forwarder
+        // retains lossless backpressure for user-visible events.
+        let identity_stream_health_task = tokio::spawn(run_identity_stream_health_monitor(
+            mob_handle.clone(),
+            agent_mob_mcp_state.clone(),
+            identity_runtime,
+        ));
         let task = tokio::spawn(run_resilient_mob_agent_event_forwarder(
             mob_handle,
             agent_mob_mcp_state,
             event_tx,
             mob_events,
-            identity_runtime,
         ));
-        MobEventIngress::Forwarder(MobEventForwarder { event_rx, task })
+        MobEventIngress::Forwarder(MobEventForwarder {
+            event_rx,
+            task,
+            identity_stream_health_task,
+        })
     }
 
     async fn rollback_mob_runtime(
@@ -1120,16 +1134,32 @@ enum ForwardedAgentEvent {
     Closed(TrackedAgentEventStream),
 }
 
-type TrackedAgentEventStream = (String, AgentIdentity, AgentRuntimeId, FenceToken);
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct TrackedAgentEventStream {
+    mob_id: String,
+    /// Trusted durable identity stamped by the identity-first spawn bridge.
+    /// Ordinary/child mobs do not carry this label and are never handed to
+    /// the primary identity repair authority.
+    durable_identity: Option<String>,
+    /// Concrete roster identity used to subscribe to Meerkat events.
+    member_identity: AgentIdentity,
+    runtime_id: AgentRuntimeId,
+    /// Identity-authority fencing token captured when the health subscription
+    /// was established. This is deliberately distinct from `fence_token`,
+    /// which belongs to Meerkat Mob's member-binding fencing domain.
+    identity_fencing_token: Option<u64>,
+    fence_token: FenceToken,
+}
 type TaggedAgentEventStream = BoxStream<'static, ForwardedAgentEvent>;
 
-/// Per-member subscribe-failure backoff for the console agent-event
-/// forwarder. The forwarder reconciles every 250ms; without backoff a
+/// Per-member subscribe-failure backoff for agent-event subscriptions.
+/// The forwarder and independent identity-health monitor reconcile every
+/// 250ms; without backoff a
 /// member that keeps failing `subscribe_agent_events` is retried 4×/s
 /// indefinitely and floods the log (observed: ~49k "failed to subscribe"
-/// warnings over 3.4h on a single wedged-retiring alias). We retry transient
-/// failures with exponential backoff and hand persistent loss to identity
-/// repair instead of suppressing the same dead session forever.
+/// warnings over 3.4h on a single wedged-retiring alias). Both retry transient
+/// failures with exponential backoff; only the independent health monitor
+/// hands persistent loss to identity repair.
 struct SubscribeBackoff {
     next_attempt: tokio::time::Instant,
     consecutive_failures: u32,
@@ -1156,18 +1186,54 @@ fn forwarder_should_subscribe(status: MobMemberStatus) -> bool {
     matches!(status, MobMemberStatus::Active)
 }
 
+fn durable_identity_label(labels: &BTreeMap<String, String>) -> Option<String> {
+    labels.get("agent_identity").cloned()
+}
+
+async fn current_identity_fencing_token(
+    primary_mob_id: &str,
+    mob_id: &str,
+    durable_identity: Option<&str>,
+    identity_runtime: Option<
+        &Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
+    >,
+) -> Option<u64> {
+    if mob_id != primary_mob_id {
+        return None;
+    }
+    let durable_identity = durable_identity?;
+    let identity_runtime = identity_runtime?;
+    let authority = identity_runtime
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()?;
+    let identity = crate::identity_first::AgentIdentity::parse(durable_identity).ok()?;
+    authority
+        .status(&identity)
+        .await
+        .ok()?
+        .lease
+        .map(|lease| lease.fencing_token.get())
+}
+
 async fn trigger_identity_stream_repair(
     primary_mob_id: &str,
     tracked_key: &TrackedAgentEventStream,
     identity_runtime: &Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
     detail: &str,
 ) {
-    let (mob_id, identity, runtime_id, _) = tracked_key;
-    if mob_id != primary_mob_id {
+    if tracked_key.mob_id != primary_mob_id {
         return;
     }
+    let Some(durable_identity) = tracked_key.durable_identity.as_deref() else {
+        return;
+    };
+    let Some(identity_fencing_token) = tracked_key.identity_fencing_token else {
+        return;
+    };
     let runtime_alias =
-        crate::member_comms_id::runtime_alias_str(runtime_id.identity.as_str()).into_owned();
+        crate::member_comms_id::runtime_alias_str(tracked_key.runtime_id.identity.as_str())
+            .into_owned();
     let authority = identity_runtime
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1175,11 +1241,11 @@ async fn trigger_identity_stream_repair(
     let Some(authority) = authority else {
         return;
     };
-    let identity = match crate::identity_first::AgentIdentity::parse(identity.as_str()) {
+    let identity = match crate::identity_first::AgentIdentity::parse(durable_identity) {
         Ok(identity) => identity,
         Err(error) => {
             tracing::warn!(
-                identity = %identity,
+                identity = %durable_identity,
                 error = %error,
                 "mobkit agent event forwarder: roster identity cannot be mapped to identity authority"
             );
@@ -1187,12 +1253,12 @@ async fn trigger_identity_stream_repair(
         }
     };
     if let Err(error) = authority
-        .mark_active_runtime_broken(&identity, &runtime_alias, detail)
+        .mark_active_runtime_broken(&identity, &runtime_alias, identity_fencing_token, detail)
         .await
     {
         tracing::warn!(
             identity = %identity,
-            runtime_id = %runtime_id,
+            runtime_id = %tracked_key.runtime_id,
             error = %error,
             "mobkit agent event forwarder: failed to trigger identity repair after permanent stream loss"
         );
@@ -1204,7 +1270,6 @@ async fn run_resilient_mob_agent_event_forwarder(
     agent_mob_mcp_state: Option<Arc<meerkat_mob_mcp::MobMcpState>>,
     event_tx: Sender<EventEnvelope<UnifiedEvent>>,
     mob_events: MobEventsStore,
-    identity_runtime: Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
 ) {
     let mut streams: SelectAll<TaggedAgentEventStream> = SelectAll::new();
     let mut tracked = HashSet::new();
@@ -1219,7 +1284,7 @@ async fn run_resilient_mob_agent_event_forwarder(
         &mut tracked,
         &mut subscribe_failures,
         &mut streams,
-        &identity_runtime,
+        None,
     ))
     .await;
 
@@ -1252,6 +1317,49 @@ async fn run_resilient_mob_agent_event_forwarder(
                     ForwardedAgentEvent::Closed(tracked_key) => {
                         tracked.remove(&tracked_key);
                         subscribe_failures.remove(&tracked_key);
+                    }
+                }
+            }
+            _ = reconcile_interval.tick() => {
+                Box::pin(reconcile_agent_event_streams(&handle, &agent_mob_mcp_state, &mut tracked, &mut subscribe_failures, &mut streams, None)).await;
+            }
+        }
+    }
+}
+
+/// Drain a second subscription set dedicated to identity health. Keeping this
+/// task separate from console/event projection ensures a full user-facing
+/// output channel cannot suppress permanent stream-loss detection.
+async fn run_identity_stream_health_monitor(
+    handle: MobHandle,
+    agent_mob_mcp_state: Option<Arc<meerkat_mob_mcp::MobMcpState>>,
+    identity_runtime: Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
+) {
+    let mut streams: SelectAll<TaggedAgentEventStream> = SelectAll::new();
+    let mut tracked = HashSet::new();
+    let mut subscribe_failures: HashMap<TrackedAgentEventStream, SubscribeBackoff> = HashMap::new();
+    let mut reconcile_interval = tokio::time::interval(Duration::from_millis(250));
+    #[cfg(not(target_arch = "wasm32"))]
+    reconcile_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    Box::pin(reconcile_agent_event_streams(
+        &handle,
+        &agent_mob_mcp_state,
+        &mut tracked,
+        &mut subscribe_failures,
+        &mut streams,
+        Some(&identity_runtime),
+    ))
+    .await;
+
+    loop {
+        tokio::select! {
+            Some(forwarded) = streams.next() => {
+                match forwarded {
+                    ForwardedAgentEvent::Event(_) => {}
+                    ForwardedAgentEvent::Closed(tracked_key) => {
+                        tracked.remove(&tracked_key);
+                        subscribe_failures.remove(&tracked_key);
                         trigger_identity_stream_repair(
                             handle.mob_id().as_str(),
                             &tracked_key,
@@ -1262,7 +1370,14 @@ async fn run_resilient_mob_agent_event_forwarder(
                 }
             }
             _ = reconcile_interval.tick() => {
-                Box::pin(reconcile_agent_event_streams(&handle, &agent_mob_mcp_state, &mut tracked, &mut subscribe_failures, &mut streams, &identity_runtime)).await;
+                Box::pin(reconcile_agent_event_streams(
+                    &handle,
+                    &agent_mob_mcp_state,
+                    &mut tracked,
+                    &mut subscribe_failures,
+                    &mut streams,
+                    Some(&identity_runtime),
+                )).await;
             }
         }
     }
@@ -1274,7 +1389,9 @@ async fn reconcile_agent_event_streams(
     tracked: &mut HashSet<TrackedAgentEventStream>,
     subscribe_failures: &mut HashMap<TrackedAgentEventStream, SubscribeBackoff>,
     streams: &mut SelectAll<TaggedAgentEventStream>,
-    identity_runtime: &Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
+    identity_runtime: Option<
+        &Arc<std::sync::RwLock<Option<Arc<crate::identity_first::IdentityRuntime>>>>,
+    >,
 ) {
     let primary_mob_id = handle.mob_id().to_string();
     let mut handles = vec![handle.clone()];
@@ -1303,12 +1420,27 @@ async fn reconcile_agent_event_streams(
             let Some((runtime_id, fence_token)) = entry.binding_atoms() else {
                 continue;
             };
-            current.insert((
-                mob_id.clone(),
-                entry.agent_identity.clone(),
+            let durable_identity = durable_identity_label(&entry.labels);
+            let identity_fencing_token = current_identity_fencing_token(
+                &primary_mob_id,
+                &mob_id,
+                durable_identity.as_deref(),
+                identity_runtime,
+            )
+            .await;
+            // The health monitor exists solely for identity-first repair.
+            // Avoid duplicating every ordinary/child-mob event stream.
+            if identity_runtime.is_some() && identity_fencing_token.is_none() {
+                continue;
+            }
+            current.insert(TrackedAgentEventStream {
+                mob_id: mob_id.clone(),
+                durable_identity,
+                member_identity: entry.agent_identity.clone(),
                 runtime_id,
+                identity_fencing_token,
                 fence_token,
-            ));
+            });
         }
     }
 
@@ -1325,12 +1457,25 @@ async fn reconcile_agent_event_streams(
             let Some((runtime_id, fence_token)) = entry.binding_atoms() else {
                 continue;
             };
-            let tracked_key = (
-                mob_id.clone(),
-                identity.clone(),
-                runtime_id.clone(),
+            let durable_identity = durable_identity_label(&entry.labels);
+            let identity_fencing_token = current_identity_fencing_token(
+                &primary_mob_id,
+                &mob_id,
+                durable_identity.as_deref(),
+                identity_runtime,
+            )
+            .await;
+            if identity_runtime.is_some() && identity_fencing_token.is_none() {
+                continue;
+            }
+            let tracked_key = TrackedAgentEventStream {
+                mob_id: mob_id.clone(),
+                durable_identity,
+                member_identity: identity.clone(),
+                runtime_id: runtime_id.clone(),
+                identity_fencing_token,
                 fence_token,
-            );
+            };
             if tracked.contains(&tracked_key) {
                 continue;
             }
@@ -1359,7 +1504,12 @@ async fn reconcile_agent_event_streams(
 
             let role = entry.role.clone();
 
-            match subscribe_agent_events_for_console_forwarder(&handle, &identity).await {
+            match subscribe_agent_events_for_console_forwarder(
+                &handle,
+                &tracked_key.member_identity,
+            )
+            .await
+            {
                 Ok(stream) => {
                     let close_key = tracked_key.clone();
                     subscribe_failures.remove(&tracked_key);
@@ -1394,14 +1544,14 @@ async fn reconcile_agent_event_streams(
                                 next_attempt: now,
                                 consecutive_failures: 0,
                             });
-                    if backoff.consecutive_failures == 0 {
+                    if identity_runtime.is_none() && backoff.consecutive_failures == 0 {
                         tracing::warn!(
                             mob_id = %mob_id,
                             identity = %identity,
                             error = %error,
                             "mobkit agent event forwarder: failed to subscribe; will retry with backoff"
                         );
-                    } else {
+                    } else if identity_runtime.is_none() {
                         tracing::debug!(
                             mob_id = %mob_id,
                             identity = %identity,
@@ -1415,7 +1565,7 @@ async fn reconcile_agent_event_streams(
                     backoff.consecutive_failures = backoff.consecutive_failures.saturating_add(1);
                     let stream_is_permanently_lost =
                         backoff.consecutive_failures >= PERMANENT_STREAM_FAILURE_THRESHOLD;
-                    if stream_is_permanently_lost {
+                    if stream_is_permanently_lost && let Some(identity_runtime) = identity_runtime {
                         trigger_identity_stream_repair(
                             &primary_mob_id,
                             &repair_key,
@@ -1611,6 +1761,21 @@ mod tests {
                 },
             },
         }
+    }
+
+    #[test]
+    fn identity_stream_tracking_uses_trusted_durable_identity_label() {
+        let labels =
+            BTreeMap::from([("agent_identity".to_string(), "review:singleton".to_string())]);
+        assert_eq!(
+            durable_identity_label(&labels).as_deref(),
+            Some("review:singleton")
+        );
+        assert_eq!(
+            durable_identity_label(&BTreeMap::new()),
+            None,
+            "ordinary mobs must not be guessed into identity authority"
+        );
     }
 
     /// Regression: identity-first members spawn under comms-safe encoded

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -1822,7 +1822,7 @@ mod tests {
     /// most ~once per cap instead of 4×/s.
     #[test]
     fn subscribe_backoff_grows_and_caps() {
-        assert!(PERMANENT_STREAM_FAILURE_THRESHOLD > 1);
+        const { assert!(PERMANENT_STREAM_FAILURE_THRESHOLD > 1) };
         assert_eq!(subscribe_backoff_delay(0), SUBSCRIBE_BACKOFF_BASE);
         assert_eq!(subscribe_backoff_delay(1), SUBSCRIBE_BACKOFF_BASE * 2);
         assert_eq!(subscribe_backoff_delay(3), SUBSCRIBE_BACKOFF_BASE * 8);

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -3420,41 +3420,39 @@ async fn identity_first_builder_lazy_run_flow_materializes_ob3_shaped_roster_bef
         "lazy build must still start without concrete members"
     );
 
-    let response: JsonRpcResponse = serde_json::from_str(
-        &handle_unified_rpc_json(
-            &runtime,
-            &json!({
-                "jsonrpc": "2.0",
-                "id": "review-flow",
-                "method": "mobkit/run_flow",
-                "params": {
-                    "flow_id": "review_cycle",
-                    "params": { "source": "ob3" }
-                }
-            })
-            .to_string(),
-            Duration::from_secs(2),
-            None,
-            None,
+    // Embedded applications such as OB3 hold the raw MobHandle. The
+    // identity-first barrier must therefore be installed on that handle,
+    // rather than living only in MobKit's JSON-RPC wrapper.
+    let run_id = runtime
+        .mob_handle()
+        .run_flow(
+            meerkat_mob::FlowId::from("review_cycle"),
+            json!({ "source": "ob3" }),
         )
-        .await,
-    )
-    .expect("json-rpc response");
+        .await
+        .expect("direct MobHandle flow should hydrate lazy identities");
 
-    assert!(
-        response.error.is_none(),
-        "run_flow should hydrate lazy identities before concrete flow execution: {:?}",
-        response.error
-    );
-    assert!(
-        response
-            .result
-            .as_ref()
-            .and_then(|result| result.get("run_id"))
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|run_id| !run_id.is_empty()),
-        "run_flow should return a concrete run id"
-    );
+    // Returning a run id is not sufficient: the production failure returned
+    // one and then remained Running forever with no admitted turn. Require the
+    // flow kernel to actually record its first step transition.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let run = runtime
+            .mob_handle()
+            .flow_status(run_id.clone())
+            .await
+            .expect("flow status query")
+            .expect("flow run should exist");
+        if !run.step_ledger.is_empty() || !run.failure_ledger.is_empty() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "flow {run_id} started but never admitted a turn: status={:?}",
+            run.status
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
 
     let members = runtime.mob_handle().list_members_including_retiring().await;
     // meerkat 0.7: roster member ids are comms-safe encodings of the public


### PR DESCRIPTION
## Summary

- Install the identity-first flow target provisioner introduced by lukacf/meerkat#911 on the shared raw `MobHandle`, so embedded callers such as OB3 materialize required durable members before concrete flow target selection. Remove the narrower JSON-RPC-only workaround.
- Mark the exact current identity embodiment `Broken` when its live event stream closes permanently or remains unavailable after bounded retries. Stale-generation closes are ignored; the retained lease lets the existing fenced continuity repair loop clean up and rematerialize safely.
- Respect each inline profile's `tools.memory` policy in `AgentMemoryCustomizer`, preventing memory-disabled profiles from receiving the recorder tool or memory prompt/injection.

## Dependency

Draft until lukacf/meerkat#911 lands and the MobKit Meerkat dependency is advanced to a release containing `MobHandle::install_flow_target_provisioner`.

The branch intentionally does not add a temporary git/path dependency. Normal pre-push compile gates against the currently published exact Meerkat 0.8.2 therefore fail at the missing new method; the joint change was validated with all Meerkat crates overridden to the rebased source of #911.

## Test plan

- Production-shaped integration regression calls raw `MobHandle::run_flow`, verifies the full lazy OB3-shaped roster becomes Active, and requires the flow ledger to record a first step rather than merely returning a run id.
- `permanent_stream_loss_breaks_only_the_current_active_embodiment`
- `stale_stream_loss_does_not_break_replacement_embodiment`
- `profile_memory_policy_is_resolved_per_member_profile`
- `subscribe_backoff_grows_and_caps`
- `cargo check -p meerkat-mobkit --tests` with all Meerkat crates overridden to the rebased #911 source.

## Reported issues covered

- Identity-first direct `run_flow` starts without admitting a turn.
- Checkpoint/session teardown leaves a permanently Active zombie identity.
- Event forwarder endlessly retries the same discarded session stream.
- Provider-global memory capability leaks an inert tool into memory-disabled profiles.
