### PR TITLE
feat(jobs): integrate durable callback jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,6 @@ dependencies = [
  "meerkat-comms",
  "meerkat-contracts",
  "meerkat-core",
- "meerkat-jobs",
  "meerkat-live",
  "meerkat-mcp",
  "meerkat-memory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,8 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1969f56d35c165740b5ae3adba8a7b70ebdfaeabbec812d2c6c33fe68b4ae257"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1817,6 +1816,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-gemini",
  "meerkat-hooks",
+ "meerkat-jobs",
  "meerkat-live",
  "meerkat-llm-core",
  "meerkat-mcp",
@@ -1842,9 +1842,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d7134e5fedfbff89f733e7f3523e5d712a02e357d7fba45ebb057c95a7ed408"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1866,9 +1865,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b0968efaca242a87c7b8e29fb92c50da9007892ba80af893ec4c96ee61f8d"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "axum",
@@ -1899,9 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307c4bc1832454a06a4ddb839be05b6c15bfb7237a0c52736b177db87dab726f"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1912,9 +1909,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a441ad549d304709d75a288cb9b2a786882c121214223027893e3c54910cd88d"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1925,9 +1921,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b7aae59c1c3b3b9df36e122afb4e6914b92dc1257ac5315f53b8a7988efbf9"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "base64",
@@ -1961,9 +1956,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c975edea0bf187265ef646c68bdf7c873b48355c1a7d73c776114a521efba2"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "base64",
  "chrono",
@@ -1983,9 +1977,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ebf1ba7eb4726e3364194a641ee82ccbc26cb8464650c0256180c99100a3b"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "base64",
@@ -2016,9 +2009,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db13d339e2a37793ede1be55dd6df040a567d3f20b49b7e39dfe9f8bbd23f1f"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2040,9 +2032,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f94510b957736a5ea3b0fc66636ff3d621d7ac06cf3fdd03a700a4909b32558"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2062,10 +2053,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "meerkat-jobs"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "meerkat-core",
+ "meerkat-machine-schema",
+ "meerkat-sqlite",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio_with_wasm",
+ "uuid",
+]
+
+[[package]]
 name = "meerkat-live"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c0dc7ff90bd1ca54dbf62a0a9ff5488d5a5ea01fe5b92693cb44bee93bfe73"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "axum",
@@ -2083,9 +2092,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e58a964cfced8a0d04c1c584a497f57516005043902911e51f983e9aba3d77"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2109,9 +2117,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a3fd4e3e3ff15d6be9013372a0403763981f80ce5ee40ae093f16640a245e0"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -2119,18 +2126,16 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2347453890398ed7e435ff42b56754bcd73ee345f92697906149c349c448eab"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256ca088e4dab67df5e1948e40fa366bc017f2e770c1eee24d77e9c9a81dcc68"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2139,9 +2144,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d795ac7d0ee4b1039a4dd037c3d649cbfa382964dfd891cef2bfcb07fb6b9f06"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2152,9 +2156,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8c59e133ad1f42a0332cf9010f0777808d3b2156c5094bf6a9b0c78cc77629"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2166,9 +2169,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7c454b8ada4008f8bc37e4d19b11b54223e715f6e663d30e8e818b8714270f"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "futures",
@@ -2191,9 +2193,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d914c750bbe8caea8da4ba6aa8a27a33469e1b485ac491b4ee3766164ed5e7"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2214,9 +2215,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899ebd6fbc200e348a6b80584b487fb3c4e8954438084120ec51bf3326cadcee"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2255,9 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0fff6c117e76915e90577cb09c4f6138d6116eabf9163e72336eca376ac456"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2305,6 +2304,7 @@ dependencies = [
  "meerkat-comms",
  "meerkat-contracts",
  "meerkat-core",
+ "meerkat-jobs",
  "meerkat-live",
  "meerkat-mcp",
  "meerkat-memory",
@@ -2339,18 +2339,16 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1ba0b138052028ade3fb40f4119e129a99686bdcd204e1dd0b54662200db4d"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97022af6f6c1ca43af4f5288f4c89c283c7c353af35fbe5a21741bd9e53fd1e"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2378,9 +2376,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f418ea6f2aaa14e1fae8595fd3c82b55394b398551a2db14a1ad1397981483e6"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2388,9 +2385,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f8264593f3ee42481ebe487d2080d392c2a3b375fc9416944487b7c5d9a595"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2418,9 +2414,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817ca6062beeb59a0d284eeea06b1bad419b4e0e8f4cdf96b86e0469f9561e2e"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2444,9 +2439,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6325dcde9cad0c627e1f618c2c44b9b320a7e24679cec555ab7592076079547"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "futures",
@@ -2470,9 +2464,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a79ce6a154b1c73a28f73f2fe217519f302150245f07746e18907afd076f7a"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2493,9 +2486,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-sqlite"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d675bcde09c66fd72ed89d1757339d0a1371a2321da7121c5f13a7dcbd5b4f2"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "rusqlite",
  "thiserror 2.0.19",
@@ -2503,9 +2495,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781b2c5426b194647121226736c4d78786a9c3278ac5ec1cde1bf2bb6da80fa7"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2528,9 +2519,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store-conformance"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bca373dba691c0c832995fcb39848b65b65beb2d89a9ae1b0e372a6371928e"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "meerkat-core",
@@ -2541,9 +2531,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0dfef95958dd4075488c8f9fb43ad0b726b5924e3d83c8199057a8d80ae603a"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "base64",
@@ -2557,11 +2546,13 @@ dependencies = [
  "meerkat-comms",
  "meerkat-contracts",
  "meerkat-core",
+ "meerkat-jobs",
  "meerkat-llm-core",
  "meerkat-mcp",
  "meerkat-runtime",
  "meerkat-skills",
  "meerkat-sqlite",
+ "meerkat-store",
  "nix 0.29.0",
  "parking_lot",
  "rusqlite",
@@ -2580,9 +2571,8 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662a3da4ec04ee78297c10609d6c3b72a467d74230370fa9083830a49f01a2c5"
+version = "0.8.7"
+source = "git+https://github.com/lukacf/meerkat?rev=5f7ff147c#5f7ff147c5e38df7c6806ec8601da61e5754ccaf"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -34,6 +34,58 @@ async def main():
 asyncio.run(main())
 ```
 
+## Durable detached tools
+
+Declare long-running host work explicitly instead of holding
+`callback/call_tool` open:
+
+```python
+from meerkat_mobkit import DetachedJobExecution, DetachedJobResult
+
+async def run_scan(ctx):
+    await ctx.progress(1, "scan started")
+    # ctx.arguments is the persisted non-secret specification.
+    # ctx.credentials is resolved for this committed attempt only.
+    result_ref = await perform_scan(ctx.arguments, ctx.credentials)
+    return DetachedJobResult(result_ref)
+
+class AppAgentBuilder:
+    async def build_agent(self, options):
+        options.register_tool(
+            "security_scan",
+            lambda args: {"error": "detached owner required"},
+            description="Run a durable security scan",
+            execution=DetachedJobExecution(
+                runner="homecore.security_scan",
+                version="v1",
+                restart_class="checkpoint_resumable",
+                idempotency_scope="interaction_and_arguments",
+                submission_timeout_ms=30_000,
+                credential_scopes=("unifi.read",),
+                handler=run_scan,
+            ),
+        )
+
+runtime = await (
+    MobKit.builder()
+    .persistent_state("state/mobkit")
+    .job_credentials(resolve_profile_credentials)
+    .session_service(AppAgentBuilder())
+    .build()
+)
+
+job = await runtime.jobs.get(job_id)
+await runtime.jobs.cancel(job_id)
+```
+
+The gateway durably accepts the job and returns a receipt; host work then runs
+outside the agent turn. Start, reconcile, and cancel are short control-plane
+callbacks subject to the 120-second public contract (the Python host and wire
+margins are 125 and 130 seconds). On reconnect, MobKit offers the exact
+committed attempt, fence, lease, checkpoint, and runner handle. Reopening does
+not mint a new fence; only a machine-authorized claim or retry can do that.
+Resolved credentials are attempt-local and never enter durable job state.
+
 ## Identity-First API
 
 For household-style apps (HomeCore), the identity-first API provides durable lifecycle management.

--- a/docs/sdks/typescript.mdx
+++ b/docs/sdks/typescript.mdx
@@ -46,6 +46,55 @@ const evaluation = await handle.schedulingEvaluate([
 ], Date.now());
 ```
 
+## Durable detached tools
+
+Long-running host work must declare detached execution rather than keeping a
+tool callback open:
+
+```typescript
+import { DetachedJobExecution, DetachedJobResult, MobKit } from "@rkat/mobkit-sdk";
+
+const runtime = await MobKit.builder()
+  .persistentState("state/mobkit")
+  .jobCredentials(resolveProfileCredentials)
+  .sessionService({
+    async buildAgent(draft) {
+      draft.registerTool(
+        "security_scan",
+        async () => ({ error: "detached owner required" }),
+        {
+          description: "Run a durable security scan",
+          execution: new DetachedJobExecution({
+            runner: "homecore.security_scan",
+            version: "v1",
+            restartClass: "checkpoint_resumable",
+            idempotencyScope: "interaction_and_arguments",
+            submissionTimeoutMs: 30_000,
+            credentialScopes: ["unifi.read"],
+            handler: async (ctx) => {
+              await ctx.progress(1, "scan started");
+              const resultRef = await performScan(ctx.arguments, ctx.credentials);
+              return new DetachedJobResult(resultRef);
+            },
+          }),
+        },
+      );
+    },
+  })
+  .build();
+
+const job = await runtime.jobs.get(jobId);
+await runtime.jobs.cancel(jobId);
+```
+
+The gateway durably accepts the job and returns a receipt; host work runs
+outside the agent turn. Start, reconcile, and cancel remain short callbacks
+inside the 120-second public contract (125-second host and 130-second wire
+margins). Reconnect offers the exact committed attempt, fence, lease,
+checkpoint, and runner handle. Reopening never mints a fence; only a
+machine-authorized claim or retry does. Credentials are resolved per attempt
+and never serialized into durable job state.
+
 For identity-first builds with a `rosterProvider`, `.agentMemory()` enables optional identity-scoped hot memory injection from `<persistentState>/agent-memory` with contextual recall by default. Options include `realm`, `selection`, `maxEntries`, `recallTimeoutMs`, `recallFailurePolicy`, and `instructionHeader`; automatic injection defaults to a 500 ms timeout and skips the memory block if recall fails. Write records with `handle.rememberAgentMemory(identity, { title, body, tags, realm })`, read them with `handle.recallAgentMemory(identity, { realm, selection, queryText, queryTerms, maxEntries })`, and delete them with `handle.forgetAgentMemory(identity, memoryId, { realm })`; new records are available on the next identity-first send and during later materialize/resume/respawn/reset flows. Forgetting a record removes it from future recall/injection, but does not erase text already delivered into an active model context.
 
 ## Type definitions

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -75,7 +75,6 @@ meerkat-session = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c"
 meerkat-sqlite = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 meerkat-store = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["sqlite"] }
 meerkat-tools = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
-meerkat-jobs = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,33 +48,34 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.8.6"
-meerkat-client = "=0.8.6"
-meerkat-comms = "=0.8.6"
-meerkat-contracts = "=0.8.6"
-meerkat-mob = "=0.8.6"
-meerkat-mob-mcp = "=0.8.6"
-meerkat-mcp = "=0.8.6"
-meerkat-models = "=0.8.6"
+meerkat-core = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-client = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-comms = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-contracts = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-mob = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-mob-mcp = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-mcp = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-models = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 # Meerkat split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.8.6", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.8.6"
+meerkat-memory = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.8.6"
-meerkat-runtime = { version = "=0.8.6", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.8.6", features = ["session-store"] }
+meerkat-live = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-runtime = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["sqlite-store", "live"] }
+meerkat-session = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["session-store"] }
 # Shared SQLite mechanics (storage-unification): named connection profiles,
 # the per-file migration ledger, per-operation maintenance fence guards
 # (every in-crate opener, M3), and the doctor's read-only ledger reads (M1).
-meerkat-sqlite = "=0.8.6"
-meerkat-store = { version = "=0.8.6", features = ["sqlite"] }
-meerkat-tools = "=0.8.6"
+meerkat-sqlite = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-store = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["sqlite"] }
+meerkat-tools = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-jobs = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -131,9 +132,9 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-schedule = "=0.8.6"
+meerkat-schedule = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.8.6", features = ["schema"] }
+meerkat-mob = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["schema"] }

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -17,7 +17,7 @@
 )]
 //! Phase 0b binary — JSON-RPC gateway bridging SDK clients to the unified runtime.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Write;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -50,11 +50,14 @@ use meerkat::{
     AgentEvent, AgentFactory, Config, CreateSessionRequest, EphemeralSessionService, FactoryAgent,
     FactoryAgentBuilder, SessionAgentBuilder, SessionError,
 };
-use meerkat_core::AgentToolDispatcher;
 use meerkat_core::ContentBlock;
 use meerkat_core::error::{AgentError, ToolError};
 use meerkat_core::ops::ToolDispatchOutcome;
 use meerkat_core::types::{ToolCallView, ToolDef, ToolResult};
+use meerkat_core::{
+    AgentToolDispatcher, ToolCatalogCapabilities, ToolCatalogEntry, ToolDeadlineContributor,
+    ToolDeadlineOwner, ToolExecutionContract, ToolExecutionMode,
+};
 use meerkat_mob::{MobDefinition, MobStorage};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -612,12 +615,20 @@ mod tests {
             CallbackToolSpec::parse(&json!({
                 "name": "weather",
                 "description": "Look up the weather",
-                "input_schema": schema
+                "input_schema": schema,
+                "execution": {
+                    "mode": "detached",
+                    "runner": {"name": "weather.scan", "version": "1"},
+                    "restart_class": "non_resumable",
+                    "idempotency_scope": "interaction_and_arguments",
+                    "submission_timeout_ms": 30000,
+                    "credential_scopes": ["weather.read"]
+                }
             }))
             .expect("object spec"),
         ];
         let dispatcher =
-            CallbackToolDispatcher::new(test_callback_bridge(), "build-1".to_string(), specs);
+            CallbackToolDispatcher::new(test_callback_bridge(), "build-1".to_string(), specs, None);
         let defs = AgentToolDispatcher::tools(&dispatcher);
         assert_eq!(defs.len(), 2);
         assert_eq!(defs[0].name.as_ref(), "legacy_name");
@@ -626,6 +637,29 @@ mod tests {
         assert_eq!(defs[1].name.as_ref(), "weather");
         assert_eq!(defs[1].description, "Look up the weather");
         assert_eq!(defs[1].input_schema, schema);
+        let catalog = AgentToolDispatcher::tool_catalog(&dispatcher);
+        assert_eq!(
+            catalog[1].execution.default_mode(),
+            meerkat_core::ToolExecutionMode::Detached
+        );
+        let detached = catalog[1]
+            .execution
+            .detached_policy()
+            .expect("detached policy");
+        assert_eq!(detached.runner().name(), "weather.scan");
+        assert_eq!(detached.runner().version(), "1");
+        assert_eq!(
+            detached.restart_class(),
+            meerkat_core::RestartClass::NonResumable
+        );
+        assert_eq!(
+            detached.idempotency_scope(),
+            meerkat_core::IdempotencyScope::InteractionAndArguments
+        );
+        assert_eq!(
+            detached.credential_scopes(),
+            &std::collections::BTreeSet::from(["weather.read".to_string()])
+        );
     }
 
     #[test]
@@ -636,12 +670,280 @@ mod tests {
             json!({"name": ""}),
             json!({"name": "x", "input_schema": "not-an-object"}),
             json!({"name": "x", "description": 3}),
+            json!({"name": "x", "execution": {"mode": "detached"}}),
         ] {
             assert!(
                 CallbackToolSpec::parse(&value).is_err(),
                 "expected rejection for {value}"
             );
         }
+    }
+
+    #[test]
+    fn callback_event_delivery_builds_stable_runtime_owned_ingress() {
+        let job_id = meerkat::JobId::new("019f74fb-1907-7b21-932d-ab22c4d1f500").expect("job id");
+        let session_id = meerkat_core::SessionId::parse("019f74fb-1907-7b21-932d-ab22c4d1f501")
+            .expect("session id");
+        let subscription = meerkat::JobSubscription::new(
+            meerkat::JobSubscriptionId::new("review-agent").expect("subscription"),
+            session_id,
+            meerkat::JobDeliveryKind::Event {
+                handling_mode: meerkat_core::HandlingMode::Queue,
+            },
+        );
+        let lineage =
+            meerkat::InteractionLineageId::from_string("019f74fb-1907-7b21-932d-ab22c4d1f502")
+                .expect("lineage");
+        let content = meerkat::JobDeliveryContent::Terminal(meerkat::JobTerminalResult::WorkerLost);
+
+        let input = callback_job_event_input(
+            &job_id,
+            7,
+            &subscription,
+            &lineage,
+            meerkat_core::HandlingMode::Queue,
+            &content,
+        );
+        let meerkat_runtime::Input::ExternalEvent(event) = input else {
+            panic!("job event delivery must use canonical external-event ingress");
+        };
+        assert_eq!(event.event_type, "job.terminal");
+        assert_eq!(event.handling_mode, meerkat_core::HandlingMode::Queue);
+        assert_eq!(
+            event
+                .header
+                .idempotency_key
+                .as_ref()
+                .map(ToString::to_string),
+            Some(format!("job:{job_id}:7:review-agent"))
+        );
+        assert_eq!(
+            event.payload,
+            json!({
+                "job_id": job_id.to_string(),
+                "delivery_sequence": 7,
+                "content": {
+                    "kind": "terminal",
+                    "result": "WorkerLost"
+                }
+            })
+        );
+        assert_eq!(
+            event.header.correlation_id.map(|id| id.to_string()),
+            Some(lineage.as_str().to_string())
+        );
+    }
+
+    #[test]
+    fn callback_runner_ownership_requires_exact_tool_runner_and_version() {
+        let binary: Arc<dyn BinaryBlobStore> = Arc::new(ObjectStoreBlobStore::memory());
+        let blobs: Arc<dyn meerkat_core::BlobStore> = Arc::new(Base64BlobStoreAdapter::new(binary));
+        let runtime = DetachedCallbackJobRuntime::new(
+            meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+            Arc::new(meerkat::MemoryDetachedJobStore::new()),
+            blobs,
+        );
+        let dispatcher = CallbackToolDispatcher::new(
+            test_callback_bridge(),
+            "build-1".to_string(),
+            vec![
+                CallbackToolSpec::parse(&json!({
+                    "name": "security_scan",
+                    "execution": {
+                        "mode": "detached",
+                        "runner": {"name": "homecore.security_scan", "version": "1"},
+                        "restart_class": "adoptable",
+                        "idempotency_scope": "interaction_and_arguments",
+                        "submission_timeout_ms": 30000
+                    }
+                }))
+                .expect("tool spec"),
+            ],
+            Some(runtime.clone()),
+        );
+        assert!(
+            dispatcher.reconcile_registered_catalog,
+            "the first exact callback owner must trigger recovery"
+        );
+        let duplicate = CallbackToolDispatcher::new(
+            test_callback_bridge(),
+            "build-2".to_string(),
+            vec![
+                CallbackToolSpec::parse(&json!({
+                    "name": "security_scan",
+                    "execution": {
+                        "mode": "detached",
+                        "runner": {"name": "homecore.security_scan", "version": "1"},
+                        "restart_class": "adoptable",
+                        "idempotency_scope": "interaction_and_arguments",
+                        "submission_timeout_ms": 30000
+                    }
+                }))
+                .expect("tool spec"),
+            ],
+            Some(runtime.clone()),
+        );
+        assert!(
+            !duplicate.reconcile_registered_catalog,
+            "rebuilding an already-known exact owner must not start a duplicate recovery census"
+        );
+        let later_runner = CallbackToolDispatcher::new(
+            test_callback_bridge(),
+            "build-3".to_string(),
+            vec![
+                CallbackToolSpec::parse(&json!({
+                    "name": "report_export",
+                    "execution": {
+                        "mode": "detached",
+                        "runner": {"name": "homecore.report_export", "version": "1"},
+                        "restart_class": "adoptable",
+                        "idempotency_scope": "interaction_and_arguments",
+                        "submission_timeout_ms": 30000
+                    }
+                }))
+                .expect("tool spec"),
+            ],
+            Some(runtime.clone()),
+        );
+        assert!(
+            later_runner.reconcile_registered_catalog,
+            "a later exact owner must get its own recovery census"
+        );
+        let make_spec = |tool: &str, runner: &str, version: &str| {
+            meerkat::JobSpec::new(
+                meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+                meerkat_core::SessionId::parse("019f74fb-1907-7b21-932d-ab22c4d1f503")
+                    .expect("session"),
+                meerkat::ExecutionIntentId::from_string(format!("intent:{tool}")).expect("intent"),
+                meerkat::InteractionLineageId::from_string(format!("lineage:{tool}"))
+                    .expect("lineage"),
+                meerkat::ToolIdentity::new(tool, version).expect("tool"),
+                meerkat::RunnerIdentity::new(runner, version).expect("runner"),
+                meerkat::RestartClass::Adoptable,
+                meerkat::CanonicalArgumentsHash::new(format!("sha256:{}", "a".repeat(64)))
+                    .expect("hash"),
+                meerkat::JobSubmissionKey::new(format!("submission:{tool}:{runner}:{version}"))
+                    .expect("submission"),
+            )
+        };
+        assert!(runtime.owns_callback_job(&make_spec(
+            "security_scan",
+            "homecore.security_scan",
+            "1"
+        )));
+        assert!(!runtime.owns_callback_job(&make_spec(
+            "other_tool",
+            "homecore.security_scan",
+            "1"
+        )));
+        assert!(!runtime.owns_callback_job(&make_spec(
+            "security_scan",
+            "homecore.security_scan",
+            "2"
+        )));
+    }
+
+    #[tokio::test]
+    async fn callback_reconcile_rehydrates_exact_committed_authority_without_advancing_fence() {
+        let store = Arc::new(meerkat::MemoryDetachedJobStore::new());
+        let service = meerkat::DetachedJobService::new(store.clone());
+        let session_id = meerkat_core::SessionId::parse("019f74fb-1907-7b21-932d-ab22c4d1f532")
+            .expect("session id");
+        let spec = meerkat::JobSpec::new(
+            meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+            session_id,
+            meerkat::ExecutionIntentId::from_string("intent:reconcile").expect("intent"),
+            meerkat::InteractionLineageId::from_string("lineage:reconcile").expect("lineage"),
+            meerkat::ToolIdentity::new("security_scan", "1").expect("tool"),
+            meerkat::RunnerIdentity::new("homecore.security_scan", "1").expect("runner"),
+            meerkat::RestartClass::Adoptable,
+            meerkat::CanonicalArgumentsHash::new(format!("sha256:{}", "a".repeat(64)))
+                .expect("arguments hash"),
+            meerkat::JobSubmissionKey::new("callback:reconcile").expect("submission key"),
+        );
+        let receipt = service.submit(spec).await.expect("submit");
+        let claim = service
+            .claim_attempt(
+                &receipt.job_id,
+                meerkat::AttemptClaim::new(
+                    meerkat::WorkerId::new("worker-1").expect("worker"),
+                    100,
+                    u64::MAX,
+                    meerkat::RunnerHandleRef::new("external:scan-1").expect("handle"),
+                ),
+            )
+            .await
+            .expect("claim");
+
+        let (stdout_tx, mut stdout_rx) = mpsc::channel::<String>(4);
+        let bridge = StdioCallbackBridge::new(stdout_tx);
+        let binary: Arc<dyn BinaryBlobStore> = Arc::new(ObjectStoreBlobStore::memory());
+        let blobs: Arc<dyn meerkat_core::BlobStore> = Arc::new(Base64BlobStoreAdapter::new(binary));
+        let dispatcher = CallbackToolDispatcher::new(
+            bridge.clone(),
+            "build-1".to_string(),
+            vec![
+                CallbackToolSpec::parse(&json!({
+                    "name": "security_scan",
+                    "execution": {
+                        "mode": "detached",
+                        "runner": {"name": "homecore.security_scan", "version": "1"},
+                        "restart_class": "adoptable",
+                        "idempotency_scope": "interaction_and_arguments",
+                        "submission_timeout_ms": 30000
+                    }
+                }))
+                .expect("tool spec"),
+            ],
+            Some(DetachedCallbackJobRuntime::new(
+                meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+                store.clone(),
+                blobs,
+            )),
+        );
+        let reconcile = tokio::spawn(async move { dispatcher.reconcile_detached_jobs().await });
+        let request_line = stdout_rx.recv().await.expect("reconcile callback");
+        let request: Value = serde_json::from_str(&request_line).expect("callback json");
+        assert_eq!(
+            request.pointer("/params/attempts/0/authority/fence"),
+            Some(&json!(claim.fence.get()))
+        );
+        assert_eq!(
+            request.pointer("/params/attempts/0/authority/attempt_id"),
+            Some(&json!(claim.attempt_id.to_string()))
+        );
+        assert_eq!(
+            request.pointer("/params/attempts/0/runner_handle"),
+            Some(&json!("external:scan-1"))
+        );
+        bridge
+            .route_callback_response(json!({
+                "jsonrpc": "2.0",
+                "id": request["id"].clone(),
+                "result": {
+                    "live_attempts": [{
+                        "job_id": receipt.job_id.to_string(),
+                        "attempt_id": claim.attempt_id.to_string(),
+                        "fence": claim.fence.get()
+                    }]
+                }
+            }))
+            .await;
+        reconcile
+            .await
+            .expect("reconcile task")
+            .expect("reconcile succeeds");
+
+        let reopened = meerkat::DetachedJobStore::get(&*store, &receipt.job_id)
+            .await
+            .expect("read")
+            .expect("job");
+        assert_eq!(reopened.machine_state.attempt_count, 1);
+        assert_eq!(reopened.machine_state.current_fence, claim.fence.get());
+        assert_eq!(
+            reopened.machine_state.current_attempt_id.as_deref(),
+            Some(claim.attempt_id.as_str())
+        );
     }
 
     #[test]
@@ -2068,6 +2370,7 @@ actions = ["agent.view"]
             bridge: StdioCallbackBridge::new(stdout_tx),
             has_session_builder: false,
             session_store: None,
+            detached_jobs: None,
         };
         let session_id = meerkat_core::SessionId::parse("019f74fb-1907-7b21-932d-ab22c4d1f532")
             .expect("valid session id");
