### PR TITLE
MobKit 0.8.10: meerkat 0.8.14 repin + repair queue carry

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,7 @@
 heavy-runtime = { max-threads = 2 }
 
 [[profile.default.overrides]]
-filter = 'package(meerkat-mobkit) & (binary(routing_delivery) + binary(list_runs) + binary(list_flows_run_flow) + binary(mob_events_cursor_persistence) + binary(mob_events_query_ledger) + binary(mob_events_streaming) + binary(access_control) + binary(unified_console))'
+filter = 'package(meerkat-mobkit) & (binary(routing_delivery) + binary(list_runs) + binary(list_flows_run_flow) + binary(mob_events_cursor_persistence) + binary(mob_events_query_ledger) + binary(mob_events_streaming) + binary(access_control) + binary(unified_console) + binary(repair_queue_carry))'
 test-group = 'heavy-runtime'
 retries = 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Continuity repair no longer destroys a member's queued work** (OB3 field
+  runs 33758a41 + 6bb7010e: repair healed a stream-dead-but-Attached review
+  member by full disposal and took its 15 pending fan-in inputs with it —
+  irrecoverably, on the ephemeral runtime-store shape). Three changes, all in
+  the identity-first repair paths:
+
+  - **Queue carry.** Before the destructive retire, the repair captures the
+    member's pending machine ingress (admitted-but-not-run inputs, payloads
+    included) through the composition's runtime machine, and re-admits it
+    into the healed successor session after the resume — fresh input
+    identity, idempotency keys dropped (the originals were durably
+    terminalized by the disposal), admission order preserved. Prompt, peer,
+    and external-event inputs carry; flow-step and runtime-internal inputs
+    cannot (their correlation is owned by the flow engine / runtime) and are
+    DESTROYED LOUDLY instead — one warn line per input id, with the class
+    and reason, before disposal proceeds.
+
+  - **Preconditions first.** The collision-repair retire now proves the
+    resume source exists (in the composition's authoritative read view — the
+    raw injected SessionStore row is deliberately not consulted; since the
+    0.8.11 store-owned repin runtime-backed compositions never project into
+    it) BEFORE destroying the stale member. A confirmed-absent resume source
+    refuses typed with no destructive step taken: retiring would destroy the
+    only live copy of the session.
+
+  - **Bounded non-identical retries.** The continuity repair supervisor
+    tracks per-identity failure signatures across passes; three consecutive
+    byte-identical failures park the identity typed
+    (`continuity_unrecoverable`, reason naming the blocking failure verbatim)
+    instead of re-executing destructive repair steps on a timer. An operator
+    clears the park to retry; a changed failure signature resets the streak.
+
 - The three tests parked on the upstream meerkat-mob actor defect family are
   re-armed — fixed by meerkat 0.8.12 (the lost-actor cleanup): S2
   (`explicit_identity_query_refreshes_stale_existing_session_history`, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **meerkat dependencies repinned `=0.8.11` → `=0.8.12`** (all 19 meerkat
+  crates in `meerkat-mobkit`, all 5 in `mobkit-store-conformance`). 0.8.12 is
+  an upstream hotfix release: fan-in stale admission drops, abandonment
+  flattening, the silent live-actor discard (the actor is now preserved on
+  recoverable turn errors), transient-context transcript-identity false
+  re-proof, terminal-receipt sequence reuse, and a live-boundary run-advance
+  race. Full suite complete-run green against the registry crates before any
+  mobkit-side change (2181/2181, idle gate excluded per its shared-runner
+  disposition).
+
+### Fixed
+
+- The three tests parked on the upstream meerkat-mob actor defect family are
+  re-armed — fixed by meerkat 0.8.12 (the lost-actor cleanup): S2
+  (`explicit_identity_query_refreshes_stale_existing_session_history`, the
+  "autonomous dispatch inject failed: inbox closed" class), S3
+  (`agent_events_route_resolves_durable_identities_and_aliases`, HTTP 500 on
+  the member-observation route), and S4
+  (`studio_k0_identity_first_gateway_retire_respawn_succeed_on_idle_members`,
+  the intermittent retire/respawn hang). Each passed 3/3 re-arm runs at the
+  0.8.12 pin (S4 solo, well under its historical hang horizon); the
+  `#[ignore]` attributes and their run records are removed.
+
 ## [0.8.9] - 2026-08-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     and reason, before disposal proceeds.
 
   - **Preconditions first.** The collision-repair retire now proves the
-    resume source exists (in the composition's authoritative read view — the
-    raw injected SessionStore row is deliberately not consulted; since the
-    0.8.11 store-owned repin runtime-backed compositions never project into
-    it) BEFORE destroying the stale member. A confirmed-absent resume source
-    refuses typed with no destructive step taken: retiring would destroy the
-    only live copy of the session.
+    resume source exists in DURABLE, NON-ACTOR authority (the continuity
+    store row, else the session service's archive-authority predicate)
+    BEFORE destroying the stale member. An actor-routed read is never used:
+    it waits on the very wedged member the repair is disposing (proven live
+    at the meerkat 0.8.13 repin as a self-deadlock inside the probe). The
+    raw injected SessionStore row is also deliberately not consulted; since
+    the 0.8.11 store-owned repin runtime-backed compositions never project
+    into it. A confirmed-absent resume source refuses typed with no
+    destructive step taken: retiring would destroy the only live copy of
+    the session. A probe fault means absence cannot be confirmed, and repair
+    proceeds as before the guard existed.
 
   - **Bounded non-identical retries.** The continuity repair supervisor
     tracks per-identity failure signatures across passes; three consecutive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,9 +1811,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0398e538d8e2d7d093db27251e582f5de93f2d0bc32044b10fb557950529884"
+checksum = "fb15ac8120073934bcaa3ed403e49f37ed62aa7833ec38337bf93489a1508173"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf5e4012d784b5fd649aa87510edbed32f7c45a54fac84ca8751632b38c7c6b"
+checksum = "46dfe2bb0db8364f3dca4891099a3afe846302e6c82435fe64258ad791da003c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1878,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e908f8552b829a8aec0cc78f63f5cf7a0df69d5f0d83a4189c0d429037cda51e"
+checksum = "676c69d8c99b69e3b1a6bfcd03486e2e2050ee485d756871d4d4d3d402a3b3b1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec9ab04c890d790ebbe50bd282f9f9502f05a36e0a5c2b05f72e611a16a4a48"
+checksum = "7544394576a077a7581fe1b6ca734f8eafdb23a9e0de9331de6b0d3b3064971e"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1a1da39b63523821a9ea05b251b75f81e5f385cb2b22129fb2b9d718f4c471"
+checksum = "f1110eccdf9ff12ef4c62bb6339023febbb9ade324167531761c373763d5fa20"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1937,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021ff9908a86656f4d5ec47c902860a37c954fccbb6ba2cf494d2889f8e4df25"
+checksum = "744748046abc22bbd1de3dd4a91bcb565521101ee722b5128139b253c6139cc6"
 dependencies = [
  "async-trait",
  "base64",
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7459ba4bdc339bbd2df0e6b25bb6d1f5f08e9bb6e7b8ceda2e492270fb64409"
+checksum = "88faf7ea1f385d4e23154c856673e3f422834b7f8774b8b34399391a06d210ec"
 dependencies = [
  "base64",
  "chrono",
@@ -1995,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9324bdd4955a79c87eaf2045813dfc64d6a903e94743b9114d5b23054e8dca20"
+checksum = "91da0d2a5d5933e7f8083e64059c0d86af2e8d9df4200acb29d62f544b2d9a2c"
 dependencies = [
  "async-trait",
  "base64",
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b795c692dc973d8cf1118600f1ff51c2661530265cc51ceacb8dfae6dfb9fe06"
+checksum = "cb64d338e1d89f04461ed84fcc7e1a5a2970b1366b14e796f267b6afbc111b30"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c7ddd26faa4072be4879434750016bd7d7f2012102c3aeee2e182b8b7b86bd"
+checksum = "ecd6c18c1b1d5a2f492d75c12ee52345589d0ab4d5b48e6a3eb5210d09d2505e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2076,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-jobs"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8bc81ffb22a2dc2d86de62bb3e111b246c1fbae7802cf06048b7f6e37851a"
+checksum = "5029a094117f98f8b6ffa3d77b52034fde14032919f71ba4758bb3a08730b5f1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293f27fa4f99cd5a5f814c080d81d45ebddab9a4d100e48681a8e9b828919046"
+checksum = "2fc579ce4590356d170d60be2810439bf4193711fbda070e2f2b4faa3b12718e"
 dependencies = [
  "async-trait",
  "axum",
@@ -2116,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9461bc7659c04568403c42b2cbe67a4402ed6c7cdb55f649d18b2dae98bc5247"
+checksum = "e0ab7f119ae2f383734c07218b970d1e0e02489510e413ce28151946af474f29"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383d1dbc2bab076bbad0544d3224cb6f06d7908d0eb710c572b99413d790aef"
+checksum = "5e0968fc4d8876c4caedb6d6332289becb6744cc6516c32cda745a80f94b6912"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -2152,18 +2152,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc9a439c696aa5d97541e0694cf35c74e688177141472061a418413749a74e3"
+checksum = "339b9f35b15b3b8b0b6a2816eb60734dccbb0e1810408720b34593901d92f8cc"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec445c142e1604030378d3aeaf6157ceba37daf8174de3d11d12c67ca2f2bfe6"
+checksum = "2ef11ccca914f783c7480c3d8d1b7860e40aa1825fb1bd5f59d69014a567f846"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2172,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c213bd5903ee8d5d6de62cf0e5d5c4e26563f128b27ec1e6174e28bcc243ff3"
+checksum = "ec8bd5d99461471257dcdb36e6998e8ef44892f2ee1d9f0d2b9c2d94209735e5"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2185,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1e3d744cf83e9eb112392250c5cbebde93f6b3ecd0f62666dfa90a567405cc"
+checksum = "7457e3b5581726a5fe9a05321726e13af1c2f6fdd7b6ad592e24b59c2ad0154f"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96735ef4ef77cbc82064a5d9db2129c40bbc9fbf158c787ed7883d7a6846d2e6"
+checksum = "bb5f5d6b972b0a70d59c272a6498dbe2b994555eb738a7a0a204e1ae6fa525df"
 dependencies = [
  "async-trait",
  "futures",
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e75e58be2b3a8cd7afb67871c6e1646f96fbfcdc87cc7f7853e2bec6247a63b"
+checksum = "1fb1a17b7359b3abedc054275b9e8c51bc93b386f1a06b1def1c7d73dd1c99e9"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8183ba12dfb05e8a84fcac5c8c25abd781d2561b830da48137fb4f3d7eb536e"
+checksum = "b951a60e7e5bcfb4181b51a9fb43f701faea436738b2023f900519c9f324c17a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2288,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc9afe485c0183227c0a81da9458c063b0fbe7d9c4ef0b2456ef52f9786da99"
+checksum = "40b48503705f234378dabe6fa8dde80b4ff2ce2e089e07088d23d8fa2466cf84"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2372,18 +2372,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4916ef2ad16194abb9bc3b45ca393d676f865ea3333570dde61021fb3c685a5c"
+checksum = "5e5495182b028a038700d52c6f81cbb47d5a3e7fae4815e0c072889f01666777"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f4c1a1d52f96762c881831da99d05217ddffccad36836caeaa88c862e9114"
+checksum = "0cc10f3730fa75a66e16f5bd7a0cd71d3e9d620befe8aabd010cce0fb7d410c6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec5f5a467db24d458cf8bffd73b2df3367993f530d53ccfce83f5c6e2e96948"
+checksum = "7805f468b713dec83de397e0dd2932e0198b60aec0fe2d796a82a42820e8723c"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2421,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74071cf658c7fb78ec81e310ac471a533c927aeaadd4150a0380766a8dd5e9f"
+checksum = "1e28593376fa4d08e2bbc58c4d38b9a61f64281adb0a26f9eb9e1b5e44040399"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2451,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566af429ae9a7e766baffac66147db1e69ddd8e8273c8536cececd4313cbb6d"
+checksum = "a28da9f64126eb78022a66b2b333fc60ecc7b048e27638924f81d4c81d8b6209"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2477,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800482739c30fbe67f6bb766f46dde6b5d3c6603c1000f49b8cb8c000cb24056"
+checksum = "32e4ac298fdfbabfd822bbd9b1f1eb46e2e872e7b2e8b9104cdcdaa002134f67"
 dependencies = [
  "async-trait",
  "futures",
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fb8f490be8fc18fe91af43c88b2ad0f89d908e8ee5c215ab7a5350b00706c8"
+checksum = "6a226083fbb67604768b2d5d06d0e79de31361de3f2842619859fb58155e08dd"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2526,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-sqlite"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f702b268140504465f3e0a1be25c50c26f472877b73557717128db3b57fe1f"
+checksum = "f041c1a24994bb01a20d1ead05a4a7ea7ad6896bc5a1810e5e1ef53e01b380b5"
 dependencies = [
  "rusqlite",
  "thiserror 2.0.19",
@@ -2536,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b1754d31ca54b0938425dadb9fde63b0e3fefd46b1806f2d1dce3e45358d11"
+checksum = "920de0e832469381eb3940b7258aa90fbb185529b7a22167978e85e4c8bf5c42"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2561,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store-conformance"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00171486bdb9611c67a3999c7ea1ccaee36153b6638981c6c2e85eda5cd68aae"
+checksum = "44a70c609335ab7bda32f571ccd29e8b02a9fea37cf6b08dffa100c2fbc6acf7"
 dependencies = [
  "async-trait",
  "meerkat-core",
@@ -2574,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6769c325d3e5421fb3c0ae0a59f2febb7be5cf372fdca8bd5592e7ecab7ec154"
+checksum = "4d89d155b100225622f31528a67224594d18a3fb2f235579056febc203b76269"
 dependencies = [
  "async-trait",
  "base64",
@@ -2615,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e083a7531755d722fc131d9a001c520bc61a53933bebb1d662f3f82da9f75d8"
+checksum = "c11b210eb6237485aa482f10537efb29b346cf9202b1c6b09026d1b12802f642"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -675,14 +675,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.6"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -718,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -1210,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1524,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1551,9 +1561,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -1575,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -1718,9 +1728,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -1801,9 +1811,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba90b550da04a775ef9f35d1fa4f2990fa5c294a473cde19bcc8e5ea4727c5ae"
+checksum = "f0398e538d8e2d7d093db27251e582f5de93f2d0bc32044b10fb557950529884"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1844,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2aefd42ee1015e52538500203e158fc8728268bfe34bd3b158f8c76d7b6bc00"
+checksum = "0bf5e4012d784b5fd649aa87510edbed32f7c45a54fac84ca8751632b38c7c6b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1868,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba77e8c8ef1d2236a25aee89b78eb3194ae62ed012a7e8fb37eae63c8d6ace9a"
+checksum = "e908f8552b829a8aec0cc78f63f5cf7a0df69d5f0d83a4189c0d429037cda51e"
 dependencies = [
  "async-trait",
  "axum",
@@ -1901,22 +1911,22 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3169300b0dc3056861f2a18a4b1a4f70e58364ebc0aaf45d42304bfed3d4d7ae"
+checksum = "cec9ab04c890d790ebbe50bd282f9f9502f05a36e0a5c2b05f72e611a16a4a48"
 dependencies = [
  "inventory",
  "meerkat-core",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "meerkat-client"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6faed0afb2cdb342e07f7294f1c7be420c41fd09d22b1e27f79a0077aa8f5a"
+checksum = "0a1a1da39b63523821a9ea05b251b75f81e5f385cb2b22129fb2b9d718f4c471"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1927,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61a749a907e534fb466e66c8b85134b7db2e7ca0d6f04148bbb85f0b575144c"
+checksum = "021ff9908a86656f4d5ec47c902860a37c954fccbb6ba2cf494d2889f8e4df25"
 dependencies = [
  "async-trait",
  "base64",
@@ -1946,7 +1956,7 @@ dependencies = [
  "meerkat-skills",
  "parking_lot",
  "rand_core 0.6.4",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1963,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92c80da940ef620715c68928c8e7eca858197b5dc63a930350d06b5ec892f74"
+checksum = "b7459ba4bdc339bbd2df0e6b25bb6d1f5f08e9bb6e7b8ceda2e492270fb64409"
 dependencies = [
  "base64",
  "chrono",
@@ -1974,7 +1984,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-schedule",
  "meerkat-workgraph",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
@@ -1985,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effa4078a06ecfd93d7e22c2f6ade6eeb1822f9759cbad67cbe9f89f5dac537b"
+checksum = "9324bdd4955a79c87eaf2045813dfc64d6a903e94743b9114d5b23054e8dca20"
 dependencies = [
  "async-trait",
  "base64",
@@ -2001,7 +2011,7 @@ dependencies = [
  "js-sys",
  "jsonschema",
  "parking_lot",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2018,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f827eae4594e1b2543adc0a0377b94132debb7c132f6e5fc503f0856522cd429"
+checksum = "b795c692dc973d8cf1118600f1ff51c2661530265cc51ceacb8dfae6dfb9fe06"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2043,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436416226ed95bec3d8d45f2644e04681185a00b8c4855259fe0917ec483791c"
+checksum = "07c7ddd26faa4072be4879434750016bd7d7f2012102c3aeee2e182b8b7b86bd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2066,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-jobs"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea2fb3978ad33ea1cd22f203feaf6087bc64df10f733cfbb60f2f88ae398090"
+checksum = "83c8bc81ffb22a2dc2d86de62bb3e111b246c1fbae7802cf06048b7f6e37851a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2086,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f4b27b0f7534ce599085286d4941f0cd9d69d0f9c8014a66684d8187a2111"
+checksum = "293f27fa4f99cd5a5f814c080d81d45ebddab9a4d100e48681a8e9b828919046"
 dependencies = [
  "async-trait",
  "axum",
@@ -2106,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6526dda724e4c26704cbe361b09ec336d730618b1b7c3b06006b5f567ad081ce"
+checksum = "9461bc7659c04568403c42b2cbe67a4402ed6c7cdb55f649d18b2dae98bc5247"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2132,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3287c762214e26e41d5c6da07738b6afed53fc313b8205f29df73e609c2674f"
+checksum = "7383d1dbc2bab076bbad0544d3224cb6f06d7908d0eb710c572b99413d790aef"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -2142,18 +2152,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4a0ae9d4010bcd3c70515ed926e771419fd9a72192bb46b817cec242467753"
+checksum = "8bc9a439c696aa5d97541e0694cf35c74e688177141472061a418413749a74e3"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78f75a766828aa50d5377b0e02894ad0fd0980d17d3c854dd4db9a89e90a9d7"
+checksum = "ec445c142e1604030378d3aeaf6157ceba37daf8174de3d11d12c67ca2f2bfe6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2162,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b413fb178d5cce4c8ee4d99d19be2af516bdad1d1d4b38b80e96f1d8f384917b"
+checksum = "1c213bd5903ee8d5d6de62cf0e5d5c4e26563f128b27ec1e6174e28bcc243ff3"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2175,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a842899898f89298b5674d026124cfe5b34cc3f3374bcfdd26d5c68b317f0e"
+checksum = "ee1e3d744cf83e9eb112392250c5cbebde93f6b3ecd0f62666dfa90a567405cc"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2189,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391b2b8ccc3fdc69c8d8600dc5e4a6a4a26809e2322d2362087334f69b13560a"
+checksum = "96735ef4ef77cbc82064a5d9db2129c40bbc9fbf158c787ed7883d7a6846d2e6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2214,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1252bc23cab45d87d94f1c245b994b58d6b3834f3e279485e925ead29a045b42"
+checksum = "7e75e58be2b3a8cd7afb67871c6e1646f96fbfcdc87cc7f7853e2bec6247a63b"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2227,7 +2237,7 @@ dependencies = [
  "meerkat-skills",
  "meerkat-sqlite",
  "rusqlite",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2237,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5245f4d1d38f82821c85c6323da1cb0c02cee4b6c194d81f4a51295efa7a1"
+checksum = "c8183ba12dfb05e8a84fcac5c8c25abd781d2561b830da48137fb4f3d7eb536e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2262,7 +2272,7 @@ dependencies = [
  "meerkat-sqlite",
  "notify",
  "rusqlite",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2278,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4149b229c38ad40f2c501bec7a4458a419c191214a51184dcc903e5859383790"
+checksum = "fcc9afe485c0183227c0a81da9458c063b0fbe7d9c4ef0b2456ef52f9786da99"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2293,7 +2303,7 @@ dependencies = [
  "meerkat-mob",
  "meerkat-runtime",
  "meerkat-session",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -2345,7 +2355,7 @@ dependencies = [
  "reqwest 0.12.28",
  "ring",
  "rusqlite",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2362,18 +2372,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933d22bd022a5a9f2acda9b9dcd1b0d28fecf54da367be077a1864ef75396631"
+checksum = "4916ef2ad16194abb9bc3b45ca393d676f865ea3333570dde61021fb3c685a5c"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72d0e33f5d4165d20f1532969d327447b2a2a74a14a72f26bf52a9c9212b5ab"
+checksum = "958f4c1a1d52f96762c881831da99d05217ddffccad36836caeaa88c862e9114"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2401,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e66dd14be876857432c312943b519b1c75f215a2ee1a80381d57a5bbe16d798"
+checksum = "fec5f5a467db24d458cf8bffd73b2df3367993f530d53ccfce83f5c6e2e96948"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2411,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e270a683faa9ac029dfc377f86d69036610fc33a8d1a404a8ef8468b4d7b8655"
+checksum = "d74071cf658c7fb78ec81e310ac471a533c927aeaadd4150a0380766a8dd5e9f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2441,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1e57a79a85a9671cf25d263baded77e6aeb9dae8a089250fc86956f3b974df"
+checksum = "3566af429ae9a7e766baffac66147db1e69ddd8e8273c8536cececd4313cbb6d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2455,7 +2465,7 @@ dependencies = [
  "meerkat-core",
  "meerkat-machine-schema",
  "meerkat-skills",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -2467,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d93133f4890b1b1b52b83290fa0c9f41cf26e4a7fd4ecf7768be8bc8c49cbf8"
+checksum = "800482739c30fbe67f6bb766f46dde6b5d3c6603c1000f49b8cb8c000cb24056"
 dependencies = [
  "async-trait",
  "futures",
@@ -2493,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb9a003cb5fa66cf09a6353f5522dd9b594cb5da1ab1048371a2b9d1a0526ab"
+checksum = "b0fb8f490be8fc18fe91af43c88b2ad0f89d908e8ee5c215ab7a5350b00706c8"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2516,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-sqlite"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4102b509564ab74cd4674f1f5aed6d805a02cb731d3d0c676ede69d64ec1ab"
+checksum = "15f702b268140504465f3e0a1be25c50c26f472877b73557717128db3b57fe1f"
 dependencies = [
  "rusqlite",
  "thiserror 2.0.19",
@@ -2526,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4041fa2d36f822194b34c76389f1cb48420c9def26d9dc01bf91a238d2eb341"
+checksum = "c5b1754d31ca54b0938425dadb9fde63b0e3fefd46b1806f2d1dce3e45358d11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2551,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store-conformance"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc54088ec8ea233e10402705195406675328efb82715aed704a93800bb6d38f4"
+checksum = "00171486bdb9611c67a3999c7ea1ccaee36153b6638981c6c2e85eda5cd68aae"
 dependencies = [
  "async-trait",
  "meerkat-core",
@@ -2564,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86436a1e2ea0e9ed451ed9a4e82670b513366158986e79eba411e4128b1bac41"
+checksum = "6769c325d3e5421fb3c0ae0a59f2febb7be5cf372fdca8bd5592e7ecab7ec154"
 dependencies = [
  "async-trait",
  "base64",
@@ -2590,7 +2600,7 @@ dependencies = [
  "nix 0.29.0",
  "parking_lot",
  "rusqlite",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "shlex 1.3.0",
@@ -2605,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2688e83353923520dd9251953dfee9da68ffcaaf3118990a570ff7ac1ae0a442"
+checksum = "8e083a7531755d722fc131d9a001c520bc61a53933bebb1d662f3f82da9f75d8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2619,7 +2629,7 @@ dependencies = [
  "meerkat-skills",
  "meerkat-sqlite",
  "rusqlite",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2968,6 +2978,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3013,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3600,7 +3633,7 @@ dependencies = [
  "process-wrap",
  "reqwest 0.13.4",
  "rmcp-macros",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sse-stream",
@@ -3681,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -3770,14 +3803,14 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive 1.2.2",
  "serde",
  "serde_json",
 ]
@@ -3790,20 +3823,20 @@ checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.29.1",
  "syn 2.0.119",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
- "syn 2.0.119",
+ "serde_derive_internals 0.30.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3890,6 +3923,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4309,9 +4353,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4381,13 +4425,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4570,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -4992,15 +5036,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -5246,6 +5246,74 @@ rust_test(
 )
 
 rust_test(
+    name = "repair_queue_carry_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "repair_queue_carry",
+    crate_root = "tests/repair_queue_carry.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+        "tests/fixtures/homecore_ledgerv1_closure/calendar-continuity-closure.json",
+        "tests/fixtures/homecore_ledgerv1_closure/continuity-schema.sql",
+        "tests/fixtures/homecore_security_idempotency/security-head-evolution.json",
+        "tests/fixtures/v0_8_10_released_session.json",
+        "tests/fixtures/v0_8_10_zero_rewrite_supervisor_session.json",
+    ],
+    srcs = [
+        "tests/repair_queue_carry.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.8.9",
+        "CARGO_BIN_NAME": "repair_queue_carry",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "routing_delivery_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -7182,6 +7250,7 @@ test_suite(
         ":module_restart_test",
         ":reference_app_test",
         ":released_realm_upgrade_drive_test",
+        ":repair_queue_carry_test",
         ":rpc_builtins_test",
         ":runtime_bootstrap_test",
         ":schedule_dispatch_test",

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,35 +48,35 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.8.12"
-meerkat-client = "=0.8.12"
-meerkat-comms = "=0.8.12"
-meerkat-contracts = "=0.8.12"
-meerkat-mob = "=0.8.12"
-meerkat-mob-mcp = "=0.8.12"
-meerkat-mcp = "=0.8.12"
-meerkat-models = "=0.8.12"
+meerkat-core = "=0.8.14"
+meerkat-client = "=0.8.14"
+meerkat-comms = "=0.8.14"
+meerkat-contracts = "=0.8.14"
+meerkat-mob = "=0.8.14"
+meerkat-mob-mcp = "=0.8.14"
+meerkat-mcp = "=0.8.14"
+meerkat-models = "=0.8.14"
 # Meerkat split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.8.12", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.8.14", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.8.12"
+meerkat-memory = "=0.8.14"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.8.12"
-meerkat-runtime = { version = "=0.8.12", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.8.12", features = ["session-store"] }
+meerkat-live = "=0.8.14"
+meerkat-runtime = { version = "=0.8.14", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.8.14", features = ["session-store"] }
 # Shared SQLite mechanics (storage-unification): named connection profiles,
 # the per-file migration ledger, per-operation maintenance fence guards
 # (every in-crate opener, M3), and the doctor's read-only ledger reads (M1).
-meerkat-sqlite = "=0.8.12"
+meerkat-sqlite = "=0.8.14"
 # `memory` is the parked-delta backend for pre-registration incremental
 # writes in the continuity adapter (nothing parked is ever durable).
-meerkat-store = { version = "=0.8.12", features = ["sqlite", "memory"] }
-meerkat-tools = "=0.8.12"
+meerkat-store = { version = "=0.8.14", features = ["sqlite", "memory"] }
+meerkat-tools = "=0.8.14"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -133,14 +133,14 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-schedule = "=0.8.12"
+meerkat-schedule = "=0.8.14"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.8.12", features = ["schema"] }
+meerkat-mob = { version = "=0.8.14", features = ["schema"] }
 # `test-realtime-fixtures` (test-only) exposes meerkat's shared
 # ScriptedRealtimeSessionFactory so the live-open cross-provider regression
 # tests (tests/gateway_live.rs) can observe the exact channel identity handed
 # to the provider lane without a provider socket or credential.
-meerkat = { version = "=0.8.12", features = ["test-realtime-fixtures"] }
+meerkat = { version = "=0.8.14", features = ["test-realtime-fixtures"] }

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,35 +48,35 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.8.11"
-meerkat-client = "=0.8.11"
-meerkat-comms = "=0.8.11"
-meerkat-contracts = "=0.8.11"
-meerkat-mob = "=0.8.11"
-meerkat-mob-mcp = "=0.8.11"
-meerkat-mcp = "=0.8.11"
-meerkat-models = "=0.8.11"
+meerkat-core = "=0.8.12"
+meerkat-client = "=0.8.12"
+meerkat-comms = "=0.8.12"
+meerkat-contracts = "=0.8.12"
+meerkat-mob = "=0.8.12"
+meerkat-mob-mcp = "=0.8.12"
+meerkat-mcp = "=0.8.12"
+meerkat-models = "=0.8.12"
 # Meerkat split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.8.11", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.8.12", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.8.11"
+meerkat-memory = "=0.8.12"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.8.11"
-meerkat-runtime = { version = "=0.8.11", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.8.11", features = ["session-store"] }
+meerkat-live = "=0.8.12"
+meerkat-runtime = { version = "=0.8.12", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.8.12", features = ["session-store"] }
 # Shared SQLite mechanics (storage-unification): named connection profiles,
 # the per-file migration ledger, per-operation maintenance fence guards
 # (every in-crate opener, M3), and the doctor's read-only ledger reads (M1).
-meerkat-sqlite = "=0.8.11"
+meerkat-sqlite = "=0.8.12"
 # `memory` is the parked-delta backend for pre-registration incremental
 # writes in the continuity adapter (nothing parked is ever durable).
-meerkat-store = { version = "=0.8.11", features = ["sqlite", "memory"] }
-meerkat-tools = "=0.8.11"
+meerkat-store = { version = "=0.8.12", features = ["sqlite", "memory"] }
+meerkat-tools = "=0.8.12"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -133,14 +133,14 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-schedule = "=0.8.11"
+meerkat-schedule = "=0.8.12"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.8.11", features = ["schema"] }
+meerkat-mob = { version = "=0.8.12", features = ["schema"] }
 # `test-realtime-fixtures` (test-only) exposes meerkat's shared
 # ScriptedRealtimeSessionFactory so the live-open cross-provider regression
 # tests (tests/gateway_live.rs) can observe the exact channel identity handed
 # to the provider lane without a provider socket or credential.
-meerkat = { version = "=0.8.11", features = ["test-realtime-fixtures"] }
+meerkat = { version = "=0.8.12", features = ["test-realtime-fixtures"] }

--- a/meerkat-mobkit/src/console_aggregator/mod.rs
+++ b/meerkat-mobkit/src/console_aggregator/mod.rs
@@ -9329,10 +9329,6 @@ comms = true
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ignore = "upstream meerkat-mob actor defect family (S2; NOT covered by #929, \
-                lead-confirmed 2026-07-31): the member actor task exits and a direct \
-                send fails 'autonomous dispatch inject failed: inbox closed'. \
-                Reproduces serially at ed7e42b75. Re-arm on the upstream fix SHA."]
     async fn explicit_identity_query_refreshes_stale_existing_session_history() -> Result<(), String>
     {
         let store = Arc::new(CountingConsoleLogStore::new());

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -982,6 +982,80 @@ pub struct MobSessionBridge {
     /// Resolved once at construction so the success path pays nothing per
     /// call. See [`BRIDGE_ACTOR_ADMISSION_BUDGET`].
     actor_admission_budget: Duration,
+    /// Machine-level ingress authority for the repair disposal paths (OB3
+    /// run 33758a41: repair destroyed 15 queued inputs with the member).
+    /// Lets repair capture a member's queued/steered inputs BEFORE the
+    /// destructive retire and re-admit them into the healed successor
+    /// session. `None` (validation-only compositions) keeps the legacy
+    /// destroy-on-dispose behavior, minus the carry observability.
+    runtime_ingress_authority: Option<Arc<dyn meerkat_runtime::SessionServiceRuntimeExt>>,
+}
+
+/// One queued/steered member input captured before a repair disposal, for
+/// re-admission into the healed successor session (OB3 run 33758a41: the
+/// disposal destroyed 15 queued review inputs with the member).
+struct CarriedMemberInput {
+    original_input_id: meerkat_core::lifecycle::InputId,
+    admission_sequence: Option<u64>,
+    input: meerkat_runtime::Input,
+}
+
+/// Pre-disposal capture of one member session's pending machine ingress.
+struct PendingIngressCapture {
+    /// Inputs whose payload survives re-admission (Prompt / Peer /
+    /// ExternalEvent classes), in admission order.
+    carryable: Vec<CarriedMemberInput>,
+    /// Pending inputs repair cannot carry: `(input id, class, reason)`.
+    /// Logged loudly per item before disposal proceeds.
+    uncarryable: Vec<(meerkat_core::lifecycle::InputId, &'static str, String)>,
+}
+
+impl PendingIngressCapture {
+    fn empty() -> Self {
+        Self {
+            carryable: Vec::new(),
+            uncarryable: Vec::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.carryable.is_empty() && self.uncarryable.is_empty()
+    }
+}
+
+/// Re-mint the runtime identity of a carried input for successor admission.
+///
+/// The disposal durably terminalized the original admission (abandonment),
+/// so the successor must admit a NEW input: reusing the original `InputId`
+/// collides with the terminal ledger row, and reusing the idempotency key
+/// would dedup the carry into that terminal record and silently drop it.
+/// Everything else — content, handling mode, visibility, correlation — rides
+/// unchanged.
+fn remint_carried_input_identity(
+    mut input: meerkat_runtime::Input,
+) -> Option<meerkat_runtime::Input> {
+    let header = match &mut input {
+        meerkat_runtime::Input::Prompt(i) => &mut i.header,
+        meerkat_runtime::Input::Peer(i) => &mut i.header,
+        meerkat_runtime::Input::FlowStep(i) => &mut i.header,
+        meerkat_runtime::Input::ExternalEvent(i) => &mut i.header,
+        meerkat_runtime::Input::Continuation(i) => &mut i.header,
+        meerkat_runtime::Input::Operation(i) => &mut i.header,
+        // `Input` is #[non_exhaustive]: a variant this build does not know
+        // has no reachable header, so it cannot be re-identified for
+        // successor admission.
+        _ => return None,
+    };
+    header.id = meerkat_core::lifecycle::InputId::new();
+    if let Some(key) = header.idempotency_key.take() {
+        tracing::debug!(
+            idempotency_key = %key,
+            readmitted_input_id = %header.id,
+            "carried input drops its idempotency key: the original admission was \
+             durably terminalized by the repair disposal"
+        );
+    }
+    Some(input)
 }
 
 impl MobSessionBridge {
@@ -998,6 +1072,7 @@ impl MobSessionBridge {
             committed_boundary_recoverer: None,
             resume_divergence_logged: std::sync::Mutex::new(std::collections::HashSet::new()),
             actor_admission_budget: bridge_actor_admission_budget(),
+            runtime_ingress_authority: None,
         }
     }
 
@@ -1017,6 +1092,7 @@ impl MobSessionBridge {
             committed_boundary_recoverer: None,
             resume_divergence_logged: std::sync::Mutex::new(std::collections::HashSet::new()),
             actor_admission_budget: bridge_actor_admission_budget(),
+            runtime_ingress_authority: None,
         }
     }
 
@@ -1036,6 +1112,7 @@ impl MobSessionBridge {
             committed_boundary_recoverer: None,
             resume_divergence_logged: std::sync::Mutex::new(std::collections::HashSet::new()),
             actor_admission_budget: bridge_actor_admission_budget(),
+            runtime_ingress_authority: None,
         }
     }
 
@@ -1056,6 +1133,7 @@ impl MobSessionBridge {
             committed_boundary_recoverer: None,
             resume_divergence_logged: std::sync::Mutex::new(std::collections::HashSet::new()),
             actor_admission_budget: bridge_actor_admission_budget(),
+            runtime_ingress_authority: None,
         }
     }
 
@@ -1076,6 +1154,7 @@ impl MobSessionBridge {
             committed_boundary_recoverer: None,
             resume_divergence_logged: std::sync::Mutex::new(std::collections::HashSet::new()),
             actor_admission_budget: bridge_actor_admission_budget(),
+            runtime_ingress_authority: None,
         }
     }
 
@@ -1100,6 +1179,20 @@ impl MobSessionBridge {
         recoverer: Arc<dyn CommittedBoundaryRecoverer>,
     ) -> Self {
         self.committed_boundary_recoverer = Some(recoverer);
+        self
+    }
+
+    /// Inject the machine-level ingress authority the repair disposal paths
+    /// use to carry a member's queued work across a heal (OB3 run 33758a41:
+    /// disposal destroyed 15 queued inputs with the member). Compositions
+    /// with a runtime machine pass it here; without it, repair proceeds but
+    /// cannot observe or carry pending inputs.
+    #[must_use]
+    pub fn with_runtime_ingress_authority(
+        mut self,
+        authority: Arc<dyn meerkat_runtime::SessionServiceRuntimeExt>,
+    ) -> Self {
+        self.runtime_ingress_authority = Some(authority);
         self
     }
 
@@ -1205,6 +1298,283 @@ impl MobSessionBridge {
         Ok(())
     }
 
+    /// Capture a member session's pending machine ingress BEFORE a repair
+    /// disposal destroys it (OB3 run 33758a41: queue_len=5 steer_queue_len=10
+    /// destroyed with the member). Pending = admitted but not yet run
+    /// (`Accepted`/`Queued`); mid-run and terminal inputs are not queue work.
+    /// Best-effort observation: an unregistered runtime or a probe fault
+    /// degrades to an empty capture (there is then nothing this bridge can
+    /// see, let alone carry).
+    /// Resolve the machine-level ingress authority for repair carry: an
+    /// explicitly injected one wins; otherwise the session service's runtime
+    /// adapter (the gateway's `MeerkatMachine`) serves.
+    fn resolved_runtime_ingress_authority(
+        &self,
+    ) -> Option<Arc<dyn meerkat_runtime::SessionServiceRuntimeExt>> {
+        if let Some(explicit) = self.runtime_ingress_authority.as_ref() {
+            return Some(Arc::clone(explicit));
+        }
+        self.session_service
+            .as_ref()?
+            .runtime_adapter()
+            .map(|machine| machine as Arc<dyn meerkat_runtime::SessionServiceRuntimeExt>)
+    }
+
+    async fn capture_pending_member_ingress(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> PendingIngressCapture {
+        let Some(authority) = self.resolved_runtime_ingress_authority() else {
+            tracing::debug!(
+                session_id = %session_id,
+                "no runtime ingress authority; repair cannot observe or carry queued member inputs"
+            );
+            return PendingIngressCapture::empty();
+        };
+        let active = match authority.list_active_inputs(session_id).await {
+            Ok(ids) => ids,
+            Err(error) => {
+                // NotReady / NotFound = no registered runtime = no live queue
+                // to destroy. Other faults mean the queue is unobservable;
+                // disposal proceeds exactly as it did before this seam.
+                tracing::debug!(
+                    session_id = %session_id,
+                    error = %error,
+                    "pending-ingress probe unavailable before repair disposal"
+                );
+                return PendingIngressCapture::empty();
+            }
+        };
+        let mut capture = PendingIngressCapture::empty();
+        for input_id in active {
+            let stored = match authority.input_state(session_id, &input_id).await {
+                Ok(Some(stored)) => stored,
+                Ok(None) => continue,
+                Err(error) => {
+                    capture
+                        .uncarryable
+                        .push((input_id, "state-unreadable", error.to_string()));
+                    continue;
+                }
+            };
+            if stored.seed.terminal_outcome.is_some() {
+                continue;
+            }
+            match stored.seed.phase {
+                meerkat_runtime::InputLifecycleState::Accepted
+                | meerkat_runtime::InputLifecycleState::Queued => {}
+                meerkat_runtime::InputLifecycleState::Staged
+                | meerkat_runtime::InputLifecycleState::Applied
+                | meerkat_runtime::InputLifecycleState::AppliedPendingConsumption => {
+                    capture.uncarryable.push((
+                        input_id,
+                        "mid-run",
+                        format!(
+                            "input was {:?} at repair disposal; the disposal cancel \
+                             terminalizes it and the sender observes that terminal",
+                            stored.seed.phase
+                        ),
+                    ));
+                    continue;
+                }
+                meerkat_runtime::InputLifecycleState::Consumed
+                | meerkat_runtime::InputLifecycleState::Superseded
+                | meerkat_runtime::InputLifecycleState::Coalesced
+                | meerkat_runtime::InputLifecycleState::Abandoned => continue,
+                other => {
+                    // #[non_exhaustive]: an unknown phase cannot be proven
+                    // pending-and-idle, so it is not carried — but it IS
+                    // named before disposal destroys it.
+                    capture.uncarryable.push((
+                        input_id,
+                        "unrecognized-phase",
+                        format!("input was in unrecognized lifecycle phase {other:?}"),
+                    ));
+                    continue;
+                }
+            }
+            match stored.state.persisted_input {
+                Some(
+                    input @ (meerkat_runtime::Input::Prompt(_)
+                    | meerkat_runtime::Input::Peer(_)
+                    | meerkat_runtime::Input::ExternalEvent(_)),
+                ) => {
+                    capture.carryable.push(CarriedMemberInput {
+                        original_input_id: input_id,
+                        admission_sequence: stored.seed.admission_sequence,
+                        input,
+                    });
+                }
+                Some(meerkat_runtime::Input::FlowStep(_)) => {
+                    capture.uncarryable.push((
+                        input_id,
+                        "flow-step",
+                        "flow-step correlation is owned by the flow engine and cannot be \
+                         re-admitted raw; the loss is bounded to the interrupted flow, \
+                         which observes its step's terminal and owns the retry"
+                            .to_string(),
+                    ));
+                }
+                Some(
+                    meerkat_runtime::Input::Continuation(_) | meerkat_runtime::Input::Operation(_),
+                ) => {
+                    capture.uncarryable.push((
+                        input_id,
+                        "runtime-internal",
+                        "continuation/operation inputs are machine-internal and cannot be \
+                         re-admitted raw; the successor runtime re-derives its own; the \
+                         loss is bounded to the disposed runtime's in-flight bookkeeping"
+                            .to_string(),
+                    ));
+                }
+                Some(_) => {
+                    capture.uncarryable.push((
+                        input_id,
+                        "unrecognized-class",
+                        "the pending input's class is unknown to this build; no carry \
+                         lane exists for it"
+                            .to_string(),
+                    ));
+                }
+                None => {
+                    capture.uncarryable.push((
+                        input_id,
+                        "payload-unavailable",
+                        "the runtime retained no payload for this pending input".to_string(),
+                    ));
+                }
+            }
+        }
+        capture
+            .carryable
+            .sort_by_key(|entry| entry.admission_sequence.unwrap_or(u64::MAX));
+        capture
+    }
+
+    /// Loud pre-disposal record of what the repair is about to do with a
+    /// member's queued work: what it will carry, and — per item, with ids —
+    /// what it is about to DESTROY because no carry lane exists for it.
+    fn log_pending_ingress_before_repair_disposal(
+        &self,
+        member_id: &MobAgentIdentity,
+        session_id: &meerkat_core::types::SessionId,
+        capture: &PendingIngressCapture,
+    ) {
+        if capture.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            member_id = %member_id,
+            session_id = %session_id,
+            carryable = capture.carryable.len(),
+            destroyed = capture.uncarryable.len(),
+            "repair disposal found pending queued inputs on the member: carrying \
+             the carryable set to the healed successor; anything listed below is \
+             destroyed with the member"
+        );
+        for (input_id, class, reason) in &capture.uncarryable {
+            tracing::warn!(
+                member_id = %member_id,
+                session_id = %session_id,
+                input_id = %input_id,
+                class,
+                reason = %reason,
+                "repair disposal DESTROYS a pending member input it cannot carry"
+            );
+        }
+    }
+
+    /// Re-admit captured queue work into the healed successor session through
+    /// ordinary machine admission. Per-item failures are loud errors — the
+    /// heal itself stands (a healed member minus one carried input is still
+    /// strictly better than a Broken member), but every lost input is named.
+    async fn readmit_carried_inputs(
+        &self,
+        member_id: &MobAgentIdentity,
+        session_id: &meerkat_core::types::SessionId,
+        capture: PendingIngressCapture,
+    ) {
+        if capture.carryable.is_empty() {
+            return;
+        }
+        let Some(authority) = self.resolved_runtime_ingress_authority() else {
+            // Unreachable in practice: a non-empty capture required the
+            // authority. Fail loud rather than silently dropping.
+            tracing::error!(
+                member_id = %member_id,
+                session_id = %session_id,
+                lost = capture.carryable.len(),
+                "runtime ingress authority disappeared between capture and carry; \
+                 captured queued inputs are lost"
+            );
+            return;
+        };
+        let total = capture.carryable.len();
+        let mut carried = 0usize;
+        for entry in capture.carryable {
+            let CarriedMemberInput {
+                original_input_id,
+                input,
+                ..
+            } = entry;
+            let Some(input) = remint_carried_input_identity(input) else {
+                tracing::error!(
+                    member_id = %member_id,
+                    session_id = %session_id,
+                    original_input_id = %original_input_id,
+                    "carried input has no re-identifiable header in this build; the \
+                     input is lost"
+                );
+                continue;
+            };
+            let readmitted_input_id = input.id().clone();
+            match authority.accept_input(session_id, input).await {
+                Ok(meerkat_runtime::AcceptOutcome::Accepted { .. }) => {
+                    carried += 1;
+                    tracing::info!(
+                        member_id = %member_id,
+                        session_id = %session_id,
+                        original_input_id = %original_input_id,
+                        readmitted_input_id = %readmitted_input_id,
+                        "carried a queued member input into the healed successor session"
+                    );
+                }
+                Ok(other) => {
+                    let outcome = match &other {
+                        meerkat_runtime::AcceptOutcome::Deduplicated { .. } => "deduplicated",
+                        meerkat_runtime::AcceptOutcome::Rejected { .. } => "rejected",
+                        _ => "unrecognized",
+                    };
+                    tracing::error!(
+                        member_id = %member_id,
+                        session_id = %session_id,
+                        original_input_id = %original_input_id,
+                        outcome,
+                        "successor admission did not accept a carried queued input; \
+                         the input is lost"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        member_id = %member_id,
+                        session_id = %session_id,
+                        original_input_id = %original_input_id,
+                        error = %error,
+                        "failed to re-admit a carried queued input into the healed \
+                         successor; the input is lost"
+                    );
+                }
+            }
+        }
+        tracing::warn!(
+            member_id = %member_id,
+            session_id = %session_id,
+            carried,
+            total,
+            "repair carried queued member inputs into the healed successor session"
+        );
+    }
+
     async fn member_wires(
         &self,
         require_reciprocal: bool,
@@ -1291,6 +1661,31 @@ impl MobSessionBridge {
         if let Some(store) = self.session_store.as_ref() {
             return matches!(store.load_meta(session_id).await, Ok(None));
         }
+        if let Some(store) = self.continuity_session_store.as_ref() {
+            use meerkat::SessionStore as _;
+            return matches!(store.load_meta(session_id).await, Ok(None));
+        }
+        if let Some(service) = self.session_service.as_ref() {
+            return matches!(
+                service.read(session_id).await,
+                Err(meerkat_core::SessionError::NotFound { .. })
+            );
+        }
+        false
+    }
+
+    /// Precondition probe for the collision-repair retire: confirmed absence
+    /// of the resume target in the AUTHORITATIVE read view this composition
+    /// resumes from. The raw injected `session_store` row is deliberately
+    /// NOT consulted here (unlike [`Self::durable_session_row_is_absent`],
+    /// whose verdict is paired with meerkat's typed Absent error): since the
+    /// 0.8.11 store-owned repin, runtime-backed compositions persist through
+    /// RuntimeStore authority and never project into a raw injected
+    /// SessionStore, so an empty raw row is not evidence of absence there.
+    async fn resume_source_confirmed_absent(
+        &self,
+        session_id: &meerkat_core::types::SessionId,
+    ) -> bool {
         if let Some(store) = self.continuity_session_store.as_ref() {
             use meerkat::SessionStore as _;
             return matches!(store.load_meta(session_id).await, Ok(None));
@@ -1498,6 +1893,12 @@ impl MobSessionBridge {
             self.runtime_session_id(runtime_id).await,
             member_entry_before_delivery.clone(),
         ) {
+            // The repair below starts with a destructive retire: capture the
+            // wedged member's queued inputs FIRST so the healed successor can
+            // re-admit them instead of losing them with the disposal (OB3
+            // run 33758a41).
+            let capture = self.capture_pending_member_ingress(&session_id).await;
+            self.log_pending_ingress_before_repair_disposal(member_id, &session_id, &capture);
             match self
                 .resume_repair_member(
                     runtime_id,
@@ -1508,7 +1909,11 @@ impl MobSessionBridge {
                 )
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    self.readmit_carried_inputs(member_id, &session_id, capture)
+                        .await;
+                    return Ok(());
+                }
                 Err(RepairResumeFailure::DurableSnapshotMissing { detail }) => {
                     tracing::warn!(
                         runtime_id = %runtime_id,
@@ -1532,9 +1937,35 @@ impl MobSessionBridge {
                         .await
                         .map_err(|e| BridgeError::Mob(e.to_string()))?;
                     self.remember_runtime_member(runtime_id, member_id).await;
+                    if let Some(fresh_session_id) =
+                        self.handle.resolve_bridge_session_id(member_id).await
+                    {
+                        self.readmit_carried_inputs(member_id, &fresh_session_id, capture)
+                            .await;
+                    } else if !capture.carryable.is_empty() {
+                        tracing::error!(
+                            runtime_id = %runtime_id,
+                            member_id = %member_id,
+                            lost = capture.carryable.len(),
+                            "fresh repair spawn has no resolvable session id; the \
+                             captured queued inputs are lost"
+                        );
+                    }
                     return Ok(());
                 }
-                Err(RepairResumeFailure::Rejected(err)) => return Err(err),
+                Err(RepairResumeFailure::Rejected(err)) => {
+                    if !capture.carryable.is_empty() {
+                        tracing::error!(
+                            runtime_id = %runtime_id,
+                            member_id = %member_id,
+                            session_id = %session_id,
+                            lost = capture.carryable.len(),
+                            "delivery repair failed after its retire; the captured \
+                             queued inputs are lost with the disposed member"
+                        );
+                    }
+                    return Err(err);
+                }
             }
         }
         match self.handle.respawn(member_id.clone(), None).await {
@@ -2219,6 +2650,27 @@ impl SessionBridge for MobSessionBridge {
                     error = %error,
                     "resume_session hit a roster collision; retiring the stale member and retrying resume"
                 );
+                // Preconditions FIRST (OB3 run 33758a41): the retire below is
+                // destructive — on the ephemeral runtime-store shape it takes
+                // the stale member's in-memory state and queued inputs with
+                // it. Before destroying anything, prove the session this
+                // retry will resume from actually exists; a CONFIRMED-absent
+                // resume source means the stale member holds the only live
+                // state and retiring it destroys the session outright.
+                if self.resume_source_confirmed_absent(session_id).await {
+                    return Err(resume_rejected(
+                        identity,
+                        session_id,
+                        &meerkat_mob::MobError::Internal(format!(
+                            "collision retire refused: the resume source for \
+                             {session_id} is confirmed absent, so retiring the stale \
+                             member would destroy the only live copy of the session"
+                        )),
+                        "collision retire precondition",
+                    ));
+                }
+                let capture = self.capture_pending_member_ingress(session_id).await;
+                self.log_pending_ingress_before_repair_disposal(&mid, session_id, &capture);
                 if let Err(err) = self.retire_session_owned_member_to_absence(&mid).await {
                     return Err(resume_rejected(
                         identity,
@@ -2233,6 +2685,16 @@ impl SessionBridge for MobSessionBridge {
                 // 0.7.34 drain-poll between retire and respawn is gone.
                 self.forget_runtime_member(runtime_id).await;
                 if let Err(error) = self.spawn_member_spec(spawn_spec).await {
+                    if !capture.carryable.is_empty() {
+                        tracing::error!(
+                            identity = %identity,
+                            session_id = %session_id,
+                            lost = capture.carryable.len(),
+                            "the collision retire already destroyed the member's queued \
+                             inputs and the resume retry failed; the captured inputs are \
+                             lost with it"
+                        );
+                    }
                     self.verify_durable_session_after_rejected_resume(identity, session_id)
                         .await;
                     return Err(resume_rejected(
@@ -2244,6 +2706,7 @@ impl SessionBridge for MobSessionBridge {
                 }
                 self.remember_runtime_member(runtime_id, &mid).await;
                 self.remember_runtime_session(runtime_id, session_id).await;
+                self.readmit_carried_inputs(&mid, session_id, capture).await;
                 Ok(ResumeSessionOutcome::Resumed {
                     session_id: session_id.clone(),
                 })
@@ -2282,7 +2745,11 @@ impl SessionBridge for MobSessionBridge {
                     );
                     // The failed resume attempt may have left a stale roster
                     // entry; retire is inert when nothing matches (see the
-                    // collision arm above).
+                    // collision arm above). When it DOES match, the retire is
+                    // destructive: capture the stale member's queued inputs
+                    // first and carry them into the fresh successor session.
+                    let capture = self.capture_pending_member_ingress(session_id).await;
+                    self.log_pending_ingress_before_repair_disposal(&mid, session_id, &capture);
                     if let Err(retire_error) =
                         self.retire_session_owned_member_to_absence(&mid).await
                     {
@@ -2295,9 +2762,27 @@ impl SessionBridge for MobSessionBridge {
                     }
                     self.forget_runtime_member(runtime_id).await;
                     let fresh_session_id = meerkat_core::types::SessionId::new();
-                    let created_session_id = self
+                    let created_session_id = match self
                         .create_session(identity, runtime_id, spec, draft, &fresh_session_id)
-                        .await?;
+                        .await
+                    {
+                        Ok(created) => created,
+                        Err(create_error) => {
+                            if !capture.carryable.is_empty() {
+                                tracing::error!(
+                                    identity = %identity,
+                                    session_id = %session_id,
+                                    lost = capture.carryable.len(),
+                                    "the never-persisted retire already destroyed the \
+                                     member's queued inputs and the fresh spawn failed; \
+                                     the captured inputs are lost with it"
+                                );
+                            }
+                            return Err(create_error);
+                        }
+                    };
+                    self.readmit_carried_inputs(&mid, &created_session_id, capture)
+                        .await;
                     return Ok(ResumeSessionOutcome::FreshSpawned {
                         session_id: created_session_id,
                         reason: ResumeFallbackReason::NeverPersisted {

--- a/meerkat-mobkit/src/identity_first/bridge.rs
+++ b/meerkat-mobkit/src/identity_first/bridge.rs
@@ -1675,28 +1675,47 @@ impl MobSessionBridge {
     }
 
     /// Precondition probe for the collision-repair retire: confirmed absence
-    /// of the resume target in the AUTHORITATIVE read view this composition
-    /// resumes from. The raw injected `session_store` row is deliberately
-    /// NOT consulted here (unlike [`Self::durable_session_row_is_absent`],
-    /// whose verdict is paired with meerkat's typed Absent error): since the
-    /// 0.8.11 store-owned repin, runtime-backed compositions persist through
-    /// RuntimeStore authority and never project into a raw injected
-    /// SessionStore, so an empty raw row is not evidence of absence there.
+    /// of the resume target in DURABLE, NON-ACTOR authority. The raw injected
+    /// `session_store` row is deliberately NOT consulted here (unlike
+    /// [`Self::durable_session_row_is_absent`], whose verdict is paired with
+    /// meerkat's typed Absent error): since the 0.8.11 store-owned repin,
+    /// runtime-backed compositions persist through RuntimeStore authority and
+    /// never project into a raw injected SessionStore, so an empty raw row is
+    /// not evidence of absence there.
+    ///
+    /// Every probe here must be answerable WITHOUT the session's live actor:
+    /// this runs while the stale member may be wedged mid-turn, and an
+    /// actor-routed read (`service.read`) waits on the very member the
+    /// repair is about to dispose — a self-deadlock, proven live at the
+    /// meerkat 0.8.13 repin (the collision arm hung inside this probe).
+    /// `session_known_to_archive_authority` is the durable disposal-routing
+    /// predicate that answers from archive authority instead.
+    ///
+    /// Verdict: `true` (refuse the destructive retire) only when at least one
+    /// durable authority was consulted and none of them knows the session.
+    /// A probe fault means absence cannot be CONFIRMED, so repair proceeds
+    /// exactly as it did before this guard existed.
     async fn resume_source_confirmed_absent(
         &self,
         session_id: &meerkat_core::types::SessionId,
     ) -> bool {
+        let mut consulted_authority = false;
         if let Some(store) = self.continuity_session_store.as_ref() {
             use meerkat::SessionStore as _;
-            return matches!(store.load_meta(session_id).await, Ok(None));
+            match store.load_meta(session_id).await {
+                Ok(Some(_)) => return false,
+                Ok(None) => consulted_authority = true,
+                Err(_) => return false,
+            }
         }
         if let Some(service) = self.session_service.as_ref() {
-            return matches!(
-                service.read(session_id).await,
-                Err(meerkat_core::SessionError::NotFound { .. })
-            );
+            match service.session_known_to_archive_authority(session_id).await {
+                Ok(true) => return false,
+                Ok(false) => consulted_authority = true,
+                Err(_) => return false,
+            }
         }
-        false
+        consulted_authority
     }
 
     async fn verify_durable_session_after_rejected_resume(

--- a/meerkat-mobkit/src/identity_first/runtime.rs
+++ b/meerkat-mobkit/src/identity_first/runtime.rs
@@ -6,7 +6,7 @@
 //! - Lifecycle: `retire()`, `respawn()`, `reset()`, `delete_identity()`
 //! - Ownership: lease tracking, fencing, and invariant enforcement
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock, Weak};
@@ -754,6 +754,13 @@ impl IdentityFirstRuntimeContext {
         mut cancellation: Option<watch::Receiver<bool>>,
     ) {
         let mut backoff = policy.initial_backoff;
+        // Bounded non-identical retries (OB3 0.8.12-era evidence): a repair
+        // pass whose failure comes back byte-identical N times in a row is a
+        // deterministic wall, and each blind retry re-executes the pass's
+        // DESTRUCTIVE dispose steps against the same blocking precondition.
+        // Track consecutive per-identity failure signatures and park typed
+        // after [`REPAIR_IDENTICAL_FAILURE_PARK_ATTEMPTS`].
+        let mut identical_failure_streaks: HashMap<AgentIdentity, (String, u32)> = HashMap::new();
         loop {
             if let Some(cancellation) = cancellation.as_mut() {
                 if *cancellation.borrow() {
@@ -844,20 +851,23 @@ impl IdentityFirstRuntimeContext {
                 broken = repairable.len(),
                 "continuity repair: retrying restore for Broken identities"
             );
-            if let Err(err) = self.refresh_desired_topology().await {
-                tracing::warn!(
-                    error = %err,
-                    "continuity repair reconcile failed; backing off"
-                );
-                backoff = (backoff * 2).min(policy.max_backoff);
-                if cancellation
-                    .as_ref()
-                    .is_some_and(|cancellation| *cancellation.borrow())
-                {
-                    return;
+            let pass = match self.refresh_desired_topology().await {
+                Ok(pass) => pass,
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "continuity repair reconcile failed; backing off"
+                    );
+                    backoff = (backoff * 2).min(policy.max_backoff);
+                    if cancellation
+                        .as_ref()
+                        .is_some_and(|cancellation| *cancellation.borrow())
+                    {
+                        return;
+                    }
+                    continue;
                 }
-                continue;
-            }
+            };
             let still_broken = self.runtime.repairable_broken_identities().await;
             let healed = repairable
                 .iter()
@@ -869,6 +879,64 @@ impl IdentityFirstRuntimeContext {
                     still_broken = still_broken.len(),
                     "continuity repair healed identities"
                 );
+            }
+            for identity in &repairable {
+                if !still_broken.contains(identity) {
+                    identical_failure_streaks.remove(identity);
+                    continue;
+                }
+                let Some(super::orchestrator::RestoreOutcome::Broken(failure)) =
+                    pass.outcomes.get(identity)
+                else {
+                    // No comparable typed failure for this pass (the identity
+                    // broke through a different door); a streak cannot be
+                    // byte-compared across shapes.
+                    identical_failure_streaks.remove(identity);
+                    continue;
+                };
+                let signature = format!("{:?}: {}", failure.kind, failure.detail);
+                let streak = identical_failure_streaks
+                    .entry(identity.clone())
+                    .or_insert_with(|| (signature.clone(), 0));
+                if streak.0 == signature {
+                    streak.1 += 1;
+                } else {
+                    *streak = (signature.clone(), 1);
+                }
+                if streak.1 >= REPAIR_IDENTICAL_FAILURE_PARK_ATTEMPTS {
+                    identical_failure_streaks.remove(identity);
+                    tracing::error!(
+                        %identity,
+                        attempts = REPAIR_IDENTICAL_FAILURE_PARK_ATTEMPTS,
+                        blocking_failure = %signature,
+                        "continuity repair failed byte-identically on every attempt; \
+                         parking the identity typed instead of re-executing destructive \
+                         repair steps on a timer. Operator path back after fixing the \
+                         blocking failure: restart the gateway (the park is \
+                         process-local; boot re-attempts repair once) or reset the \
+                         identity via `mobkit/reset` (deliberate fresh start)"
+                    );
+                    if !self
+                        .runtime
+                        .mark_continuity_unrecoverable(
+                            identity,
+                            format!(
+                                "continuity repair parked after \
+                                 {REPAIR_IDENTICAL_FAILURE_PARK_ATTEMPTS} consecutive \
+                                 byte-identical repair failures; blocking failure: \
+                                 {signature}. After fixing it, restart the gateway \
+                                 (process-local park; boot re-attempts repair) or reset \
+                                 the identity via `mobkit/reset`"
+                            ),
+                        )
+                        .await
+                    {
+                        tracing::debug!(
+                            %identity,
+                            "identity left Broken before the repair park could be recorded"
+                        );
+                    }
+                }
             }
             backoff = if still_broken.is_empty() && recovery_failures == 0 {
                 policy.initial_backoff
@@ -1003,6 +1071,12 @@ impl TrackedLeaseRenewalTask {
         let _ = self.join.await;
     }
 }
+
+/// Consecutive byte-identical repair failures tolerated for one identity
+/// before the repair supervisor parks it typed
+/// ([`IdentityRuntime::mark_continuity_unrecoverable`]) instead of
+/// re-executing the pass's destructive dispose steps on a timer.
+const REPAIR_IDENTICAL_FAILURE_PARK_ATTEMPTS: u32 = 3;
 
 /// Retry cadence for [`IdentityFirstRuntimeContext::spawn_broken_identity_repair_task`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12147,7 +12221,195 @@ mod lease_renewal_backoff_tests {
 #[cfg(test)]
 mod continuity_repair_supervisor_tests {
     use super::*;
+    use crate::identity_first::bridge::{BridgeError, ResumeSessionOutcome, SessionBridge};
+    use crate::identity_first::types::{AgentBuildDraft, SessionSnapshot};
     use crate::identity_first::{LocalContinuityStore, LocalLeaseProvider, MutableRosterProvider};
+
+    /// A resume path that is deterministically wedged: every attempt fails
+    /// with the SAME error bytes, and every attempt is counted. This is the
+    /// shape whose blind re-execution the bounded-identical-retry park
+    /// exists to stop (each real repair attempt re-runs destructive dispose
+    /// steps against the same blocking precondition).
+    struct IdenticallyWedgedResumeBridge {
+        resume_attempts: std::sync::atomic::AtomicUsize,
+    }
+
+    impl IdenticallyWedgedResumeBridge {
+        fn attempts(&self) -> usize {
+            self.resume_attempts
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SessionBridge for IdenticallyWedgedResumeBridge {
+        async fn create_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            _session_id: &SessionId,
+        ) -> Result<SessionId, BridgeError> {
+            Err(BridgeError::Mob(
+                "create not expected: the identity resolves Ready".to_string(),
+            ))
+        }
+
+        async fn resume_session(
+            &self,
+            _identity: &AgentIdentity,
+            _runtime_id: &AgentRuntimeId,
+            _spec: &DurableAgentSpec,
+            _draft: &AgentBuildDraft,
+            _session_id: &SessionId,
+            _snapshot: &SessionSnapshot,
+        ) -> Result<ResumeSessionOutcome, BridgeError> {
+            self.resume_attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(BridgeError::Mob(
+                "collision retire blocked: disposal precondition holds (wedged for park test)"
+                    .to_string(),
+            ))
+        }
+
+        async fn deliver(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _content: &meerkat_core::ContentInput,
+        ) -> Result<SessionId, BridgeError> {
+            Err(BridgeError::Mob("deliver not used".to_string()))
+        }
+
+        async fn checkpoint_session(
+            &self,
+            _runtime_id: &AgentRuntimeId,
+            _session_id: &SessionId,
+        ) -> Result<SessionSnapshot, BridgeError> {
+            Err(BridgeError::Mob("checkpoint not used".to_string()))
+        }
+
+        async fn retire_member(&self, _runtime_id: &AgentRuntimeId) -> Result<(), BridgeError> {
+            Ok(())
+        }
+    }
+
+    fn park_test_spec(identity: AgentIdentity) -> DurableAgentSpec {
+        DurableAgentSpec {
+            identity,
+            profile: meerkat_mob::ProfileName::from("domain"),
+            addressability: crate::identity_first::AgentAddressability::Addressable,
+            display_name: None,
+            labels: BTreeMap::new(),
+            context: None,
+            additional_instructions: Vec::new(),
+            initial_message: None,
+            runtime_mode_override: None,
+            backend: None,
+            binding: None,
+        }
+    }
+
+    /// Task #48 (c) — bounded non-identical retries: a Broken identity whose
+    /// repair fails byte-identically on three consecutive passes is parked
+    /// TYPED (`continuity_unrecoverable`, reason naming the blocking
+    /// failure), and the supervisor never re-executes the repair afterwards.
+    #[tokio::test]
+    async fn repair_loop_parks_typed_after_three_byte_identical_failures()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identity = AgentIdentity::parse("domain:wedged")?;
+        let spec = park_test_spec(identity.clone());
+        let session_id = SessionId::new();
+        let record = ContinuityRecord {
+            identity: identity.clone(),
+            agent_runtime_id: AgentRuntimeId::parse(&format!("rt:{identity}:0"))?,
+            session_id: session_id.clone(),
+            generation: ContinuityGeneration::new(1),
+            checkpoint_version: CheckpointVersion::new(1),
+        };
+        let continuity_store = Arc::new(LocalContinuityStore::in_memory()?);
+        continuity_store
+            .upsert_continuity_record(&record, FencingToken::new(1))
+            .await?;
+        let bridge = Arc::new(IdenticallyWedgedResumeBridge {
+            resume_attempts: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let runtime = Arc::new(IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store,
+            lease_provider: Arc::new(LocalLeaseProvider::new()),
+            runtime_instance_id: "identical-failure-park-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge.clone()),
+            default_timeout: None,
+        }));
+        runtime
+            .register(
+                spec.clone(),
+                IdentityLifecycleState::Broken,
+                Some(record),
+                None,
+            )
+            .await;
+        let context = Arc::new(IdentityFirstRuntimeContext::new(
+            Arc::clone(&runtime),
+            Arc::new(MutableRosterProvider::new(vec![spec])),
+            None,
+            None,
+            None,
+        ));
+        let task = context.spawn_tracked_broken_identity_repair_task(ContinuityRepairPolicy {
+            initial_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(10),
+        });
+
+        // The park must arrive after EXACTLY the bounded attempt count.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let park = loop {
+            if let Some(park) = runtime.continuity_unrecoverable(&identity).await {
+                break park;
+            }
+            if Instant::now() > deadline {
+                task.cancel_and_join().await;
+                return Err("repair loop never parked the identically-failing identity".into());
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+        assert!(
+            park.reason.contains("byte-identical"),
+            "park reason must name the bounded-identical-retry cause: {}",
+            park.reason
+        );
+        assert!(
+            park.reason
+                .contains("disposal precondition holds (wedged for park test)"),
+            "park reason must carry the blocking failure verbatim: {}",
+            park.reason
+        );
+        let attempts_at_park = bridge.attempts();
+        assert_eq!(
+            attempts_at_park, 3,
+            "the destructive repair must run exactly the bounded attempt count"
+        );
+
+        // Parked = no further destructive re-execution on the timer.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            bridge.attempts(),
+            attempts_at_park,
+            "a parked identity must not be re-repaired on the timer"
+        );
+        assert!(
+            runtime
+                .repairable_broken_identities()
+                .await
+                .iter()
+                .all(|id| id != &identity),
+            "a parked identity must leave the repairable set"
+        );
+        task.cancel_and_join().await;
+        Ok(())
+    }
 
     #[tokio::test]
     async fn repair_loop_exits_when_supervisor_sender_is_dropped()

--- a/meerkat-mobkit/src/identity_first/types.rs
+++ b/meerkat-mobkit/src/identity_first/types.rs
@@ -445,18 +445,30 @@ pub struct ContinuityFailure {
     pub detail: String,
 }
 
-/// Terminal heal verdict recorded against a Broken identity.
+/// Terminal repair verdict recorded against a Broken identity.
 ///
-/// Minted when the session bridge's heal authority reports that the durable
-/// session head is provably NOT recoverable to a strict-resume-acceptable
-/// committed boundary (`CommittedBoundaryRepair::Unprovable`). The verdict is
-/// stable across calls, so the continuity repair supervisor must not
-/// retry-loop it: before this marker existed, every repair pass cosmetically
-/// re-registered the identity and the next materialization re-Broke it
-/// (measured in production on 2026-07-29 as an infinite heal/re-Break cycle).
+/// Two producers mint it:
+///
+/// - The session bridge's heal authority reporting that the durable session
+///   head is provably NOT recoverable to a strict-resume-acceptable
+///   committed boundary (`CommittedBoundaryRepair::Unprovable`). The verdict
+///   is stable across calls, so the continuity repair supervisor must not
+///   retry-loop it: before this marker existed, every repair pass
+///   cosmetically re-registered the identity and the next materialization
+///   re-Broke it (measured in production on 2026-07-29 as an infinite
+///   heal/re-Break cycle).
+/// - The repair supervisor's bounded-identical-retry park: three consecutive
+///   byte-identical repair failures prove a deterministic wall, and each
+///   blind retry re-executes destructive dispose steps against it (OB3
+///   0.8.12-era field evidence).
+///
+/// The park is process-local (entry state, not durable): after the operator
+/// fixes the blocking cause, a gateway restart re-attempts repair once, and
+/// `mobkit/reset` remains the deliberate fresh-start path. Any non-Broken
+/// lifecycle projection also clears it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContinuityUnrecoverable {
-    /// The heal authority's reason, verbatim, for operators.
+    /// The producing authority's reason, verbatim, for operators.
     pub reason: String,
 }
 

--- a/meerkat-mobkit/src/schedule_wiring.rs
+++ b/meerkat-mobkit/src/schedule_wiring.rs
@@ -768,6 +768,13 @@ impl InternalDeliveryScheduleMobHost {
             // DispatchInput.idempotency_key exists), so crash-redelivery dedup
             // for this sink is still ABSENT - carrying the key here stages the
             // admission-threading follow-up, it does not implement it.
+            // Re-checked at the 0.8.12 repin: the internal work lane is still
+            // closed upstream - meerkat-mob 0.8.12 `submit_work_with_mode`
+            // (src/runtime/handle.rs:7177) hardcodes
+            // `external_delivery_identity: None` and offers no submit variant
+            // that accepts a delivery identity; the dedup ledger
+            // (`begin_external_delivery`/`complete_external_delivery`) serves
+            // the external door only.
             let input = crate::identity_first::DispatchInput {
                 content: content.clone(),
                 origin: crate::identity_first::DispatchOrigin::Scheduler,

--- a/meerkat-mobkit/tests/agent_events_identity_resolution.rs
+++ b/meerkat-mobkit/tests/agent_events_identity_resolution.rs
@@ -50,10 +50,6 @@ fn open_console_decisions() -> meerkat_mobkit::RuntimeDecisionState {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "upstream meerkat-mob actor defect family (S3; NOT covered by #929, \
-            lead-confirmed 2026-07-31): GET /agents/<id>/events returns HTTP 500 on \
-            the member-observation route. Reproduces serially at ed7e42b75. Re-arm \
-            on the upstream fix SHA."]
 async fn agent_events_route_resolves_durable_identities_and_aliases() {
     let definition = MobDefinition::from_toml(
         r#"

--- a/meerkat-mobkit/tests/released_realm_upgrade_drive.rs
+++ b/meerkat-mobkit/tests/released_realm_upgrade_drive.rs
@@ -362,6 +362,30 @@ impl Gateway {
         )
     }
 
+    /// Task #21 pin: a boot over healthy (or once-healed) durable state must
+    /// classify CLEAN — zero Broken classifications, zero continuity-repair
+    /// activity. A heal that does not persist a clean boundary re-Breaks on
+    /// the NEXT boot (the 2026-07-29 heal/re-Break production loop), and this
+    /// is where that would surface.
+    fn assert_no_repair_activity(&self) {
+        let Ok(sink) = self.stderr.lock() else {
+            panic!("[{}] gateway stderr unavailable: poisoned lock", self.label);
+        };
+        for marker in [
+            "marking identity Broken",
+            "continuity repair",
+            "continuity heal",
+        ] {
+            if let Some(line) = sink.iter().find(|line| line.contains(marker)) {
+                panic!(
+                    "({}) boot must classify clean, but the gateway logged repair \
+                     activity ({marker}): {line}",
+                    self.label
+                );
+            }
+        }
+    }
+
     fn wait_for(
         &mut self,
         deadline: Duration,
@@ -1024,6 +1048,7 @@ fn drive_released_realm(spec: &RealmSpec) {
         floor += MESSAGES_PER_TURN;
         wait_for_durable_messages(&state, floor, &format!("{label_a} turn for {identity}"));
     }
+    gateway.assert_no_repair_activity();
     gateway.shutdown_and_reap();
 
     // --- Post-exit: the upgrade, read from bytes ----------------------------
@@ -1085,6 +1110,11 @@ fn drive_released_realm(spec: &RealmSpec) {
         floor += MESSAGES_PER_TURN;
         wait_for_durable_messages(&state, floor, &format!("{label_b} turn for {identity}"));
     }
+    // Task #21 two-boot property on real released bytes: boot B inherits
+    // state the NEW build wrote (boot A upgraded, drove, and shut down
+    // clean) and must classify CLEAN — zero repairs. On the crash realm this
+    // additionally pins heal-then-clean over SIGKILL residue.
+    gateway.assert_no_repair_activity();
     gateway.shutdown_and_reap();
 
     let after_b = read_durable_transcript(&state, &format!("{label_b} post-turn"));

--- a/meerkat-mobkit/tests/repair_queue_carry.rs
+++ b/meerkat-mobkit/tests/repair_queue_carry.rs
@@ -1,0 +1,540 @@
+// Repair must not destroy queued work (task #48; OB3 field runs 33758a41 +
+// 6bb7010e): identity-first continuity repair used to heal a wedged member by
+// FULL disposal — `cancel_active_runtime_turn_before_retire` observed
+// queue_len=5 steer_queue_len=10 and PROCEEDED; ArchiveSession destroyed the
+// 15 pending review inputs with the member. On the ephemeral runtime-store
+// shape those queued inputs are in-memory, so disposal loses them
+// irrecoverably.
+//
+// The two regressions here pin the bridge-side fix:
+// 1. `repair_carries_queued_inputs_to_the_healed_successor` — the collision
+//    repair captures the member's pending machine ingress BEFORE the
+//    destructive retire and re-admits it into the healed successor session,
+//    which then DRAINS it (real MeerkatMachine, real mob, gated LLM client).
+// 2. `repair_refuses_disposal_when_the_durable_row_is_confirmed_absent` — the
+//    preconditions-first gate: when the durable session row the resume retry
+//    needs is confirmed absent, no destructive step executes at all and the
+//    member (with its queue) is left untouched behind a typed rejection.
+//
+// The bounded byte-identical-failure park (task #48 (c)) is pinned separately
+// in `identity_first::runtime`'s continuity_repair_supervisor_tests.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use meerkat::{AgentFactory, Config, FactoryAgentBuilder, PersistentSessionService};
+use meerkat_client::types::LlmStream;
+use meerkat_client::{LlmClient, LlmDoneOutcome, LlmError, LlmEvent, LlmRequest};
+use meerkat_mob::{MobDefinition, MobStorage};
+use meerkat_mobkit::identity_first::{
+    AgentAddressability, AgentBuildDraft, AgentRuntimeServices, BridgeError, DurabilityPolicy,
+    DurableAgentSpec, IdentityRuntime, IdentityRuntimeConfig, LocalContinuityStore,
+    LocalLeaseProvider, MobSessionBridge, RestoreOutcome, SessionBridge, SessionSnapshot,
+    restore_flow,
+};
+use meerkat_mobkit::{
+    DiscoverySpec, MobBootstrapOptions, MobBootstrapSpec, MobKitConfig, UnifiedRuntime,
+};
+use meerkat_runtime::SessionServiceRuntimeExt;
+use tokio::sync::watch;
+
+/// Deterministic LLM whose stream blocks until the shared gate opens, and
+/// which records the last request message of every turn it is asked to run.
+/// Closed gate = the OB3 wedge shape (a turn parked inside the provider
+/// stream while fan-in piles up behind it).
+struct GatedRecordingClient {
+    gate: watch::Receiver<bool>,
+    prompts: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl LlmClient for GatedRecordingClient {
+    fn project_replay_messages(
+        &self,
+        messages: &[meerkat_core::Message],
+    ) -> Result<Vec<meerkat_core::Message>, LlmError> {
+        Ok(messages.to_vec())
+    }
+
+    fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
+        self.prompts
+            .lock()
+            .expect("prompt record lock")
+            .push(format!("{:?}", request.messages.last()));
+        let mut gate = self.gate.clone();
+        let text = futures::stream::once(async move {
+            while !*gate.borrow() {
+                if gate.changed().await.is_err() {
+                    break;
+                }
+            }
+            Ok(LlmEvent::TextDelta {
+                delta: "ok".to_string(),
+                meta: None,
+            })
+        });
+        let done = futures::stream::once(async {
+            Ok(LlmEvent::Done {
+                outcome: LlmDoneOutcome::Success {
+                    stop_reason: meerkat_core::StopReason::EndTurn,
+                },
+            })
+        });
+        Box::pin(text.chain(done))
+    }
+
+    fn provider(&self) -> meerkat_core::Provider {
+        meerkat_core::Provider::Other
+    }
+
+    async fn health_check(&self) -> Result<(), LlmError> {
+        Ok(())
+    }
+}
+
+struct Harness {
+    _temp: tempfile::TempDir,
+    _runtime: UnifiedRuntime,
+    machine: Arc<meerkat_runtime::MeerkatMachine>,
+    mob_handle: meerkat_mob::MobHandle,
+    bridge: Arc<MobSessionBridge>,
+    identity: meerkat_mobkit::identity_first::AgentIdentity,
+    spec: DurableAgentSpec,
+    runtime_id: meerkat_mobkit::identity_first::AgentRuntimeId,
+    session_id: meerkat_core::types::SessionId,
+    prompts: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+fn empty_draft(spec: &DurableAgentSpec) -> AgentBuildDraft {
+    AgentBuildDraft {
+        model: None,
+        system_prompt: None,
+        additional_instructions: spec.additional_instructions.clone(),
+        labels: spec.labels.clone(),
+        app_context: spec.context.clone(),
+        external_tools: Vec::new(),
+        local_external_tools: Default::default(),
+        provider_params: None,
+    }
+}
+
+fn prompt_input(text: &str) -> meerkat_runtime::Input {
+    meerkat_runtime::Input::Prompt(meerkat_runtime::PromptInput::new(text, None))
+}
+
+fn flow_step_input(text: &str) -> meerkat_runtime::Input {
+    meerkat_runtime::Input::FlowStep(meerkat_runtime::FlowStepInput {
+        header: meerkat_runtime::InputHeader {
+            id: meerkat_core::lifecycle::InputId::new(),
+            timestamp: chrono::Utc::now(),
+            source: meerkat_runtime::InputOrigin::Flow {
+                flow_id: "carry-test-flow".to_string(),
+                step_index: 0,
+            },
+            durability: meerkat_runtime::InputDurability::Durable,
+            visibility: meerkat_runtime::InputVisibility::default(),
+            idempotency_key: None,
+            supersession_key: None,
+            correlation_id: None,
+        },
+        step_id: "carry-test-step".to_string(),
+        content: meerkat_core::ContentInput::Text(text.to_string()),
+        directed_interaction_id: None,
+        turn_metadata: None,
+    })
+}
+
+async fn build_harness(gate: watch::Receiver<bool>) -> Harness {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let state = temp.path().join("state");
+    std::fs::create_dir_all(&state).expect("state dir");
+    let session_store: Arc<dyn meerkat::SessionStore> = Arc::new(
+        meerkat_store::SqliteSessionStore::open(state.join("sessions.db")).expect("session store"),
+    );
+    let runtime_store: Arc<dyn meerkat_runtime::RuntimeStore> = Arc::new(
+        meerkat_runtime::store::SqliteRuntimeStore::new(state.join("runtime.sqlite"))
+            .expect("runtime store"),
+    );
+    let blob_store: Arc<dyn meerkat_core::BlobStore> =
+        Arc::new(meerkat_store::MemoryBlobStore::new());
+    let factory = AgentFactory::new(&state).comms(true);
+    let mut builder = FactoryAgentBuilder::new(factory, Config::default());
+    builder.default_session_store = Some(Arc::new(meerkat_store::StoreAdapter::new(
+        session_store.clone(),
+    )));
+    builder.default_blob_store = Some(blob_store.clone());
+    let machine = Arc::new(meerkat_runtime::MeerkatMachine::persistent(
+        Arc::clone(&runtime_store),
+        Arc::clone(&blob_store),
+    ));
+    let service = Arc::new(PersistentSessionService::new(
+        builder,
+        16,
+        session_store.clone(),
+        runtime_store,
+        blob_store,
+    ));
+    let definition = MobDefinition::from_toml(
+        r#"
+[mob]
+id = "repair-carry"
+
+[profiles.general]
+model = "gpt-5.5"
+
+[profiles.general.tools]
+comms = true
+"#,
+    )
+    .expect("definition");
+    let prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mob_spec = MobBootstrapSpec::new(definition, MobStorage::in_memory(), service)
+        .with_session_runtime_adapter(machine.clone())
+        .with_options(MobBootstrapOptions {
+            allow_ephemeral_sessions: true,
+            notify_orchestrator_on_resume: true,
+            default_llm_client: Some(Arc::new(GatedRecordingClient {
+                gate,
+                prompts: Arc::clone(&prompts),
+            })),
+        });
+    let module_config = MobKitConfig {
+        modules: vec![],
+        discovery: DiscoverySpec {
+            namespace: "repair-carry".to_string(),
+            modules: vec![],
+        },
+        pre_spawn: vec![],
+    };
+    let runtime = UnifiedRuntime::bootstrap(mob_spec, module_config, Duration::from_secs(2))
+        .await
+        .expect("bootstrap");
+
+    let continuity_store =
+        LocalContinuityStore::open(state.join("continuity.db")).expect("continuity store");
+    let fencing_floor = continuity_store
+        .max_fencing_token()
+        .expect("fencing high-water");
+    let mob_handle = runtime.mob_handle();
+    let session_service = runtime
+        .mob_runtime()
+        .session_service()
+        .cloned()
+        .expect("session service");
+    // A tight actor-admission budget so a test failure surfaces as a typed
+    // deadline error in seconds instead of parking inside the production
+    // 10-minute budget.
+    let bridge = Arc::new(
+        MobSessionBridge::with_session_store_and_service(
+            mob_handle.clone(),
+            session_store,
+            session_service,
+        )
+        .with_actor_admission_budget(Duration::from_secs(15)),
+    );
+    let irt = Arc::new(
+        IdentityRuntime::new(IdentityRuntimeConfig {
+            continuity_store: Arc::new(continuity_store),
+            lease_provider: Arc::new(LocalLeaseProvider::with_floor(fencing_floor)),
+            runtime_instance_id: "repair-carry-test".to_string(),
+            has_runtime_store: true,
+            durability_policy: DurabilityPolicy::SyncWriteThrough,
+            bridge: Some(bridge.clone()),
+            default_timeout: None,
+        })
+        .with_runtime_services(AgentRuntimeServices::new(mob_handle.clone())),
+    );
+    let identity = meerkat_mobkit::identity_first::AgentIdentity::parse("crew:worker")
+        .expect("identity parses");
+    let spec = DurableAgentSpec {
+        identity: identity.clone(),
+        profile: meerkat_mob::ProfileName::from("general"),
+        addressability: AgentAddressability::Addressable,
+        display_name: None,
+        labels: BTreeMap::new(),
+        context: None,
+        additional_instructions: Vec::new(),
+        initial_message: None,
+        runtime_mode_override: None,
+        backend: None,
+        binding: None,
+    };
+    let result = restore_flow(&irt, std::slice::from_ref(&spec), None, None)
+        .await
+        .expect("restore_flow");
+    let record = match result.outcomes.get(&identity) {
+        Some(RestoreOutcome::Created { record, .. }) => record.clone(),
+        other => panic!("worker must fresh-create, got {other:?}"),
+    };
+
+    Harness {
+        _temp: temp,
+        _runtime: runtime,
+        machine,
+        mob_handle,
+        bridge,
+        identity,
+        spec,
+        runtime_id: record.agent_runtime_id,
+        session_id: record.session_id,
+        prompts,
+    }
+}
+
+async fn wait_until<F>(what: &str, timeout: Duration, mut condition: F)
+where
+    F: AsyncFnMut() -> bool,
+{
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if condition().await {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for: {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// OB3 run 33758a41 shape: a member wedged mid-turn with fan-in queued behind
+/// it. The collision repair must carry the queued Prompt inputs into the
+/// healed successor session (which drains them), and must not resurrect the
+/// flow-step (its correlation belongs to the flow engine — it is destroyed
+/// loudly, by class).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repair_carries_queued_inputs_to_the_healed_successor() {
+    let (gate_tx, gate_rx) = watch::channel(true);
+    let harness = build_harness(gate_rx).await;
+    let machine = harness.machine.as_ref();
+
+    // Seed the durable row the resume retry will need: one completed turn
+    // through the sanctioned mob deliver lane (machine-direct admission on a
+    // never-delivered member has no attached loop to run it).
+    harness
+        .bridge
+        .deliver(
+            &harness.runtime_id,
+            &meerkat_core::ContentInput::Text("seed turn".to_string()),
+        )
+        .await
+        .expect("seed turn delivery");
+    eprintln!("PHASE: seed delivered");
+    wait_until(
+        "the seed turn to complete",
+        Duration::from_secs(20),
+        || async {
+            let ran = harness
+                .prompts
+                .lock()
+                .expect("prompt record lock")
+                .iter()
+                .any(|prompt| prompt.contains("seed turn"));
+            ran && SessionServiceRuntimeExt::list_active_inputs(machine, &harness.session_id)
+                .await
+                .map(|active| active.is_empty())
+                .unwrap_or(false)
+        },
+    )
+    .await;
+
+    // Wedge the member: close the gate, start a turn that parks inside the
+    // provider stream, then pile queued fan-in behind it (the OB3 shape).
+    gate_tx.send(false).expect("close gate");
+    harness
+        .bridge
+        .deliver(
+            &harness.runtime_id,
+            &meerkat_core::ContentInput::Text("wedged".to_string()),
+        )
+        .await
+        .expect("wedged turn delivery");
+    eprintln!("PHASE: wedged delivered");
+    wait_until(
+        "the wedged turn to bind the runtime",
+        Duration::from_secs(10),
+        || async {
+            matches!(
+                SessionServiceRuntimeExt::runtime_state(machine, &harness.session_id).await,
+                Ok(meerkat_runtime::RuntimeState::Running)
+            )
+        },
+    )
+    .await;
+    harness
+        .bridge
+        .deliver(
+            &harness.runtime_id,
+            &meerkat_core::ContentInput::Text("carried-one".to_string()),
+        )
+        .await
+        .expect("queued delivery one");
+    eprintln!("PHASE: carried-one delivered");
+    harness
+        .bridge
+        .deliver(
+            &harness.runtime_id,
+            &meerkat_core::ContentInput::Text("carried-two".to_string()),
+        )
+        .await
+        .expect("queued delivery two");
+    eprintln!("PHASE: carried-two delivered");
+    SessionServiceRuntimeExt::accept_input(
+        machine,
+        &harness.session_id,
+        flow_step_input("flow-step-content"),
+    )
+    .await
+    .expect("queued flow step");
+    eprintln!("PHASE: flow step admitted");
+    let pending = SessionServiceRuntimeExt::list_active_inputs(machine, &harness.session_id)
+        .await
+        .expect("pending queue readable");
+    assert!(
+        pending.len() >= 4,
+        "the wedge must hold the running turn plus three queued inputs, got {}",
+        pending.len()
+    );
+
+    // The repair: a resume over the live (wedged) member takes the roster-
+    // collision arm — capture, retire, resume retry, carry.
+    let outcome = harness
+        .bridge
+        .resume_session(
+            &harness.identity,
+            &harness.runtime_id,
+            &harness.spec,
+            &empty_draft(&harness.spec),
+            &harness.session_id,
+            &SessionSnapshot { data: Vec::new() },
+        )
+        .await
+        .expect("collision repair resumes");
+    eprintln!("PHASE: repair resumed");
+    assert!(
+        matches!(
+            outcome,
+            meerkat_mobkit::identity_first::ResumeSessionOutcome::Resumed { ref session_id }
+                if *session_id == harness.session_id
+        ),
+        "repair must resume the SAME durable session, got {outcome:?}"
+    );
+
+    // The healed successor drains the carried inputs once the gate opens.
+    // A post-heal delivery rides along, as it would in the field (the fan-in
+    // source keeps delivering); it also guarantees the fresh member's loop is
+    // engaged for the machine-level re-admissions.
+    gate_tx.send(true).expect("open gate");
+    harness
+        .bridge
+        .deliver(
+            &harness.runtime_id,
+            &meerkat_core::ContentInput::Text("post-heal ping".to_string()),
+        )
+        .await
+        .expect("post-heal delivery");
+    eprintln!("PHASE: post-heal ping delivered");
+    wait_until(
+        "the healed successor to drain the carried inputs",
+        Duration::from_secs(30),
+        || async {
+            SessionServiceRuntimeExt::list_active_inputs(machine, &harness.session_id)
+                .await
+                .map(|active| active.is_empty())
+                .unwrap_or(false)
+        },
+    )
+    .await;
+    let prompts = harness.prompts.lock().expect("prompt record lock").clone();
+    assert!(
+        prompts.iter().any(|prompt| prompt.contains("carried-one")),
+        "the successor must run the first carried input; ran: {prompts:?}"
+    );
+    assert!(
+        prompts.iter().any(|prompt| prompt.contains("carried-two")),
+        "the successor must run the second carried input; ran: {prompts:?}"
+    );
+    assert!(
+        !prompts
+            .iter()
+            .any(|prompt| prompt.contains("flow-step-content")),
+        "the flow-step must NOT be resurrected by the repair (its correlation \
+         is owned by the flow engine); ran: {prompts:?}"
+    );
+}
+
+/// Preconditions-first (task #48 (a)): when the session the resume retry
+/// would need is CONFIRMED absent from the composition's authoritative read
+/// view (a continuity record pointing at a vanished session — the external-
+/// row-deletion / lost-store shape), the collision arm refuses typed BEFORE
+/// any destructive step — the stale member (holding the only live copy of
+/// its state, queue included) survives untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repair_refuses_disposal_when_the_resume_source_is_confirmed_absent() {
+    // Gate closed: the member's queued work must stay pending through the
+    // refused repair.
+    let (gate_tx, gate_rx) = watch::channel(false);
+    let harness = build_harness(gate_rx).await;
+    let machine = harness.machine.as_ref();
+
+    SessionServiceRuntimeExt::accept_input(
+        machine,
+        &harness.session_id,
+        prompt_input("only-live-copy"),
+    )
+    .await
+    .expect("queued input");
+    let queued_before = SessionServiceRuntimeExt::list_active_inputs(machine, &harness.session_id)
+        .await
+        .expect("queue readable");
+    assert!(
+        !queued_before.is_empty(),
+        "the member must hold queued work"
+    );
+    let members_before = harness.mob_handle.list_all_members().await.len();
+    assert_eq!(members_before, 1, "exactly the worker member exists");
+
+    // A resume target the service has never seen: the continuity-record-
+    // points-at-a-vanished-session shape.
+    let vanished_session = meerkat_core::types::SessionId::new();
+    let error = harness
+        .bridge
+        .resume_session(
+            &harness.identity,
+            &harness.runtime_id,
+            &harness.spec,
+            &empty_draft(&harness.spec),
+            &vanished_session,
+            &SessionSnapshot { data: Vec::new() },
+        )
+        .await
+        .expect_err("repair must refuse disposal without a resume source");
+    match &error {
+        BridgeError::ResumeRejected { detail, .. } => {
+            assert!(
+                detail.contains("collision retire precondition"),
+                "the refusal must name the failed precondition: {detail}"
+            );
+        }
+        other => panic!("expected a typed ResumeRejected, got {other:?}"),
+    }
+
+    // No destructive step ran: the member and its queue are untouched.
+    assert_eq!(
+        harness.mob_handle.list_all_members().await.len(),
+        members_before,
+        "the stale member must survive a precondition-refused repair"
+    );
+    let queued_after = SessionServiceRuntimeExt::list_active_inputs(machine, &harness.session_id)
+        .await
+        .expect("queue still readable");
+    assert_eq!(
+        queued_after, queued_before,
+        "the queued inputs must survive a precondition-refused repair"
+    );
+    drop(gate_tx);
+}

--- a/meerkat-mobkit/tests/repair_queue_carry.rs
+++ b/meerkat-mobkit/tests/repair_queue_carry.rs
@@ -42,7 +42,9 @@ use meerkat_runtime::SessionServiceRuntimeExt;
 use tokio::sync::watch;
 
 /// Deterministic LLM whose stream blocks until the shared gate opens, and
-/// which records the last request message of every turn it is asked to run.
+/// which records EVERY message of every request it is asked to run (carried
+/// inputs may be batched with a later delivery into ONE turn, so recording
+/// only the last message would hide them from the assertions).
 /// Closed gate = the OB3 wedge shape (a turn parked inside the provider
 /// stream while fan-in piles up behind it).
 struct GatedRecordingClient {
@@ -60,10 +62,12 @@ impl LlmClient for GatedRecordingClient {
     }
 
     fn stream<'a>(&'a self, request: &'a LlmRequest) -> LlmStream<'a> {
-        self.prompts
-            .lock()
-            .expect("prompt record lock")
-            .push(format!("{:?}", request.messages.last()));
+        {
+            let mut prompts = self.prompts.lock().expect("prompt record lock");
+            for message in &request.messages {
+                prompts.push(format!("{message:?}"));
+            }
+        }
         let mut gate = self.gate.clone();
         let text = futures::stream::once(async move {
             while !*gate.borrow() {
@@ -394,9 +398,12 @@ async fn repair_carries_queued_inputs_to_the_healed_successor() {
     let pending = SessionServiceRuntimeExt::list_active_inputs(machine, &harness.session_id)
         .await
         .expect("pending queue readable");
+    // Whether the mid-run (wedged) input is itself listed as active varies
+    // with the runtime version; the substance this pin needs is the three
+    // QUEUED inputs piled behind the wedge.
     assert!(
-        pending.len() >= 4,
-        "the wedge must hold the running turn plus three queued inputs, got {}",
+        pending.len() >= 3,
+        "the wedge must hold at least the three queued inputs, got {}",
         pending.len()
     );
 

--- a/meerkat-mobkit/tests/studio_k_asks.rs
+++ b/meerkat-mobkit/tests/studio_k_asks.rs
@@ -355,14 +355,6 @@ comms = true
 /// substrate attached, retire and respawn of NEVER-RAN members succeed:
 /// the ask-20 failure class is unreachable by construction.
 #[tokio::test]
-#[ignore = "upstream meerkat-mob actor defect family (S4; lead decision 2026-08-01): \
-            retire/respawn of idle members hangs INTERMITTENTLY on the same actor \
-            paths as S2/S3. Run records: hung >8m inside the withdrawn-candidate \
-            full-suite run (2026-07-31, killed with the torn suite); PASSED solo \
-            once (0.97s, 2026-08-01 gate lane); hung solo again for 3181s until \
-            SIGTERM (2026-08-01 successor gate lane, quiet machine). Admin-path \
-            operation exercised by neither fleet's acceptance flow; filed with the \
-            S2/S3 upstream report. Re-arm on the upstream fix SHA."]
 async fn studio_k0_identity_first_gateway_retire_respawn_succeed_on_idle_members() {
     use meerkat_mobkit::identity_first::{
         AgentRuntimeServices, DurabilityPolicy, IdentityFirstRuntimeContext, IdentityRuntime,

--- a/mobkit-store-conformance/Cargo.toml
+++ b/mobkit-store-conformance/Cargo.toml
@@ -19,14 +19,14 @@ workspace = true
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
-meerkat-core = "=0.8.12"
+meerkat-core = "=0.8.14"
 # The one-remote-bundle reference provider (M4b) implements both levels of
 # the composite seam: meerkat's RealmStorageProvider (facade storage_provider
 # module + in-memory store implementations) next to MobKit's realm store set.
-meerkat = { version = "=0.8.12", features = ["session-store", "memory-store"] }
-meerkat-runtime = "=0.8.12"
-meerkat-store = { version = "=0.8.12", features = ["memory"] }
-meerkat-store-conformance = "=0.8.12"
+meerkat = { version = "=0.8.14", features = ["session-store", "memory-store"] }
+meerkat-runtime = "=0.8.14"
+meerkat-store = { version = "=0.8.14", features = ["memory"] }
+meerkat-store-conformance = "=0.8.14"
 meerkat-mobkit = { path = "../meerkat-mobkit" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"

--- a/mobkit-store-conformance/Cargo.toml
+++ b/mobkit-store-conformance/Cargo.toml
@@ -19,14 +19,14 @@ workspace = true
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
-meerkat-core = "=0.8.11"
+meerkat-core = "=0.8.12"
 # The one-remote-bundle reference provider (M4b) implements both levels of
 # the composite seam: meerkat's RealmStorageProvider (facade storage_provider
 # module + in-memory store implementations) next to MobKit's realm store set.
-meerkat = { version = "=0.8.11", features = ["session-store", "memory-store"] }
-meerkat-runtime = "=0.8.11"
-meerkat-store = { version = "=0.8.11", features = ["memory"] }
-meerkat-store-conformance = "=0.8.11"
+meerkat = { version = "=0.8.12", features = ["session-store", "memory-store"] }
+meerkat-runtime = "=0.8.12"
+meerkat-store = { version = "=0.8.12", features = ["memory"] }
+meerkat-store-conformance = "=0.8.12"
 meerkat-mobkit = { path = "../meerkat-mobkit" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

Repin to published meerkat =0.8.14 (retire quiesce-ordering hotfix; tag 3c93687801e3543c443e617fbf2ffc3713828088, 41/41 crates verified on crates.io) and ship the 0.8.10 fix set:

- **Continuity repair no longer destroys queued member work** (OB3 field runs 33758a41 + 6bb7010e). Pre-disposal capture of pending machine ingress at all three repair disposal sites, re-admission into the healed successor (fresh input identity, admission order preserved); uncarryable classes (flow-step, runtime-internal, payload-less) destroyed LOUDLY per item.
- **Preconditions-first collision retire** via durable NON-ACTOR authority (continuity-store row, else session_known_to_archive_authority). The actor-routed probe self-deadlocked on the wedged member being repaired (proven live at the 0.8.13 repin). Confirmed-absent resume source refuses typed with zero destructive steps.
- **Bounded non-identical retries**: three consecutive byte-identical repair failures park the identity typed instead of re-executing destructive dispose steps on a timer.
- S2/S3/S4 permanently re-armed (fixed by meerkat 0.8.12 actor-cleanup family).
- Task #21 two-boot zero-repairs assert in the released-realm upgrade drive lane.
- CI timing-honesty carryovers from the 0.8.9 endgame.

## Validation

- Full gate on the exact candidate tree at =0.8.14: **2188/2188** nextest, clippy `--all-targets -D warnings` clean, full pre-push battery.
- **HomeCore drill: BINDING PASS** (exact-SHA gateway, production-lineage 17-identity corpus, two boots, 17/17 active, zero broken, idle CPU in budget).
- OB3 final-pin battery + production proof: in flight (binding; release gates on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)