### PR TITLE
chore: complete the 0.8.12 version parity set

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "meerkat_mobkit",
-    version = "0.8.11",
+    version = "0.8.12",
 )
 
 bazel_dep(name = "rules_rust", version = "0.70.0")

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -10,7 +10,7 @@ icon: "rocket"
   <Tab title="Rust crate">
     ```toml Cargo.toml
     [dependencies]
-    meerkat-mobkit = "0.8.11"
+    meerkat-mobkit = "0.8.12"
     tokio = { version = "1", features = ["full"] }
     ```
   </Tab>

--- a/docs/sdks/rust.mdx
+++ b/docs/sdks/rust.mdx
@@ -10,7 +10,7 @@ The Rust crate `meerkat-mobkit` is the primary interface for MobKit. All other i
 
 ```toml Cargo.toml
 [dependencies]
-meerkat-mobkit = "0.8.11"
+meerkat-mobkit = "0.8.12"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -56,7 +56,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -103,7 +103,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -157,7 +157,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -201,7 +201,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "distiller-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -245,7 +245,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -289,7 +289,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "hygienist-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -333,7 +333,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -377,7 +377,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -421,7 +421,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mobkit_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -465,7 +465,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -509,7 +509,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "selector-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -553,7 +553,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "steward-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -611,7 +611,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -679,7 +679,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "agent_events_identity_resolution",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -747,7 +747,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -820,7 +820,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -889,7 +889,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -957,7 +957,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1025,7 +1025,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "classic_agent_memory",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1093,7 +1093,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1160,7 +1160,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1228,7 +1228,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1298,7 +1298,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1366,7 +1366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1434,7 +1434,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1502,7 +1502,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1570,7 +1570,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1638,7 +1638,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "distiller_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1709,7 +1709,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1777,7 +1777,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1848,7 +1848,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "edge_wiring_reconcile",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1916,7 +1916,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1986,7 +1986,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2054,7 +2054,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "gateway_concurrent_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2122,7 +2122,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2190,7 +2190,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "gateway_live",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2257,7 +2257,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2327,7 +2327,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2399,7 +2399,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2469,7 +2469,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2537,7 +2537,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2605,7 +2605,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "hygienist_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2676,7 +2676,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2744,7 +2744,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2812,7 +2812,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2880,7 +2880,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_cold_restart_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2948,7 +2948,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_completion_cursor",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3016,7 +3016,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3084,7 +3084,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3151,7 +3151,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_head_canonical_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3221,7 +3221,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3292,7 +3292,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_lazy_recall_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3362,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3433,7 +3433,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_respawn_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3501,7 +3501,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_resume_pair_coherence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3569,7 +3569,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3640,7 +3640,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_subprocess_reboot",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3710,7 +3710,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3778,7 +3778,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "idle_cpu_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3846,7 +3846,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3914,7 +3914,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "judgment_plane_deweld",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3982,7 +3982,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4050,7 +4050,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4118,7 +4118,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4186,7 +4186,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4254,7 +4254,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4322,7 +4322,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4390,7 +4390,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4462,7 +4462,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "memory_comms_taint_contract",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4530,7 +4530,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "memory_dispatch_taint",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4598,7 +4598,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4666,7 +4666,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4734,7 +4734,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4802,7 +4802,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4870,7 +4870,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4938,7 +4938,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5006,7 +5006,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5074,7 +5074,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "mobkit_gateway_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5146,7 +5146,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5214,7 +5214,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5285,7 +5285,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "released_realm_upgrade_drive",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5355,7 +5355,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "repair_queue_carry",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5423,7 +5423,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5494,7 +5494,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5562,7 +5562,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5630,7 +5630,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5698,7 +5698,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "schedule_store_text_carry",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5766,7 +5766,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5837,7 +5837,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5908,7 +5908,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "selector_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5979,7 +5979,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "session_compaction_wiring",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6048,7 +6048,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6116,7 +6116,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6184,7 +6184,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6252,7 +6252,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "steward_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6323,7 +6323,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "storage_doctor_gateway",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6391,7 +6391,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "storage_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6461,7 +6461,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "storage_health_gateway",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6529,7 +6529,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "storage_layout_boot",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6601,7 +6601,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "storage_migrate_cli",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6671,7 +6671,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "storage_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6739,7 +6739,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "studio_k_asks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6807,7 +6807,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6878,7 +6878,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6946,7 +6946,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "topology_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7016,7 +7016,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7084,7 +7084,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7156,7 +7156,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "workgraph_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7223,7 +7223,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.11",
+        "CARGO_PKG_VERSION": "0.8.12",
         "CARGO_BIN_NAME": "workgraph_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.8.11"
+version = "0.8.12"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release-gate fix: full SDK/Bazel/docs version parity for v0.8.12. verify-version-parity green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)