@@ -3852,6 +4155,499 @@ struct CallbackToolSpec {
     name: String,
     description: Option<String>,
     input_schema: Option<Value>,
+    execution: ToolExecutionContract,
+}
+
+#[derive(Clone)]
+struct DetachedCallbackJobRuntime {
+    realm_id: String,
+    store: Arc<dyn meerkat::DetachedJobStore>,
+    service: meerkat::DetachedJobService,
+    blob_store: Arc<dyn meerkat_core::BlobStore>,
+    runtime_inbox: Option<meerkat_runtime::RuntimeDeliveryInbox>,
+    delivery_service: Arc<std::sync::RwLock<Option<Arc<dyn meerkat_mob::MobSessionService>>>>,
+    delivery_driver_started: Arc<AtomicBool>,
+    monitor_recovery_completed: Arc<AtomicBool>,
+    monitor_shell_config: Option<meerkat_tools::builtin::shell::ShellConfig>,
+    monitor_managers: Arc<Mutex<HashMap<String, Arc<meerkat_tools::builtin::shell::JobManager>>>>,
+    callback_runners: Arc<std::sync::RwLock<BTreeSet<(String, String, String)>>>,
+}
+
+impl DetachedCallbackJobRuntime {
+    fn new(
+        realm_id: impl Into<String>,
+        store: Arc<dyn meerkat::DetachedJobStore>,
+        blob_store: Arc<dyn meerkat_core::BlobStore>,
+    ) -> Self {
+        Self {
+            realm_id: realm_id.into(),
+            service: meerkat::DetachedJobService::new(Arc::clone(&store)),
+            store,
+            blob_store,
+            runtime_inbox: None,
+            delivery_service: Arc::new(std::sync::RwLock::new(None)),
+            delivery_driver_started: Arc::new(AtomicBool::new(false)),
+            monitor_recovery_completed: Arc::new(AtomicBool::new(false)),
+            monitor_shell_config: None,
+            monitor_managers: Arc::new(Mutex::new(HashMap::new())),
+            callback_runners: Arc::new(std::sync::RwLock::new(BTreeSet::new())),
+        }
+    }
+
+    fn with_runtime_delivery_store(
+        mut self,
+        runtime_store: Arc<dyn meerkat_runtime::RuntimeStore>,
+    ) -> Self {
+        self.runtime_inbox = Some(meerkat_runtime::RuntimeDeliveryInbox::new(runtime_store));
+        self
+    }
+
+    fn with_monitor_shell(mut self, project_root: PathBuf, enabled: bool) -> Self {
+        if enabled {
+            self.monitor_shell_config =
+                Some(meerkat_tools::builtin::shell::ShellConfig::with_project_root(project_root));
+        }
+        self
+    }
+
+    fn shell_delivery_projector(
+        &self,
+    ) -> Result<Arc<dyn meerkat_tools::builtin::shell::ShellJobDeliveryProjector>, String> {
+        let runtime_inbox = self.runtime_inbox.clone().ok_or_else(|| {
+            "durable monitor execution requires the persistent runtime inbox".to_string()
+        })?;
+        Ok(Arc::new(meerkat::JobOutboxProjector::new_for_realm(
+            Arc::clone(&self.store),
+            runtime_inbox,
+            self.realm_id.clone(),
+        )))
+    }
+
+    async fn monitor_manager(
+        &self,
+        session_id: &meerkat_core::SessionId,
+    ) -> Result<Arc<meerkat_tools::builtin::shell::JobManager>, String> {
+        let key = session_id.to_string();
+        let mut managers = self.monitor_managers.lock().await;
+        if let Some(manager) = managers.get(&key) {
+            return Ok(Arc::clone(manager));
+        }
+        let config = self.monitor_shell_config.clone().ok_or_else(|| {
+            "monitors/start requires shell tooling to be enabled for this MobKit runtime"
+                .to_string()
+        })?;
+        let durable = meerkat_tools::builtin::shell::DurableShellJobRuntime::new(
+            self.realm_id.clone(),
+            session_id.clone(),
+            Arc::clone(&self.store),
+            Arc::clone(&self.blob_store),
+            self.shell_delivery_projector()?,
+        )
+        .map_err(|error| error.to_string())?;
+        let manager = Arc::new(
+            meerkat_tools::builtin::shell::JobManager::new(config)
+                .with_durable_job_runtime(durable)
+                .bind_canonical_async_ops(
+                    session_id.clone(),
+                    Arc::new(meerkat_runtime::RuntimeOpsLifecycleRegistry::new()),
+                ),
+        );
+        managers.insert(key, Arc::clone(&manager));
+        Ok(manager)
+    }
+
+    fn register_callback_catalog(&self, catalog: &[ToolCatalogEntry]) -> bool {
+        let mut runners = self
+            .callback_runners
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut registered_new_runner = false;
+        for entry in catalog {
+            if let Some(policy) = entry.execution.detached_policy() {
+                registered_new_runner |= runners.insert((
+                    entry.tool.name.to_string(),
+                    policy.runner().name().to_string(),
+                    policy.runner().version().to_string(),
+                ));
+            }
+        }
+        registered_new_runner
+    }
+
+    fn owns_callback_job(&self, spec: &meerkat::JobSpec) -> bool {
+        self.callback_runners
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(&(
+                spec.tool.name().to_string(),
+                spec.runner.name().to_string(),
+                spec.runner.version().to_string(),
+            ))
+    }
+
+    async fn recover_monitor_jobs(&self) -> Result<(), String> {
+        if self.monitor_shell_config.is_none()
+            || self.monitor_recovery_completed.load(Ordering::Acquire)
+        {
+            return Ok(());
+        }
+        let sessions = self
+            .store
+            .list_all(usize::MAX)
+            .await
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|job| {
+                job.spec.realm_id == self.realm_id
+                    && matches!(
+                        job.spec.runner.name(),
+                        "meerkat.shell" | "meerkat.monitor_script"
+                    )
+            })
+            .map(|job| {
+                let session_id = job.spec.origin_session_id;
+                (session_id.to_string(), session_id)
+            })
+            .collect::<BTreeMap<_, _>>();
+        for session_id in sessions.into_values() {
+            self.monitor_manager(&session_id)
+                .await?
+                .list_jobs()
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        self.monitor_recovery_completed
+            .store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn attach_delivery_service(&self, service: Arc<dyn meerkat_mob::MobSessionService>) {
+        *self
+            .delivery_service
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(service);
+    }
+
+    fn arm_delivery_driver(&self, unified_runtime: Arc<UnifiedRuntime>) {
+        if self
+            .delivery_driver_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            loop {
+                if let Err(error) = runtime.recover_monitor_jobs().await {
+                    tracing::warn!(%error, "durable monitor recovery failed");
+                }
+                if let Err(error) = runtime.drain_deliveries().await {
+                    tracing::warn!(%error, "durable callback delivery drain failed");
+                }
+                match runtime.health_projection().await {
+                    Ok(projection) => unified_runtime.set_job_health_projection(Some(projection)),
+                    Err(error) => {
+                        tracing::warn!(%error, "durable callback health projection failed");
+                        unified_runtime.set_job_health_projection(Some(json!({
+                            "status": "degraded",
+                            "detached_jobs": {
+                                "status": "degraded",
+                                "reason": "job_health_projection_failed"
+                            }
+                        })));
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        });
+    }
+
+    async fn drain_deliveries(&self) -> Result<(), String> {
+        let Some(runtime_inbox) = self.runtime_inbox.clone() else {
+            return Ok(());
+        };
+        let delivery_service = self
+            .delivery_service
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let Some(delivery_service) = delivery_service else {
+            return Ok(());
+        };
+        let projector = meerkat::JobOutboxProjector::new_for_realm(
+            Arc::clone(&self.store),
+            runtime_inbox.clone(),
+            self.realm_id.clone(),
+        );
+        projector
+            .project_pending(256)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let sink: Arc<dyn meerkat::JobDeliverySink> =
+            Arc::new(CallbackJobDeliverySink { delivery_service });
+        let applier = meerkat::JobRuntimeDeliveryApplier::new(runtime_inbox, sink);
+        for session_id in self.delivery_origin_sessions().await? {
+            applier
+                .apply_pending(
+                    &meerkat_runtime::LogicalRuntimeId::for_session(&session_id),
+                    256,
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        Ok(())
+    }
+
+    async fn delivery_origin_sessions(&self) -> Result<Vec<meerkat_core::SessionId>, String> {
+        Ok(self
+            .store
+            .list_all(usize::MAX)
+            .await
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|job| job.spec.realm_id == self.realm_id)
+            .map(|job| {
+                let origin = job.spec.origin_session_id;
+                (origin.to_string(), origin)
+            })
+            .collect::<BTreeMap<_, _>>()
+            .into_values()
+            .collect())
+    }
+
+    async fn runtime_delivery_backlog(&self) -> Result<u64, String> {
+        let Some(runtime_inbox) = self.runtime_inbox.clone() else {
+            return Ok(0);
+        };
+        let mut total = 0_u64;
+        for session_id in self.delivery_origin_sessions().await? {
+            let pending = runtime_inbox
+                .list_pending(
+                    &meerkat_runtime::LogicalRuntimeId::for_session(&session_id),
+                    usize::MAX,
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+            total = total.saturating_add(u64::try_from(pending.len()).unwrap_or(u64::MAX));
+        }
+        Ok(total)
+    }
+
+    async fn health_projection(&self) -> Result<Value, String> {
+        let now_ms = callback_unix_time_ms()?;
+        let health = self
+            .service
+            .health_snapshot_for_realm(&self.realm_id, now_ms, usize::MAX)
+            .await
+            .map_err(|error| error.to_string())?;
+        let runtime_delivery_backlog = self.runtime_delivery_backlog().await?;
+        let delivery_backlog = health
+            .delivery_backlog
+            .saturating_add(runtime_delivery_backlog);
+        let degraded = health.is_degraded() || runtime_delivery_backlog > 0;
+        let mut by_session = serde_json::Map::new();
+        for job in self
+            .store
+            .list_all(usize::MAX)
+            .await
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|job| job.spec.realm_id == self.realm_id)
+        {
+            let key = job.spec.origin_session_id.to_string();
+            let entry = by_session.entry(key).or_insert_with(|| {
+                json!({
+                    "active": 0_u64,
+                    "awaiting_detached": false,
+                    "queued": 0_u64,
+                    "running": 0_u64,
+                    "needs_attention": 0_u64
+                })
+            });
+            let active = matches!(
+                job.machine_state.lifecycle_phase,
+                meerkat::JobPhase::Unsubmitted
+                    | meerkat::JobPhase::Queued
+                    | meerkat::JobPhase::Claimed
+                    | meerkat::JobPhase::Running
+                    | meerkat::JobPhase::WaitingExternal
+                    | meerkat::JobPhase::LossObserved
+                    | meerkat::JobPhase::RetryScheduled
+            );
+            if active {
+                entry["active"] = json!(
+                    entry["active"]
+                        .as_u64()
+                        .unwrap_or_default()
+                        .saturating_add(1)
+                );
+                entry["awaiting_detached"] = Value::Bool(true);
+            }
+            let field = match job.machine_state.lifecycle_phase {
+                meerkat::JobPhase::Queued | meerkat::JobPhase::RetryScheduled => Some("queued"),
+                meerkat::JobPhase::Running | meerkat::JobPhase::WaitingExternal => Some("running"),
+                meerkat::JobPhase::NeedsAttention => Some("needs_attention"),
+                _ => None,
+            };
+            if let Some(field) = field {
+                entry[field] = json!(entry[field].as_u64().unwrap_or_default().saturating_add(1));
+            }
+        }
+        Ok(json!({
+            "status": if degraded { "degraded" } else { "ok" },
+            "monitors_available": self.monitor_shell_config.is_some(),
+            "detached_jobs": {
+                "status": if degraded { "degraded" } else { "ok" },
+                "queued": health.queued,
+                "running": health.running,
+                "awaiting_members": health.awaiting_members,
+                "stale_leases": health.stale_leases,
+                "needs_attention": health.needs_attention,
+                "delivery_backlog": delivery_backlog
+            },
+            "by_session": by_session
+        }))
+    }
+}
+
+struct CallbackJobDeliverySink {
+    delivery_service: Arc<dyn meerkat_mob::MobSessionService>,
+}
+
+#[async_trait]
+impl meerkat::JobDeliverySink for CallbackJobDeliverySink {
+    async fn apply(&self, application: meerkat::JobDeliveryApplication) -> Result<(), String> {
+        match application {
+            meerkat::JobDeliveryApplication::Record { .. } => Ok(()),
+            meerkat::JobDeliveryApplication::Notification {
+                job_id,
+                delivery_sequence,
+                subscription,
+                content,
+            } => {
+                let mut request = meerkat_core::service::AppendSystemContextRequest::from_text(
+                    callback_job_delivery_text(&job_id, &content),
+                );
+                request.source = Some(format!("detached_job:{job_id}"));
+                request.idempotency_key = Some(format!(
+                    "job:{job_id}:{delivery_sequence}:{}",
+                    subscription.subscription_id()
+                ));
+                self.delivery_service
+                    .append_system_context(subscription.session_id(), request)
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+            }
+            meerkat::JobDeliveryApplication::Event {
+                job_id,
+                delivery_sequence,
+                subscription,
+                interaction_lineage_id,
+                handling_mode,
+                content,
+            } => {
+                let runtime_adapter = self
+                    .delivery_service
+                    .runtime_adapter()
+                    .ok_or_else(|| {
+                        format!(
+                            "session {} has no runtime-owned durable event ingress for detached job {job_id}",
+                            subscription.session_id()
+                        )
+                    })?;
+                let input = callback_job_event_input(
+                    &job_id,
+                    delivery_sequence,
+                    &subscription,
+                    &interaction_lineage_id,
+                    handling_mode,
+                    &content,
+                );
+                meerkat_runtime::SessionServiceRuntimeExt::accept_input(
+                    runtime_adapter.as_ref(),
+                    subscription.session_id(),
+                    input,
+                )
+                .await
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+            }
+        }
+    }
+}
+
+fn callback_job_event_input(
+    job_id: &meerkat::JobId,
+    delivery_sequence: u64,
+    subscription: &meerkat::JobSubscription,
+    interaction_lineage_id: &meerkat::InteractionLineageId,
+    handling_mode: meerkat_core::HandlingMode,
+    content: &meerkat::JobDeliveryContent,
+) -> meerkat_runtime::Input {
+    let event_type = match content {
+        meerkat::JobDeliveryContent::Notification(_) => "job.notification",
+        meerkat::JobDeliveryContent::Terminal(_) => "job.terminal",
+    };
+    let content_value = match content {
+        meerkat::JobDeliveryContent::Notification(notification) => json!({
+            "kind": "notification",
+            "notification": notification,
+        }),
+        meerkat::JobDeliveryContent::Terminal(result) => json!({
+            "kind": "terminal",
+            "result": result,
+        }),
+    };
+    let correlation_id = uuid::Uuid::parse_str(interaction_lineage_id.as_str())
+        .ok()
+        .map(meerkat_runtime::CorrelationId::from_uuid);
+    let idempotency_key = format!(
+        "job:{job_id}:{delivery_sequence}:{}",
+        subscription.subscription_id()
+    );
+    meerkat_runtime::Input::ExternalEvent(meerkat_runtime::ExternalEventInput {
+        objective_id: None,
+        header: meerkat_runtime::InputHeader {
+            id: meerkat_core::lifecycle::InputId::new(),
+            timestamp: chrono::Utc::now(),
+            source: meerkat_runtime::InputOrigin::External {
+                source_name: event_type.to_string(),
+            },
+            durability: meerkat_runtime::InputDurability::Durable,
+            visibility: meerkat_runtime::InputVisibility::default(),
+            idempotency_key: Some(meerkat_runtime::IdempotencyKey::new(idempotency_key)),
+            supersession_key: None,
+            correlation_id,
+        },
+        event_type: event_type.to_string(),
+        payload: json!({
+            "job_id": job_id.to_string(),
+            "delivery_sequence": delivery_sequence,
+            "content": content_value,
+        }),
+        blocks: None,
+        handling_mode,
+        render_metadata: None,
+    })
+}
+
+fn callback_job_delivery_text(
+    job_id: &meerkat::JobId,
+    content: &meerkat::JobDeliveryContent,
+) -> String {
+    match content {
+        meerkat::JobDeliveryContent::Notification(notification) => format!(
+            "Detached job {job_id}: {}\n\n{}",
+            notification.title(),
+            notification.body()
+        ),
+        meerkat::JobDeliveryContent::Terminal(result) => {
+            format!("Detached job {job_id} reached terminal state: {result:?}")
+        }
+    }
 }
 
 impl CallbackToolSpec {
@@ -3861,6 +4657,7 @@ impl CallbackToolSpec {
                 name: name.to_string(),
                 description: None,
                 input_schema: None,
+                execution: ToolExecutionContract::default(),
             });
         }
         let Some(object) = value.as_object() else {
@@ -3893,11 +4690,80 @@ impl CallbackToolSpec {
                 ));
             }
         };
+        let execution = object
+            .get("execution")
+            .cloned()
+            .map(serde_json::from_value::<meerkat_contracts::CallbackToolExecution>)
+            .transpose()
+            .map_err(|error| format!("tool '{name}' execution is invalid: {error}"))?
+            .map_or_else(
+                || Ok(ToolExecutionContract::default()),
+                callback_execution_contract,
+            )?;
         Ok(Self {
             name,
             description,
             input_schema,
+            execution,
         })
+    }
+}
+
+fn callback_execution_contract(
+    execution: meerkat_contracts::CallbackToolExecution,
+) -> Result<ToolExecutionContract, String> {
+    match execution {
+        meerkat_contracts::CallbackToolExecution::Fast => Ok(ToolExecutionContract::default()),
+        meerkat_contracts::CallbackToolExecution::Detached {
+            runner,
+            restart_class,
+            idempotency_scope,
+            submission_timeout_ms,
+            credential_scopes,
+        } => {
+            let runner = meerkat_core::RunnerIdentity::new(runner.name, runner.version)
+                .map_err(|error| error.to_string())?;
+            let restart_class = match restart_class {
+                meerkat_contracts::JobRestartClass::Adoptable => {
+                    meerkat_core::RestartClass::Adoptable
+                }
+                meerkat_contracts::JobRestartClass::CheckpointResumable => {
+                    meerkat_core::RestartClass::CheckpointResumable
+                }
+                meerkat_contracts::JobRestartClass::Replayable => {
+                    meerkat_core::RestartClass::Replayable
+                }
+                meerkat_contracts::JobRestartClass::NonResumable => {
+                    meerkat_core::RestartClass::NonResumable
+                }
+            };
+            let idempotency_scope = match idempotency_scope {
+                meerkat_contracts::JobIdempotencyScope::ToolCall => {
+                    meerkat_core::IdempotencyScope::ToolCall
+                }
+                meerkat_contracts::JobIdempotencyScope::InteractionAndArguments => {
+                    meerkat_core::IdempotencyScope::InteractionAndArguments
+                }
+                meerkat_contracts::JobIdempotencyScope::HostSemanticKey => {
+                    meerkat_core::IdempotencyScope::HostSemanticKey
+                }
+            };
+            let policy = meerkat_core::DetachedToolExecutionPolicy::new(
+                runner,
+                restart_class,
+                idempotency_scope,
+                Duration::from_millis(submission_timeout_ms),
+            )
+            .map_err(|error| error.to_string())?
+            .with_credential_scopes(credential_scopes);
+            ToolExecutionContract::new(
+                std::collections::BTreeSet::from([ToolExecutionMode::Detached]),
+                ToolExecutionMode::Detached,
+                None,
+                Some(policy),
+            )
+            .map_err(|error| error.to_string())
+        }
     }
 }
 
@@ -3907,34 +4773,567 @@ impl CallbackToolSpec {
 /// (`add_tools()` names or `register_tool()` name + description + schema).
 /// When the agent calls a tool, `dispatch()` sends `callback/call_tool` to
 /// Python and returns the result.
+#[derive(Clone)]
 struct CallbackToolDispatcher {
     bridge: StdioCallbackBridge,
     scope_id: String,
     tool_defs: Arc<[Arc<ToolDef>]>,
+    tool_catalog: Arc<[ToolCatalogEntry]>,
+    detached_jobs: Option<DetachedCallbackJobRuntime>,
+    reconcile_registered_catalog: bool,
 }
 
 impl CallbackToolDispatcher {
-    fn new(bridge: StdioCallbackBridge, scope_id: String, tools: Vec<CallbackToolSpec>) -> Self {
-        let tool_defs: Vec<Arc<ToolDef>> = tools
+    fn new(
+        bridge: StdioCallbackBridge,
+        scope_id: String,
+        tools: Vec<CallbackToolSpec>,
+        detached_jobs: Option<DetachedCallbackJobRuntime>,
+    ) -> Self {
+        let entries: Vec<(Arc<ToolDef>, ToolExecutionContract)> = tools
             .into_iter()
             .map(|tool| {
-                Arc::new(ToolDef {
-                    name: tool.name.into(),
-                    description: tool
-                        .description
-                        .unwrap_or_else(|| "Python callback tool".to_string()),
-                    input_schema: tool
-                        .input_schema
-                        .unwrap_or_else(|| json!({"type": "object"})),
-                    provenance: None,
-                })
+                (
+                    Arc::new(ToolDef {
+                        name: tool.name.into(),
+                        description: tool
+                            .description
+                            .unwrap_or_else(|| "Python callback tool".to_string()),
+                        input_schema: tool
+                            .input_schema
+                            .unwrap_or_else(|| json!({"type": "object"})),
+                        provenance: None,
+                    }),
+                    tool.execution,
+                )
             })
             .collect();
+        let tool_defs = entries
+            .iter()
+            .map(|(tool, _)| Arc::clone(tool))
+            .collect::<Vec<_>>();
+        let tool_catalog = entries
+            .into_iter()
+            .map(|(tool, execution)| {
+                ToolCatalogEntry::session_inline(tool, true).with_execution_contract(execution)
+            })
+            .collect::<Vec<_>>();
+        let reconcile_registered_catalog = detached_jobs
+            .as_ref()
+            .is_some_and(|runtime| runtime.register_callback_catalog(&tool_catalog));
         Self {
             bridge,
             scope_id,
             tool_defs: tool_defs.into(),
+            tool_catalog: tool_catalog.into(),
+            detached_jobs,
+            reconcile_registered_catalog,
         }
+    }
+
+    async fn submit_detached(
+        &self,
+        call: ToolCallView<'_>,
+        context: &meerkat_core::ToolDispatchContext,
+        plan: &meerkat_core::ResolvedToolExecutionPlan,
+    ) -> Result<ToolDispatchOutcome, ToolError> {
+        let runtime = self.detached_jobs.clone().ok_or_else(|| {
+            ToolError::unavailable(
+                call.name,
+                meerkat_core::ToolUnavailableReason::ExecutionModeOwnerUnavailable,
+            )
+        })?;
+        let origin_session_id = context.origin_session_id().cloned().ok_or_else(|| {
+            ToolError::execution_failed(
+                "detached callback dispatch requires runtime-owned session identity".to_string(),
+            )
+        })?;
+        let interaction_lineage = context.interaction_lineage_id().ok_or_else(|| {
+            ToolError::execution_failed(
+                "detached callback dispatch requires runtime-owned interaction lineage".to_string(),
+            )
+        })?;
+        let arguments_sha256 = plan.canonical_arguments_sha256().ok_or_else(|| {
+            ToolError::execution_failed(
+                "detached callback dispatch requires a root-fenced canonical argument digest"
+                    .to_string(),
+            )
+        })?;
+        let policy = match plan.kind() {
+            meerkat_core::ResolvedExecutionKind::Detached(policy) => policy,
+            _ => {
+                return Err(ToolError::execution_failed(
+                    "detached callback owner received a non-detached execution plan".to_string(),
+                ));
+            }
+        };
+        let arguments: Value = serde_json::from_str(call.args.get())
+            .map_err(|error| ToolError::invalid_arguments(call.name, error.to_string()))?;
+        let arguments_hash = callback_sha256(arguments_sha256);
+        let lineage = interaction_lineage.to_string();
+        let submission_key = callback_submission_key(
+            &runtime.realm_id,
+            &origin_session_id,
+            &lineage,
+            call,
+            policy,
+            &arguments_hash,
+            &arguments,
+        )?;
+        let specification = runtime
+            .blob_store
+            .put_artifact(
+                "application/vnd.meerkat.callback-arguments+json",
+                call.args.get(),
+            )
+            .await
+            .map_err(|error| {
+                ToolError::execution_failed(format!(
+                    "failed to persist detached callback specification: {error}"
+                ))
+            })?;
+        let spec = meerkat::JobSpec::new(
+            runtime.realm_id.clone(),
+            origin_session_id,
+            meerkat::ExecutionIntentId::from_string(format!(
+                "intent:{lineage}:{}:{arguments_hash}",
+                call.name
+            ))
+            .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+            meerkat::InteractionLineageId::from_string(lineage)
+                .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+            meerkat::ToolIdentity::new(call.name, policy.runner().version())
+                .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+            meerkat::RunnerIdentity::new(policy.runner().name(), policy.runner().version())
+                .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+            callback_job_restart_class(policy.restart_class()),
+            meerkat::CanonicalArgumentsHash::new(arguments_hash)
+                .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+            meerkat::JobSubmissionKey::new(submission_key)
+                .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+        )
+        .with_runner_specification_ref(
+            meerkat::RunnerSpecificationRef::new(specification.blob_id.to_string())
+                .map_err(|error| ToolError::execution_failed(error.to_string()))?,
+        )
+        .with_credential_context_refs(match plan.credential_context_refs() {
+            meerkat_core::ToolExecutionApplicability::Applicable(references) => references.clone(),
+            meerkat_core::ToolExecutionApplicability::NotApplicable => Vec::new(),
+        });
+        let receipt = runtime
+            .service
+            .submit(spec)
+            .await
+            .map_err(|error| ToolError::execution_failed(error.to_string()))?;
+        let projected = meerkat::project_job_receipt(receipt.clone());
+        let bridge = self.bridge.clone();
+        tokio::spawn(async move {
+            if let Err(error) =
+                start_detached_callback_attempt(runtime, bridge, receipt.job_id).await
+            {
+                tracing::warn!(%error, "detached callback attempt start did not complete");
+            }
+        });
+        let content = serde_json::to_string(&projected).map_err(|error| {
+            ToolError::execution_failed(format!("failed to encode detached job receipt: {error}"))
+        })?;
+        Ok(ToolResult::new(call.id.to_string(), content, false).into())
+    }
+
+    fn owns_detached_callback_spec(&self, spec: &meerkat::JobSpec) -> bool {
+        self.tool_catalog.iter().any(|entry| {
+            entry.tool.name == spec.tool.name()
+                && entry.execution.detached_policy().is_some_and(|policy| {
+                    policy.runner().name() == spec.runner.name()
+                        && policy.runner().version() == spec.runner.version()
+                })
+        })
+    }
+
+    /// Rehydrate exact committed authority. Offering an attempt to the host
+    /// never claims, retries, or advances its fence.
+    async fn reconcile_detached_jobs(&self) -> Result<(), String> {
+        let Some(runtime) = self.detached_jobs.clone() else {
+            return Ok(());
+        };
+        let jobs = runtime.store.list_all(usize::MAX).await.map_err(|error| {
+            format!("failed to enumerate detached callbacks for reconciliation: {error}")
+        })?;
+        let mut attempts = Vec::new();
+        for job in jobs.into_iter().filter(|job| {
+            job.spec.realm_id == runtime.realm_id && self.owns_detached_callback_spec(&job.spec)
+        }) {
+            if matches!(
+                job.machine_state.lifecycle_phase,
+                meerkat::JobPhase::Running | meerkat::JobPhase::WaitingExternal
+            ) {
+                let attempt_id =
+                    job.machine_state
+                        .current_attempt_id
+                        .as_deref()
+                        .ok_or_else(|| {
+                            format!(
+                                "active detached callback {} has no committed attempt id",
+                                job.job_id
+                            )
+                        })?;
+                let runner_handle =
+                    job.machine_state.runner_handle.as_deref().ok_or_else(|| {
+                        format!(
+                            "active detached callback {} has no committed runner handle",
+                            job.job_id
+                        )
+                    })?;
+                let lease_expires_at_ms =
+                    job.machine_state.lease_expires_at_ms.ok_or_else(|| {
+                        format!(
+                            "active detached callback {} has no committed lease",
+                            job.job_id
+                        )
+                    })?;
+                attempts.push(meerkat_contracts::CallbackJobReconcileAttempt {
+                    authority: meerkat_contracts::JobAttemptAuthority {
+                        job_id: job.job_id.to_string(),
+                        attempt_id: attempt_id.to_string(),
+                        fence: job.machine_state.current_fence,
+                    },
+                    runner: meerkat_contracts::JobRunner {
+                        name: job.spec.runner.name().to_string(),
+                        version: job.spec.runner.version().to_string(),
+                    },
+                    restart_class: callback_wire_restart_class(job.spec.restart_class),
+                    runner_handle: runner_handle.to_string(),
+                    checkpoint_ref: job
+                        .machine_state
+                        .checkpoint_ref
+                        .as_ref()
+                        .map(ToString::to_string),
+                    lease_expires_at_ms,
+                });
+            }
+        }
+        if !attempts.is_empty() {
+            let offered_attempts = attempts.clone();
+            let offered = attempts
+                .iter()
+                .map(|attempt| attempt.authority.clone())
+                .collect::<Vec<_>>();
+            let result: meerkat_contracts::CallbackJobReconcileResult = serde_json::from_value(
+                self.bridge
+                    .call(
+                        "callback/job/reconcile",
+                        serde_json::to_value(meerkat_contracts::CallbackJobReconcileParams {
+                            attempts,
+                        })
+                        .map_err(|error| error.to_string())?,
+                    )
+                    .await?,
+            )
+            .map_err(|error| error.to_string())?;
+            if result
+                .live_attempts
+                .iter()
+                .any(|authority| !offered.contains(authority))
+            {
+                return Err(
+                    "callback/job/reconcile returned authority that was not offered".to_string(),
+                );
+            }
+            let now_ms = callback_unix_time_ms()?;
+            for attempt in offered_attempts.iter().filter(|attempt| {
+                attempt.lease_expires_at_ms <= now_ms
+                    && !result.live_attempts.contains(&attempt.authority)
+            }) {
+                let job_id =
+                    meerkat::JobId::new(&attempt.authority.job_id).map_err(|e| e.to_string())?;
+                let write = meerkat::AttemptWriteAuthority {
+                    attempt_id: meerkat::AttemptId::new(&attempt.authority.attempt_id)
+                        .map_err(|e| e.to_string())?,
+                    fence: meerkat::FenceToken::new(attempt.authority.fence),
+                };
+                match runtime
+                    .service
+                    .observe_lease_expired(&job_id, write, now_ms)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(
+                        meerkat::DetachedJobError::StaleRevision { .. }
+                        | meerkat::DetachedJobError::InvalidTransition { .. },
+                    ) => continue,
+                    Err(error) => return Err(error.to_string()),
+                }
+                match attempt.restart_class {
+                    meerkat_contracts::JobRestartClass::NonResumable => {
+                        runtime
+                            .service
+                            .classify_worker_loss(&job_id, now_ms)
+                            .await
+                            .map_err(|error| error.to_string())?;
+                    }
+                    meerkat_contracts::JobRestartClass::CheckpointResumable
+                        if attempt.checkpoint_ref.is_none() =>
+                    {
+                        runtime
+                            .service
+                            .mark_needs_attention(
+                                &job_id,
+                                now_ms,
+                                meerkat::JobFailureCode::new(
+                                    "checkpoint_resume_missing_checkpoint",
+                                )
+                                .map_err(|error| error.to_string())?,
+                            )
+                            .await
+                            .map_err(|error| error.to_string())?;
+                    }
+                    meerkat_contracts::JobRestartClass::Adoptable
+                    | meerkat_contracts::JobRestartClass::CheckpointResumable
+                    | meerkat_contracts::JobRestartClass::Replayable => {
+                        runtime
+                            .service
+                            .schedule_retry(&job_id, now_ms)
+                            .await
+                            .map_err(|error| error.to_string())?;
+                    }
+                }
+            }
+            for attempt in offered_attempts.iter().filter(|attempt| {
+                attempt.lease_expires_at_ms > now_ms
+                    || result.live_attempts.contains(&attempt.authority)
+            }) {
+                let runtime = runtime.clone();
+                let bridge = self.bridge.clone();
+                let authority = attempt.authority.clone();
+                spawn_callback_lease_tracker(runtime, bridge, authority);
+            }
+        }
+        self.start_due_detached_jobs().await
+    }
+
+    async fn start_due_detached_jobs(&self) -> Result<(), String> {
+        let Some(runtime) = self.detached_jobs.clone() else {
+            return Ok(());
+        };
+        let now_ms = callback_unix_time_ms()?;
+        let jobs = runtime.store.list_all(usize::MAX).await.map_err(|error| {
+            format!("failed to enumerate detached callbacks for runnable work: {error}")
+        })?;
+        for job in jobs.into_iter().filter(|job| {
+            job.spec.realm_id == runtime.realm_id
+                && self.owns_detached_callback_spec(&job.spec)
+                && (job.machine_state.lifecycle_phase == meerkat::JobPhase::Queued
+                    || job.machine_state.lifecycle_phase == meerkat::JobPhase::RetryScheduled)
+        }) {
+            let runtime = runtime.clone();
+            let bridge = self.bridge.clone();
+            let delay_ms = job
+                .machine_state
+                .retry_due_at_ms
+                .unwrap_or(now_ms)
+                .saturating_sub(now_ms);
+            tokio::spawn(async move {
+                if delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                if let Err(error) =
+                    start_detached_callback_attempt(runtime, bridge, job.job_id).await
+                {
+                    tracing::warn!(%error, "runnable detached callback start did not complete");
+                }
+            });
+        }
+        Ok(())
+    }
+}
+
+fn spawn_callback_lease_tracker(
+    runtime: DetachedCallbackJobRuntime,
+    bridge: StdioCallbackBridge,
+    authority: meerkat_contracts::JobAttemptAuthority,
+) {
+    tokio::spawn(async move {
+        if let Err(error) = reconcile_missing_callback_after_lease(runtime, bridge, authority).await
+        {
+            tracing::warn!(%error, "detached callback lease tracking failed");
+        }
+    });
+}
+
+async fn reconcile_missing_callback_after_lease(
+    runtime: DetachedCallbackJobRuntime,
+    bridge: StdioCallbackBridge,
+    authority: meerkat_contracts::JobAttemptAuthority,
+) -> Result<(), String> {
+    let job_id = meerkat::JobId::new(&authority.job_id).map_err(|error| error.to_string())?;
+    loop {
+        let stored = runtime
+            .store
+            .get(&job_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| format!("detached callback {job_id} disappeared before lease expiry"))?;
+        let exact_attempt = stored.machine_state.current_attempt_id.as_deref()
+            == Some(authority.attempt_id.as_str())
+            && stored.machine_state.current_fence == authority.fence
+            && matches!(
+                stored.machine_state.lifecycle_phase,
+                meerkat::JobPhase::Running | meerkat::JobPhase::WaitingExternal
+            );
+        if !exact_attempt {
+            return Ok(());
+        }
+        let lease_expires_at_ms = stored
+            .machine_state
+            .lease_expires_at_ms
+            .ok_or_else(|| format!("active detached callback {job_id} has no committed lease"))?;
+        let now_ms = callback_unix_time_ms()?;
+        if lease_expires_at_ms > now_ms {
+            tokio::time::sleep(Duration::from_millis(
+                lease_expires_at_ms.saturating_sub(now_ms).saturating_add(1),
+            ))
+            .await;
+            // Heartbeats may have extended the exact committed lease and
+            // checkpoint while this task slept. Rehydrate again before
+            // offering recovery so reopen never regresses durable authority.
+            continue;
+        }
+
+        let offered = meerkat_contracts::CallbackJobReconcileAttempt {
+            authority: authority.clone(),
+            runner: meerkat_contracts::JobRunner {
+                name: stored.spec.runner.name().to_string(),
+                version: stored.spec.runner.version().to_string(),
+            },
+            restart_class: callback_wire_restart_class(stored.spec.restart_class),
+            runner_handle: stored
+                .machine_state
+                .runner_handle
+                .as_ref()
+                .ok_or_else(|| {
+                    format!("active detached callback {job_id} has no committed runner handle")
+                })?
+                .clone(),
+            checkpoint_ref: stored
+                .machine_state
+                .checkpoint_ref
+                .as_ref()
+                .map(ToString::to_string),
+            lease_expires_at_ms,
+        };
+        let _live_attempts = match bridge
+            .call(
+                "callback/job/reconcile",
+                serde_json::to_value(meerkat_contracts::CallbackJobReconcileParams {
+                    attempts: vec![offered],
+                })
+                .map_err(|error| error.to_string())?,
+            )
+            .await
+        {
+            Ok(value) => {
+                let result: meerkat_contracts::CallbackJobReconcileResult =
+                    serde_json::from_value(value).map_err(|error| error.to_string())?;
+                if result
+                    .live_attempts
+                    .iter()
+                    .any(|candidate| candidate != &authority)
+                {
+                    return Err(
+                        "callback/job/reconcile returned authority that was not offered"
+                            .to_string(),
+                    );
+                }
+                result.live_attempts
+            }
+            // Once the committed lease has elapsed, an unavailable host is a
+            // missing worker observation. The generated machine still decides
+            // whether this becomes loss, retry, or needs-attention.
+            Err(error) => {
+                tracing::warn!(%error, %job_id, "host unavailable at detached callback lease boundary");
+                Vec::new()
+            }
+        };
+        let current = runtime
+            .store
+            .get(&job_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| format!("detached callback {job_id} disappeared during reconcile"))?;
+        let still_exact = current.machine_state.current_attempt_id.as_deref()
+            == Some(authority.attempt_id.as_str())
+            && current.machine_state.current_fence == authority.fence
+            && matches!(
+                current.machine_state.lifecycle_phase,
+                meerkat::JobPhase::Running | meerkat::JobPhase::WaitingExternal
+            );
+        if !still_exact {
+            return Ok(());
+        }
+        let current_lease = current
+            .machine_state
+            .lease_expires_at_ms
+            .ok_or_else(|| format!("active detached callback {job_id} has no committed lease"))?;
+        let now_ms = callback_unix_time_ms()?;
+        if current_lease > now_ms {
+            continue;
+        }
+        let write = meerkat::AttemptWriteAuthority {
+            attempt_id: meerkat::AttemptId::new(&authority.attempt_id)
+                .map_err(|error| error.to_string())?,
+            fence: meerkat::FenceToken::new(authority.fence),
+        };
+        match runtime
+            .service
+            .observe_lease_expired(&job_id, write, now_ms)
+            .await
+        {
+            Ok(_) => {}
+            Err(
+                meerkat::DetachedJobError::StaleRevision { .. }
+                | meerkat::DetachedJobError::InvalidTransition { .. },
+            ) => return Ok(()),
+            Err(error) => return Err(error.to_string()),
+        }
+        let retry = match current.spec.restart_class {
+            meerkat::RestartClass::NonResumable => {
+                runtime
+                    .service
+                    .classify_worker_loss(&job_id, now_ms)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                false
+            }
+            meerkat::RestartClass::CheckpointResumable
+                if current.machine_state.checkpoint_ref.is_none() =>
+            {
+                runtime
+                    .service
+                    .mark_needs_attention(
+                        &job_id,
+                        now_ms,
+                        meerkat::JobFailureCode::new("checkpoint_resume_missing_checkpoint")
+                            .map_err(|error| error.to_string())?,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                false
+            }
+            meerkat::RestartClass::Adoptable
+            | meerkat::RestartClass::CheckpointResumable
+            | meerkat::RestartClass::Replayable => {
+                runtime
+                    .service
+                    .schedule_retry(&job_id, now_ms)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                true
+            }
+        };
+        if retry {
+            start_detached_callback_attempt(runtime, bridge, job_id).await?;
+        }
+        return Ok(());
     }
 }
 
@@ -3942,6 +5341,42 @@ impl CallbackToolDispatcher {
 impl AgentToolDispatcher for CallbackToolDispatcher {
     fn tools(&self) -> Arc<[Arc<ToolDef>]> {
         Arc::clone(&self.tool_defs)
+    }
+
+    fn tool_catalog_capabilities(&self) -> ToolCatalogCapabilities {
+        ToolCatalogCapabilities {
+            exact_catalog: true,
+            may_require_catalog_control_plane: false,
+        }
+    }
+
+    fn tool_catalog(&self) -> Arc<[ToolCatalogEntry]> {
+        Arc::clone(&self.tool_catalog)
+    }
+
+    fn resolve_execution_plan(
+        &self,
+        call: ToolCallView<'_>,
+        _dispatch_context: &meerkat_core::ToolDispatchContext,
+        resolution_context: &meerkat_core::ToolExecutionResolutionContext,
+    ) -> Result<meerkat_core::ResolvedToolExecutionPlan, meerkat_core::ToolExecutionResolutionError>
+    {
+        let entry = self
+            .tool_catalog
+            .iter()
+            .find(|entry| entry.tool.name == call.name)
+            .ok_or_else(|| meerkat_core::ToolExecutionResolutionError::NotFound {
+                tool_name: call.name.to_string(),
+            })?;
+        let resolution_context =
+            resolution_context.with_deadline(ToolDeadlineContributor::finite(
+                ToolDeadlineOwner::ToolInternal,
+                Duration::from_mins(2),
+            ))?;
+        entry
+            .execution
+            .resolve_default(resolution_context.deadlines().clone())
+            .map_err(Into::into)
     }
 
     async fn dispatch(&self, call: ToolCallView<'_>) -> Result<ToolDispatchOutcome, ToolError> {
@@ -3975,6 +5410,823 @@ impl AgentToolDispatcher for CallbackToolDispatcher {
             .into()),
         }
     }
+
+    async fn dispatch_resolved_with_context(
+        &self,
+        call: ToolCallView<'_>,
+        context: &meerkat_core::ToolDispatchContext,
+        plan: &meerkat_core::ResolvedToolExecutionPlan,
+    ) -> Result<ToolDispatchOutcome, ToolError> {
+        match plan.mode() {
+            ToolExecutionMode::Fast => self.dispatch(call).await,
+            ToolExecutionMode::Detached => self.submit_detached(call, context, plan).await,
+            ToolExecutionMode::Streaming => Err(ToolError::unavailable(
+                call.name,
+                meerkat_core::ToolUnavailableReason::ExecutionModeOwnerUnavailable,
+            )),
+        }
+    }
+}
+
+fn callback_sha256(digest: [u8; 32]) -> String {
+    let mut encoded = String::with_capacity("sha256:".len() + digest.len() * 2);
+    encoded.push_str("sha256:");
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn callback_submission_key(
+    realm_id: &str,
+    origin_session_id: &meerkat_core::SessionId,
+    interaction_lineage: &str,
+    call: ToolCallView<'_>,
+    policy: &meerkat_core::DetachedToolExecutionPolicy,
+    arguments_hash: &str,
+    arguments: &Value,
+) -> Result<String, ToolError> {
+    let scope = match policy.idempotency_scope() {
+        meerkat_core::IdempotencyScope::ToolCall => format!("tool-call:{}", call.id),
+        meerkat_core::IdempotencyScope::InteractionAndArguments => {
+            format!("interaction:{interaction_lineage}:arguments:{arguments_hash}")
+        }
+        meerkat_core::IdempotencyScope::HostSemanticKey => {
+            let semantic_key = arguments
+                .get("idempotency_key")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| {
+                    ToolError::invalid_arguments(
+                        call.name,
+                        "host_semantic_key execution requires a non-empty string idempotency_key",
+                    )
+                })?;
+            format!(
+                "host-semantic:sha256:{:x}",
+                Sha256::digest(semantic_key.as_bytes())
+            )
+        }
+    };
+    Ok(format!(
+        "callback:{realm_id}:{origin_session_id}:{}:{}:{}:{scope}",
+        call.name,
+        policy.runner().name(),
+        policy.runner().version(),
+    ))
+}
+
+fn callback_job_restart_class(class: meerkat_core::RestartClass) -> meerkat::RestartClass {
+    match class {
+        meerkat_core::RestartClass::Adoptable => meerkat::RestartClass::Adoptable,
+        meerkat_core::RestartClass::CheckpointResumable => {
+            meerkat::RestartClass::CheckpointResumable
+        }
+        meerkat_core::RestartClass::Replayable => meerkat::RestartClass::Replayable,
+        meerkat_core::RestartClass::NonResumable => meerkat::RestartClass::NonResumable,
+    }
+}
+
+fn callback_wire_restart_class(class: meerkat::RestartClass) -> meerkat_contracts::JobRestartClass {
+    match class {
+        meerkat::RestartClass::Adoptable => meerkat_contracts::JobRestartClass::Adoptable,
+        meerkat::RestartClass::CheckpointResumable => {
+            meerkat_contracts::JobRestartClass::CheckpointResumable
+        }
+        meerkat::RestartClass::Replayable => meerkat_contracts::JobRestartClass::Replayable,
+        meerkat::RestartClass::NonResumable => meerkat_contracts::JobRestartClass::NonResumable,
+    }
+}
+
+async fn start_detached_callback_attempt(
+    runtime: DetachedCallbackJobRuntime,
+    bridge: StdioCallbackBridge,
+    job_id: meerkat::JobId,
+) -> Result<(), String> {
+    let stored = runtime
+        .store
+        .get(&job_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| format!("detached callback job {job_id} disappeared after submission"))?;
+    let claimed_at_ms = callback_unix_time_ms()?;
+    let runnable = stored.machine_state.lifecycle_phase == meerkat::JobPhase::Queued
+        || (stored.machine_state.lifecycle_phase == meerkat::JobPhase::RetryScheduled
+            && stored
+                .machine_state
+                .retry_due_at_ms
+                .is_some_and(|due_at_ms| claimed_at_ms >= due_at_ms));
+    if !runnable {
+        return Ok(());
+    }
+    let lease_expires_at_ms = claimed_at_ms
+        .checked_add(120_000)
+        .ok_or_else(|| "detached callback lease timestamp overflowed".to_string())?;
+    let runner_handle = format!(
+        "callback:{job_id}:attempt:{}",
+        stored.machine_state.attempt_count.saturating_add(1)
+    );
+    let claim = match runtime
+        .service
+        .claim_attempt(
+            &job_id,
+            meerkat::AttemptClaim::new(
+                meerkat::WorkerId::new(format!("mobkit-callback:{}", std::process::id()))
+                    .map_err(|error| error.to_string())?,
+                claimed_at_ms,
+                lease_expires_at_ms,
+                meerkat::RunnerHandleRef::new(runner_handle.clone())
+                    .map_err(|error| error.to_string())?,
+            ),
+        )
+        .await
+    {
+        Ok(claim) => claim,
+        Err(
+            meerkat::DetachedJobError::StaleRevision { .. }
+            | meerkat::DetachedJobError::InvalidTransition { .. },
+        ) => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+    let specification_ref = stored
+        .spec
+        .runner_specification_ref
+        .as_ref()
+        .ok_or_else(|| format!("detached callback job {job_id} has no runner specification"))?;
+    let specification = runtime
+        .blob_store
+        .get(&meerkat_core::BlobId::new(specification_ref.as_str()))
+        .await
+        .map_err(|error| error.to_string())?;
+    let arguments: Value =
+        serde_json::from_str(&specification.data).map_err(|error| error.to_string())?;
+    let credential_scopes = stored
+        .spec
+        .credential_context_refs
+        .iter()
+        .flat_map(|reference| match reference {
+            meerkat_core::ToolCredentialContextRef::OwningProfile { required_scopes }
+            | meerkat_core::ToolCredentialContextRef::AuthBinding {
+                required_scopes, ..
+            } => required_scopes.iter().cloned().collect::<Vec<_>>(),
+        })
+        .collect();
+    let params = meerkat_contracts::CallbackJobStartParams {
+        authority: meerkat_contracts::JobAttemptAuthority {
+            job_id: job_id.to_string(),
+            attempt_id: claim.attempt_id.to_string(),
+            fence: claim.fence.get(),
+        },
+        runner: meerkat_contracts::JobRunner {
+            name: stored.spec.runner.name().to_string(),
+            version: stored.spec.runner.version().to_string(),
+        },
+        restart_class: callback_wire_restart_class(stored.spec.restart_class),
+        runner_handle: runner_handle.clone(),
+        runner_specification_ref: Some(specification_ref.to_string()),
+        arguments,
+        credential_scopes,
+        resume_checkpoint: claim.resume_checkpoint.as_ref().map(ToString::to_string),
+    };
+    spawn_callback_lease_tracker(runtime.clone(), bridge.clone(), params.authority.clone());
+    let result: meerkat_contracts::CallbackJobStartResult = serde_json::from_value(
+        bridge
+            .call(
+                "callback/job/start",
+                serde_json::to_value(params).map_err(|error| error.to_string())?,
+            )
+            .await?,
+    )
+    .map_err(|error| error.to_string())?;
+    if !result.accepted || result.runner_handle != runner_handle {
+        runtime
+            .service
+            .mark_needs_attention(
+                &job_id,
+                callback_unix_time_ms().unwrap_or(claimed_at_ms),
+                meerkat::JobFailureCode::new(if result.accepted {
+                    "callback_runner_handle_mismatch"
+                } else {
+                    "callback_start_rejected"
+                })
+                .map_err(|error| error.to_string())?,
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn callback_unix_time_ms() -> Result<u64, String> {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| error.to_string())?
+        .as_millis();
+    u64::try_from(millis).map_err(|_| "wall clock exceeds u64 milliseconds".to_string())
+}
+
+async fn callback_job_description(
+    runtime: &DetachedCallbackJobRuntime,
+    job_id: &meerkat::JobId,
+) -> Result<meerkat::JobDescription, String> {
+    runtime
+        .service
+        .describe_for_realm(&runtime.realm_id, job_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| format!("detached job {job_id} does not exist in this realm"))
+}
+
+fn callback_write_authority(
+    authority: meerkat_contracts::JobAttemptAuthority,
+) -> Result<(meerkat::JobId, meerkat::AttemptWriteAuthority), String> {
+    Ok((
+        meerkat::JobId::new(authority.job_id).map_err(|error| error.to_string())?,
+        meerkat::AttemptWriteAuthority {
+            attempt_id: meerkat::AttemptId::new(authority.attempt_id)
+                .map_err(|error| error.to_string())?,
+            fence: meerkat::FenceToken::new(authority.fence),
+        },
+    ))
+}
+
+fn callback_job_rpc_response(id: Value, result: Result<Value, String>) -> Result<String, String> {
+    serde_json::to_string(&match result {
+        Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+        Err(message) => {
+            json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32602, "message": message}})
+        }
+    })
+    .map_err(|error| error.to_string())
+}
+
+/// Handle the canonical Meerkat job surface over MobKit's inherited job
+/// store. Returns `None` for methods owned by the ordinary MobKit router.
+async fn handle_callback_job_rpc(
+    request_line: &str,
+    runtime: Option<&DetachedCallbackJobRuntime>,
+    bridge: &StdioCallbackBridge,
+) -> Option<String> {
+    const METHODS: &[&str] = &[
+        "jobs/get",
+        "jobs/list",
+        "jobs/cancel",
+        "jobs/progress",
+        "jobs/result",
+        "jobs/artifacts",
+        "jobs/retry",
+        "jobs/health",
+        "jobs/subscribe",
+        "jobs/unsubscribe",
+        "monitors/start",
+        "mobkit/jobs/heartbeat",
+        "mobkit/jobs/progress",
+        "mobkit/jobs/checkpoint",
+        "mobkit/jobs/complete",
+        "mobkit/jobs/fail",
+        "mobkit/jobs/cancel_ack",
+    ];
+    let request: Value = serde_json::from_str(request_line).ok()?;
+    let method = request.get("method").and_then(Value::as_str)?;
+    if !METHODS.contains(&method) {
+        return None;
+    }
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+    let Some(runtime) = runtime else {
+        return Some(
+            callback_job_rpc_response(
+                id,
+                Err(
+                    "durable jobs require persistent_state; semantic detached admission is disabled"
+                        .to_string(),
+                ),
+            )
+            .unwrap_or_default(),
+        );
+    };
+    let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+    let result: Result<Value, String> = async {
+        match method {
+            "jobs/get" => {
+                let params: meerkat_contracts::JobsGetParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                let job = callback_job_description(runtime, &job_id).await?;
+                serde_json::to_value(meerkat_contracts::JobsGetResult {
+                    job: meerkat::project_job_description(job),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/list" => {
+                let params: meerkat_contracts::JobsListParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let session = params
+                    .session_id
+                    .ok_or_else(|| "jobs/list requires session_id".to_string())
+                    .and_then(|raw| {
+                        meerkat_core::SessionId::parse(&raw).map_err(|error| error.to_string())
+                    })?;
+                let limit =
+                    usize::try_from(params.limit.unwrap_or(100).min(1_000)).unwrap_or(1_000);
+                let jobs = runtime
+                    .service
+                    .list_descriptions_for_origin(&runtime.realm_id, &session, limit)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .into_iter()
+                    .map(meerkat::project_job_description)
+                    .collect();
+                serde_json::to_value(meerkat_contracts::JobsListResult { jobs })
+                    .map_err(|error| error.to_string())
+            }
+            "jobs/cancel" => {
+                let params: meerkat_contracts::JobsCancelParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                let stored = runtime
+                    .store
+                    .get(&job_id)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .filter(|job| job.spec.realm_id == runtime.realm_id)
+                    .ok_or_else(|| format!("detached job {job_id} does not exist in this realm"))?;
+                if matches!(
+                    stored.spec.runner.name(),
+                    "meerkat.shell" | "meerkat.monitor_script"
+                ) {
+                    let manager = runtime
+                        .monitor_manager(&stored.spec.origin_session_id)
+                        .await?;
+                    manager
+                        .cancel_job(&meerkat_tools::builtin::shell::JobId::from_string(
+                            job_id.to_string(),
+                        ))
+                        .await
+                        .map_err(|error| error.to_string())?;
+                } else {
+                    let snapshot = runtime
+                        .service
+                        .request_cancel(&job_id)
+                        .await
+                        .map_err(|error| error.to_string())?;
+                    if runtime.owns_callback_job(&stored.spec)
+                        && let Some(attempt_id) = snapshot.current_attempt_id.as_ref()
+                        && matches!(
+                            snapshot.phase,
+                            meerkat::JobPhase::Running | meerkat::JobPhase::WaitingExternal
+                        )
+                    {
+                        let cancel: meerkat_contracts::CallbackJobCancelResult =
+                            serde_json::from_value(
+                                bridge
+                                    .call(
+                                        "callback/job/cancel",
+                                        serde_json::to_value(
+                                            meerkat_contracts::CallbackJobCancelParams {
+                                                authority: meerkat_contracts::JobAttemptAuthority {
+                                                    job_id: job_id.to_string(),
+                                                    attempt_id: attempt_id.to_string(),
+                                                    fence: snapshot.current_fence.get(),
+                                                },
+                                            },
+                                        )
+                                        .map_err(|error| error.to_string())?,
+                                    )
+                                    .await?,
+                            )
+                            .map_err(|error| error.to_string())?;
+                        if !cancel.accepted {
+                            return Err(
+                                "callback/job/cancel rejected the committed active attempt"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                }
+                let job = callback_job_description(runtime, &job_id).await?;
+                serde_json::to_value(meerkat_contracts::JobsCancelResult {
+                    job: meerkat::project_job_description(job),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/progress" => {
+                let params: meerkat_contracts::JobsProgressParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                let job = meerkat::project_job_description(
+                    callback_job_description(runtime, &job_id).await?,
+                );
+                serde_json::to_value(meerkat_contracts::JobsProgressResult {
+                    job_id: job.job_id,
+                    phase: job.phase,
+                    progress: job.progress,
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/result" => {
+                let params: meerkat_contracts::JobsResultParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                let job = meerkat::project_job_description(
+                    callback_job_description(runtime, &job_id).await?,
+                );
+                serde_json::to_value(meerkat_contracts::JobsResultResult {
+                    job_id: job.job_id,
+                    phase: job.phase,
+                    result: job.terminal_result,
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/artifacts" => {
+                let params: meerkat_contracts::JobsArtifactsParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                let job = callback_job_description(runtime, &job_id).await?;
+                let reference = match job.terminal_result {
+                    Some(
+                        meerkat::JobTerminalResult::Succeeded {
+                            result_ref: Some(reference),
+                        }
+                        | meerkat::JobTerminalResult::Failed {
+                            detail_ref: Some(reference),
+                            ..
+                        },
+                    ) => Some(reference.to_string()),
+                    _ => None,
+                };
+                serde_json::to_value(meerkat_contracts::JobsArtifactsResult {
+                    job_id: job_id.to_string(),
+                    artifacts: reference
+                        .into_iter()
+                        .map(|reference| meerkat_contracts::JobArtifactRef { reference })
+                        .collect(),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/retry" => {
+                let params: meerkat_contracts::JobsRetryParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                let stored = runtime
+                    .store
+                    .get(&job_id)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .filter(|job| job.spec.realm_id == runtime.realm_id)
+                    .ok_or_else(|| format!("detached job {job_id} does not exist in this realm"))?;
+                let shell_owned = matches!(
+                    stored.spec.runner.name(),
+                    "meerkat.shell" | "meerkat.monitor_script"
+                );
+                runtime
+                    .service
+                    .schedule_retry(&job_id, params.retry_due_at_ms)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                let now = callback_unix_time_ms()?;
+                let delay_ms = params.retry_due_at_ms.saturating_sub(now);
+                if shell_owned {
+                    let manager = runtime
+                        .monitor_manager(&stored.spec.origin_session_id)
+                        .await?;
+                    let public_job_id =
+                        meerkat_tools::builtin::shell::JobId::from_string(job_id.to_string());
+                    tokio::spawn(async move {
+                        if delay_ms > 0 {
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        }
+                        if let Err(error) = manager.get_status(&public_job_id).await {
+                            tracing::warn!(%error, "durable shell/monitor retry start failed");
+                        }
+                    });
+                } else if runtime.owns_callback_job(&stored.spec) {
+                    let runtime = (*runtime).clone();
+                    let bridge = bridge.clone();
+                    let retry_job_id = job_id.clone();
+                    tokio::spawn(async move {
+                        if delay_ms > 0 {
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        }
+                        if let Err(error) =
+                            start_detached_callback_attempt(runtime, bridge, retry_job_id).await
+                        {
+                            tracing::warn!(%error, "detached callback retry start failed");
+                        }
+                    });
+                } else {
+                    // Retry scheduling is machine authority. An unregistered
+                    // runner may be claimed by another host; this gateway
+                    // simply refrains from impersonating that execution owner.
+                }
+                let job = callback_job_description(runtime, &job_id).await?;
+                serde_json::to_value(meerkat_contracts::JobsRetryResult {
+                    job: meerkat::project_job_description(job),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/health" => {
+                let health = runtime
+                    .service
+                    .health_snapshot_for_realm(
+                        &runtime.realm_id,
+                        callback_unix_time_ms()?,
+                        usize::MAX,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                let runtime_delivery_backlog = runtime.runtime_delivery_backlog().await?;
+                let delivery_backlog = health
+                    .delivery_backlog
+                    .saturating_add(runtime_delivery_backlog);
+                serde_json::to_value(meerkat_contracts::JobsHealthResult {
+                    detached_jobs: meerkat_contracts::JobHealthSummary {
+                        status: if health.is_degraded() || runtime_delivery_backlog > 0 {
+                            meerkat_contracts::JobHealthStatus::Degraded
+                        } else {
+                            meerkat_contracts::JobHealthStatus::Ok
+                        },
+                        queued: health.queued,
+                        running: health.running,
+                        awaiting_members: health.awaiting_members,
+                        stale_leases: health.stale_leases,
+                        needs_attention: health.needs_attention,
+                        delivery_backlog,
+                    },
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/subscribe" => {
+                let params: meerkat_contracts::JobsSubscribeParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                callback_job_description(runtime, &job_id).await?;
+                let delivery = match params.delivery {
+                    meerkat_contracts::JobDeliveryKind::Record => meerkat::JobDeliveryKind::Record,
+                    meerkat_contracts::JobDeliveryKind::Notification => {
+                        meerkat::JobDeliveryKind::Notification
+                    }
+                    meerkat_contracts::JobDeliveryKind::Event { handling_mode } => {
+                        meerkat::JobDeliveryKind::Event {
+                            handling_mode: handling_mode.into(),
+                        }
+                    }
+                };
+                runtime
+                    .service
+                    .subscribe(
+                        &job_id,
+                        meerkat::JobSubscription::new(
+                            meerkat::JobSubscriptionId::new(params.subscription_id)
+                                .map_err(|error| error.to_string())?,
+                            meerkat_core::SessionId::parse(&params.session_id)
+                                .map_err(|error| error.to_string())?,
+                            delivery,
+                        ),
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                let job = callback_job_description(runtime, &job_id).await?;
+                serde_json::to_value(meerkat_contracts::JobsSubscribeResult {
+                    job: meerkat::project_job_description(job),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "jobs/unsubscribe" => {
+                let params: meerkat_contracts::JobsUnsubscribeParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(params.job_id).map_err(|error| error.to_string())?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .unsubscribe(
+                        &job_id,
+                        &meerkat::JobSubscriptionId::new(params.subscription_id)
+                            .map_err(|error| error.to_string())?,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                let job = callback_job_description(runtime, &job_id).await?;
+                serde_json::to_value(meerkat_contracts::JobsUnsubscribeResult {
+                    job: meerkat::project_job_description(job),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "monitors/start" => {
+                let params: meerkat_contracts::MonitorsStartParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let session_id = meerkat_core::SessionId::parse(&params.session_id)
+                    .map_err(|error| error.to_string())?;
+                let mut limits = meerkat_tools::builtin::shell::MonitorProtocolLimits::default();
+                if let Some(value) = params.max_line_bytes {
+                    limits.max_line_bytes = usize::try_from(value)
+                        .map_err(|_| "max_line_bytes exceeds this host's size limit".to_string())?;
+                }
+                if let Some(value) = params.max_notifications_per_window {
+                    limits.max_notifications_per_window = usize::try_from(value).map_err(|_| {
+                        "max_notifications_per_window exceeds this host's size limit".to_string()
+                    })?;
+                }
+                if let Some(value) = params.notification_window_ms {
+                    limits.notification_window_ms = value;
+                }
+                if let Some(value) = params.max_retained_diagnostic_bytes {
+                    limits.max_retained_diagnostic_bytes =
+                        usize::try_from(value).map_err(|_| {
+                            "max_retained_diagnostic_bytes exceeds this host's size limit"
+                                .to_string()
+                        })?;
+                }
+                let protocol = match params.protocol {
+                    meerkat_contracts::MonitorOutputProtocol::FramedJsonl => {
+                        meerkat_tools::builtin::shell::MonitorOutputProtocol::FramedJsonl
+                    }
+                    meerkat_contracts::MonitorOutputProtocol::Lines => {
+                        meerkat_tools::builtin::shell::MonitorOutputProtocol::Lines
+                    }
+                };
+                let restart_class = match params.restart_class {
+                    meerkat_contracts::JobRestartClass::Adoptable => {
+                        meerkat::RestartClass::Adoptable
+                    }
+                    meerkat_contracts::JobRestartClass::CheckpointResumable => {
+                        meerkat::RestartClass::CheckpointResumable
+                    }
+                    meerkat_contracts::JobRestartClass::Replayable => {
+                        meerkat::RestartClass::Replayable
+                    }
+                    meerkat_contracts::JobRestartClass::NonResumable => {
+                        meerkat::RestartClass::NonResumable
+                    }
+                };
+                let delivery = match params.delivery {
+                    meerkat_contracts::JobDeliveryKind::Record => meerkat::JobDeliveryKind::Record,
+                    meerkat_contracts::JobDeliveryKind::Notification => {
+                        meerkat::JobDeliveryKind::Notification
+                    }
+                    meerkat_contracts::JobDeliveryKind::Event { handling_mode } => {
+                        meerkat::JobDeliveryKind::Event {
+                            handling_mode: handling_mode.into(),
+                        }
+                    }
+                };
+                let manager = runtime.monitor_manager(&session_id).await?;
+                let job_id = manager
+                    .spawn_monitor_for_call(
+                        &params.command,
+                        params.working_dir.as_deref().map(std::path::Path::new),
+                        params.timeout_secs,
+                        &params.submission_key,
+                        meerkat_tools::builtin::shell::MonitorStartOptions {
+                            protocol,
+                            restart_class,
+                            limits,
+                            delivery,
+                        },
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                let job_id =
+                    meerkat::JobId::new(job_id.to_string()).map_err(|error| error.to_string())?;
+                let job = callback_job_description(runtime, &job_id).await?;
+                serde_json::to_value(meerkat_contracts::MonitorsStartResult {
+                    job: meerkat::project_job_description(job),
+                })
+                .map_err(|error| error.to_string())
+            }
+            "mobkit/jobs/heartbeat" => {
+                let params: meerkat_contracts::MobkitJobHeartbeatParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let (job_id, write) = callback_write_authority(params.authority)?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .renew_lease(
+                        &job_id,
+                        write,
+                        params.heartbeat_at_ms,
+                        params.lease_expires_at_ms,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                callback_mutation_projection(runtime, &job_id).await
+            }
+            "mobkit/jobs/progress" => {
+                let params: meerkat_contracts::MobkitJobProgressParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let (job_id, write) = callback_write_authority(params.authority)?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .report_progress(
+                        &job_id,
+                        write,
+                        meerkat::JobProgress::new(params.cursor, params.detail)
+                            .map_err(|error| error.to_string())?,
+                        params.observed_at_ms,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                callback_mutation_projection(runtime, &job_id).await
+            }
+            "mobkit/jobs/checkpoint" => {
+                let params: meerkat_contracts::MobkitJobCheckpointParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let (job_id, write) = callback_write_authority(params.authority)?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .record_checkpoint(
+                        &job_id,
+                        write,
+                        meerkat::CheckpointRef::new(params.checkpoint_ref)
+                            .map_err(|error| error.to_string())?,
+                        params.observed_at_ms,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                callback_mutation_projection(runtime, &job_id).await
+            }
+            "mobkit/jobs/complete" => {
+                let params: meerkat_contracts::MobkitJobCompleteParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let (job_id, write) = callback_write_authority(params.authority)?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .complete_attempt(
+                        &job_id,
+                        write,
+                        params.completed_at_ms,
+                        params
+                            .result_ref
+                            .map(meerkat::JobResultRef::new)
+                            .transpose()
+                            .map_err(|error| error.to_string())?,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                callback_mutation_projection(runtime, &job_id).await
+            }
+            "mobkit/jobs/fail" => {
+                let params: meerkat_contracts::MobkitJobFailParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let (job_id, write) = callback_write_authority(params.authority)?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .fail_attempt(
+                        &job_id,
+                        write,
+                        params.failed_at_ms,
+                        meerkat::JobFailureCode::new(params.code)
+                            .map_err(|error| error.to_string())?,
+                        params
+                            .detail_ref
+                            .map(meerkat::JobResultRef::new)
+                            .transpose()
+                            .map_err(|error| error.to_string())?,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                callback_mutation_projection(runtime, &job_id).await
+            }
+            "mobkit/jobs/cancel_ack" => {
+                let params: meerkat_contracts::MobkitJobCancelAckParams =
+                    serde_json::from_value(params).map_err(|error| error.to_string())?;
+                let (job_id, write) = callback_write_authority(params.authority)?;
+                callback_job_description(runtime, &job_id).await?;
+                runtime
+                    .service
+                    .acknowledge_cancel(&job_id, write, params.acknowledged_at_ms)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                callback_mutation_projection(runtime, &job_id).await
+            }
+            _ => unreachable!("method allowlist and match must stay in sync"),
+        }
+    }
+    .await;
+    Some(callback_job_rpc_response(id, result).unwrap_or_default())
+}
+
+async fn callback_mutation_projection(
+    runtime: &DetachedCallbackJobRuntime,
+    job_id: &meerkat::JobId,
+) -> Result<Value, String> {
+    let job = callback_job_description(runtime, job_id).await?;
+    serde_json::to_value(meerkat_contracts::MobkitJobMutationResult {
+        job: meerkat::project_job_description(job),
+    })
+    .map_err(|error| error.to_string())
 }
 
 /// Wraps FactoryAgentBuilder — sends callback/build_agent to Python before building.
@@ -3985,6 +6237,7 @@ struct StdioCallbackAgentBuilder {
     /// Session store for loading sessions by ID when the Python builder
     /// sets `resume_session_id`. Only populated in persistent mode.
     session_store: Option<Arc<dyn meerkat::SessionStore>>,
+    detached_jobs: Option<DetachedCallbackJobRuntime>,
 }
 
 fn callback_build_agent_options(req: &CreateSessionRequest, scope_id: &str) -> Value {
@@ -4202,7 +6455,21 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                                     self.bridge.clone(),
                                     scope_id.clone(),
                                     tool_specs,
+                                    self.detached_jobs.clone(),
                                 );
+                                if dispatcher.reconcile_registered_catalog {
+                                    let reconciliation = dispatcher.clone();
+                                    tokio::spawn(async move {
+                                        if let Err(error) =
+                                            reconciliation.reconcile_detached_jobs().await
+                                        {
+                                            tracing::warn!(
+                                                %error,
+                                                "detached callback reconciliation failed"
+                                            );
+                                        }
+                                    });
+                                }
                                 let build = modified_req.build.get_or_insert_with(|| {
                                     meerkat_core::service::SessionBuildOptions::default()
                                 });
@@ -4469,6 +6736,38 @@ external_addressable = true
             meerkat_mobkit::storage_layout::default_ephemeral_scratch_root(),
         ),
     };
+    let callback_job_store: Option<Arc<dyn meerkat::DetachedJobStore>> =
+        persistent_state.as_ref().map(|state_path| {
+            let path = meerkat_store::realm_paths_in(
+                state_path,
+                meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+            )
+            .jobs_sqlite_path;
+            if let Some(parent) = path.parent()
+                && let Err(error) = std::fs::create_dir_all(parent)
+            {
+                fail_init(
+                    &request_id,
+                    STORAGE_RESOLUTION_CODE,
+                    format!(
+                        "failed to create detached job store directory {}: {error}",
+                        parent.display()
+                    ),
+                );
+            }
+            match meerkat::SqliteDetachedJobStore::open(path.clone()) {
+                Ok(store) => Arc::new(store) as Arc<dyn meerkat::DetachedJobStore>,
+                Err(error) => fail_init(
+                    &request_id,
+                    STORAGE_RESOLUTION_CODE,
+                    meerkat_mobkit::storage_health::JobStoreResolutionError {
+                        path,
+                        message: error.to_string(),
+                    }
+                    .to_string(),
+                ),
+            }
+        });
 
     // 3. Set up stdout writer channel for multiplexed output
     let (stdout_tx, mut stdout_rx) = mpsc::channel::<String>(64);
@@ -4736,6 +7035,7 @@ external_addressable = true
         transcript_edit_service,
         workgraph_service,
         live_inputs,
+        gateway_detached_jobs,
     ) = if let Some(ref state_path) = persistent_state {
         if let Err(e) = std::fs::create_dir_all(state_path) {
             fail_init(
@@ -4864,6 +7164,15 @@ external_addressable = true
             session_store.clone(),
         )));
         inner_builder.default_blob_store = Some(blob_store.clone());
+        inner_builder.default_detached_job_store = callback_job_store.clone();
+        if let Some(job_store) = callback_job_store.as_ref() {
+            inner_builder.default_shell_job_delivery_projector =
+                Some(Arc::new(meerkat::JobOutboxProjector::new_for_realm(
+                    Arc::clone(job_store),
+                    meerkat_runtime::RuntimeDeliveryInbox::new(Arc::clone(&runtime_store)),
+                    meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+                )));
+        }
         // Attach meerkat's per-session schedule tools so SDK-hosted members whose
         // profile sets tools.schedule=true get the meerkat_schedule_* surface (the
         // slot lives on the inner FactoryAgentBuilder and propagates through the
@@ -4961,11 +7270,28 @@ external_addressable = true
         };
         let workgraph_service = workgraph.as_ref().map(|(service, _, _)| service.clone());
         let agent_mob_tools_slot = Arc::clone(&inner_builder.default_mob_tools);
+        let detached_jobs = callback_job_store.as_ref().map(|store| {
+            DetachedCallbackJobRuntime::new(
+                meerkat_mobkit::storage_provider::MEERKAT_LEVEL_REALM_ID,
+                Arc::clone(store),
+                blob_store.clone(),
+            )
+            .with_runtime_delivery_store(Arc::clone(&runtime_store))
+            .with_monitor_shell(
+                state_path
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .unwrap_or(state_path)
+                    .to_path_buf(),
+                shell,
+            )
+        });
         let callback_builder = StdioCallbackAgentBuilder {
             inner: inner_builder,
             bridge: bridge.clone(),
             has_session_builder,
             session_store: Some(session_store.clone()),
+            detached_jobs: detached_jobs.clone(),
         };
         // Keep the CONCRETE typed service for the firing host (the runtime-backed
         // host needs PersistentSessionService<StdioCallbackAgentBuilder>, not the
@@ -4977,6 +7303,11 @@ external_addressable = true
             Arc::clone(&runtime_store),
             blob_store,
         ));
+        if let Some(detached_jobs) = detached_jobs.as_ref() {
+            let delivery_service: Arc<dyn meerkat_mob::MobSessionService> =
+                concrete_service.clone();
+            detached_jobs.attach_delivery_service(delivery_service);
+        }
         let schedule_host_inputs = schedule_tools.map(|tools| {
             (
                 tools.service,
@@ -5061,6 +7392,10 @@ external_addressable = true
             ),
             schedule_slot,
             workgraph_slot,
+            meerkat_mobkit::storage_health::StorageSlotSummary::persistent(
+                "jobs",
+                "SqliteDetachedJobStore",
+            ),
             gateway_event_log_slot(&gateway_options),
         ];
         // Configured agent memory is a durable disk-backed slot under the
@@ -5098,6 +7433,7 @@ external_addressable = true
             transcript_edit_service,
             workgraph_service,
             live_inputs,
+            detached_jobs,
         )
     } else {
         // Ephemeral mode (original behavior).
@@ -5234,6 +7570,7 @@ external_addressable = true
             bridge: bridge.clone(),
             has_session_builder,
             session_store: None,
+            detached_jobs: None,
         };
         let mut transcript_edit_service: Option<
             Arc<dyn meerkat_mobkit::memory::hygienist::TranscriptEditSessionService>,
@@ -5277,6 +7614,7 @@ external_addressable = true
                     bridge: bridge.clone(),
                     has_session_builder,
                     session_store: Some(session_store.clone()),
+                    detached_jobs: None,
                 };
                 let concrete = Arc::new(meerkat_session::PersistentSessionService::new(
                     callback_builder,
@@ -5350,6 +7688,11 @@ external_addressable = true
                 "declared default of the ephemeral launch mode",
             ),
             ephemeral_workgraph_slot,
+            meerkat_mobkit::storage_health::StorageSlotSummary::declared_ephemeral(
+                "jobs",
+                "disabled",
+                "semantic detached admission is unavailable in ephemeral gateway mode",
+            ),
             gateway_event_log_slot(&gateway_options),
         ];
         if identity_continuity_store.is_some() {
@@ -5385,6 +7728,7 @@ external_addressable = true
             None,
             transcript_edit_service,
             workgraph_service,
+            None,
             None,
         )
     };
@@ -6250,6 +8594,22 @@ external_addressable = true
     };
 
     let runtime = Arc::new(runtime);
+    if let Some(detached_jobs) = gateway_detached_jobs.as_ref() {
+        match detached_jobs.health_projection().await {
+            Ok(projection) => runtime.set_job_health_projection(Some(projection)),
+            Err(error) => {
+                tracing::warn!(%error, "initial durable callback health projection failed");
+                runtime.set_job_health_projection(Some(json!({
+                    "status": "degraded",
+                    "detached_jobs": {
+                        "status": "degraded",
+                        "reason": "job_health_projection_failed"
+                    }
+                })));
+            }
+        }
+        detached_jobs.arm_delivery_driver(Arc::clone(&runtime));
+    }
     // Bind the steward's late runtime seams and wire gating decisions back
     // to staged promotion commits (§10.2).
     steward_late_runtime.bind(runtime.clone());
@@ -6411,16 +8771,29 @@ external_addressable = true
             let identity_ctx = identity_ctx.clone();
             let http_base_url = http_base_url_shared.clone();
             let live_rpc = live_rpc.clone();
+            let gateway_detached_jobs = gateway_detached_jobs.clone();
+            let callback_bridge = bridge.clone();
             inflight.spawn(async move {
-                let response = meerkat_mobkit::rpc::handle_unified_rpc_json_with_live_arc(
-                    &runtime,
+                let response = match handle_callback_job_rpc(
                     &request_line,
-                    timeout,
-                    Some(http_base_url.as_ref()),
-                    identity_ctx.as_deref(),
-                    live_rpc.as_ref(),
+                    gateway_detached_jobs.as_ref(),
+                    &callback_bridge,
                 )
-                .await;
+                .await
+                {
+                    Some(response) => response,
+                    None => {
+                        meerkat_mobkit::rpc::handle_unified_rpc_json_with_live_arc(
+                            &runtime,
+                            &request_line,
+                            timeout,
+                            Some(http_base_url.as_ref()),
+                            identity_ctx.as_deref(),
+                            live_rpc.as_ref(),
+                        )
+                        .await
+                    }
+                };
                 if !response.is_empty() {
                     let _ = stdout_tx.send(response).await;
                 }

--- a/meerkat-mobkit/src/http_console.rs
+++ b/meerkat-mobkit/src/http_console.rs
@@ -122,6 +122,8 @@ pub struct ConsoleJsonState {
     /// leave this absent; unified runtimes always pass their handle, even
     /// while policy mode is disabled, so query remains available.
     pub(crate) topology: Option<crate::topology_control::TopologyRuntimeHandle>,
+    /// Rebuildable detached-job observability supplied by the unified host.
+    pub(crate) job_health_projection: Option<Arc<std::sync::RwLock<Option<serde_json::Value>>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -269,6 +271,7 @@ pub fn console_json_router(decisions: RuntimeDecisionState) -> Router {
         identity_roster: None,
         workgraph: None,
         topology: None,
+        job_health_projection: None,
     })
 }
 
@@ -304,6 +307,7 @@ pub fn console_json_router_with_aggregator_and_access(
         identity_roster: None,
         workgraph: None,
         topology: None,
+        job_health_projection: None,
     })
 }
 
@@ -361,6 +365,7 @@ pub(crate) fn console_json_router_with_runtime_and_events(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -384,6 +389,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
     identity_roster: Option<Arc<crate::identity_first::MutableRosterProvider>>,
     workgraph: Option<meerkat::WorkGraphService>,
     topology: Option<crate::topology_control::TopologyRuntimeHandle>,
+    job_health_projection: Option<Arc<std::sync::RwLock<Option<serde_json::Value>>>>,
 ) -> Router {
     let console_aggregator = console_events.clone().map(|events| {
         if let Some(store) = console_log_store {
@@ -435,6 +441,7 @@ pub(crate) fn console_json_router_with_runtime_events_and_policy(
         identity_roster,
         workgraph,
         topology,
+        job_health_projection,
     })
 }
 
@@ -586,6 +593,7 @@ pub async fn console_rpc_handler(
             );
         }
     };
+    let request_method = parsed_request.method.clone();
 
     // Auth enforcement:
     // - When require_app_auth is true: validate bearer token (OIDC + allowlist)
@@ -650,7 +658,50 @@ pub async fn console_rpc_handler(
         state.topology.as_ref(),
     ))
     .await;
+    let response_value = decorate_console_job_projection(
+        response_value,
+        &request_method,
+        state.job_health_projection.as_ref(),
+    );
     (StatusCode::OK, Json::<Value>(response_value))
+}
+
+fn decorate_console_job_projection(
+    mut response: Value,
+    method: &str,
+    projection_slot: Option<&Arc<std::sync::RwLock<Option<Value>>>>,
+) -> Value {
+    let projection = projection_slot.and_then(|slot| {
+        slot.read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    });
+    let Some(projection) = projection else {
+        return response;
+    };
+    match method {
+        "mobkit/status" | "mobkit/capabilities" => {
+            response["result"]["detached_jobs"] = projection
+                .get("detached_jobs")
+                .cloned()
+                .unwrap_or(Value::Null);
+        }
+        "mobkit/member_status" => {
+            if let Some(session_id) = response["result"]["current_session_id"].as_str()
+                && let Some(session_jobs) = projection
+                    .get("by_session")
+                    .and_then(|by_session| by_session.get(session_id))
+            {
+                response["result"]["detached_jobs"] = session_jobs.clone();
+                response["result"]["awaiting_detached"] = session_jobs
+                    .get("awaiting_detached")
+                    .cloned()
+                    .unwrap_or(Value::Bool(false));
+            }
+        }
+        _ => {}
+    }
+    response
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/meerkat-mobkit/src/mob_handle_runtime.rs
+++ b/meerkat-mobkit/src/mob_handle_runtime.rs
@@ -4277,6 +4277,28 @@ impl MobBootstrapSpec {
         let mut builder = FactoryAgentBuilder::new(factory, config);
         builder.default_session_store = Some(Arc::new(StoreAdapter::new(session_store.clone())));
         builder.default_blob_store = Some(blob_store.clone());
+        let (job_store, job_store_slot): (Arc<dyn meerkat::DetachedJobStore>, StorageSlotSummary) =
+            if let Some(provider) = provider_meerkat_stores.as_ref() {
+                (Arc::clone(&provider.job_store), provider.job_slot_summary())
+            } else {
+                let path = meerkat_store::realm_paths_in(
+                    &store_path,
+                    crate::storage_provider::MEERKAT_LEVEL_REALM_ID,
+                )
+                .jobs_sqlite_path;
+                let store =
+                    meerkat::SqliteDetachedJobStore::open(path.clone()).map_err(|error| {
+                        crate::storage_health::JobStoreResolutionError {
+                            path,
+                            message: error.to_string(),
+                        }
+                    })?;
+                (
+                    Arc::new(store),
+                    StorageSlotSummary::persistent("jobs", "SqliteDetachedJobStore"),
+                )
+            };
+        builder.default_detached_job_store = Some(job_store);
         let (session_llm_reconfigure_blueprint, session_llm_default_client_slot) =
             session_llm_reconfigure_blueprint(&builder, &store_path);
         let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
@@ -4390,6 +4412,7 @@ impl MobBootstrapSpec {
             runtime_store_slot,
             blob_slot_summary(blob_durability),
             workgraph_slot,
+            job_store_slot,
         ];
         if let Some(slot) = schedule_slot {
             slots.push(slot);
@@ -4531,6 +4554,9 @@ impl MobBootstrapSpec {
         let mut builder = FactoryAgentBuilder::new(factory, config);
         builder.default_session_store = Some(Arc::new(StoreAdapter::new(session_store.clone())));
         builder.default_blob_store = Some(blob_store.clone());
+        if let Some(provider) = provider_meerkat_stores.as_ref() {
+            builder.default_detached_job_store = Some(Arc::clone(&provider.job_store));
+        }
         let (session_llm_reconfigure_blueprint, session_llm_default_client_slot) =
             session_llm_reconfigure_blueprint(&builder, &store_path);
         let mob_tools_slot = Arc::clone(&builder.default_mob_tools);
@@ -4669,6 +4695,15 @@ impl MobBootstrapSpec {
                     "workgraph",
                     "MemoryWorkGraphStore",
                     "declared by the ephemeral launch mode",
+                )
+            },
+            if let Some(provider) = provider_meerkat_stores.as_ref() {
+                provider.job_slot_summary()
+            } else {
+                StorageSlotSummary::declared_ephemeral(
+                    "jobs",
+                    "disabled",
+                    "semantic detached admission is unavailable in ephemeral launch mode",
                 )
             },
         ];
@@ -7340,6 +7375,7 @@ realm_profile = "worker-v2"
             self.record("stage_tool_results");
             Ok(meerkat_core::service::StageToolResultsResult {
                 accepted_result_count: 7,
+                disposition: meerkat_core::service::StageToolResultsDisposition::Staged,
             })
         }
     }

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -1665,6 +1665,12 @@ async fn handle_unified_rpc_json_inner(
             if let Some(storage) = runtime.resolved_storage() {
                 result["storage"] = storage.status_json();
             }
+            if let Some(job_health) = runtime.job_health_projection() {
+                result["detached_jobs"] = job_health
+                    .get("detached_jobs")
+                    .cloned()
+                    .unwrap_or(Value::Null);
+            }
             JsonRpcResponse {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: response_id,
@@ -1822,6 +1828,29 @@ async fn handle_unified_rpc_json_inner(
                     "mobkit/cross_mob/send",
                 ]);
             }
+            let job_health = runtime.job_health_projection();
+            if job_health.is_some() {
+                methods.extend_from_slice(&[
+                    "jobs/get",
+                    "jobs/list",
+                    "jobs/cancel",
+                    "jobs/progress",
+                    "jobs/result",
+                    "jobs/artifacts",
+                    "jobs/retry",
+                    "jobs/health",
+                    "jobs/subscribe",
+                    "jobs/unsubscribe",
+                ]);
+                if job_health
+                    .as_ref()
+                    .and_then(|projection| projection.get("monitors_available"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    methods.push("monitors/start");
+                }
+            }
             let topology = runtime.topology_runtime_handle();
             let (topology_methods, topology_capabilities) =
                 topology_methods::capability_projection(&topology, None, false);
@@ -1848,6 +1877,11 @@ async fn handle_unified_rpc_json_inner(
                     // True when a WorkGraph service is configured and the
                     // mobkit/workgraph/* group is live.
                     "workgraph": workgraph_configured,
+                    "detached_jobs": job_health
+                        .as_ref()
+                        .and_then(|projection| projection.get("detached_jobs"))
+                        .cloned()
+                        .unwrap_or(Value::Null),
                     "loaded_modules": loaded,
                     "runtime_capabilities": {
                         "can_spawn_members": true,

--- a/meerkat-mobkit/src/rpc/mob_methods.rs
+++ b/meerkat-mobkit/src/rpc/mob_methods.rs
@@ -1945,12 +1945,27 @@ pub(super) async fn handle_member_status(
                 .member_status(&crate::member_comms_id::mob_member_id(&mid))
                 .await
             {
-                Ok(snapshot) => JsonRpcResponse {
-                    jsonrpc: JSONRPC_VERSION.to_string(),
-                    id: response_id,
-                    result: Some(serde_json::to_value(&snapshot).unwrap_or(Value::Null)),
-                    error: None,
-                },
+                Ok(snapshot) => {
+                    let mut result = serde_json::to_value(&snapshot).unwrap_or(Value::Null);
+                    if let Some(session_id) = snapshot.current_session_id.as_ref()
+                        && let Some(job_health) = runtime.job_health_projection()
+                        && let Some(session_jobs) = job_health
+                            .get("by_session")
+                            .and_then(|by_session| by_session.get(session_id.to_string()))
+                    {
+                        result["detached_jobs"] = session_jobs.clone();
+                        result["awaiting_detached"] = session_jobs
+                            .get("awaiting_detached")
+                            .cloned()
+                            .unwrap_or(Value::Bool(false));
+                    }
+                    JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: response_id,
+                        result: Some(result),
+                        error: None,
+                    }
+                }
                 Err(err) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: response_id,

--- a/meerkat-mobkit/src/storage_doctor.rs
+++ b/meerkat-mobkit/src/storage_doctor.rs
@@ -399,6 +399,19 @@ fn sweep_state_dir(state_dir: &Path, identity_filter: Option<&str>, out: &mut St
         }
     }
 
+    // The canonical jobs database is inherited from the Meerkat-level realm
+    // bundle, so it lives under `<state>/mobkit/jobs.sqlite3` rather than in
+    // MobKit's top-level database family. Diagnose it through that composed
+    // path and its own schema-domain ledger.
+    let jobs_path = state_dir
+        .join(crate::storage_provider::MEERKAT_LEVEL_REALM_ID)
+        .join("jobs.sqlite3");
+    if jobs_path.is_file() {
+        entry
+            .databases
+            .push(inspect_database(&jobs_path, &["jobs"], out));
+    }
+
     // Agent-memory realm roots: twin census across the two spellings, then
     // per-realm database inventory inside each existing root.
     let memory_roots: Vec<PathBuf> = MEMORY_ROOT_SPELLINGS
@@ -1418,5 +1431,27 @@ mod tests {
             .await
             .expect("diagnose never fails on disk");
         assert_eq!(diagnosis.inventory.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn doctor_censuses_the_inherited_canonical_jobs_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp
+            .path()
+            .join(crate::storage_provider::MEERKAT_LEVEL_REALM_ID)
+            .join("jobs.sqlite3");
+        let _store = meerkat::SqliteDetachedJobStore::open(path.clone()).unwrap();
+
+        let diagnosis = diagnose_state_dir(&scope(&[temp.path()])).await;
+        let jobs = diagnosis.inventory[0]
+            .databases
+            .iter()
+            .find(|database| database.path == path)
+            .expect("jobs database inventory");
+        assert!(
+            jobs.domains
+                .iter()
+                .any(|(domain, version)| domain == "jobs" && version.is_some())
+        );
     }
 }

--- a/meerkat-mobkit/src/storage_health.rs
+++ b/meerkat-mobkit/src/storage_health.rs
@@ -348,12 +348,34 @@ impl std::fmt::Display for RuntimeStoreResolutionError {
 
 impl std::error::Error for RuntimeStoreResolutionError {}
 
+/// Fail-closed canonical detached-job store open failure.
+#[derive(Debug)]
+pub struct JobStoreResolutionError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl std::fmt::Display for JobStoreResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "failed to open the canonical detached-job store at {}: {} \
+             (durable detached admission is unavailable; fix the database file)",
+            self.path.display(),
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for JobStoreResolutionError {}
+
 /// Composite fail-closed storage composition failure for the persistent
 /// bootstrap path: any durable slot that can refuse at composition time.
 #[derive(Debug)]
 pub enum StorageResolutionError {
     Blob(BlobStoreResolutionError),
     RuntimeStore(RuntimeStoreResolutionError),
+    JobStore(JobStoreResolutionError),
 }
 
 impl std::fmt::Display for StorageResolutionError {
@@ -361,6 +383,7 @@ impl std::fmt::Display for StorageResolutionError {
         match self {
             Self::Blob(error) => error.fmt(f),
             Self::RuntimeStore(error) => error.fmt(f),
+            Self::JobStore(error) => error.fmt(f),
         }
     }
 }
@@ -376,6 +399,12 @@ impl From<BlobStoreResolutionError> for StorageResolutionError {
 impl From<RuntimeStoreResolutionError> for StorageResolutionError {
     fn from(error: RuntimeStoreResolutionError) -> Self {
         Self::RuntimeStore(error)
+    }
+}
+
+impl From<JobStoreResolutionError> for StorageResolutionError {
+    fn from(error: JobStoreResolutionError) -> Self {
+        Self::JobStore(error)
     }
 }
 

--- a/meerkat-mobkit/src/storage_layout.rs
+++ b/meerkat-mobkit/src/storage_layout.rs
@@ -435,6 +435,16 @@ impl MobKitStorageLayout {
         self.state_dir.join(WORKGRAPH_STORE_FILE)
     }
 
+    /// Canonical Meerkat-level detached-job database inherited by MobKit's
+    /// composite provider. This is realm-owned, not a second MobKit store.
+    pub fn jobs_db(&self) -> PathBuf {
+        meerkat_store::realm_paths_in(
+            &self.state_dir,
+            crate::storage_provider::MEERKAT_LEVEL_REALM_ID,
+        )
+        .jobs_sqlite_path
+    }
+
     /// The reserved event-log locator (nothing opens it before M4).
     pub fn event_log_db(&self) -> PathBuf {
         self.state_dir.join(EVENT_LOG_DB_FILE_NAME)
@@ -827,6 +837,12 @@ mod tests {
             layout.workgraph_db(),
             tmp.path()
                 .join(crate::workgraph_wiring::WORKGRAPH_STORE_FILE)
+        );
+        assert_eq!(
+            layout.jobs_db(),
+            tmp.path()
+                .join(crate::storage_provider::MEERKAT_LEVEL_REALM_ID)
+                .join("jobs.sqlite3")
         );
         assert_eq!(layout.blob_root(), tmp.path().join("blobs"));
         assert_eq!(layout.event_log_db(), tmp.path().join("event_log.sqlite3"));

--- a/meerkat-mobkit/src/storage_migrate.rs
+++ b/meerkat-mobkit/src/storage_migrate.rs
@@ -21,9 +21,12 @@
 //!    `SqliteAgentMemoryStore` realm-connection path). Dry-run is a
 //!    read-only version matrix. The workgraph admission sidecar is
 //!    **exempt** (M3 decision: the lock database deliberately carries no
-//!    tables and no ledger); meerkat-shared databases (sessions, runtime,
-//!    schedule, workgraph) are report-only here — the owning meerkat store
-//!    converges each on its next open.
+//!    tables and no ledger); most meerkat-shared databases (sessions, runtime,
+//!    schedule, workgraph) are report-only here. The inherited jobs database
+//!    is the deliberate exception: this verb invokes Meerkat's canonical
+//!    `SqliteDetachedJobStore` constructor while holding the same state-wide
+//!    fence, so offline migration covers the Phase-4 jobs domain without
+//!    introducing a MobKit-owned schema authority.
 //! 2. **File-name unification (auto-safe, rename-only).** A lone legacy
 //!    spelling ([`crate::storage_layout::DatabaseSlot::legacy_names`])
 //!    renames to its M2 canonical name under the fence, WITH its `-wal` /
@@ -169,8 +172,9 @@ const LEFTOVER_FINDING_CODES: &[&str] = &[
 
 /// Enumerate every SQLite database file currently materialized under a
 /// MobKit state directory: each [`DatabaseSlot`]'s canonical **and** legacy
-/// spellings that exist as files, plus the per-realm agent-memory databases
-/// under both memory-root spellings. Sorted (deterministic fence order).
+/// spellings that exist as files, the inherited canonical jobs database, plus
+/// the per-realm agent-memory databases under both memory-root spellings.
+/// Sorted (deterministic fence order).
 ///
 /// The workgraph admission sidecar is deliberately excluded: it carries no
 /// per-operation fence guard by M3 design (it IS a cross-process lock), so
@@ -202,7 +206,12 @@ pub fn enumerate_state_dir_databases(state_dir: &Path) -> Vec<PathBuf> {
             }
         }
     }
+    let jobs = MobKitStorageLayout::with_injected_roots(state_dir.to_path_buf(), None).jobs_db();
+    if jobs.is_file() {
+        files.push(jobs);
+    }
     files.sort();
+    files.dedup();
     files
 }
 
@@ -796,7 +805,9 @@ enum LedgerDomainClass {
 
 fn ledger_domain_class(domain: &str) -> LedgerDomainClass {
     match domain {
-        "mobkit-continuity" | "mobkit-metadata" | "mobkit-console" => LedgerDomainClass::Stampable,
+        "mobkit-continuity" | "mobkit-metadata" | "mobkit-console" | "jobs" => {
+            LedgerDomainClass::Stampable
+        }
         "mobkit-workgraph-admission" => LedgerDomainClass::Exempt,
         _ if domain == MEMORY_LEDGER_DOMAIN => LedgerDomainClass::Stampable,
         _ => LedgerDomainClass::ReportOnly,
@@ -880,6 +891,10 @@ fn read_ledger_matrix(state_dir: &Path) -> Vec<(PathBuf, String, Option<i64>)> {
             push_db(db_path, &[MEMORY_LEDGER_DOMAIN]);
         }
     }
+    let jobs = MobKitStorageLayout::with_injected_roots(state_dir.to_path_buf(), None).jobs_db();
+    if jobs.is_file() {
+        push_db(jobs, &["jobs"]);
+    }
     matrix
 }
 
@@ -944,6 +959,13 @@ fn open_stores_through_ledgered_constructors(
         }
         Ok(_) => {}
         Err(error) => errors.push(format!("agent-memory locator unresolved: {error}")),
+    }
+    let jobs = layout.jobs_db();
+    if jobs.is_file()
+        && !unfenced.contains(&jobs)
+        && let Err(error) = meerkat::SqliteDetachedJobStore::open(&jobs)
+    {
+        errors.push(format!("detached-job store open failed: {error}"));
     }
 }
 
@@ -1918,6 +1940,8 @@ mod tests {
         drop(Connection::open(state.join("runtime.sqlite")).expect("runtime"));
         fs::create_dir_all(state.join("agent-memory")).expect("memory root");
         drop(Connection::open(state.join("agent-memory/alpha.sqlite3")).expect("realm"));
+        let jobs = MobKitStorageLayout::with_injected_roots(state.to_path_buf(), None).jobs_db();
+        drop(meerkat::SqliteDetachedJobStore::open(&jobs).expect("jobs"));
         // Excluded: the admission sidecar (no fence guard by design) and
         // non-database files.
         drop(Connection::open(state.join(WORKGRAPH_ADMISSION_SIDECAR_FILE)).expect("sidecar"));
@@ -1927,12 +1951,13 @@ mod tests {
         let mut expected = vec![
             state.join("agent-memory/alpha.sqlite3"),
             state.join("continuity.db"),
+            jobs,
             state.join("runtime.sqlite"),
             state.join("sessions.sqlite3"),
         ];
         expected.sort();
         assert_eq!(fence.fenced_databases(), expected.as_slice());
-        assert_eq!(fence.len(), 4);
+        assert_eq!(fence.len(), 5);
         assert!(!fence.is_empty());
         for database in fence.fenced_databases() {
             assert!(meerkat_sqlite::fence_lock_path(database).is_file());
@@ -2073,7 +2098,10 @@ mod tests {
                 .expect("sessions ddl");
         }
         drop(Connection::open(state.join(WORKGRAPH_ADMISSION_SIDECAR_FILE)).expect("sidecar"));
+        let jobs = MobKitStorageLayout::with_injected_roots(state.to_path_buf(), None).jobs_db();
+        drop(meerkat::SqliteDetachedJobStore::open(&jobs).expect("jobs"));
         let before = file_digest_hex(&state.join("continuity.db"));
+        let jobs_before = file_digest_hex(&jobs);
 
         let report = migrate_state_dir(state, MigrateMode::DryRun, None);
         assert!(!report.has_errors(), "{:?}", report.errors);
@@ -2084,6 +2112,10 @@ mod tests {
         assert_eq!(
             ledger_entry(&report, "sessions.db", "session-store").action,
             LedgerBaselineAction::ReportOnly
+        );
+        assert_eq!(
+            ledger_entry(&report, "jobs.sqlite3", "jobs").action,
+            LedgerBaselineAction::Recorded
         );
         assert_eq!(
             ledger_entry(
@@ -2115,6 +2147,11 @@ mod tests {
             file_digest_hex(&state.join("continuity.db")),
             before,
             "dry-run must leave the database byte-identical"
+        );
+        assert_eq!(
+            file_digest_hex(&jobs),
+            jobs_before,
+            "dry-run must leave the inherited jobs database byte-identical"
         );
         assert!(
             state.join("continuity.db").is_file(),

--- a/meerkat-mobkit/src/storage_provider.rs
+++ b/meerkat-mobkit/src/storage_provider.rs
@@ -234,6 +234,8 @@ pub(crate) struct ProviderMeerkatStores {
     pub runtime_declaration: DurabilityDeclaration,
     pub workgraph_store: Arc<dyn meerkat::WorkGraphStore>,
     pub workgraph_declaration: DurabilityDeclaration,
+    pub job_store: Arc<dyn meerkat::DetachedJobStore>,
+    pub job_declaration: DurabilityDeclaration,
 }
 
 impl ProviderMeerkatStores {
@@ -243,6 +245,10 @@ impl ProviderMeerkatStores {
 
     pub(crate) fn workgraph_slot_summary(&self) -> crate::storage_health::StorageSlotSummary {
         self.slot_summary(&self.workgraph_declaration)
+    }
+
+    pub(crate) fn job_slot_summary(&self) -> crate::storage_health::StorageSlotSummary {
+        self.slot_summary(&self.job_declaration)
     }
 
     fn slot_summary(
@@ -334,12 +340,15 @@ pub(crate) async fn open_provider_meerkat_stores(
     };
     let runtime_declaration = declaration("runtime")?;
     let workgraph_declaration = declaration("workgraph")?;
+    let job_declaration = declaration("jobs")?;
     Ok(ProviderMeerkatStores {
         provider_name,
         runtime_store: set.runtime_store,
         runtime_declaration,
         workgraph_store: set.workgraph_store,
         workgraph_declaration,
+        job_store: set.job_store,
+        job_declaration,
     })
 }
 
@@ -647,23 +656,28 @@ mod tests {
                 runtime_store: Arc::new(meerkat_runtime::InMemoryRuntimeStore::new()),
                 schedule_store: Arc::new(meerkat_schedule::MemoryScheduleStore::new()),
                 workgraph_store: Arc::new(meerkat::MemoryWorkGraphStore::new()),
+                job_store: Arc::new(meerkat::MemoryDetachedJobStore::new()),
                 blob_store: Arc::new(meerkat_store::MemoryBlobStore::new()),
                 artifact_store: Arc::new(meerkat_store::MemoryArtifactStore::new()),
                 store_path: ctx.paths.root.clone(),
                 projection_root: None,
-                durability: ["sessions", "schedule", "workgraph", "blobs", "artifacts"]
-                    .iter()
-                    .map(|domain| {
-                        DurabilityDeclaration::durable(
-                            domain,
-                            DurabilityResolution::DeclaredEphemeral,
-                        )
-                    })
-                    .chain(std::iter::once(DurabilityDeclaration::durable(
-                        "runtime",
-                        self.runtime_resolution,
-                    )))
-                    .collect(),
+                durability: [
+                    "sessions",
+                    "schedule",
+                    "workgraph",
+                    "jobs",
+                    "blobs",
+                    "artifacts",
+                ]
+                .iter()
+                .map(|domain| {
+                    DurabilityDeclaration::durable(domain, DurabilityResolution::DeclaredEphemeral)
+                })
+                .chain(std::iter::once(DurabilityDeclaration::durable(
+                    "runtime",
+                    self.runtime_resolution,
+                )))
+                .collect(),
             })
         }
     }

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -1560,7 +1560,8 @@ impl UnifiedRuntimeBuilder {
                 crate::storage_health::StorageResolutionError::Blob(
                     crate::storage_health::BlobStoreResolutionError::OpenFailed { .. },
                 )
-                | crate::storage_health::StorageResolutionError::RuntimeStore(_) => {
+                | crate::storage_health::StorageResolutionError::RuntimeStore(_)
+                | crate::storage_health::StorageResolutionError::JobStore(_) => {
                     UnifiedRuntimeBuilderError::Io(error.to_string())
                 }
             })?

--- a/meerkat-mobkit/src/unified_runtime/http.rs
+++ b/meerkat-mobkit/src/unified_runtime/http.rs
@@ -3,8 +3,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::Router;
+use axum::http::{HeaderMap, header};
+use axum::response::IntoResponse;
 use axum::routing::get;
+use axum::{Json, Router};
 use futures::StreamExt;
 use meerkat_core::comms::EventStream;
 
@@ -23,6 +25,48 @@ use crate::runtime::RuntimeDecisionState;
 use tower::limit::ConcurrencyLimitLayer;
 
 use super::UnifiedRuntime;
+
+async fn healthz_response(
+    headers: HeaderMap,
+    job_health_projection: Arc<std::sync::RwLock<Option<serde_json::Value>>>,
+) -> axum::response::Response {
+    let wants_json = headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .any(|item| item.trim().starts_with("application/json"))
+        });
+    if !wants_json {
+        return "ok".into_response();
+    }
+    let projection = job_health_projection
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let public_projection = projection.map_or_else(
+        || {
+            serde_json::json!({
+                "status": "ok",
+                "detached_jobs": null
+            })
+        },
+        |projection| {
+            serde_json::json!({
+                "status": projection
+                    .get("status")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!("ok")),
+                "detached_jobs": projection
+                    .get("detached_jobs")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null)
+            })
+        },
+    );
+    Json(public_projection).into_response()
+}
 
 /// Default cap for the stock reference app router.
 ///
@@ -176,6 +220,7 @@ impl UnifiedRuntime {
             self.console_identity_roster(),
             self.workgraph_service(),
             Some(self.topology_runtime_handle()),
+            Some(Arc::clone(&self.job_health_projection)),
         )
     }
 
@@ -212,8 +257,15 @@ impl UnifiedRuntime {
         let agent_sse_visibility_policy = visibility_policy.clone();
         let mob_sse_visibility_policy = visibility_policy.clone();
         let structural_sse_visibility_policy = visibility_policy.clone();
+        let job_health_projection = Arc::clone(&self.job_health_projection);
         Router::new()
-            .route("/healthz", get(|| async { "ok" }))
+            .route(
+                "/healthz",
+                get(move |headers: HeaderMap| {
+                    let job_health_projection = Arc::clone(&job_health_projection);
+                    healthz_response(headers, job_health_projection)
+                }),
+            )
             .merge(self.build_console_frontend_router())
             .merge(protected_flow_editor_router_with_runtime_catalog(
                 flow_editor_decisions,
@@ -329,6 +381,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use axum::http::{HeaderMap, header};
     use futures::StreamExt;
     use meerkat_client::TestClient;
     use meerkat_core::comms::EventStream;
@@ -336,6 +389,7 @@ mod tests {
 
     use super::{
         DEFAULT_REFERENCE_APP_MAX_CONCURRENT_REQUESTS, generation_authoritative_agent_event_stream,
+        healthz_response,
     };
     use crate::identity_first::{
         AgentAddressability, AgentIdentity, DurableAgentSpec, LocalContinuityStore,
@@ -346,6 +400,38 @@ mod tests {
     #[test]
     fn reference_router_default_concurrency_allows_sse_fanout() {
         assert_eq!(DEFAULT_REFERENCE_APP_MAX_CONCURRENT_REQUESTS, 1024);
+    }
+
+    #[tokio::test]
+    async fn healthz_preserves_text_probe_and_negotiates_structured_jobs() {
+        let projection = Arc::new(std::sync::RwLock::new(Some(serde_json::json!({
+            "status": "ok",
+            "detached_jobs": {
+                "queued": 1,
+                "running": 2,
+                "awaiting_members": 1,
+                "stale_leases": 0,
+                "needs_attention": 0,
+                "delivery_backlog": 0
+            }
+        }))));
+        let text = healthz_response(HeaderMap::new(), Arc::clone(&projection)).await;
+        assert_eq!(text.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            axum::body::to_bytes(text.into_body(), usize::MAX)
+                .await
+                .expect("text body"),
+            "ok"
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ACCEPT, "application/json".parse().expect("accept"));
+        let json = healthz_response(headers, projection).await;
+        let body = axum::body::to_bytes(json.into_body(), usize::MAX)
+            .await
+            .expect("json body");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(body["detached_jobs"]["running"], 2);
     }
 
     #[tokio::test]

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -187,6 +187,9 @@ pub struct UnifiedRuntime {
     // the store is constructed.
     memory_panel_store:
         std::sync::RwLock<Option<Arc<dyn crate::memory::capabilities::MemoryPanelStore>>>,
+    /// Rebuildable detached-job health/status projection supplied by the
+    /// host that owns the canonical Meerkat job service.
+    job_health_projection: Arc<std::sync::RwLock<Option<serde_json::Value>>>,
     // Realm-scoped WorkGraph service backing the `mobkit/workgraph/*` RPC
     // group and the console experience section. Seeded from the bootstrap
     // spec and deliberately FIXED from then on: the admission guards
@@ -305,6 +308,7 @@ impl UnifiedRuntime {
             access_controller: None,
             topology_controller: crate::topology_control::TopologyController::default(),
             memory_panel_store: std::sync::RwLock::new(None),
+            job_health_projection: Arc::new(std::sync::RwLock::new(None)),
             workgraph_service,
             console_identity_roster: std::sync::RwLock::new(None),
             console_operator_resolver: std::sync::RwLock::new(None),
@@ -524,6 +528,25 @@ impl UnifiedRuntime {
 
     pub fn binary_blob_store(&self) -> Option<Arc<dyn crate::blob_store::BinaryBlobStore>> {
         self.mob_runtime.binary_blob_store()
+    }
+
+    /// Publish the latest rebuildable detached-job observability projection.
+    ///
+    /// Lifecycle remains owned by Meerkat's generated job machine; this slot
+    /// exists only so status, capability, console, and health surfaces can
+    /// expose the host-owned projection without a parallel semantic store.
+    pub fn set_job_health_projection(&self, projection: Option<serde_json::Value>) {
+        *self
+            .job_health_projection
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = projection;
+    }
+
+    pub fn job_health_projection(&self) -> Option<serde_json::Value> {
+        self.job_health_projection
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     pub(crate) fn module_runtime_handle(&self) -> Arc<tokio::sync::Mutex<MobkitRuntimeHandle>> {

--- a/meerkat-mobkit/tests/identity_first_builder.rs
+++ b/meerkat-mobkit/tests/identity_first_builder.rs
@@ -3927,6 +3927,7 @@ async fn builder_storage_provider_routes_meerkat_level_bundle_and_census() {
                 runtime_store: Arc::new(meerkat_runtime::InMemoryRuntimeStore::new()),
                 schedule_store: Arc::new(meerkat_schedule::MemoryScheduleStore::new()),
                 workgraph_store: Arc::new(meerkat::MemoryWorkGraphStore::new()),
+                job_store: Arc::new(meerkat::MemoryDetachedJobStore::new()),
                 blob_store: Arc::new(meerkat_store::MemoryBlobStore::new()),
                 artifact_store: Arc::new(meerkat_store::MemoryArtifactStore::new()),
                 store_path: ctx.paths.root.clone(),
@@ -3936,6 +3937,7 @@ async fn builder_storage_provider_routes_meerkat_level_bundle_and_census() {
                     "runtime",
                     "schedule",
                     "workgraph",
+                    "jobs",
                     "blobs",
                     "artifacts",
                 ]

--- a/mobkit-store-conformance/Cargo.toml
+++ b/mobkit-store-conformance/Cargo.toml
@@ -19,14 +19,14 @@ workspace = true
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
-meerkat-core = "=0.8.6"
+meerkat-core = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 # The one-remote-bundle reference provider (M4b) implements both levels of
 # the composite seam: meerkat's RealmStorageProvider (facade storage_provider
 # module + in-memory store implementations) next to MobKit's realm store set.
-meerkat = { version = "=0.8.6", features = ["session-store", "memory-store"] }
-meerkat-runtime = "=0.8.6"
-meerkat-store = { version = "=0.8.6", features = ["memory"] }
-meerkat-store-conformance = "=0.8.6"
+meerkat = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["session-store", "memory-store"] }
+meerkat-runtime = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
+meerkat-store = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c", features = ["memory"] }
+meerkat-store-conformance = { git = "https://github.com/lukacf/meerkat", rev = "5f7ff147c" }
 meerkat-mobkit = { path = "../meerkat-mobkit" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"

--- a/mobkit-store-conformance/src/reference.rs
+++ b/mobkit-store-conformance/src/reference.rs
@@ -446,6 +446,7 @@ impl meerkat::storage_provider::RealmStorageProvider for ReferenceMemoryRealmPro
             runtime_store: Arc::new(meerkat_runtime::InMemoryRuntimeStore::new()),
             schedule_store: Arc::new(meerkat::MemoryScheduleStore::new()),
             workgraph_store: Arc::new(meerkat::MemoryWorkGraphStore::new()),
+            job_store: Arc::new(meerkat::MemoryDetachedJobStore::new()),
             blob_store,
             artifact_store: Arc::new(meerkat_store::MemoryArtifactStore::new()),
             store_path: ctx.paths.root.clone(),
@@ -455,6 +456,7 @@ impl meerkat::storage_provider::RealmStorageProvider for ReferenceMemoryRealmPro
                 "runtime",
                 "schedule",
                 "workgraph",
+                "jobs",
                 "blobs",
                 "artifacts",
             ]

--- a/mobkit-store-conformance/tests/one_remote_bundle.rs
+++ b/mobkit-store-conformance/tests/one_remote_bundle.rs
@@ -329,3 +329,29 @@ async fn bundle_meerkat_level_passes_the_upstream_profiles() {
     .await
     .expect("the bundle's meerkat artifact store must satisfy the artifact profile");
 }
+
+#[tokio::test]
+async fn bundle_meerkat_level_supplies_the_inherited_jobs_authority() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let provider = bundle();
+    let set = open_fresh_meerkat_realm(&provider, dir.path()).await;
+    let service = meerkat::DetachedJobService::new(set.job_store);
+    let session =
+        meerkat_core::SessionId::parse("019f74fb-1907-7b21-932d-ab22c4d1f532").expect("session");
+    let receipt = service
+        .submit(meerkat::JobSpec::new(
+            "bundle-conformance",
+            session,
+            meerkat::ExecutionIntentId::from_string("intent:bundle").expect("intent"),
+            meerkat::InteractionLineageId::from_string("lineage:bundle").expect("lineage"),
+            meerkat::ToolIdentity::new("scan", "1").expect("tool"),
+            meerkat::RunnerIdentity::new("scan.runner", "1").expect("runner"),
+            meerkat::RestartClass::NonResumable,
+            meerkat::CanonicalArgumentsHash::new(format!("sha256:{}", "b".repeat(64)))
+                .expect("arguments"),
+            meerkat::JobSubmissionKey::new("bundle:jobs:1").expect("submission"),
+        ))
+        .await
+        .expect("submit");
+    assert!(service.get(&receipt.job_id).await.expect("get").is_some());
+}

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Python SDK are documented here.
 
 ## Unreleased
 
+- Added durable detached callback tools. `register_tool(..., execution=...)`
+  declares runner identity, restart and idempotency policy, submission timeout,
+  and credential scopes; the host accepts short `start`/`reconcile`/`cancel`
+  control callbacks and reports fenced progress, checkpoints, and terminal
+  results asynchronously.
+- Added `runtime.jobs` and `runtime.monitors` domain handles for the stable
+  job/monitor RPC surface. Reconnect reconciliation reuses the exact committed
+  attempt, fence, lease, checkpoint, and handle; it never advances authority
+  merely because the gateway reopened.
+- Detached credentials are resolved from the runner's bound SDK profile for
+  each committed attempt and are never serialized into job state or reports.
 - Persistent gateway shutdown now negotiates an explicit bounded horizon and
   keeps stdin/provider callbacks open until the gateway acknowledges runtime
   cleanup. The stock 335-second horizon covers provider operations that meet

--- a/sdk/python/meerkat_mobkit/__init__.py
+++ b/sdk/python/meerkat_mobkit/__init__.py
@@ -17,7 +17,13 @@ from __future__ import annotations
 
 # Builder + Runtime
 from .builder import MobKit, MobKitBuilder
-from .runtime import MobKitRuntime, ToolCaller
+from .runtime import JobsHandle, MobKitRuntime, MonitorsHandle, ToolCaller
+from .jobs import (
+    DetachedJobAuthority,
+    DetachedJobContext,
+    DetachedJobExecution,
+    DetachedJobResult,
+)
 from .identity_first_models import (
     IdentityBootstrapCounts,
     IdentityBootstrapEntry,
@@ -193,6 +199,12 @@ __all__ = [
     "MobKit",
     "MobKitBuilder",
     "MobKitRuntime",
+    "JobsHandle",
+    "MonitorsHandle",
+    "DetachedJobAuthority",
+    "DetachedJobContext",
+    "DetachedJobExecution",
+    "DetachedJobResult",
     "IdentityBootstrapMode",
     "IdentityBootstrapState",
     "IdentityBootstrapCounts",

--- a/sdk/python/meerkat_mobkit/agent_builder.py
+++ b/sdk/python/meerkat_mobkit/agent_builder.py
@@ -2,14 +2,48 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import inspect
 import logging
-from typing import Any, Callable, Protocol, runtime_checkable
+import time
+from typing import Any, Callable, Mapping, Protocol, runtime_checkable
 
+from .jobs import (
+    CredentialResolver,
+    DetachedJobAuthority,
+    DetachedJobContext,
+    DetachedJobExecution,
+    DetachedJobResult,
+    DetachedJobRpc,
+    _DetachedJobReporter,
+)
 from .models import SessionBuildOptions
 from .types import ErrorEvent
 
 _log = logging.getLogger("meerkat_mobkit")
+
+
+@dataclass
+class _RegisteredJobRunner:
+    execution: DetachedJobExecution
+    profile_name: str | None
+
+
+@dataclass
+class _ActiveJobAttempt:
+    authority: DetachedJobAuthority
+    runner_key: tuple[str, str]
+    runner_handle: str
+    cancellation: asyncio.Event
+    task: asyncio.Task[None] | None
+    adopted: bool = False
+    superseded: bool = False
+
+
+@dataclass
+class _JobMutationLock:
+    lock: asyncio.Lock
+    users: int = 0
 
 
 @runtime_checkable
@@ -66,6 +100,15 @@ class CallbackDispatcher:
         # Host-runnable schedule-fire handlers, keyed by runnable name
         # (callback/schedule_fire from runtime_options.host_runnables targets)
         self._schedule_fire_handlers: dict[str, Any] = {}
+        # Detached jobs remain machine-owned in Meerkat. These maps hold only
+        # the host process's mechanical runner/task projection.
+        self._job_rpc: DetachedJobRpc | None = None
+        self._job_credential_resolver: CredentialResolver | None = None
+        self._job_runners: dict[tuple[str, str], _RegisteredJobRunner] = {}
+        self._job_attempts: dict[str, _ActiveJobAttempt] = {}
+        self._job_highest_fence: dict[str, int] = {}
+        self._job_tasks: set[asyncio.Task[None]] = set()
+        self._job_mutation_locks: dict[str, _JobMutationLock] = {}
 
     def register_builder(self, builder: SessionAgentBuilder) -> None:
         self._builder = builder
@@ -102,6 +145,26 @@ class CallbackDispatcher:
         if not callable(handler):
             raise TypeError(f"handler must be callable, got {type(handler).__name__}: {handler!r}")
         self._schedule_fire_handlers[name] = handler
+
+    def register_job_rpc(self, rpc: DetachedJobRpc) -> None:
+        """Bind the ordinary gateway RPC path used by asynchronous reporters."""
+        if not callable(rpc):
+            raise TypeError(f"job rpc must be callable, got {type(rpc).__name__}")
+        self._job_rpc = rpc
+
+    def register_job_credential_resolver(self, resolver: CredentialResolver) -> None:
+        """Bind execution-time credential resolution for detached attempts."""
+        if not callable(resolver):
+            raise TypeError(
+                f"job credential resolver must be callable, got {type(resolver).__name__}"
+            )
+        self._job_credential_resolver = resolver
+
+    async def wait_for_job_tasks(self) -> None:
+        """Wait for the current in-process host tasks (test/shutdown helper)."""
+        while self._job_tasks:
+            tasks = list(self._job_tasks)
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def release_scope(self, scope_id: str) -> None:
         """Remove all tool handlers for a scope. Call when a session ends."""
@@ -159,6 +222,8 @@ class CallbackDispatcher:
                 self._tool_handlers[(scope_id, name)] = handler
                 tool_names.append(name)
             self._scope_tools[scope_id] = tool_names
+            for execution in opts.job_executions.values():
+                self._register_job_runner(execution, opts.profile_name)
             return opts.to_dict()
 
         if method == "callback/call_tool":
@@ -183,6 +248,15 @@ class CallbackDispatcher:
             if isinstance(result, ToolResultContent):
                 return {"content_blocks": result.blocks}
             return {"content": result}
+
+        if method == "callback/job/start":
+            return await self._start_job(params)
+
+        if method == "callback/job/reconcile":
+            return await self._reconcile_jobs(params)
+
+        if method == "callback/job/cancel":
+            return await self._cancel_job(params)
 
         if method == "callback/schedule_fire":
             runnable = params.get("runnable", "")
@@ -213,6 +287,316 @@ class CallbackDispatcher:
             return await self._handle_agent_customizer(method, params)
 
         raise ValueError(f"unknown callback method: {method}")
+
+    # --- Detached callback job shell -------------------------------------
+
+    def _register_job_runner(
+        self,
+        execution: DetachedJobExecution,
+        profile_name: str | None,
+    ) -> None:
+        key = execution.runner_key
+        existing = self._job_runners.get(key)
+        if existing is not None and existing.profile_name != profile_name:
+            raise ValueError(
+                f"detached runner {execution.runner!r}@{execution.version} is already "
+                f"bound to profile {existing.profile_name!r}; refusing conflicting "
+                f"profile {profile_name!r}"
+            )
+        self._job_runners[key] = _RegisteredJobRunner(execution, profile_name)
+
+    @staticmethod
+    def _runner_key(params: Mapping[str, Any]) -> tuple[str, str]:
+        runner = params.get("runner")
+        if not isinstance(runner, Mapping):
+            raise ValueError("job callback requires a runner object")
+        name = runner.get("name")
+        version = runner.get("version")
+        if not isinstance(name, str) or not name:
+            raise ValueError("job callback runner requires a non-empty name")
+        if not isinstance(version, str) or not version:
+            raise ValueError("job callback runner requires a non-empty version")
+        return (name, version)
+
+    async def _resolve_job_credentials(
+        self,
+        registration: _RegisteredJobRunner,
+        scopes: tuple[str, ...],
+    ) -> Mapping[str, Any]:
+        if not scopes:
+            return {}
+        resolver = self._job_credential_resolver
+        if resolver is None:
+            raise ValueError(
+                "detached callback requires credential scopes but no execution-time "
+                "credential resolver is configured"
+            )
+        resolved = resolver(registration.profile_name, scopes)
+        if inspect.isawaitable(resolved):
+            resolved = await resolved
+        if not isinstance(resolved, Mapping):
+            raise TypeError("job credential resolver must return a mapping")
+        return resolved
+
+    async def _start_job(self, params: dict[str, Any]) -> dict[str, Any]:
+        authority_raw = params.get("authority")
+        if not isinstance(authority_raw, Mapping):
+            raise ValueError("callback/job/start requires authority")
+        authority = DetachedJobAuthority.from_dict(authority_raw)
+        mutation = self._job_mutation_locks.setdefault(
+            authority.job_id,
+            _JobMutationLock(asyncio.Lock()),
+        )
+        mutation.users += 1
+        try:
+            async with mutation.lock:
+                return await self._start_job_locked(params, authority)
+        finally:
+            mutation.users -= 1
+            if mutation.users == 0:
+                self._job_mutation_locks.pop(authority.job_id, None)
+
+    async def _start_job_locked(
+        self,
+        params: dict[str, Any],
+        authority: DetachedJobAuthority,
+    ) -> dict[str, Any]:
+        runner_key = self._runner_key(params)
+        registration = self._job_runners.get(runner_key)
+        runner_handle = params.get("runner_handle")
+        if not isinstance(runner_handle, str) or not runner_handle:
+            raise ValueError("callback/job/start requires a non-empty runner_handle")
+        if registration is None or self._job_rpc is None:
+            return {"accepted": False, "runner_handle": runner_handle}
+
+        highest = self._job_highest_fence.get(authority.job_id)
+        active = self._job_attempts.get(authority.job_id)
+        if highest is not None and authority.fence < highest:
+            return {"accepted": False, "runner_handle": runner_handle}
+        if highest == authority.fence:
+            if (
+                active is not None
+                and active.authority == authority
+                and active.runner_handle == runner_handle
+                and (active.task is None or not active.task.done())
+            ):
+                return {"accepted": True, "runner_handle": runner_handle}
+            # A completed/foreign attempt at the same fence is never replayed
+            # merely because its start callback was delivered again.
+            return {"accepted": False, "runner_handle": runner_handle}
+
+        scopes_raw = params.get("credential_scopes", [])
+        if not isinstance(scopes_raw, list) or not all(
+            isinstance(scope, str) and scope for scope in scopes_raw
+        ):
+            raise ValueError("credential_scopes must be a list of non-empty strings")
+        try:
+            credentials = await self._resolve_job_credentials(
+                registration,
+                tuple(scopes_raw),
+            )
+        except Exception:
+            # Credential material never crosses the callback boundary. A
+            # resolution failure is a clean start rejection so Meerkat's
+            # machine can classify the committed attempt as attention-needed.
+            return {"accepted": False, "runner_handle": runner_handle}
+
+        # A strictly newer fence can only arrive from a later committed
+        # machine claim. Supersede the old host shell; this does not mint or
+        # mutate authority.
+        if active is not None:
+            active.superseded = True
+            active.cancellation.set()
+            if active.task is not None and not active.task.done():
+                active.task.cancel()
+
+        cancellation = asyncio.Event()
+        reporter = _DetachedJobReporter(authority, self._job_rpc)
+        context = DetachedJobContext(
+            authority=authority,
+            runner_handle=runner_handle,
+            arguments=params.get("arguments"),
+            credentials=credentials,
+            resume_checkpoint=(
+                params.get("resume_checkpoint")
+                if isinstance(params.get("resume_checkpoint"), str)
+                else None
+            ),
+            cancellation=cancellation,
+            reporter=reporter,
+        )
+        attempt = _ActiveJobAttempt(
+            authority=authority,
+            runner_key=runner_key,
+            runner_handle=runner_handle,
+            cancellation=cancellation,
+            task=None,
+        )
+        self._job_highest_fence[authority.job_id] = authority.fence
+        self._job_attempts[authority.job_id] = attempt
+        task = asyncio.create_task(
+            self._run_job(attempt, registration.execution.handler, context, reporter),
+            name=f"mobkit-job-{authority.job_id}-{authority.attempt_id}",
+        )
+        attempt.task = task
+        self._job_tasks.add(task)
+        task.add_done_callback(self._job_tasks.discard)
+        return {"accepted": True, "runner_handle": runner_handle}
+
+    async def _run_job(
+        self,
+        attempt: _ActiveJobAttempt,
+        runner: Any,
+        context: DetachedJobContext,
+        reporter: _DetachedJobReporter,
+    ) -> None:
+        run = getattr(runner, "run", runner)
+        try:
+            if inspect.iscoroutinefunction(run):
+                result = await run(context)
+            else:
+                result = await asyncio.to_thread(run, context)
+                if inspect.isawaitable(result):
+                    result = await result
+            if attempt.superseded:
+                return
+            if context.cancelled:
+                await reporter.cancel_ack()
+            elif isinstance(result, DetachedJobResult):
+                await reporter.complete(result.result_ref)
+            elif result is None:
+                await reporter.complete(None)
+            else:
+                raise TypeError(
+                    "detached runner must return DetachedJobResult or None; "
+                    "persist result bytes and return only their reference"
+                )
+        except asyncio.CancelledError:
+            if not attempt.superseded:
+                context.cancellation.set()
+                try:
+                    await reporter.cancel_ack()
+                except Exception:
+                    _log.exception("detached job cancel acknowledgement failed")
+        except Exception:
+            if not attempt.superseded:
+                try:
+                    # Do not copy exception text across the durable boundary:
+                    # it can contain arguments or resolved secret material.
+                    await reporter.fail("host_runner_failed")
+                except Exception:
+                    _log.exception("detached job failure report failed")
+        finally:
+            current = self._job_attempts.get(attempt.authority.job_id)
+            if current is attempt and not attempt.adopted:
+                self._job_attempts.pop(attempt.authority.job_id, None)
+
+    async def _renew_reconciled_attempt(
+        self,
+        authority: DetachedJobAuthority,
+    ) -> bool:
+        if self._job_rpc is None:
+            return False
+        now_ms = time.time_ns() // 1_000_000
+        try:
+            await _DetachedJobReporter(authority, self._job_rpc).heartbeat(
+                heartbeat_at_ms=now_ms,
+                lease_expires_at_ms=now_ms + 120_000,
+            )
+        except Exception:
+            return False
+        return True
+
+    async def _reconcile_jobs(self, params: dict[str, Any]) -> dict[str, Any]:
+        raw_attempts = params.get("attempts")
+        if not isinstance(raw_attempts, list):
+            raise ValueError("callback/job/reconcile requires attempts")
+        live: list[dict[str, Any]] = []
+        for raw_attempt in raw_attempts:
+            if not isinstance(raw_attempt, dict):
+                raise ValueError("reconcile attempts must be objects")
+            authority_raw = raw_attempt.get("authority")
+            if not isinstance(authority_raw, Mapping):
+                raise ValueError("reconcile attempt requires authority")
+            authority = DetachedJobAuthority.from_dict(authority_raw)
+            runner_key = self._runner_key(raw_attempt)
+            runner_handle = raw_attempt.get("runner_handle")
+            if not isinstance(runner_handle, str) or not runner_handle:
+                raise ValueError("reconcile attempt requires runner_handle")
+            active = self._job_attempts.get(authority.job_id)
+            if active is not None and (
+                active.authority == authority
+                and active.runner_key == runner_key
+                and active.runner_handle == runner_handle
+            ):
+                if (
+                    not active.cancellation.is_set()
+                    and (active.task is None or not active.task.done())
+                    and await self._renew_reconciled_attempt(authority)
+                ):
+                    live.append(authority.to_dict())
+                continue
+
+            registration = self._job_runners.get(runner_key)
+            if raw_attempt.get("restart_class") != "adoptable":
+                # A reconstruction hook may adopt only work whose generated
+                # lifecycle declaration permits adoption. Replay/resume is a
+                # later machine-authorized claim, never a host inference.
+                continue
+            reconcile = (
+                getattr(registration.execution.handler, "reconcile", None)
+                if registration is not None
+                else None
+            )
+            if not callable(reconcile):
+                continue
+            adopted = reconcile(raw_attempt)
+            if inspect.isawaitable(adopted):
+                adopted = await adopted
+            if adopted is not True:
+                continue
+            highest = self._job_highest_fence.get(authority.job_id)
+            if highest is not None and authority.fence < highest:
+                continue
+            self._job_highest_fence[authority.job_id] = authority.fence
+            self._job_attempts[authority.job_id] = _ActiveJobAttempt(
+                authority=authority,
+                runner_key=runner_key,
+                runner_handle=runner_handle,
+                cancellation=asyncio.Event(),
+                task=None,
+                adopted=True,
+            )
+            if not await self._renew_reconciled_attempt(authority):
+                current = self._job_attempts.get(authority.job_id)
+                if current is not None and current.authority == authority:
+                    self._job_attempts.pop(authority.job_id, None)
+                continue
+            live.append(authority.to_dict())
+        return {"live_attempts": live}
+
+    async def _cancel_job(self, params: dict[str, Any]) -> dict[str, Any]:
+        authority_raw = params.get("authority")
+        if not isinstance(authority_raw, Mapping):
+            raise ValueError("callback/job/cancel requires authority")
+        authority = DetachedJobAuthority.from_dict(authority_raw)
+        active = self._job_attempts.get(authority.job_id)
+        if active is None or active.authority != authority:
+            return {"accepted": False}
+        active.cancellation.set()
+        registration = self._job_runners.get(active.runner_key)
+        cancel = (
+            getattr(registration.execution.handler, "cancel", None)
+            if registration is not None
+            else None
+        )
+        if callable(cancel):
+            result = cancel(authority.to_dict())
+            if inspect.isawaitable(result):
+                await result
+        if active.task is not None and not active.task.done():
+            active.task.cancel()
+        return {"accepted": True}
 
     # --- Provider dispatch helpers ---
 

--- a/sdk/python/meerkat_mobkit/builder.py
+++ b/sdk/python/meerkat_mobkit/builder.py
@@ -17,6 +17,7 @@ class MobKitBuilderConfig:
     discovery_callback: Any | None = None
     pre_spawn_callback: Any | None = None
     error_callback: Any | None = None
+    job_credential_resolver: Any | None = None
     event_log: Any | None = None
     runtime_store: Any | None = None
     console_read_only: bool | None = None
@@ -155,6 +156,26 @@ class MobKitBuilder:
             rt = await MobKit.builder().mob("mob.toml").on_error(on_error).build()
         """
         self._config.error_callback = callback
+        return self
+
+    def job_credentials(
+        self,
+        resolver: Callable[
+            [str | None, tuple[str, ...]],
+            Any | Awaitable[Any],
+        ],
+    ) -> MobKitBuilder:
+        """Resolve detached-job credentials afresh for each committed attempt.
+
+        The resolver receives the runner's single bound profile name and the
+        required scopes. It must return an ephemeral mapping; MobKit passes it
+        only to the host runner context and never serializes it to job RPC.
+        """
+        if not callable(resolver):
+            raise TypeError(
+                f"job credential resolver must be callable, got {type(resolver).__name__}"
+            )
+        self._config.job_credential_resolver = resolver
         return self
 
     def gating(self, config_path: str) -> MobKitBuilder:

--- a/sdk/python/meerkat_mobkit/jobs.py
+++ b/sdk/python/meerkat_mobkit/jobs.py
@@ -1,0 +1,317 @@
+"""Detached callback-job contracts for the MobKit host SDK.
+
+The Meerkat job machine owns lifecycle, fences, retries, loss, and terminality.
+This module is a mechanical host shell: it accepts an already-committed
+attempt, runs the registered host runner outside the callback, and reports
+mutations with the exact authority supplied by Meerkat.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import time
+from typing import Any, Awaitable, Callable, Literal, Mapping
+
+
+RestartClass = Literal[
+    "adoptable",
+    "checkpoint_resumable",
+    "replayable",
+    "non_resumable",
+]
+IdempotencyScope = Literal[
+    "tool_call",
+    "interaction_and_arguments",
+    "host_semantic_key",
+]
+
+
+@dataclass(frozen=True)
+class DetachedJobAuthority:
+    job_id: str
+    attempt_id: str
+    fence: int
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> DetachedJobAuthority:
+        job_id = value.get("job_id")
+        attempt_id = value.get("attempt_id")
+        fence = value.get("fence")
+        if not isinstance(job_id, str) or not job_id:
+            raise ValueError("job authority requires a non-empty job_id")
+        if not isinstance(attempt_id, str) or not attempt_id:
+            raise ValueError("job authority requires a non-empty attempt_id")
+        if isinstance(fence, bool) or not isinstance(fence, int) or fence < 1:
+            raise ValueError("job authority requires a positive integer fence")
+        return cls(job_id=job_id, attempt_id=attempt_id, fence=fence)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "attempt_id": self.attempt_id,
+            "fence": self.fence,
+        }
+
+
+@dataclass(frozen=True)
+class DetachedJobResult:
+    """A host runner's terminal result reference.
+
+    Result bytes belong in the canonical blob/artifact store. This object
+    carries only the durable non-secret reference.
+    """
+
+    result_ref: str | None = None
+
+
+DetachedJobRpc = Callable[[str, dict[str, Any]], Awaitable[Any]]
+CredentialResolver = Callable[
+    [str | None, tuple[str, ...]],
+    Mapping[str, Any] | Awaitable[Mapping[str, Any]],
+]
+
+
+@dataclass(frozen=True)
+class DetachedJobExecution:
+    """Private execution metadata plus the host-side runner implementation."""
+
+    runner: str
+    version: str
+    restart_class: RestartClass
+    idempotency_scope: IdempotencyScope
+    submission_timeout_ms: int
+    credential_scopes: tuple[str, ...] = ()
+    handler: Any = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.runner, str) or not self.runner.strip():
+            raise ValueError("detached runner must be a non-empty string")
+        if not isinstance(self.version, str) or not self.version.strip():
+            raise ValueError("detached runner version must be a non-empty string")
+        if self.restart_class not in {
+            "adoptable",
+            "checkpoint_resumable",
+            "replayable",
+            "non_resumable",
+        }:
+            raise ValueError(f"unsupported restart_class: {self.restart_class!r}")
+        if self.idempotency_scope not in {
+            "tool_call",
+            "interaction_and_arguments",
+            "host_semantic_key",
+        }:
+            raise ValueError(
+                f"unsupported idempotency_scope: {self.idempotency_scope!r}"
+            )
+        if (
+            isinstance(self.submission_timeout_ms, bool)
+            or not isinstance(self.submission_timeout_ms, int)
+            or not 0 < self.submission_timeout_ms <= 120_000
+        ):
+            raise ValueError(
+                "submission_timeout_ms must be an integer in the public "
+                "1..=120000ms callback window"
+            )
+        if self.handler is None or not (
+            callable(self.handler) or callable(getattr(self.handler, "run", None))
+        ):
+            raise TypeError("detached execution requires a callable handler or runner.run")
+        normalized_scopes: list[str] = []
+        for scope in self.credential_scopes:
+            if not isinstance(scope, str) or not scope.strip():
+                raise ValueError("credential scopes must be non-empty strings")
+            normalized_scopes.append(scope)
+        object.__setattr__(self, "credential_scopes", tuple(normalized_scopes))
+
+    @property
+    def runner_key(self) -> tuple[str, str]:
+        return (self.runner, self.version)
+
+    def to_wire(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "mode": "detached",
+            "runner": {"name": self.runner, "version": self.version},
+            "restart_class": self.restart_class,
+            "idempotency_scope": self.idempotency_scope,
+            "submission_timeout_ms": self.submission_timeout_ms,
+        }
+        if self.credential_scopes:
+            result["credential_scopes"] = list(self.credential_scopes)
+        return result
+
+
+class _DetachedJobReporter:
+    def __init__(self, authority: DetachedJobAuthority, rpc: DetachedJobRpc) -> None:
+        self._authority = authority
+        self._rpc = rpc
+        self._terminal = False
+
+    @property
+    def terminal(self) -> bool:
+        return self._terminal
+
+    async def _send(self, method: str, params: dict[str, Any]) -> Any:
+        return await self._rpc(
+            method,
+            {"authority": self._authority.to_dict(), **params},
+        )
+
+    async def heartbeat(
+        self,
+        *,
+        heartbeat_at_ms: int | None = None,
+        lease_expires_at_ms: int,
+    ) -> Any:
+        return await self._send(
+            "mobkit/jobs/heartbeat",
+            {
+                "heartbeat_at_ms": heartbeat_at_ms or _unix_time_ms(),
+                "lease_expires_at_ms": lease_expires_at_ms,
+            },
+        )
+
+    async def progress(
+        self,
+        cursor: int,
+        detail: str,
+        *,
+        observed_at_ms: int | None = None,
+    ) -> Any:
+        return await self._send(
+            "mobkit/jobs/progress",
+            {
+                "cursor": cursor,
+                "detail": detail,
+                "observed_at_ms": observed_at_ms or _unix_time_ms(),
+            },
+        )
+
+    async def checkpoint(
+        self,
+        checkpoint_ref: str,
+        *,
+        observed_at_ms: int | None = None,
+    ) -> Any:
+        return await self._send(
+            "mobkit/jobs/checkpoint",
+            {
+                "checkpoint_ref": checkpoint_ref,
+                "observed_at_ms": observed_at_ms or _unix_time_ms(),
+            },
+        )
+
+    async def complete(
+        self,
+        result_ref: str | None,
+        *,
+        completed_at_ms: int | None = None,
+    ) -> Any:
+        if self._terminal:
+            return None
+        params: dict[str, Any] = {
+            "completed_at_ms": completed_at_ms or _unix_time_ms(),
+        }
+        if result_ref is not None:
+            params["result_ref"] = result_ref
+        result = await self._send("mobkit/jobs/complete", params)
+        self._terminal = True
+        return result
+
+    async def fail(
+        self,
+        code: str,
+        *,
+        detail_ref: str | None = None,
+        failed_at_ms: int | None = None,
+    ) -> Any:
+        if self._terminal:
+            return None
+        params: dict[str, Any] = {
+            "failed_at_ms": failed_at_ms or _unix_time_ms(),
+            "code": code,
+        }
+        if detail_ref is not None:
+            params["detail_ref"] = detail_ref
+        result = await self._send("mobkit/jobs/fail", params)
+        self._terminal = True
+        return result
+
+    async def cancel_ack(self, *, acknowledged_at_ms: int | None = None) -> Any:
+        if self._terminal:
+            return None
+        result = await self._send(
+            "mobkit/jobs/cancel_ack",
+            {"acknowledged_at_ms": acknowledged_at_ms or _unix_time_ms()},
+        )
+        self._terminal = True
+        return result
+
+
+class DetachedJobContext:
+    """Attempt-local host context.
+
+    Credentials are freshly resolved ephemeral values. They are never included
+    by any reporter method and must not be retained by the runner.
+    """
+
+    def __init__(
+        self,
+        *,
+        authority: DetachedJobAuthority,
+        runner_handle: str,
+        arguments: Any,
+        credentials: Mapping[str, Any],
+        resume_checkpoint: str | None,
+        cancellation: asyncio.Event,
+        reporter: _DetachedJobReporter,
+    ) -> None:
+        self.authority = authority
+        self.runner_handle = runner_handle
+        self.arguments = arguments
+        self.credentials = dict(credentials)
+        self.resume_checkpoint = resume_checkpoint
+        self.cancellation = cancellation
+        self._reporter = reporter
+
+    @property
+    def cancelled(self) -> bool:
+        return self.cancellation.is_set()
+
+    async def heartbeat(
+        self,
+        *,
+        lease_expires_at_ms: int,
+        heartbeat_at_ms: int | None = None,
+    ) -> Any:
+        return await self._reporter.heartbeat(
+            heartbeat_at_ms=heartbeat_at_ms,
+            lease_expires_at_ms=lease_expires_at_ms,
+        )
+
+    async def progress(
+        self,
+        cursor: int,
+        detail: str,
+        *,
+        observed_at_ms: int | None = None,
+    ) -> Any:
+        return await self._reporter.progress(
+            cursor,
+            detail,
+            observed_at_ms=observed_at_ms,
+        )
+
+    async def checkpoint(
+        self,
+        checkpoint_ref: str,
+        *,
+        observed_at_ms: int | None = None,
+    ) -> Any:
+        return await self._reporter.checkpoint(
+            checkpoint_ref,
+            observed_at_ms=observed_at_ms,
+        )
+
+
+def _unix_time_ms() -> int:
+    return time.time_ns() // 1_000_000

--- a/sdk/python/meerkat_mobkit/models.py
+++ b/sdk/python/meerkat_mobkit/models.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .jobs import DetachedJobExecution
 
 
 @dataclass
@@ -117,6 +120,12 @@ class SessionBuildOptions:
     # Per-tool wire metadata from register_tool(description=/input_schema=);
     # tools without an entry cross the wire as bare name strings.
     _tool_defs: dict[str, dict[str, Any]] = field(default_factory=dict, repr=False)
+    # Host-only runner implementations paired with their private execution
+    # declarations. Only the declarations cross the build callback wire.
+    _job_executions: dict[str, DetachedJobExecution] = field(
+        default_factory=dict,
+        repr=False,
+    )
 
     def add_tools(self, tools: list[str]) -> None:
         """Declare tool names the agent can use."""
@@ -132,6 +141,7 @@ class SessionBuildOptions:
         *,
         description: str = "",
         input_schema: dict[str, Any] | None = None,
+        execution: DetachedJobExecution | None = None,
     ) -> None:
         """Register a callable tool with the agent.
 
@@ -144,6 +154,7 @@ class SessionBuildOptions:
             description: Human-readable tool description.
             input_schema: JSON Schema for the tool arguments. When omitted
                 the gateway advertises the permissive ``{"type": "object"}``.
+            execution: Optional detached-job declaration and host runner.
         """
         if not isinstance(name, str):
             raise TypeError(f"tool name must be a string, got {type(name).__name__}: {name!r}")
@@ -153,14 +164,25 @@ class SessionBuildOptions:
             raise TypeError(
                 f"input_schema must be a dict, got {type(input_schema).__name__}: {input_schema!r}"
             )
+        if execution is not None:
+            from .jobs import DetachedJobExecution
+
+            if not isinstance(execution, DetachedJobExecution):
+                raise TypeError(
+                    "execution must be DetachedJobExecution, got "
+                    f"{type(execution).__name__}: {execution!r}"
+                )
         self._tools.append(name)
         self._tool_handlers[name] = handler
-        if description or input_schema is not None:
+        if description or input_schema is not None or execution is not None:
             tool_def: dict[str, Any] = {"name": name}
             if description:
                 tool_def["description"] = description
             if input_schema is not None:
                 tool_def["input_schema"] = input_schema
+            if execution is not None:
+                tool_def["execution"] = execution.to_wire()
+                self._job_executions[name] = execution
             self._tool_defs[name] = tool_def
 
     @property
@@ -170,6 +192,10 @@ class SessionBuildOptions:
     @property
     def tool_handlers(self) -> dict[str, Any]:
         return dict(self._tool_handlers)
+
+    @property
+    def job_executions(self) -> dict[str, DetachedJobExecution]:
+        return dict(self._job_executions)
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {}

--- a/sdk/python/meerkat_mobkit/runtime.py
+++ b/sdk/python/meerkat_mobkit/runtime.py
@@ -226,6 +226,115 @@ def _normalize_upload_item(
     return _read_upload_source(item, media_type="image/png", filename=filename)
 
 
+class JobsHandle:
+    """Safe application-facing durable-job surface."""
+
+    def __init__(self, runtime: MobKitRuntime) -> None:
+        self._runtime = runtime
+
+    async def get(self, job_id: str) -> Any:
+        return await self._runtime._rpc("jobs/get", {"job_id": job_id})
+
+    async def list(
+        self,
+        *,
+        session_id: str,
+        limit: int | None = None,
+    ) -> Any:
+        params: dict[str, Any] = {"session_id": session_id}
+        if limit is not None:
+            params["limit"] = limit
+        return await self._runtime._rpc("jobs/list", params)
+
+    async def cancel(self, job_id: str) -> Any:
+        return await self._runtime._rpc("jobs/cancel", {"job_id": job_id})
+
+    async def progress(self, job_id: str) -> Any:
+        return await self._runtime._rpc("jobs/progress", {"job_id": job_id})
+
+    async def result(self, job_id: str) -> Any:
+        return await self._runtime._rpc("jobs/result", {"job_id": job_id})
+
+    async def artifacts(self, job_id: str) -> Any:
+        return await self._runtime._rpc("jobs/artifacts", {"job_id": job_id})
+
+    async def retry(self, job_id: str, *, retry_due_at_ms: int) -> Any:
+        return await self._runtime._rpc(
+            "jobs/retry",
+            {"job_id": job_id, "retry_due_at_ms": retry_due_at_ms},
+        )
+
+    async def health(self) -> Any:
+        return await self._runtime._rpc("jobs/health", {})
+
+    async def subscribe(
+        self,
+        job_id: str,
+        *,
+        subscription_id: str,
+        session_id: str,
+        delivery: dict[str, Any],
+    ) -> Any:
+        return await self._runtime._rpc(
+            "jobs/subscribe",
+            {
+                "job_id": job_id,
+                "subscription_id": subscription_id,
+                "session_id": session_id,
+                "delivery": delivery,
+            },
+        )
+
+    async def unsubscribe(self, job_id: str, *, subscription_id: str) -> Any:
+        return await self._runtime._rpc(
+            "jobs/unsubscribe",
+            {"job_id": job_id, "subscription_id": subscription_id},
+        )
+
+
+class MonitorsHandle:
+    """Durable monitor convenience surface; lifecycle remains job-owned."""
+
+    def __init__(self, runtime: MobKitRuntime) -> None:
+        self._runtime = runtime
+
+    async def start(
+        self,
+        *,
+        session_id: str,
+        submission_key: str,
+        command: str,
+        timeout_secs: int,
+        restart_class: str,
+        delivery: dict[str, Any],
+        protocol: str = "framed_jsonl",
+        working_dir: str | None = None,
+        max_line_bytes: int | None = None,
+        max_notifications_per_window: int | None = None,
+        notification_window_ms: int | None = None,
+        max_retained_diagnostic_bytes: int | None = None,
+    ) -> Any:
+        params: dict[str, Any] = {
+            "session_id": session_id,
+            "submission_key": submission_key,
+            "command": command,
+            "timeout_secs": timeout_secs,
+            "protocol": protocol,
+            "restart_class": restart_class,
+            "delivery": delivery,
+        }
+        for key, value in (
+            ("working_dir", working_dir),
+            ("max_line_bytes", max_line_bytes),
+            ("max_notifications_per_window", max_notifications_per_window),
+            ("notification_window_ms", notification_window_ms),
+            ("max_retained_diagnostic_bytes", max_retained_diagnostic_bytes),
+        ):
+            if value is not None:
+                params[key] = value
+        return await self._runtime._rpc("monitors/start", params)
+
+
 class MobKitRuntime:
     """Running MobKit runtime instance.
 
@@ -251,6 +360,8 @@ class MobKitRuntime:
         self._rust_http_base: str | None = None
         self._lifecycle_lock = asyncio.Lock()
         self._shutdown_task: asyncio.Task[None] | None = None
+        self.jobs = JobsHandle(self)
+        self.monitors = MonitorsHandle(self)
 
     async def __aenter__(self) -> MobKitRuntime:
         if not self._running:
@@ -348,6 +459,13 @@ class MobKitRuntime:
             self._transport = transport
             self._rust_http_base = None
             try:
+                # Detached host work reports asynchronously through ordinary
+                # gateway RPC after the short callback/job/start response.
+                self._dispatcher.register_job_rpc(self._rpc)
+                if self._config.job_credential_resolver is not None:
+                    self._dispatcher.register_job_credential_resolver(
+                        self._config.job_credential_resolver
+                    )
                 # Register builder FIRST — init may trigger callback/build_agent
                 if self._config.session_builder and isinstance(
                     self._config.session_builder, SessionAgentBuilder

--- a/sdk/python/tests/test_bughunt_regressions.py
+++ b/sdk/python/tests/test_bughunt_regressions.py
@@ -432,7 +432,7 @@ def test_stop_honors_negotiated_horizon_and_waits_for_gated_shutdown_callback():
     # `time.monotonic` function. `threading.Barrier` also uses monotonic time on
     # current Python versions and must remain real while this callback is gated.
     with patch("meerkat_mobkit._transport.time") as transport_time:
-        transport_time.monotonic.side_effect = [100.0, 100.0]
+        transport_time.monotonic.return_value = 100.0
         worker = threading.Thread(target=stop_transport)
         worker.start()
         gate.wait(timeout=2)

--- a/sdk/python/tests/test_detached_jobs.py
+++ b/sdk/python/tests/test_detached_jobs.py
@@ -1,0 +1,442 @@
+"""Detached callback jobs: private wire metadata and host control-plane behavior."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from meerkat_mobkit.agent_builder import CallbackDispatcher
+from meerkat_mobkit.jobs import (
+    DetachedJobContext,
+    DetachedJobExecution,
+    DetachedJobResult,
+)
+from meerkat_mobkit.models import SessionBuildOptions
+
+
+AUTHORITY_1 = {"job_id": "job-1", "attempt_id": "attempt-1", "fence": 7}
+AUTHORITY_2 = {"job_id": "job-1", "attempt_id": "attempt-2", "fence": 8}
+
+
+def start_params(
+    authority: dict[str, Any] = AUTHORITY_1,
+    *,
+    runner_handle: str = "callback:job-1:attempt:1",
+) -> dict[str, Any]:
+    return {
+        "authority": dict(authority),
+        "runner": {"name": "homecore.security_scan", "version": "1"},
+        "restart_class": "non_resumable",
+        "runner_handle": runner_handle,
+        "runner_specification_ref": "blob-args",
+        "arguments": {"target": "lan"},
+        "credential_scopes": ["network.read"],
+    }
+
+
+class Builder:
+    def __init__(self, runner: Any, *, profile_name: str = "network") -> None:
+        self.runner = runner
+        self.profile_name = profile_name
+
+    async def build_agent(self, options: SessionBuildOptions) -> None:
+        options.profile_name = self.profile_name
+        options.register_tool(
+            "security_scan",
+            lambda _args: None,
+            execution=DetachedJobExecution(
+                runner="homecore.security_scan",
+                version="1",
+                restart_class="non_resumable",
+                idempotency_scope="interaction_and_arguments",
+                submission_timeout_ms=30_000,
+                credential_scopes=("network.read",),
+                handler=self.runner,
+            ),
+        )
+
+
+async def register(
+    dispatcher: CallbackDispatcher,
+    runner: Any,
+    *,
+    profile_name: str = "network",
+    scope_id: str = "build-1",
+) -> dict[str, Any]:
+    dispatcher.register_builder(Builder(runner, profile_name=profile_name))
+    return await dispatcher.handle_callback(
+        "callback/build_agent",
+        {"options": {"scope_id": scope_id}},
+    )
+
+
+def test_detached_registration_emits_exact_private_execution_contract() -> None:
+    async def runner(_context: DetachedJobContext) -> None:
+        return None
+
+    options = SessionBuildOptions(profile_name="network")
+    options.register_tool(
+        "security_scan",
+        lambda _args: None,
+        description="Scan the LAN",
+        input_schema={"type": "object"},
+        execution=DetachedJobExecution(
+            runner="homecore.security_scan",
+            version="1",
+            restart_class="non_resumable",
+            idempotency_scope="interaction_and_arguments",
+            submission_timeout_ms=30_000,
+            credential_scopes=("network.read",),
+            handler=runner,
+        ),
+    )
+
+    assert options.to_dict()["tools"] == [
+        {
+            "name": "security_scan",
+            "description": "Scan the LAN",
+            "input_schema": {"type": "object"},
+            "execution": {
+                "mode": "detached",
+                "runner": {"name": "homecore.security_scan", "version": "1"},
+                "restart_class": "non_resumable",
+                "idempotency_scope": "interaction_and_arguments",
+                "submission_timeout_ms": 30_000,
+                "credential_scopes": ["network.read"],
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_returns_before_work_and_reports_with_exact_authority() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    rpc_calls: list[tuple[str, dict[str, Any]]] = []
+    resolver_calls: list[tuple[str | None, tuple[str, ...]]] = []
+
+    async def resolve_credentials(
+        profile_name: str | None,
+        scopes: tuple[str, ...],
+    ) -> dict[str, str]:
+        resolver_calls.append((profile_name, scopes))
+        return {"token": "secret-current-attempt"}
+
+    async def rpc(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        rpc_calls.append((method, params))
+        return {"job": {"job_id": "job-1"}}
+
+    async def runner(context: DetachedJobContext) -> DetachedJobResult:
+        assert context.arguments == {"target": "lan"}
+        assert context.credentials == {"token": "secret-current-attempt"}
+        await context.progress(1, "started", observed_at_ms=101)
+        entered.set()
+        await release.wait()
+        return DetachedJobResult(result_ref="artifact:scan")
+
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(rpc)
+    dispatcher.register_job_credential_resolver(resolve_credentials)
+    await register(dispatcher, runner)
+
+    result = await asyncio.wait_for(
+        dispatcher.handle_callback("callback/job/start", start_params()),
+        timeout=0.2,
+    )
+    assert result == {
+        "accepted": True,
+        "runner_handle": "callback:job-1:attempt:1",
+    }
+    await asyncio.wait_for(entered.wait(), timeout=0.2)
+    assert resolver_calls == [("network", ("network.read",))]
+    assert rpc_calls[0] == (
+        "mobkit/jobs/progress",
+        {
+            "authority": AUTHORITY_1,
+            "cursor": 1,
+            "detail": "started",
+            "observed_at_ms": 101,
+        },
+    )
+
+    release.set()
+    await dispatcher.wait_for_job_tasks()
+    assert rpc_calls[-1] == (
+        "mobkit/jobs/complete",
+        {
+            "authority": AUTHORITY_1,
+            "completed_at_ms": rpc_calls[-1][1]["completed_at_ms"],
+            "result_ref": "artifact:scan",
+        },
+    )
+    assert "secret-current-attempt" not in repr(rpc_calls)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_start_is_idempotent_and_newer_fence_supersedes_old() -> None:
+    starts: list[int] = []
+    releases = {7: asyncio.Event(), 8: asyncio.Event()}
+
+    async def runner(context: DetachedJobContext) -> None:
+        starts.append(context.authority.fence)
+        try:
+            await releases[context.authority.fence].wait()
+        except asyncio.CancelledError:
+            raise
+
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(lambda _method, _params: asyncio.sleep(0))
+    dispatcher.register_job_credential_resolver(
+        lambda _profile, _scopes: {},
+    )
+    await register(dispatcher, runner)
+
+    first = await dispatcher.handle_callback("callback/job/start", start_params())
+    duplicate = await dispatcher.handle_callback("callback/job/start", start_params())
+    await asyncio.sleep(0)
+    assert first == duplicate
+    assert starts == [7]
+
+    second = await dispatcher.handle_callback(
+        "callback/job/start",
+        start_params(AUTHORITY_2, runner_handle="callback:job-1:attempt:2"),
+    )
+    await asyncio.sleep(0)
+    assert second["accepted"] is True
+    assert starts == [7, 8]
+
+    stale = await dispatcher.handle_callback("callback/job/start", start_params())
+    assert stale == {
+        "accepted": False,
+        "runner_handle": "callback:job-1:attempt:1",
+    }
+    releases[8].set()
+    await dispatcher.wait_for_job_tasks()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_start_resolves_credentials_and_runs_once() -> None:
+    resolver_entered = asyncio.Event()
+    release_resolver = asyncio.Event()
+    release_runner = asyncio.Event()
+    resolver_calls = 0
+    starts = 0
+
+    async def resolve_credentials(
+        _profile_name: str | None,
+        _scopes: tuple[str, ...],
+    ) -> dict[str, str]:
+        nonlocal resolver_calls
+        resolver_calls += 1
+        resolver_entered.set()
+        await release_resolver.wait()
+        return {"token": "fresh"}
+
+    async def runner(_context: DetachedJobContext) -> None:
+        nonlocal starts
+        starts += 1
+        await release_runner.wait()
+
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(lambda _method, _params: asyncio.sleep(0))
+    dispatcher.register_job_credential_resolver(resolve_credentials)
+    await register(dispatcher, runner)
+
+    first = asyncio.create_task(
+        dispatcher.handle_callback("callback/job/start", start_params())
+    )
+    await asyncio.wait_for(resolver_entered.wait(), timeout=0.2)
+    duplicate = asyncio.create_task(
+        dispatcher.handle_callback("callback/job/start", start_params())
+    )
+    await asyncio.sleep(0)
+    release_resolver.set()
+    first_result, duplicate_result = await asyncio.gather(first, duplicate)
+    await asyncio.sleep(0)
+
+    assert first_result == duplicate_result
+    assert resolver_calls == 1
+    assert starts == 1
+    release_runner.set()
+    await dispatcher.wait_for_job_tasks()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_only_reports_exact_live_authority_and_never_starts_work() -> None:
+    release = asyncio.Event()
+    starts = 0
+    rpc_calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def runner(_context: DetachedJobContext) -> None:
+        nonlocal starts
+        starts += 1
+        await release.wait()
+
+    async def rpc(method: str, params: dict[str, Any]) -> None:
+        rpc_calls.append((method, params))
+
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(rpc)
+    dispatcher.register_job_credential_resolver(
+        lambda _profile, _scopes: {},
+    )
+    await register(dispatcher, runner)
+    await dispatcher.handle_callback("callback/job/start", start_params())
+    await asyncio.sleep(0)
+
+    result = await dispatcher.handle_callback(
+        "callback/job/reconcile",
+        {
+            "attempts": [
+                {
+                    "authority": AUTHORITY_1,
+                    "runner": {"name": "homecore.security_scan", "version": "1"},
+                    "restart_class": "non_resumable",
+                    "runner_handle": "callback:job-1:attempt:1",
+                    "lease_expires_at_ms": 999,
+                },
+                {
+                    "authority": {
+                        "job_id": "job-missing",
+                        "attempt_id": "attempt-missing",
+                        "fence": 11,
+                    },
+                    "runner": {"name": "homecore.security_scan", "version": "1"},
+                    "restart_class": "adoptable",
+                    "runner_handle": "external:missing",
+                    "lease_expires_at_ms": 999,
+                },
+            ]
+        },
+    )
+    assert result == {"live_attempts": [AUTHORITY_1]}
+    assert starts == 1
+    heartbeat_method, heartbeat_params = rpc_calls[-1]
+    assert heartbeat_method == "mobkit/jobs/heartbeat"
+    assert heartbeat_params["authority"] == AUTHORITY_1
+    assert heartbeat_params["lease_expires_at_ms"] > heartbeat_params["heartbeat_at_ms"]
+    release.set()
+    await dispatcher.wait_for_job_tasks()
+
+
+@pytest.mark.asyncio
+async def test_external_adoption_and_cancel_are_runner_owned_but_authority_exact() -> None:
+    class AdoptableRunner:
+        def __init__(self) -> None:
+            self.cancelled: list[dict[str, Any]] = []
+
+        async def run(self, _context: DetachedJobContext) -> None:
+            raise AssertionError("reconcile must not start a fresh run")
+
+        async def reconcile(self, attempt: dict[str, Any]) -> bool:
+            return attempt["runner_handle"] == "external:still-live"
+
+        async def cancel(self, authority: dict[str, Any]) -> None:
+            self.cancelled.append(authority)
+
+    runner = AdoptableRunner()
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(lambda _method, _params: asyncio.sleep(0))
+    await register(dispatcher, runner)
+
+    offered = {
+        "authority": AUTHORITY_1,
+        "runner": {"name": "homecore.security_scan", "version": "1"},
+        "restart_class": "adoptable",
+        "runner_handle": "external:still-live",
+        "lease_expires_at_ms": 999,
+    }
+    reconciled = await dispatcher.handle_callback(
+        "callback/job/reconcile",
+        {
+            "attempts": [
+                offered,
+                {
+                    "authority": {
+                        "job_id": "job-replay",
+                        "attempt_id": "attempt-replay",
+                        "fence": 1,
+                    },
+                    "runner": {
+                        "name": "homecore.security_scan",
+                        "version": "1",
+                    },
+                    "restart_class": "replayable",
+                    "runner_handle": "external:still-live",
+                    "lease_expires_at_ms": 999,
+                },
+            ]
+        },
+    )
+    assert reconciled == {"live_attempts": [AUTHORITY_1]}
+
+    stale_cancel = await dispatcher.handle_callback(
+        "callback/job/cancel",
+        {"authority": AUTHORITY_2},
+    )
+    assert stale_cancel == {"accepted": False}
+
+    exact_cancel = await dispatcher.handle_callback(
+        "callback/job/cancel",
+        {"authority": AUTHORITY_1},
+    )
+    assert exact_cancel == {"accepted": True}
+    assert runner.cancelled == [AUTHORITY_1]
+
+
+@pytest.mark.asyncio
+async def test_credentials_are_re_resolved_per_attempt_and_profile_conflicts_fail() -> None:
+    resolved: list[str] = []
+    attempt_done = asyncio.Event()
+
+    async def resolver(
+        profile_name: str | None,
+        _scopes: tuple[str, ...],
+    ) -> dict[str, str]:
+        token = f"{profile_name}-{len(resolved) + 1}"
+        resolved.append(token)
+        return {"token": token}
+
+    async def runner(_context: DetachedJobContext) -> None:
+        attempt_done.set()
+
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(lambda _method, _params: asyncio.sleep(0))
+    dispatcher.register_job_credential_resolver(resolver)
+    await register(dispatcher, runner)
+    await dispatcher.handle_callback("callback/job/start", start_params())
+    await asyncio.wait_for(attempt_done.wait(), timeout=0.2)
+    await dispatcher.wait_for_job_tasks()
+
+    attempt_done.clear()
+    await dispatcher.handle_callback(
+        "callback/job/start",
+        start_params(AUTHORITY_2, runner_handle="callback:job-1:attempt:2"),
+    )
+    await asyncio.wait_for(attempt_done.wait(), timeout=0.2)
+    await dispatcher.wait_for_job_tasks()
+    assert resolved == ["network-1", "network-2"]
+
+    with pytest.raises(ValueError, match="already bound to profile 'network'"):
+        await register(
+            dispatcher,
+            runner,
+            profile_name="security",
+            scope_id="build-2",
+        )
+
+
+@pytest.mark.asyncio
+async def test_scoped_credential_resolution_failure_rejects_start_cleanly() -> None:
+    dispatcher = CallbackDispatcher()
+    dispatcher.register_job_rpc(lambda _method, _params: asyncio.sleep(0))
+    await register(dispatcher, lambda _context: None)
+
+    assert await dispatcher.handle_callback(
+        "callback/job/start",
+        start_params(),
+    ) == {
+        "accepted": False,
+        "runner_handle": "callback:job-1:attempt:1",
+    }

--- a/sdk/python/tests/test_job_surfaces.py
+++ b/sdk/python/tests/test_job_surfaces.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from meerkat_mobkit import MobKit, MobKitRuntime
+
+
+@pytest.mark.asyncio
+async def test_jobs_and_monitors_use_canonical_domain_methods() -> None:
+    runtime = MobKitRuntime(MobKit.builder()._config)
+    calls: list[tuple[str, dict]] = []
+
+    async def rpc(method: str, params: dict | None = None):
+        calls.append((method, params or {}))
+        return {"method": method}
+
+    runtime._rpc = rpc  # type: ignore[method-assign]
+
+    await runtime.jobs.get("job-1")
+    await runtime.jobs.list(session_id="session-1", limit=25)
+    await runtime.jobs.cancel("job-1")
+    await runtime.jobs.progress("job-1")
+    await runtime.jobs.result("job-1")
+    await runtime.jobs.artifacts("job-1")
+    await runtime.jobs.retry("job-1", retry_due_at_ms=123)
+    await runtime.jobs.health()
+    await runtime.jobs.subscribe(
+        "job-1",
+        subscription_id="sub-1",
+        session_id="session-1",
+        delivery={"kind": "event", "handling_mode": "steer"},
+    )
+    await runtime.jobs.unsubscribe("job-1", subscription_id="sub-1")
+    await runtime.monitors.start(
+        session_id="session-1",
+        submission_key="monitor:lan",
+        command="./scan --watch",
+        timeout_secs=600,
+        restart_class="non_resumable",
+        delivery={"kind": "notification"},
+        protocol="framed_jsonl",
+        working_dir="/srv/homecore",
+        max_line_bytes=4096,
+    )
+
+    assert calls == [
+        ("jobs/get", {"job_id": "job-1"}),
+        ("jobs/list", {"session_id": "session-1", "limit": 25}),
+        ("jobs/cancel", {"job_id": "job-1"}),
+        ("jobs/progress", {"job_id": "job-1"}),
+        ("jobs/result", {"job_id": "job-1"}),
+        ("jobs/artifacts", {"job_id": "job-1"}),
+        ("jobs/retry", {"job_id": "job-1", "retry_due_at_ms": 123}),
+        ("jobs/health", {}),
+        (
+            "jobs/subscribe",
+            {
+                "job_id": "job-1",
+                "subscription_id": "sub-1",
+                "session_id": "session-1",
+                "delivery": {"kind": "event", "handling_mode": "steer"},
+            },
+        ),
+        (
+            "jobs/unsubscribe",
+            {"job_id": "job-1", "subscription_id": "sub-1"},
+        ),
+        (
+            "monitors/start",
+            {
+                "session_id": "session-1",
+                "submission_key": "monitor:lan",
+                "command": "./scan --watch",
+                "timeout_secs": 600,
+                "protocol": "framed_jsonl",
+                "restart_class": "non_resumable",
+                "delivery": {"kind": "notification"},
+                "working_dir": "/srv/homecore",
+                "max_line_bytes": 4096,
+            },
+        ),
+    ]

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Durable detached jobs
+
+- Added durable detached callback registration with runner identity, restart
+  and idempotency policy, submission timeout, and credential scopes.
+- Added `runtime.jobs` and `runtime.monitors` domain handles plus the fenced
+  asynchronous start/reconcile/cancel and report protocol. Reconciliation
+  reuses the exact committed attempt, fence, lease, checkpoint, and handle
+  without minting authority on reopen.
+- Detached credentials are resolved from the runner's bound SDK profile for
+  each committed attempt and never enter durable job state or reports.
+
 ### Lease renewal authority
 
 - Documented the `LeaseProvider.renewLeases()` commit boundary: rejected

--- a/sdk/typescript/src/agent-builder.ts
+++ b/sdk/typescript/src/agent-builder.ts
@@ -8,6 +8,20 @@
 import { SessionBuildOptions, type ToolHandler } from "./models.js";
 import { ToolResultContent } from "./tool-content.js";
 import {
+  DetachedJobContext,
+  DetachedJobExecution,
+  DetachedJobReporter,
+  DetachedJobResult,
+  jobAuthorityToDict,
+  parseDetachedJobAuthority,
+  sameJobAuthority,
+  type DetachedJobAuthority,
+  type DetachedJobHandler,
+  type DetachedJobRpc,
+  type DetachedJobRunner,
+  type JobCredentialResolver,
+} from "./jobs.js";
+import {
   parseErrorEvent,
   parseContinuityRecord,
   parseSessionSnapshot,
@@ -58,6 +72,21 @@ export interface SessionAgentBuilder {
 
 export type ErrorCallback = (event: ErrorEvent) => void | Promise<void>;
 
+interface RegisteredJobRunner {
+  readonly execution: DetachedJobExecution;
+  readonly profileName: string | null;
+}
+
+interface ActiveJobAttempt {
+  readonly authority: DetachedJobAuthority;
+  readonly runnerKey: string;
+  readonly runnerHandle: string;
+  readonly controller: AbortController;
+  task: Promise<void> | null;
+  adopted: boolean;
+  superseded: boolean;
+}
+
 // -- CallbackDispatcher ---------------------------------------------------
 
 /**
@@ -80,6 +109,13 @@ export class CallbackDispatcher {
   private _rosterProvider: RosterProvider | null = null;
   private _agentCustomizer: AgentCustomizer | null = null;
   private _topologyProvider: TopologyProvider | null = null;
+  private _jobRpc: DetachedJobRpc | null = null;
+  private _jobCredentialResolver: JobCredentialResolver | null = null;
+  private readonly _jobRunners = new Map<string, RegisteredJobRunner>();
+  private readonly _jobAttempts = new Map<string, ActiveJobAttempt>();
+  private readonly _jobHighestFence = new Map<string, number>();
+  private readonly _jobTasks = new Set<Promise<void>>();
+  private readonly _jobMutationTails = new Map<string, Promise<void>>();
 
   registerBuilder(builder: SessionAgentBuilder): void {
     this._builder = builder;
@@ -107,6 +143,26 @@ export class CallbackDispatcher {
 
   registerTopologyProvider(provider: TopologyProvider): void {
     this._topologyProvider = provider;
+  }
+
+  registerJobRpc(rpc: DetachedJobRpc): void {
+    if (typeof rpc !== "function") {
+      throw new TypeError("job rpc must be callable");
+    }
+    this._jobRpc = rpc;
+  }
+
+  registerJobCredentialResolver(resolver: JobCredentialResolver): void {
+    if (typeof resolver !== "function") {
+      throw new TypeError("job credential resolver must be callable");
+    }
+    this._jobCredentialResolver = resolver;
+  }
+
+  async waitForJobTasks(): Promise<void> {
+    while (this._jobTasks.size > 0) {
+      await Promise.allSettled([...this._jobTasks]);
+    }
   }
 
   /** Remove all tool handlers for a scope. Call when a session ends. */
@@ -204,6 +260,9 @@ export class CallbackDispatcher {
         toolNames.push(name);
       }
       this._scopeTools.set(scopeId, toolNames);
+      for (const execution of opts.jobExecutions.values()) {
+        this._registerJobRunner(execution, opts.profileName);
+      }
 
       return opts.toDict();
     }
@@ -235,6 +294,18 @@ export class CallbackDispatcher {
         return { content_blocks: result.blocks };
       }
       return { content: result };
+    }
+
+    if (method === "callback/job/start") {
+      return this._startJob(params);
+    }
+
+    if (method === "callback/job/reconcile") {
+      return this._reconcileJobs(params);
+    }
+
+    if (method === "callback/job/cancel") {
+      return this._cancelJob(params);
     }
 
     // -- Continuity callbacks -----------------------------------------------
@@ -472,5 +543,337 @@ export class CallbackDispatcher {
     }
 
     throw new Error(`unknown callback method: ${method}`);
+  }
+
+  // -- Detached callback job shell ----------------------------------------
+
+  private _registerJobRunner(
+    execution: DetachedJobExecution,
+    profileName: string | null,
+  ): void {
+    const existing = this._jobRunners.get(execution.runnerKey);
+    if (existing && existing.profileName !== profileName) {
+      throw new Error(
+        `detached runner "${execution.runner}"@${execution.version} is already ` +
+          `bound to profile "${String(existing.profileName)}"; refusing ` +
+          `conflicting profile "${String(profileName)}"`,
+      );
+    }
+    this._jobRunners.set(execution.runnerKey, { execution, profileName });
+  }
+
+  private static _runnerKey(params: Record<string, unknown>): string {
+    const runner = params.runner;
+    if (typeof runner !== "object" || runner === null) {
+      throw new Error("job callback requires a runner object");
+    }
+    const raw = runner as Record<string, unknown>;
+    if (typeof raw.name !== "string" || raw.name === "") {
+      throw new Error("job callback runner requires a non-empty name");
+    }
+    if (typeof raw.version !== "string" || raw.version === "") {
+      throw new Error("job callback runner requires a non-empty version");
+    }
+    return `${raw.name}\u0000${raw.version}`;
+  }
+
+  private async _resolveJobCredentials(
+    registration: RegisteredJobRunner,
+    scopes: readonly string[],
+  ): Promise<Readonly<Record<string, unknown>>> {
+    if (scopes.length === 0) return {};
+    if (this._jobCredentialResolver === null) {
+      throw new Error(
+        "detached callback requires credential scopes but no execution-time " +
+          "credential resolver is configured",
+      );
+    }
+    const resolved = await this._jobCredentialResolver(
+      registration.profileName,
+      scopes,
+    );
+    if (typeof resolved !== "object" || resolved === null || Array.isArray(resolved)) {
+      throw new TypeError("job credential resolver must return an object");
+    }
+    return resolved;
+  }
+
+  private async _startJob(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const authority = parseDetachedJobAuthority(params.authority);
+    return this._withJobMutation(
+      authority.jobId,
+      () => this._startJobLocked(params, authority),
+    );
+  }
+
+  private async _withJobMutation<T>(
+    jobId: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this._jobMutationTails.get(jobId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this._jobMutationTails.set(jobId, tail);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this._jobMutationTails.get(jobId) === tail) {
+        this._jobMutationTails.delete(jobId);
+      }
+    }
+  }
+
+  private async _startJobLocked(
+    params: Record<string, unknown>,
+    authority: DetachedJobAuthority,
+  ): Promise<Record<string, unknown>> {
+    const runnerKey = CallbackDispatcher._runnerKey(params);
+    const registration = this._jobRunners.get(runnerKey);
+    const runnerHandle = params.runner_handle;
+    if (typeof runnerHandle !== "string" || runnerHandle === "") {
+      throw new Error("callback/job/start requires a non-empty runner_handle");
+    }
+    if (registration === undefined || this._jobRpc === null) {
+      return { accepted: false, runner_handle: runnerHandle };
+    }
+
+    const highest = this._jobHighestFence.get(authority.jobId);
+    const active = this._jobAttempts.get(authority.jobId);
+    if (highest !== undefined && authority.fence < highest) {
+      return { accepted: false, runner_handle: runnerHandle };
+    }
+    if (highest === authority.fence) {
+      if (
+        active !== undefined &&
+        sameJobAuthority(active.authority, authority) &&
+        active.runnerHandle === runnerHandle &&
+        active.task !== null
+      ) {
+        return { accepted: true, runner_handle: runnerHandle };
+      }
+      return { accepted: false, runner_handle: runnerHandle };
+    }
+
+    const scopes = params.credential_scopes ?? [];
+    if (
+      !Array.isArray(scopes) ||
+      !scopes.every((scope) => typeof scope === "string" && scope !== "")
+    ) {
+      throw new Error("credential_scopes must be a list of non-empty strings");
+    }
+    let credentials: Readonly<Record<string, unknown>>;
+    try {
+      credentials = await this._resolveJobCredentials(
+        registration,
+        scopes as string[],
+      );
+    } catch {
+      return { accepted: false, runner_handle: runnerHandle };
+    }
+
+    if (active !== undefined) {
+      active.superseded = true;
+      active.controller.abort();
+    }
+
+    const controller = new AbortController();
+    const reporter = new DetachedJobReporter(authority, this._jobRpc);
+    const context = new DetachedJobContext(
+      authority,
+      runnerHandle,
+      params.arguments,
+      credentials,
+      typeof params.resume_checkpoint === "string"
+        ? params.resume_checkpoint
+        : null,
+      controller.signal,
+      reporter,
+    );
+    const attempt: ActiveJobAttempt = {
+      authority,
+      runnerKey,
+      runnerHandle,
+      controller,
+      task: null,
+      adopted: false,
+      superseded: false,
+    };
+    this._jobHighestFence.set(authority.jobId, authority.fence);
+    this._jobAttempts.set(authority.jobId, attempt);
+    const task = this._runJob(
+      attempt,
+      registration.execution.handler,
+      context,
+      reporter,
+    );
+    attempt.task = task;
+    this._jobTasks.add(task);
+    void task.finally(() => this._jobTasks.delete(task));
+    return { accepted: true, runner_handle: runnerHandle };
+  }
+
+  private async _runJob(
+    attempt: ActiveJobAttempt,
+    runner: DetachedJobHandler,
+    context: DetachedJobContext,
+    reporter: DetachedJobReporter,
+  ): Promise<void> {
+    try {
+      const result = typeof runner === "function"
+        ? await runner(context)
+        : await runner.run(context);
+      if (attempt.superseded) return;
+      if (context.signal.aborted) {
+        await reporter.cancelAck();
+      } else if (result instanceof DetachedJobResult) {
+        await reporter.complete(result.resultRef);
+      } else if (result === undefined || result === null) {
+        await reporter.complete(null);
+      } else {
+        throw new TypeError(
+          "detached runner must return DetachedJobResult or undefined; " +
+            "persist result bytes and return only their reference",
+        );
+      }
+    } catch {
+      if (!attempt.superseded) {
+        try {
+          if (context.signal.aborted) {
+            await reporter.cancelAck();
+          } else {
+            await reporter.fail("host_runner_failed");
+          }
+        } catch {
+          // The durable runtime remains authoritative and reconciles an
+          // ambiguous report after transport recovery.
+        }
+      }
+    } finally {
+      const current = this._jobAttempts.get(attempt.authority.jobId);
+      if (current === attempt && !attempt.adopted) {
+        this._jobAttempts.delete(attempt.authority.jobId);
+      }
+    }
+  }
+
+  private async _renewReconciledAttempt(
+    authority: DetachedJobAuthority,
+  ): Promise<boolean> {
+    if (this._jobRpc === null) return false;
+    const nowMs = Date.now();
+    try {
+      await new DetachedJobReporter(authority, this._jobRpc).heartbeat({
+        heartbeatAtMs: nowMs,
+        leaseExpiresAtMs: nowMs + 120_000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async _reconcileJobs(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!Array.isArray(params.attempts)) {
+      throw new Error("callback/job/reconcile requires attempts");
+    }
+    const live: Record<string, unknown>[] = [];
+    for (const candidate of params.attempts) {
+      if (typeof candidate !== "object" || candidate === null) {
+        throw new Error("reconcile attempts must be objects");
+      }
+      const raw = candidate as Record<string, unknown>;
+      const authority = parseDetachedJobAuthority(raw.authority);
+      const runnerKey = CallbackDispatcher._runnerKey(raw);
+      const runnerHandle = raw.runner_handle;
+      if (typeof runnerHandle !== "string" || runnerHandle === "") {
+        throw new Error("reconcile attempt requires runner_handle");
+      }
+      const active = this._jobAttempts.get(authority.jobId);
+      if (
+        active !== undefined &&
+        sameJobAuthority(active.authority, authority) &&
+        active.runnerKey === runnerKey &&
+        active.runnerHandle === runnerHandle
+      ) {
+        if (
+          !active.controller.signal.aborted &&
+          (active.adopted || active.task !== null) &&
+          await this._renewReconciledAttempt(authority)
+        ) {
+          live.push(jobAuthorityToDict(authority));
+        }
+        continue;
+      }
+
+      const registration = this._jobRunners.get(runnerKey);
+      if (raw.restart_class !== "adoptable") {
+        // A reconstruction hook may adopt only work whose generated lifecycle
+        // declaration permits adoption. Replay/resume requires a later
+        // machine-authorized claim.
+        continue;
+      }
+      const runner = registration?.execution.handler;
+      const reconcile = typeof runner === "object" && runner !== null
+        ? (runner as DetachedJobRunner).reconcile
+        : undefined;
+      if (reconcile === undefined || await reconcile.call(runner, raw) !== true) {
+        continue;
+      }
+      const highest = this._jobHighestFence.get(authority.jobId);
+      if (highest !== undefined && authority.fence < highest) continue;
+      this._jobHighestFence.set(authority.jobId, authority.fence);
+      this._jobAttempts.set(authority.jobId, {
+        authority,
+        runnerKey,
+        runnerHandle,
+        controller: new AbortController(),
+        task: null,
+        adopted: true,
+        superseded: false,
+      });
+      if (!await this._renewReconciledAttempt(authority)) {
+        const current = this._jobAttempts.get(authority.jobId);
+        if (
+          current !== undefined &&
+          sameJobAuthority(current.authority, authority)
+        ) {
+          this._jobAttempts.delete(authority.jobId);
+        }
+        continue;
+      }
+      live.push(jobAuthorityToDict(authority));
+    }
+    return { live_attempts: live };
+  }
+
+  private async _cancelJob(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const authority = parseDetachedJobAuthority(params.authority);
+    const active = this._jobAttempts.get(authority.jobId);
+    if (
+      active === undefined ||
+      !sameJobAuthority(active.authority, authority)
+    ) {
+      return { accepted: false };
+    }
+    active.controller.abort();
+    const runner = this._jobRunners.get(active.runnerKey)?.execution.handler;
+    const cancel = typeof runner === "object" && runner !== null
+      ? (runner as DetachedJobRunner).cancel
+      : undefined;
+    if (cancel !== undefined) {
+      await cancel.call(runner, jobAuthorityToDict(authority));
+    }
+    return { accepted: true };
   }
 }

--- a/sdk/typescript/src/builder.ts
+++ b/sdk/typescript/src/builder.ts
@@ -19,6 +19,7 @@
 import { existsSync } from "node:fs";
 import type { SessionAgentBuilder, ErrorCallback } from "./agent-builder.js";
 import type { MobKitRuntime } from "./runtime.js";
+import type { JobCredentialResolver } from "./jobs.js";
 import type {
   ContinuityStore,
   LeaseProvider,
@@ -127,6 +128,7 @@ export interface MobKitBuilderConfig {
   rosterProvider: RosterProvider | null;
   agentCustomizer: AgentCustomizer | null;
   topologyProvider: TopologyProvider | null;
+  jobCredentialResolver: JobCredentialResolver | null;
 }
 
 function defaultConfig(): MobKitBuilderConfig {
@@ -165,6 +167,7 @@ function defaultConfig(): MobKitBuilderConfig {
     rosterProvider: null,
     agentCustomizer: null,
     topologyProvider: null,
+    jobCredentialResolver: null,
   };
 }
 
@@ -624,6 +627,18 @@ export class MobKitBuilder {
   /** Set a TopologyProvider. */
   topologyProvider(provider: TopologyProvider): this {
     this._config.topologyProvider = provider;
+    return this;
+  }
+
+  /**
+   * Resolve scoped credentials immediately before each committed detached
+   * attempt. Resolved values remain host-local and never cross job RPC.
+   */
+  jobCredentials(resolver: JobCredentialResolver): this {
+    if (typeof resolver !== "function") {
+      throw new TypeError("job credential resolver must be callable");
+    }
+    this._config.jobCredentialResolver = resolver;
     return this;
   }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -28,7 +28,14 @@
 
 export { MobKit, MobKitBuilder } from "./builder.js";
 export type { MobKitBuilderConfig } from "./builder.js";
-export { MobKitRuntime, MobHandle, ToolCaller, SseBridge } from "./runtime.js";
+export {
+  MobKitRuntime,
+  MobHandle,
+  ToolCaller,
+  SseBridge,
+  JobsHandle,
+  MonitorsHandle,
+} from "./runtime.js";
 export type {
   BlobUploadInput,
   BlobUploadSource,
@@ -42,6 +49,9 @@ export type {
   MobpackCreateOptions,
   MobpackSaveOptions,
   MobpackHistoryOptions,
+  JobsListOptions,
+  JobSubscriptionOptions,
+  MonitorStartOptions,
 } from "./runtime.js";
 
 // -- Data models ----------------------------------------------------------
@@ -57,6 +67,23 @@ export type {
   SessionQuery,
   ToolHandler,
 } from "./models.js";
+
+// Detached callback-job host contracts. The runtime's generated machine
+// remains authoritative; these types only bind host execution/reporting.
+export {
+  DetachedJobExecution,
+  DetachedJobResult,
+} from "./jobs.js";
+export type {
+  DetachedJobAuthority,
+  DetachedJobContext,
+  DetachedJobExecutionOptions,
+  DetachedJobHandler,
+  DetachedJobRunner,
+  JobCredentialResolver,
+  JobIdempotencyScope,
+  JobRestartClass,
+} from "./jobs.js";
 export {
   discoverySpecToDict,
   preSpawnDataToDict,

--- a/sdk/typescript/src/jobs.ts
+++ b/sdk/typescript/src/jobs.ts
@@ -1,0 +1,305 @@
+/**
+ * Detached callback-job host contracts.
+ *
+ * Meerkat's generated job machine owns lifecycle and authority. These types
+ * only run host work outside the callback and echo the exact committed
+ * attempt authority on ordinary gateway RPC.
+ */
+
+export type JobRestartClass =
+  | "adoptable"
+  | "checkpoint_resumable"
+  | "replayable"
+  | "non_resumable";
+
+export type JobIdempotencyScope =
+  | "tool_call"
+  | "interaction_and_arguments"
+  | "host_semantic_key";
+
+export interface DetachedJobAuthority {
+  readonly jobId: string;
+  readonly attemptId: string;
+  readonly fence: number;
+}
+
+export interface DetachedJobRunner {
+  run(context: DetachedJobContext): unknown | Promise<unknown>;
+  reconcile?(attempt: Record<string, unknown>): boolean | Promise<boolean>;
+  cancel?(authority: Record<string, unknown>): void | Promise<void>;
+}
+
+export type DetachedJobHandler =
+  | ((context: DetachedJobContext) => unknown | Promise<unknown>)
+  | DetachedJobRunner;
+
+export type DetachedJobRpc = (
+  method: string,
+  params: Record<string, unknown>,
+) => Promise<unknown>;
+
+export type JobCredentialResolver = (
+  profileName: string | null,
+  scopes: readonly string[],
+) => Readonly<Record<string, unknown>> | Promise<Readonly<Record<string, unknown>>>;
+
+export class DetachedJobResult {
+  constructor(readonly resultRef: string | null = null) {}
+}
+
+export interface DetachedJobExecutionOptions {
+  readonly runner: string;
+  readonly version: string;
+  readonly restartClass: JobRestartClass;
+  readonly idempotencyScope: JobIdempotencyScope;
+  readonly submissionTimeoutMs: number;
+  readonly credentialScopes?: readonly string[];
+  readonly handler: DetachedJobHandler;
+}
+
+export class DetachedJobExecution {
+  readonly runner: string;
+  readonly version: string;
+  readonly restartClass: JobRestartClass;
+  readonly idempotencyScope: JobIdempotencyScope;
+  readonly submissionTimeoutMs: number;
+  readonly credentialScopes: readonly string[];
+  readonly handler: DetachedJobHandler;
+
+  constructor(options: DetachedJobExecutionOptions) {
+    if (typeof options.runner !== "string" || options.runner.trim() === "") {
+      throw new TypeError("detached runner must be a non-empty string");
+    }
+    if (typeof options.version !== "string" || options.version.trim() === "") {
+      throw new TypeError("detached runner version must be a non-empty string");
+    }
+    if (
+      !["adoptable", "checkpoint_resumable", "replayable", "non_resumable"]
+        .includes(options.restartClass)
+    ) {
+      throw new TypeError(`unsupported restartClass: ${String(options.restartClass)}`);
+    }
+    if (
+      !["tool_call", "interaction_and_arguments", "host_semantic_key"]
+        .includes(options.idempotencyScope)
+    ) {
+      throw new TypeError(
+        `unsupported idempotencyScope: ${String(options.idempotencyScope)}`,
+      );
+    }
+    if (
+      !Number.isSafeInteger(options.submissionTimeoutMs) ||
+      options.submissionTimeoutMs < 1 ||
+      options.submissionTimeoutMs > 120_000
+    ) {
+      throw new TypeError(
+        "submissionTimeoutMs must be an integer in the public 1..=120000ms callback window",
+      );
+    }
+    if (
+      typeof options.handler !== "function" &&
+      (typeof options.handler !== "object" ||
+        options.handler === null ||
+        typeof options.handler.run !== "function")
+    ) {
+      throw new TypeError("detached execution requires a function or runner.run");
+    }
+    const scopes = [...(options.credentialScopes ?? [])];
+    if (scopes.some((scope) => typeof scope !== "string" || scope.trim() === "")) {
+      throw new TypeError("credential scopes must be non-empty strings");
+    }
+
+    this.runner = options.runner;
+    this.version = options.version;
+    this.restartClass = options.restartClass;
+    this.idempotencyScope = options.idempotencyScope;
+    this.submissionTimeoutMs = options.submissionTimeoutMs;
+    this.credentialScopes = scopes;
+    this.handler = options.handler;
+  }
+
+  get runnerKey(): string {
+    return `${this.runner}\u0000${this.version}`;
+  }
+
+  toWire(): Record<string, unknown> {
+    const result: Record<string, unknown> = {
+      mode: "detached",
+      runner: { name: this.runner, version: this.version },
+      restart_class: this.restartClass,
+      idempotency_scope: this.idempotencyScope,
+      submission_timeout_ms: this.submissionTimeoutMs,
+    };
+    if (this.credentialScopes.length > 0) {
+      result.credential_scopes = [...this.credentialScopes];
+    }
+    return result;
+  }
+}
+
+export function parseDetachedJobAuthority(
+  raw: unknown,
+): DetachedJobAuthority {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("job callback requires authority");
+  }
+  const value = raw as Record<string, unknown>;
+  const jobId = value.job_id;
+  const attemptId = value.attempt_id;
+  const fence = value.fence;
+  if (typeof jobId !== "string" || jobId === "") {
+    throw new Error("job authority requires a non-empty job_id");
+  }
+  if (typeof attemptId !== "string" || attemptId === "") {
+    throw new Error("job authority requires a non-empty attempt_id");
+  }
+  if (!Number.isSafeInteger(fence) || Number(fence) < 1) {
+    throw new Error("job authority requires a positive integer fence");
+  }
+  return { jobId, attemptId, fence: Number(fence) };
+}
+
+export function jobAuthorityToDict(
+  authority: DetachedJobAuthority,
+): Record<string, unknown> {
+  return {
+    job_id: authority.jobId,
+    attempt_id: authority.attemptId,
+    fence: authority.fence,
+  };
+}
+
+export function sameJobAuthority(
+  left: DetachedJobAuthority,
+  right: DetachedJobAuthority,
+): boolean {
+  return (
+    left.jobId === right.jobId &&
+    left.attemptId === right.attemptId &&
+    left.fence === right.fence
+  );
+}
+
+/** @internal */
+export class DetachedJobReporter {
+  private terminal = false;
+
+  constructor(
+    private readonly authority: DetachedJobAuthority,
+    private readonly rpc: DetachedJobRpc,
+  ) {}
+
+  private async send(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
+    return this.rpc(method, {
+      authority: jobAuthorityToDict(this.authority),
+      ...params,
+    });
+  }
+
+  async heartbeat(options: {
+    leaseExpiresAtMs: number;
+    heartbeatAtMs?: number;
+  }): Promise<unknown> {
+    return this.send("mobkit/jobs/heartbeat", {
+      heartbeat_at_ms: options.heartbeatAtMs ?? Date.now(),
+      lease_expires_at_ms: options.leaseExpiresAtMs,
+    });
+  }
+
+  async progress(
+    cursor: number,
+    detail: string,
+    options?: { observedAtMs?: number },
+  ): Promise<unknown> {
+    return this.send("mobkit/jobs/progress", {
+      cursor,
+      detail,
+      observed_at_ms: options?.observedAtMs ?? Date.now(),
+    });
+  }
+
+  async checkpoint(
+    checkpointRef: string,
+    options?: { observedAtMs?: number },
+  ): Promise<unknown> {
+    return this.send("mobkit/jobs/checkpoint", {
+      checkpoint_ref: checkpointRef,
+      observed_at_ms: options?.observedAtMs ?? Date.now(),
+    });
+  }
+
+  async complete(resultRef: string | null): Promise<unknown> {
+    if (this.terminal) return null;
+    const params: Record<string, unknown> = { completed_at_ms: Date.now() };
+    if (resultRef !== null) params.result_ref = resultRef;
+    const result = await this.send("mobkit/jobs/complete", params);
+    this.terminal = true;
+    return result;
+  }
+
+  async fail(code: string, detailRef?: string): Promise<unknown> {
+    if (this.terminal) return null;
+    const params: Record<string, unknown> = {
+      failed_at_ms: Date.now(),
+      code,
+    };
+    if (detailRef !== undefined) params.detail_ref = detailRef;
+    const result = await this.send("mobkit/jobs/fail", params);
+    this.terminal = true;
+    return result;
+  }
+
+  async cancelAck(): Promise<unknown> {
+    if (this.terminal) return null;
+    const result = await this.send("mobkit/jobs/cancel_ack", {
+      acknowledged_at_ms: Date.now(),
+    });
+    this.terminal = true;
+    return result;
+  }
+}
+
+export class DetachedJobContext {
+  readonly credentials: Readonly<Record<string, unknown>>;
+
+  constructor(
+    readonly authority: DetachedJobAuthority,
+    readonly runnerHandle: string,
+    private readonly _arguments: unknown,
+    credentials: Readonly<Record<string, unknown>>,
+    readonly resumeCheckpoint: string | null,
+    readonly signal: AbortSignal,
+    private readonly reporter: DetachedJobReporter,
+  ) {
+    this.credentials = { ...credentials };
+  }
+
+  get arguments(): unknown {
+    return this._arguments;
+  }
+
+  heartbeat(options: {
+    leaseExpiresAtMs: number;
+    heartbeatAtMs?: number;
+  }): Promise<unknown> {
+    return this.reporter.heartbeat(options);
+  }
+
+  progress(
+    cursor: number,
+    detail: string,
+    options?: { observedAtMs?: number },
+  ): Promise<unknown> {
+    return this.reporter.progress(cursor, detail, options);
+  }
+
+  checkpoint(
+    checkpointRef: string,
+    options?: { observedAtMs?: number },
+  ): Promise<unknown> {
+    return this.reporter.checkpoint(checkpointRef, options);
+  }
+}

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -2,6 +2,8 @@
  * Typed data models for MobKit SDK — input/config objects sent to the runtime.
  */
 
+import { DetachedJobExecution } from "./jobs.js";
+
 // -- DiscoverySpec --------------------------------------------------------
 
 export interface DiscoverySpec {
@@ -115,6 +117,7 @@ export class SessionBuildOptions {
 
   private _tools: string[] = [];
   private _toolHandlers: Map<string, ToolHandler> = new Map();
+  private _jobExecutions: Map<string, DetachedJobExecution> = new Map();
   // Per-tool wire metadata from registerTool options; tools without an
   // entry cross the wire as bare name strings.
   private _toolDefs: Map<string, Record<string, unknown>> = new Map();
@@ -140,7 +143,11 @@ export class SessionBuildOptions {
   registerTool(
     name: string,
     handler: ToolHandler,
-    options?: { description?: string; inputSchema?: Record<string, unknown> },
+    options?: {
+      description?: string;
+      inputSchema?: Record<string, unknown>;
+      execution?: DetachedJobExecution;
+    },
   ): void {
     if (typeof name !== "string") {
       throw new TypeError(
@@ -154,10 +161,24 @@ export class SessionBuildOptions {
     }
     this._tools.push(name);
     this._toolHandlers.set(name, handler);
-    if (options?.description !== undefined || options?.inputSchema !== undefined) {
+    if (
+      options?.execution !== undefined &&
+      !(options.execution instanceof DetachedJobExecution)
+    ) {
+      throw new TypeError("execution must be a DetachedJobExecution");
+    }
+    if (
+      options?.description !== undefined ||
+      options?.inputSchema !== undefined ||
+      options?.execution !== undefined
+    ) {
       const def: Record<string, unknown> = { name };
       if (options.description !== undefined) def.description = options.description;
       if (options.inputSchema !== undefined) def.input_schema = options.inputSchema;
+      if (options.execution !== undefined) {
+        def.execution = options.execution.toWire();
+        this._jobExecutions.set(name, options.execution);
+      }
       this._toolDefs.set(name, def);
     }
   }
@@ -168,6 +189,10 @@ export class SessionBuildOptions {
 
   get toolHandlers(): ReadonlyMap<string, ToolHandler> {
     return new Map(this._toolHandlers);
+  }
+
+  get jobExecutions(): ReadonlyMap<string, DetachedJobExecution> {
+    return new Map(this._jobExecutions);
   }
 
   toDict(): Record<string, unknown> {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -400,6 +400,124 @@ function normalizeBlobUpload(
 
 // -- MobKitRuntime --------------------------------------------------------
 
+export interface JobsListOptions {
+  readonly sessionId: string;
+  readonly limit?: number;
+}
+
+export interface JobSubscriptionOptions {
+  readonly subscriptionId: string;
+  readonly sessionId: string;
+  readonly delivery: Record<string, unknown>;
+}
+
+export interface MonitorStartOptions {
+  readonly sessionId: string;
+  readonly submissionKey: string;
+  readonly command: string;
+  readonly timeoutSecs: number;
+  readonly restartClass:
+    | "checkpoint_resumable"
+    | "replayable"
+    | "non_resumable";
+  readonly delivery: Record<string, unknown>;
+  readonly protocol?: "framed_jsonl" | "lines";
+  readonly workingDir?: string;
+  readonly maxLineBytes?: number;
+  readonly maxNotificationsPerWindow?: number;
+  readonly notificationWindowMs?: number;
+  readonly maxRetainedDiagnosticBytes?: number;
+}
+
+/** Safe application-facing durable-job surface. */
+export class JobsHandle {
+  /** @internal */
+  constructor(private readonly runtime: MobKitRuntime) {}
+
+  get(jobId: string): Promise<unknown> {
+    return this.runtime._rpc("jobs/get", { job_id: jobId });
+  }
+
+  list(options: JobsListOptions): Promise<unknown> {
+    const params: Record<string, unknown> = { session_id: options.sessionId };
+    if (options.limit !== undefined) params.limit = options.limit;
+    return this.runtime._rpc("jobs/list", params);
+  }
+
+  cancel(jobId: string): Promise<unknown> {
+    return this.runtime._rpc("jobs/cancel", { job_id: jobId });
+  }
+
+  progress(jobId: string): Promise<unknown> {
+    return this.runtime._rpc("jobs/progress", { job_id: jobId });
+  }
+
+  result(jobId: string): Promise<unknown> {
+    return this.runtime._rpc("jobs/result", { job_id: jobId });
+  }
+
+  artifacts(jobId: string): Promise<unknown> {
+    return this.runtime._rpc("jobs/artifacts", { job_id: jobId });
+  }
+
+  retry(jobId: string, retryDueAtMs: number): Promise<unknown> {
+    return this.runtime._rpc("jobs/retry", {
+      job_id: jobId,
+      retry_due_at_ms: retryDueAtMs,
+    });
+  }
+
+  health(): Promise<unknown> {
+    return this.runtime._rpc("jobs/health", {});
+  }
+
+  subscribe(jobId: string, options: JobSubscriptionOptions): Promise<unknown> {
+    return this.runtime._rpc("jobs/subscribe", {
+      job_id: jobId,
+      subscription_id: options.subscriptionId,
+      session_id: options.sessionId,
+      delivery: options.delivery,
+    });
+  }
+
+  unsubscribe(jobId: string, subscriptionId: string): Promise<unknown> {
+    return this.runtime._rpc("jobs/unsubscribe", {
+      job_id: jobId,
+      subscription_id: subscriptionId,
+    });
+  }
+}
+
+/** Durable monitor convenience surface; lifecycle remains job-owned. */
+export class MonitorsHandle {
+  /** @internal */
+  constructor(private readonly runtime: MobKitRuntime) {}
+
+  start(options: MonitorStartOptions): Promise<unknown> {
+    const params: Record<string, unknown> = {
+      session_id: options.sessionId,
+      submission_key: options.submissionKey,
+      command: options.command,
+      timeout_secs: options.timeoutSecs,
+      protocol: options.protocol ?? "framed_jsonl",
+      restart_class: options.restartClass,
+      delivery: options.delivery,
+    };
+    if (options.workingDir !== undefined) params.working_dir = options.workingDir;
+    if (options.maxLineBytes !== undefined) params.max_line_bytes = options.maxLineBytes;
+    if (options.maxNotificationsPerWindow !== undefined) {
+      params.max_notifications_per_window = options.maxNotificationsPerWindow;
+    }
+    if (options.notificationWindowMs !== undefined) {
+      params.notification_window_ms = options.notificationWindowMs;
+    }
+    if (options.maxRetainedDiagnosticBytes !== undefined) {
+      params.max_retained_diagnostic_bytes = options.maxRetainedDiagnosticBytes;
+    }
+    return this.runtime._rpc("monitors/start", params);
+  }
+}
+
 /**
  * Running MobKit runtime instance.
  *
@@ -415,6 +533,8 @@ export class MobKitRuntime {
   private _lifecycleSequence = 0;
   private _dispatcher = new CallbackDispatcher();
   private _rustHttpBase: string | null = null;
+  readonly jobs = new JobsHandle(this);
+  readonly monitors = new MonitorsHandle(this);
 
   /** @internal */
   constructor(config: MobKitBuilderConfig, transport?: PersistentTransport) {
@@ -513,6 +633,14 @@ export class MobKitRuntime {
       }
       if (this._config.agentCustomizer !== null) {
         this._dispatcher.registerAgentCustomizer(this._config.agentCustomizer);
+      }
+      this._dispatcher.registerJobRpc(
+        (method, params) => this._rpcUnchecked(method, params),
+      );
+      if (this._config.jobCredentialResolver !== null) {
+        this._dispatcher.registerJobCredentialResolver(
+          this._config.jobCredentialResolver,
+        );
       }
       this._transport.setCallbackHandler(
         this._dispatcher.handleCallback.bind(this._dispatcher),

--- a/sdk/typescript/tests/detached-jobs.test.ts
+++ b/sdk/typescript/tests/detached-jobs.test.ts
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { CallbackDispatcher } from "../src/agent-builder.js";
+import {
+  DetachedJobExecution,
+  DetachedJobResult,
+  type DetachedJobContext,
+} from "../src/jobs.js";
+import { SessionBuildOptions } from "../src/models.js";
+
+const AUTHORITY_1 = { job_id: "job-1", attempt_id: "attempt-1", fence: 7 };
+const AUTHORITY_2 = { job_id: "job-1", attempt_id: "attempt-2", fence: 8 };
+
+function startParams(
+  authority = AUTHORITY_1,
+  runnerHandle = "callback:job-1:attempt:1",
+): Record<string, unknown> {
+  return {
+    authority: { ...authority },
+    runner: { name: "homecore.security_scan", version: "1" },
+    restart_class: "non_resumable",
+    runner_handle: runnerHandle,
+    runner_specification_ref: "blob-args",
+    arguments: { target: "lan" },
+    credential_scopes: ["network.read"],
+  };
+}
+
+async function register(
+  dispatcher: CallbackDispatcher,
+  runner: ((context: DetachedJobContext) => unknown) | object,
+  profileName = "network",
+  scopeId = "build-1",
+): Promise<Record<string, unknown>> {
+  dispatcher.registerBuilder({
+    async buildAgent(options: SessionBuildOptions): Promise<void> {
+      options.profileName = profileName;
+      options.registerTool("security_scan", () => null, {
+        execution: new DetachedJobExecution({
+          runner: "homecore.security_scan",
+          version: "1",
+          restartClass: "non_resumable",
+          idempotencyScope: "interaction_and_arguments",
+          submissionTimeoutMs: 30_000,
+          credentialScopes: ["network.read"],
+          handler: runner,
+        }),
+      });
+    },
+  });
+  return await dispatcher.handleCallback("callback/build_agent", {
+    options: { scope_id: scopeId },
+  }) as Record<string, unknown>;
+}
+
+describe("detached callback jobs", () => {
+  it("serializes the exact private execution declaration", () => {
+    const options = new SessionBuildOptions();
+    options.profileName = "network";
+    options.registerTool("security_scan", () => null, {
+      description: "Scan the LAN",
+      inputSchema: { type: "object" },
+      execution: new DetachedJobExecution({
+        runner: "homecore.security_scan",
+        version: "1",
+        restartClass: "non_resumable",
+        idempotencyScope: "interaction_and_arguments",
+        submissionTimeoutMs: 30_000,
+        credentialScopes: ["network.read"],
+        handler: async () => undefined,
+      }),
+    });
+
+    assert.deepEqual(options.toDict().tools, [{
+      name: "security_scan",
+      description: "Scan the LAN",
+      input_schema: { type: "object" },
+      execution: {
+        mode: "detached",
+        runner: { name: "homecore.security_scan", version: "1" },
+        restart_class: "non_resumable",
+        idempotency_scope: "interaction_and_arguments",
+        submission_timeout_ms: 30_000,
+        credential_scopes: ["network.read"],
+      },
+    }]);
+  });
+
+  it("returns from start before work and reports exact authority", async () => {
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered!: () => void;
+    const started = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const calls: Array<[string, Record<string, unknown>]> = [];
+    const resolverCalls: Array<[string | null, readonly string[]]> = [];
+
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerJobRpc(async (method, params) => {
+      calls.push([method, params]);
+      return { job: { job_id: "job-1" } };
+    });
+    dispatcher.registerJobCredentialResolver(async (profile, scopes) => {
+      resolverCalls.push([profile, scopes]);
+      return { token: "secret-current-attempt" };
+    });
+    await register(dispatcher, async (context: DetachedJobContext) => {
+      assert.deepEqual(context.arguments, { target: "lan" });
+      assert.deepEqual(context.credentials, { token: "secret-current-attempt" });
+      await context.progress(1, "started", { observedAtMs: 101 });
+      entered();
+      await blocked;
+      return new DetachedJobResult("artifact:scan");
+    });
+
+    const result = await dispatcher.handleCallback(
+      "callback/job/start",
+      startParams(),
+    );
+    assert.deepEqual(result, {
+      accepted: true,
+      runner_handle: "callback:job-1:attempt:1",
+    });
+    await started;
+    assert.deepEqual(resolverCalls, [["network", ["network.read"]]]);
+    assert.deepEqual(calls[0], [
+      "mobkit/jobs/progress",
+      {
+        authority: AUTHORITY_1,
+        cursor: 1,
+        detail: "started",
+        observed_at_ms: 101,
+      },
+    ]);
+
+    release();
+    await dispatcher.waitForJobTasks();
+    assert.equal(calls.at(-1)?.[0], "mobkit/jobs/complete");
+    assert.deepEqual(calls.at(-1)?.[1].authority, AUTHORITY_1);
+    assert.equal(calls.at(-1)?.[1].result_ref, "artifact:scan");
+    assert.equal(JSON.stringify(calls).includes("secret-current-attempt"), false);
+  });
+
+  it("deduplicates an exact start and rejects an older fence after a later claim", async () => {
+    const starts: number[] = [];
+    const controllers = new Map<number, AbortSignal>();
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerJobRpc(async () => null);
+    dispatcher.registerJobCredentialResolver(async () => ({}));
+    await register(dispatcher, async (context: DetachedJobContext) => {
+      starts.push(context.authority.fence);
+      controllers.set(context.authority.fence, context.signal);
+      await new Promise<void>((resolve) => {
+        context.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+
+    const first = await dispatcher.handleCallback("callback/job/start", startParams());
+    const duplicate = await dispatcher.handleCallback("callback/job/start", startParams());
+    await Promise.resolve();
+    assert.deepEqual(first, duplicate);
+    assert.deepEqual(starts, [7]);
+
+    await dispatcher.handleCallback(
+      "callback/job/start",
+      startParams(AUTHORITY_2, "callback:job-1:attempt:2"),
+    );
+    await Promise.resolve();
+    assert.deepEqual(starts, [7, 8]);
+    assert.equal(controllers.get(7)?.aborted, true);
+
+    assert.deepEqual(
+      await dispatcher.handleCallback("callback/job/start", startParams()),
+      { accepted: false, runner_handle: "callback:job-1:attempt:1" },
+    );
+    await dispatcher.handleCallback("callback/job/cancel", {
+      authority: AUTHORITY_2,
+    });
+    await dispatcher.waitForJobTasks();
+  });
+
+  it("serializes concurrent duplicate starts before credential resolution", async () => {
+    let releaseResolver!: () => void;
+    const resolverBlocked = new Promise<void>((resolve) => {
+      releaseResolver = resolve;
+    });
+    let releaseRunner!: () => void;
+    const runnerBlocked = new Promise<void>((resolve) => {
+      releaseRunner = resolve;
+    });
+    let resolverEntered!: () => void;
+    const resolverStarted = new Promise<void>((resolve) => {
+      resolverEntered = resolve;
+    });
+    let resolverCalls = 0;
+    let starts = 0;
+
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerJobRpc(async () => null);
+    dispatcher.registerJobCredentialResolver(async () => {
+      resolverCalls += 1;
+      resolverEntered();
+      await resolverBlocked;
+      return { token: "fresh" };
+    });
+    await register(dispatcher, async () => {
+      starts += 1;
+      await runnerBlocked;
+    });
+
+    const first = dispatcher.handleCallback("callback/job/start", startParams());
+    await resolverStarted;
+    const duplicate = dispatcher.handleCallback("callback/job/start", startParams());
+    await Promise.resolve();
+    releaseResolver();
+    const [firstResult, duplicateResult] = await Promise.all([first, duplicate]);
+    await Promise.resolve();
+
+    assert.deepEqual(firstResult, duplicateResult);
+    assert.equal(resolverCalls, 1);
+    assert.equal(starts, 1);
+    releaseRunner();
+    await dispatcher.waitForJobTasks();
+  });
+
+  it("reconciles only exact live or runner-adopted attempts without starting work", async () => {
+    let runs = 0;
+    const rpcCalls: Array<[string, Record<string, unknown>]> = [];
+    const runner = {
+      async run(): Promise<void> {
+        runs += 1;
+        throw new Error("reconcile must not start work");
+      },
+      async reconcile(attempt: Record<string, unknown>): Promise<boolean> {
+        return attempt.runner_handle === "external:live";
+      },
+      async cancel(): Promise<void> {},
+    };
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerJobRpc(async (method, params) => {
+      rpcCalls.push([method, params]);
+      return null;
+    });
+    await register(dispatcher, runner);
+
+    const result = await dispatcher.handleCallback("callback/job/reconcile", {
+      attempts: [
+        {
+          authority: AUTHORITY_1,
+          runner: { name: "homecore.security_scan", version: "1" },
+          restart_class: "adoptable",
+          runner_handle: "external:live",
+          lease_expires_at_ms: 999,
+        },
+        {
+          authority: {
+            job_id: "job-replay",
+            attempt_id: "attempt-replay",
+            fence: 1,
+          },
+          runner: { name: "homecore.security_scan", version: "1" },
+          restart_class: "replayable",
+          runner_handle: "external:live",
+          lease_expires_at_ms: 999,
+        },
+      ],
+    });
+    assert.deepEqual(result, { live_attempts: [AUTHORITY_1] });
+    assert.equal(runs, 0);
+    assert.equal(rpcCalls.at(-1)?.[0], "mobkit/jobs/heartbeat");
+    assert.deepEqual(rpcCalls.at(-1)?.[1].authority, AUTHORITY_1);
+    assert.ok(
+      Number(rpcCalls.at(-1)?.[1].lease_expires_at_ms) >
+        Number(rpcCalls.at(-1)?.[1].heartbeat_at_ms),
+    );
+    assert.deepEqual(
+      await dispatcher.handleCallback("callback/job/cancel", {
+        authority: AUTHORITY_2,
+      }),
+      { accepted: false },
+    );
+    assert.deepEqual(
+      await dispatcher.handleCallback("callback/job/cancel", {
+        authority: AUTHORITY_1,
+      }),
+      { accepted: true },
+    );
+  });
+
+  it("re-resolves credentials per attempt and rejects runner/profile ambiguity", async () => {
+    const resolved: string[] = [];
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerJobRpc(async () => null);
+    dispatcher.registerJobCredentialResolver(async (profile) => {
+      const token = `${profile}-${resolved.length + 1}`;
+      resolved.push(token);
+      return { token };
+    });
+    await register(dispatcher, async () => undefined);
+    await dispatcher.handleCallback("callback/job/start", startParams());
+    await dispatcher.waitForJobTasks();
+    await dispatcher.handleCallback(
+      "callback/job/start",
+      startParams(AUTHORITY_2, "callback:job-1:attempt:2"),
+    );
+    await dispatcher.waitForJobTasks();
+    assert.deepEqual(resolved, ["network-1", "network-2"]);
+
+    await assert.rejects(
+      register(dispatcher, async () => undefined, "security", "build-2"),
+      /already bound to profile "network"/,
+    );
+  });
+
+  it("rejects cleanly when scoped credentials cannot resolve", async () => {
+    const dispatcher = new CallbackDispatcher();
+    dispatcher.registerJobRpc(async () => null);
+    await register(dispatcher, async () => undefined);
+    assert.deepEqual(
+      await dispatcher.handleCallback("callback/job/start", startParams()),
+      {
+        accepted: false,
+        runner_handle: "callback:job-1:attempt:1",
+      },
+    );
+  });
+});

--- a/sdk/typescript/tests/job-surfaces.test.ts
+++ b/sdk/typescript/tests/job-surfaces.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+
+import { MobKitBuilder } from "../src/builder.js";
+import { MobKitRuntime } from "../src/runtime.js";
+
+it("uses the canonical job and monitor domain methods", async () => {
+  const runtime = new MobKitRuntime(new MobKitBuilder()._config);
+  const calls: Array<[string, Record<string, unknown>]> = [];
+  (runtime as unknown as { _rpc: Function })._rpc = async (
+    method: string,
+    params: Record<string, unknown>,
+  ) => {
+    calls.push([method, params]);
+    return { method };
+  };
+
+  await runtime.jobs.get("job-1");
+  await runtime.jobs.list({ sessionId: "session-1", limit: 25 });
+  await runtime.jobs.cancel("job-1");
+  await runtime.jobs.progress("job-1");
+  await runtime.jobs.result("job-1");
+  await runtime.jobs.artifacts("job-1");
+  await runtime.jobs.retry("job-1", 123);
+  await runtime.jobs.health();
+  await runtime.jobs.subscribe("job-1", {
+    subscriptionId: "sub-1",
+    sessionId: "session-1",
+    delivery: { kind: "event", handling_mode: "steer" },
+  });
+  await runtime.jobs.unsubscribe("job-1", "sub-1");
+  await runtime.monitors.start({
+    sessionId: "session-1",
+    submissionKey: "monitor:lan",
+    command: "./scan --watch",
+    timeoutSecs: 600,
+    restartClass: "non_resumable",
+    delivery: { kind: "notification" },
+    protocol: "framed_jsonl",
+    workingDir: "/srv/homecore",
+    maxLineBytes: 4096,
+  });
+
+  assert.deepEqual(calls, [
+    ["jobs/get", { job_id: "job-1" }],
+    ["jobs/list", { session_id: "session-1", limit: 25 }],
+    ["jobs/cancel", { job_id: "job-1" }],
+    ["jobs/progress", { job_id: "job-1" }],
+    ["jobs/result", { job_id: "job-1" }],
+    ["jobs/artifacts", { job_id: "job-1" }],
+    ["jobs/retry", { job_id: "job-1", retry_due_at_ms: 123 }],
+    ["jobs/health", {}],
+    ["jobs/subscribe", {
+      job_id: "job-1",
+      subscription_id: "sub-1",
+      session_id: "session-1",
+      delivery: { kind: "event", handling_mode: "steer" },
+    }],
+    ["jobs/unsubscribe", { job_id: "job-1", subscription_id: "sub-1" }],
+    ["monitors/start", {
+      session_id: "session-1",
+      submission_key: "monitor:lan",
+      command: "./scan --watch",
+      timeout_secs: 600,
+      protocol: "framed_jsonl",
+      restart_class: "non_resumable",
+      delivery: { kind: "notification" },
+      working_dir: "/srv/homecore",
+      max_line_bytes: 4096,
+    }],
+  ]);
+});


### PR DESCRIPTION
## Summary

- adds detached callback job declarations, handles, reconciliation, monitoring, and event delivery across the Python and TypeScript SDKs
- integrates the MobKit gateway with the canonical Meerkat jobs service and generated lifecycle machines; MobKit does not introduce a second lifecycle authority or jobs store
- wires canonical jobs storage into provider, migration, doctor, health, and conformance surfaces
- preserves exact callback ownership by tool, runner, and version and resolves credentials per attempt

## Stack dependency

This draft is stacked on Meerkat PR #913 and pins the exact reviewed Meerkat Phase 4 commit 5f7ff147c. The git pin is intentional while that upstream PR is unmerged and the jobs APIs are not yet in a released crate.

Do not merge this PR, merge the upstream PR, tag, or publish a release until the parallel Cloud Code fixes have been released and the user explicitly authorizes merging.

## Recovery and fencing contract

Reconstruction rehydrates the latest committed attempt, fence, lease, checkpoint, and runner handle. Reopen/reconcile alone does not advance attempt or fence. A new fence is minted only by an explicit machine-authorized claim or retry transition, and an older writer is rejected only after a genuinely later committed claim.

## Validation

- one scoped static adversarial review completed; findings remediated and narrowly reverified
- make fmt, make fmt-check, make check, and make lint
- make test: 2028 passed, 160 skipped
- Python SDK: 731 passed against the freshly built gateway
- TypeScript SDK validate: typecheck, build, and 650 passed
- Flow Editor controller, visual, browser-source, and browser-interaction gates
- version parity, memory bright-line, deterministic memory calibration, and cargo-deny audit
- repository pre-push secret, hygiene, clippy, and workspace unit gates

Cargo-deny reports non-fatal source warnings for the intentional exact Meerkat git pin; advisories, bans, licenses, and sources pass.