### PR TITLE
MobKit 0.8.14: meerkat 0.8.20 direct pairing - accretion fixes, mobkit-repair, resume signal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           # release runner wants the predictable ./target path.) rpc_gateway is the
           # SDK stdin-RPC gateway; mobkit_gateway is the console/HTTP one — SDK
           # users need rpc_gateway, so both ship.
-          cargo build -p meerkat-mobkit --bin mobkit_gateway --bin rpc_gateway \
+          cargo build -p meerkat-mobkit --bin mobkit_gateway --bin rpc_gateway --bin mobkit_repair \
             --release --target "${{ matrix.target }}"
 
       - name: Ad-hoc codesign macOS binaries
@@ -189,7 +189,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for bin in mobkit_gateway rpc_gateway; do
+          for bin in mobkit_gateway rpc_gateway mobkit_repair; do
             codesign --force --sign - "target/${{ matrix.target }}/release/${bin}"
           done
 
@@ -204,7 +204,7 @@ jobs:
           VERSION="${VERSION#v}"; VERSION="${VERSION//\//-}"
           mkdir -p dist
           # cargo bin name -> published archive prefix
-          BINS=("mobkit_gateway:mobkit-gateway" "rpc_gateway:mobkit-rpc-gateway")
+          BINS=("mobkit_gateway:mobkit-gateway" "rpc_gateway:mobkit-rpc-gateway" "mobkit_repair:mobkit-repair")
           for entry in "${BINS[@]}"; do
             bin="${entry%%:*}"; prefix="${entry##*:}"
             if [[ "${RUNNER_OS}" == "Windows" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.8.13] - 2026-08-06
 
-Paired release on meerkat 0.8.18 (burst-wake FIFO fix, preserving_live
-audited-history acceptance, and the first-wake interaction-threaded
-steer-content fix). Field-driven: every fix below was drilled against
-HomeCore's byte-exact window-4 evidence or OB3's 69-board rig, and OB3
-field-accepted the 0.8.18 pairing against this exact branch.
+Paired release on meerkat 0.8.20 (the direct pairing: 0.8.19's
+resume-authoring fix and 0.8.20's singular input-lane authority ship
+together under one adoption; no intermediate 0.8.19 artifact exists).
+Field-driven: every fix below was drilled against HomeCore's byte-exact
+production corpus or OB3's 69-board rig, and the exact shipping pair
+(this tree + the 0.8.20 release tree) passed the 17-member restore gate,
+the three-boot accretion drill, and a real end-to-end member
+resurrection before tagging.
 
 ### Changed
 
-- **Paired on meerkat 0.8.18.** All meerkat crates repin to the published
-  0.8.18 line (both workspace pin sites). This pairing is MANDATORY: the
-  cold-mint graph hydration below requires meerkat's preserving_live
-  audited-history acceptance (0.8.17+), and the console steer path into a
-  not-yet-resident member requires meerkat's first-wake queue-behind-
-  kickoff fix (0.8.18) - the regression pinning it
-  (steer_into_non_resident_member_delivers_content) runs live in this
-  pairing.
+- **Paired on meerkat 0.8.20.** All meerkat crates repin to the published
+  0.8.20 line (both workspace pin sites). The pairing floor is MANDATORY:
+  cold-mint graph hydration requires preserving_live audited-history
+  acceptance (0.8.17+), the first-wake steer regression requires the
+  queue-behind-kickoff fix (0.8.18+), and resumed builds author no prompt
+  rows under 0.8.19+'s resume contract - all guarded live by this
+  branch's regression suite on the exact pairing.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,9 +1811,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "meerkat"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258794374a088f74bdc8393aed1f40121df0ddbf18a1d36432b2762d11010790"
+checksum = "9aad6af2526ed3edfcdb2a4bf2100620401a5198178984c58d0677f678e82f0b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-anthropic"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c243dc9f2bf99c9a2ba71e8fac28d457f654bcddc9ca5a113a2ba68e2d80eb98"
+checksum = "856f92e66aa2c882fca4a4896043b17a2ed5f45cacddb223a2b48f7545309a9d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1879,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-auth-core"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735300d366d40d0987f4a232c35a102962240367b64da5d1309d92998f906fa7"
+checksum = "42e099da67e7667a67177031ba12626394bb2c3981f11ee023ab903eb3888840"
 dependencies = [
  "async-trait",
  "axum",
@@ -1912,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-capabilities"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b33bbb915bc711259d7d184144e0cd687e2168b3b4a236f386c123a532777d"
+checksum = "9c060918767b0e9bf0e1fd3cf4281d1f2b7257ee08144215eb7ab4e55b349ada"
 dependencies = [
  "inventory",
  "meerkat-core",
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-client"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5207d91f14d5287d42231babe3881c3243cd29f387e005acdcfa22ebec9c99b7"
+checksum = "606128f1ac97265a6e06fde52f63b28179d975072efa5ea3de0dbea0befe8af4"
 dependencies = [
  "meerkat-anthropic",
  "meerkat-core",
@@ -1938,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-comms"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10779424b753413dfe3691d369be0214ebb0fbbaa8196574cfcd05bf8d218a94"
+checksum = "ce3336313e525482d9e3715a7d5240f74d81574fa1b5fa2cec51e10e340d0e7c"
 dependencies = [
  "async-trait",
  "base64",
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-contracts"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bead946ab6aadf508514574e3b7912eb9bc996a48b97888f953a5fc5f56ce0"
+checksum = "11bc20dade566d92ad801bc3461eb4ce484079a4c7d3435a2775f34a6a03bf96"
 dependencies = [
  "base64",
  "chrono",
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-core"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd184a4f10be75684a351a30a9a906bfb8bab9233cc81e906ae1c5220304a564"
+checksum = "3a7985d33a483750e1f35cf3a05601914c9fc3b905a656971d76f0dac20be6de"
 dependencies = [
  "async-trait",
  "base64",
@@ -2029,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-gemini"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fc5277f774c8ea6c52798f576a6bf32f1e25aa7f7e2b4e619de279fcd10ecf"
+checksum = "359c8b92c5f54489fc72acf815dd206eb73e52b5a45e4af19bb9e2ad8db07cf6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2054,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-hooks"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75bb3eb07ef5dc4170d87ee2c4af16ca83034546cc9f931594585251259b816b"
+checksum = "8e517b56ed0ad9d61116a4242064df4171d85358fd345c5b280017df06b3e662"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2077,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-jobs"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9246b3bbda9f11da844e32423c0b24475c9e03884c955025415d91b125fb8aaa"
+checksum = "1eb6f46d2715782c20c8954c81f45e138c72997c43e2c7259ebd0554f1cf4cb7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-live"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97561ae0b952b359e6ac3ebfcea15af2bddc2ce94dcd2edc23fab1930c6d5b84"
+checksum = "e23061c66f84457d6d9545a8157bc71ea74ac55d688cc4aeb7ca26b5e13504a6"
 dependencies = [
  "async-trait",
  "axum",
@@ -2117,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-llm-core"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08694defc744972f2c9fcbef2f1223a5e18ca7c432ed80f41c7cbce1965bcf1"
+checksum = "203ab14d46e3518cd40bb4eb1d1032029bad632f40b4d317c2465c6bf0b697dd"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2143,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-derive"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4a8443800f3073e1b9cbd158ec53dcd860eb5bdfcce42322b908931e4e6974"
+checksum = "2c218e5dbe61a88b4d4f81a18547e6580af304e1a3b24e8e250095f5c9db4d45"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -2153,18 +2153,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-dsl"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f508e89d44b8e1805eaa5176b28b3c4393711e38432d87b0abd53e3f0354e559"
+checksum = "e8c51131a7722d4c822877584a1ce69411e72f9e0a69c6d5d485217800e9072e"
 dependencies = [
  "meerkat-machine-dsl-core",
 ]
 
 [[package]]
 name = "meerkat-machine-dsl-core"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e914abf2b2dbd6a8cb0d1c560146d57fb354ded4a4bf107a123feb20e0f0671c"
+checksum = "28d3891027bf3a0af8b7ac882eabab146cfda6eb4ed211852b77910f3dab10ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-kernels"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa268c1c2e4bf5f59831a1fb8a6f50acf4324c4df868cf38bca7a8d82bc1c3ff"
+checksum = "4feb4aadbd8e77dc38c50e6b93fd7d577950363cbaa26e0dd5df93a92e90eed7"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-machine-schema"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a77d505b966d641b2d25efbf7a01a98ebfca5463916dbb832d1e67758ea2ac8"
+checksum = "d2c8eb10bb8497129897d63d3914c6a4d08b1573e058863946864aed65be1556"
 dependencies = [
  "indexmap",
  "meerkat-core",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mcp"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36c86bab13e76f2c15403903661ecb3a334deb4839308f5f596789ec9ddaf6c"
+checksum = "9b85d60cb6a65f12062952e54945da796b68c689e30ec066d678036b76b9dcb1"
 dependencies = [
  "async-trait",
  "futures",
@@ -2225,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-memory"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec17ba9dc85a99738834811581dfff53c69d4223413c3c8286eb159db8040d8"
+checksum = "35745d0a170a92f09113d5bd75f3f484c9305c1f593b8440b6c04f5c443c65ff"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e679477ded7061c45b17564dc9f9c9c192062f06a67254e07377038d76cb36a0"
+checksum = "c2f0076efab66f2171bcf3386e4528986ac3be96875e746068e7b97086998054"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mob-mcp"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a8c493b567b728913ed5f6ddaec863f5909bd0a227e4e02d9abbe050de941f"
+checksum = "ad38a6e9e750bb73562d4999b4b4b9d85f9db2158fe4ecd95bf97661bce31eb1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2373,18 +2373,18 @@ dependencies = [
 
 [[package]]
 name = "meerkat-models"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158ff437aeb8aadbee2f3af595e59720fd666674818cd7bf9d8faef9098592cf"
+checksum = "09da488102a46a63f89909a0455149d0f2099c91a655720b773327e7623b9827"
 dependencies = [
  "meerkat-core",
 ]
 
 [[package]]
 name = "meerkat-openai"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d252e513cd587279320187d85df20a30a973eef25dadd448ac03734ebbcf416"
+checksum = "f221255b6089b907c34ea7320bdcb8da81813a0518d6b1a42b1512d88442ddb0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2412,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-providers"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fb8ebedd315f4bbefd1c49a74220f3df1439b1ce828e457acff3094e14ccf1"
+checksum = "bd905e98d130635e65f42483b1a4de7b4976f82dc497193cf397ceda1490004a"
 dependencies = [
  "meerkat-auth-core",
  "meerkat-llm-core",
@@ -2422,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-runtime"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f2a22984726a8157ce636d2e8753b01a30a53b153dcf34887ef03d6aeea559"
+checksum = "191b13788ed7c840a168fc0b737a23576fed98a30b5ba12b94a308014cc3e85b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2452,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-schedule"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fb5f7999c1a4f5d91700a352df31f826cf18cff1875271b44e1dd9fa1038d4"
+checksum = "9c0e0c03cf4d91728b3f2900d456abf12794c5048b24552ce069df39e48aa612"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2478,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-session"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f0d0091979cf48dc031b8730af0ca9651767be146e62aa928db49df8dcb5f8"
+checksum = "9027af43e3ce315315da0028905e5c710f742f0aef3d522e691ae62700f69a9c"
 dependencies = [
  "async-trait",
  "futures",
@@ -2504,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-skills"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8004009715cedded10e7d78ad609ee8261d2d362320939a127a704e3273ec0"
+checksum = "21eb014f57ab8d2a321feb059de0d60d98e6e5bb1c455070e28383109612af5a"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -2527,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-sqlite"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c28c6646067af5afbb9351000dac8b159d9b82fa67ef206e88812f177bad688"
+checksum = "74c24d2f62e49b4fc582089389932a938b0b1ad604f40a159bc6a82bfcae32aa"
 dependencies = [
  "rusqlite",
  "thiserror 2.0.19",
@@ -2537,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7344c6b3dc109a10311de1f9c270e270e41df213d1a3bab005a74ccf44e42d"
+checksum = "98323d46ca22b402afb83919925421b34562de94f62eff08b98246b8b3e1ccd9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2562,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-store-conformance"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed192e2eeaf49298f289f2d5e7f248bd3462ed72c347217f903409117f788b4"
+checksum = "febea6e98afe51f3f88751e241b5736f768e718e42c08b964d78bd6ab0f8b730"
 dependencies = [
  "async-trait",
  "meerkat-core",
@@ -2575,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-tools"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85409dbdc73a331b64e5ed788acee7fa2c409a4fdff0b9be3c11f0e6560ca8c4"
+checksum = "ebe9748509baf714b667fb3e0b1f680a39cbbefb81d5bb723629aac56bc4d1d0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2616,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "meerkat-workgraph"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e4217abbce84a0c8ab99a78a424927963cd77475f06afe16c5492302caecda"
+checksum = "bf0ac6d0a12cb3e35425313a88f9e93d837274056960f356ddcf66aff0edadfb"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "meerkat-mobkit"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "mobkit-store-conformance"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.8.13"
+version = "0.8.14"
 authors = ["Luka Crnkovic-Friis"]
 repository = "https://github.com/lukacf/meerkat-mobkit"
 homepage = "https://docs.rkat.ai/mobkit/introduction"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "meerkat_mobkit",
-    version = "0.8.13",
+    version = "0.8.14",
 )
 
 bazel_dep(name = "rules_rust", version = "0.70.0")

--- a/docs/proposals/seam-assessment-mobkit.md
+++ b/docs/proposals/seam-assessment-mobkit.md
@@ -1,0 +1,158 @@
+# Dual-authority seam assessment - mobkit lane
+
+**In response to** HomeCore's `dual-authority-seam-inventory.md` (their PR
+#154), at the owner's request. The meerkat lead has answered separately; this
+is the mobkit chair. Written the same week we lived incidents 1.2, 1.3, 1.4,
+1.5, 1.6 and 1.11, so the classifications below are from the trench, not the
+whiteboard.
+
+**Headline position:** the inventory's tally is correct and its minimum
+invariant should be adopted verbatim by all three parties:
+
+> No layer keeps a second copy of another layer's durable state, and no layer
+> makes a semantic ruling about a store it does not own.
+
+Both of this week's defects violated exactly that sentence, and both fixes
+consisted of restoring it (the wrapper fold stopped ruling on transcript
+authoring; the mint stopped seeding from a lagging projection). I also concur
+with the meerkat lead's projection rule: one-way, typed, observable,
+rebuildable, non-authoritative. MobKit's job below is to say, per row, which
+of its holdings are *host state* (legitimate, distinct scope) and which are
+*shadows* (to be demoted or deleted), and what that costs.
+
+---
+
+## Row-by-row (the mobkit column)
+
+### 1. Session transcript
+- **Authority:** meerkat. Not contested, and not actually dual today: the
+  mobkit continuity store is a meerkat `SessionStore` *implementation*
+  (the adapter), not a second truth.
+- **The real shadows:** (a) the WholeBlob snapshot lane - known to lag
+  (inventory 1.6), already demoted from every read path this week
+  (head-canonical-first reads; the cold mint seeds from `session_store.load`
+  and hydrates the rewrite graph as of 0.8.13). (b) `runtime.sqlite` - a
+  projection by design; the reset-reseed lane exists *because* it is
+  disposable.
+- **Ruling:** keep both demotions and make them enforceable: the
+  representation+count load traces (shipped 0.8.13) plus a `doctor` check
+  that flags any read served from the blob lane while a head row exists.
+  Classification: **mechanical, mostly already paid for.**
+- **Blast radius of finishing it:** legacy blob-canonical sessions still
+  need the fallback until the head-canonical migration deadlock (1.11) has a
+  supported crossing. That crossing is the one structural item in this row
+  and it is meerkat-store-format work; mobkit's part is refusing to invent
+  side doors around it.
+
+### 2. Schedules - the row I most want consolidated
+- **Authority:** conceded to meerkat per their assessment, **on one
+  condition that is the actual lesson of Bug C: no store may accept a write
+  that no driver drains.** Authority without the drainer is how 30
+  occurrences rotted in a store nobody read.
+- **Consolidation shape:** mobkit's firing driver becomes a client of the
+  single meerkat store (or meerkat hosts the driver outright); either way
+  `schedule.sqlite` stops being a second truth. Until that lands, the
+  fail-closed stopgap is cheap and mobkit-side: **refuse schedule writes
+  when no firing host is bound to the target store** - turning the silent
+  Bug C class into a typed refusal at write time. I will ship the stopgap
+  in 0.8.15 regardless of the consolidation schedule.
+- **Classification:** stopgap mechanical; consolidation structural
+  (store migration + driver rehoming).
+
+### 3. Mob orchestration / runtime projections
+- **Authority:** meerkat-mob for mob durable lifecycle (per their
+  assessment). MobKit's identity-first layer holds *host desired state*
+  (roster intent, identity continuity, leases) - legitimate, distinct
+  scope - plus *projections* of runtime lifecycle (`runtime_state` rows,
+  bindings) that Bug K proved can become load-bearing lies.
+- **Ruling:** adopt the owner's durable-kernel doctrine mechanically here:
+  every mobkit projection row must be rebuildable from meerkat authority at
+  boot, and boot reconciliation (not operator surgery) is the repair path.
+  The #56/#61 walks were steps; the remaining gap is an explicit
+  "reconcile projections from authority" pass replacing per-incident fixes.
+- **Classification:** structural, staged; aligns with meerkat's post-0.8.18
+  direction. This row and row 2 are my answer to question 5: **the two I
+  would least like OB3 to discover at scale** - both fail silently and both
+  scale with fleet size.
+
+### 4. Instruction/prompt semantics
+- **Authority:** meerkat, full stop. The wrapper fold was mobkit making a
+  transcript-authoring ruling it did not own; 0.8.14 removes it on resumes.
+- **Remaining debt:** on *mint* builds the wrapper still translates
+  `additional_instructions` into `SystemPromptOverride::Set` because the RPC
+  session lane lacks a native standing-instructions carrier. The complete
+  fix is to carry them as meerkat's own `additional_instructions` (the mob
+  spawn lane already does exactly this via
+  `spawn_spec.with_additional_instructions`). If `CreateSessionRequest`
+  cannot carry them today, that is a one-field meerkat ask; mobkit deletes
+  the translation the day it exists. **Mechanical.**
+
+### 5. Transcript repair
+- **Authority:** meerkat's typed rewrite door - and the 0.8.14 maintenance
+  binary is a *client* of that door, not a second implementation: it
+  composes `commit_transcript_rewrite` through the adapter, and the door's
+  guards hold on every path. What is host-owned by design (ratified by all
+  three parties this week) is the *selection policy*. The 0.8.15 live verb
+  will thread mobkit → `session/rewrite_transcript` with a proper member
+  quiesce, not reimplement rewrite semantics.
+- **Classification:** settled this week; the quiesce design is the
+  remaining structural piece and it is deliberately not being rushed.
+
+### 6. Agent memory
+- **Authority proposal:** meerkat's semantic memory is the engine; mobkit's
+  `agent_memory` RPCs + recorder are the single *host surface*; nothing
+  else writes. HomeCore's shadow tool exists because mobkit's in-turn
+  recall RPC deadlocks - that deadlock is a mobkit defect and the honest
+  first move: fix it, then the shadow (and its direct sqlite reads) can be
+  deleted by its owner. Bug D (host builder clobbering the recorder) argues
+  for the recorder being non-clobberable rather than convention-protected.
+- **Classification:** structural-lite; needs its own pass with HomeCore as
+  the consumer. I will take the deadlock as a named 0.8.15 item.
+
+### 7. Compaction / retention
+- **Authority:** meerkat. MobKit's revision retention is storage policy
+  over its own store - a distinct concern, not a copy - and the KB cap
+  living in HomeCore is evidence for meerkat's already-queued
+  context-budget/limit-degradation work, not for a mobkit holding.
+- **Classification:** no mobkit change beyond observability hooks.
+
+### 8. Live channels
+- **Authority:** meerkat for adapter capability; the 0.8.12 per-open
+  provider selection already made the binding explicit at `live_open`.
+  Residual risk is regression, not architecture. **Closed, guard with
+  tests.**
+
+---
+
+## Answers to the five questions, compressed
+
+1. **Ownership:** meerkat owns rows 1, 2, 4, 5, 7, 8; mob durable lifecycle
+   in row 3. MobKit legitimately holds: host desired state (roster/identity
+   continuity/leases), selection policy for operator repair, the host memory
+   surface, and projections - which must obey the projection rule.
+2. **Blast radius:** the two store consolidations (schedules; blob-lane
+   retirement behind the 1.11 crossing) are the only ones needing
+   migrations. Everything else is field-threading or deletion of a
+   translation.
+3. **Sequencing:** mechanical first, exactly as this week showed
+   (1.3 and 1.4 were both closed within a day of being named). Order:
+   instruction carrier (4), schedule write-refusal stopgap (2), memory
+   deadlock (6), then the structural pair (2's consolidation, 3's
+   reconciliation pass) with meerkat.
+4. **Where the seam is load-bearing:** runtime.sqlite's disposability IS the
+   recovery model - consolidating it away would remove the reset-reseed
+   lane that saved the fleet twice this week. Keep it, but as a projection
+   under the rule, never as truth.
+5. **OB3 ranking:** rows 2 and 3, for silence-at-scale. Row 6 third - the
+   shadow-tool pattern will be copied by every host that hits the deadlock.
+
+## Commitments (mobkit 0.8.15 queue unless noted)
+
+- [0.8.14, shipped] resume signal + fold removal on resumes (#62); repair
+  binary as a door-client (#63).
+- Schedule write-refusal without a bound firing host (fail-closed Bug C).
+- `additional_instructions` carried natively on the RPC session lane
+  (meerkat one-field ask if needed); delete the mint-side translation.
+- In-turn memory recall deadlock fix; recorder made non-clobberable.
+- Doctor check: blob-lane read while a head row exists = flagged.
+- Live rewrite verb through meerkat's door with a designed quiesce.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -10,7 +10,7 @@ icon: "rocket"
   <Tab title="Rust crate">
     ```toml Cargo.toml
     [dependencies]
-    meerkat-mobkit = "0.8.13"
+    meerkat-mobkit = "0.8.14"
     tokio = { version = "1", features = ["full"] }
     ```
   </Tab>

--- a/docs/sdks/rust.mdx
+++ b/docs/sdks/rust.mdx
@@ -10,7 +10,7 @@ The Rust crate `meerkat-mobkit` is the primary interface for MobKit. All other i
 
 ```toml Cargo.toml
 [dependencies]
-meerkat-mobkit = "0.8.13"
+meerkat-mobkit = "0.8.14"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -56,7 +56,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -103,7 +103,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
     tags = [
@@ -157,7 +157,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "baseline_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -201,7 +201,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "distiller-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -245,7 +245,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "governance_check",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -289,7 +289,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "hygienist-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -333,7 +333,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mcp_fixture",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -377,7 +377,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mobkit_flow_editor",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -421,8 +421,52 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mobkit_gateway",
+        "CARGO_MANIFEST_DIR": "meerkat-mobkit",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+    ),
+)
+
+rust_binary(
+    name = "mobkit_repair_bin",
+    aliases = aliases(package_name = "meerkat-mobkit"),
+    crate_name = "mobkit_repair",
+    crate_root = "src/bin/mobkit_repair.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "tests/fixtures/homecore_security_idempotency/security-head-evolution.json",
+        "tests/fixtures/v0_8_10_released_session.json",
+        "tests/fixtures/v0_8_10_zero_rewrite_supervisor_session.json",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.8.14",
+        "CARGO_BIN_NAME": "mobkit_repair",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
     proc_macro_deps = all_crate_deps(
@@ -465,7 +509,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "rpc_gateway",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -509,7 +553,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "selector-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -553,7 +597,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "steward-eval",
         "CARGO_MANIFEST_DIR": "meerkat-mobkit",
     },
@@ -611,7 +655,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "access_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -679,7 +723,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "agent_events_identity_resolution",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -747,7 +791,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "agent_lifecycle",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -820,7 +864,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "bigquery_adapter",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -889,7 +933,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "bigquery_gc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -957,7 +1001,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "builder_api",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1025,7 +1069,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "classic_agent_memory",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1093,7 +1137,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "console_customization_fixtures",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1160,7 +1204,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "console_experience",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1228,7 +1272,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "console_route_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1298,7 +1342,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "core_types_and_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1366,7 +1410,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "cross_mob_signed",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1434,7 +1478,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "cross_mob_tcp",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1502,7 +1546,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "cross_mob_uds",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1570,7 +1614,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "discovery_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1638,7 +1682,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "distiller_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1709,7 +1753,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "e2e_sdk_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1777,7 +1821,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "e2e_target_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1848,7 +1892,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "edge_wiring_reconcile",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1916,7 +1960,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "event_log_recovery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -1986,7 +2030,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "external_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2054,7 +2098,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "gateway_concurrent_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2122,7 +2166,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "gateway_external",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2190,7 +2234,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "gateway_live",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2257,7 +2301,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "gateway_memory_config",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2327,7 +2371,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "gating_policy",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2399,7 +2443,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "governance_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2469,7 +2513,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "hooks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2537,7 +2581,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "http_router",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2605,7 +2649,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "hygienist_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2676,7 +2720,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2744,7 +2788,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_builder",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2812,7 +2856,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_choke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2880,7 +2924,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_cold_restart_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -2948,7 +2992,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_completion_cursor",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3016,7 +3060,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3084,7 +3128,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3151,7 +3195,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_head_canonical_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3221,7 +3265,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_kitchen_sink",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3292,7 +3336,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_lazy_recall_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3362,7 +3406,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_ob3_smoke",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3433,7 +3477,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_respawn_continuity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3501,7 +3545,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_resume_pair_coherence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3569,7 +3613,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_runtime",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3640,7 +3684,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_subprocess_reboot",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3710,7 +3754,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "identity_first_types",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3778,7 +3822,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "idle_cpu_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3846,7 +3890,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "incident_command_center_pack",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3914,7 +3958,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "judgment_plane_deweld",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -3982,7 +4026,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "jwks_cache_and_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4050,7 +4094,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "jwt_oidc_auth",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4118,7 +4162,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "jwt_rsa",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4186,7 +4230,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "legacy_session_resume",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4254,7 +4298,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "list_flows_run_flow",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4322,7 +4366,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "list_runs",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4390,7 +4434,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mcp_boundary",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4462,7 +4506,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "memory_comms_taint_contract",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4530,7 +4574,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "memory_dispatch_taint",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4598,7 +4642,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "memory_store",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4666,7 +4710,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mob_events_cursor_persistence",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4734,7 +4778,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mob_events_ingestion",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4802,7 +4846,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mob_events_query",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4870,7 +4914,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mob_events_query_ledger",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -4938,7 +4982,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mob_events_streaming",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5006,7 +5050,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mob_run_labels",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5074,7 +5118,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "mobkit_gateway_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5146,7 +5190,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "module_restart",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5214,7 +5258,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "reference_app",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5285,7 +5329,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "released_realm_upgrade_drive",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5355,7 +5399,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "repair_queue_carry",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5423,7 +5467,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "routing_delivery",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5494,7 +5538,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "rpc_builtins",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5562,7 +5606,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "runtime_bootstrap",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5630,7 +5674,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "schedule_dispatch",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5698,7 +5742,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "schedule_store_text_carry",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5766,7 +5810,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "sdk_parity",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5837,7 +5881,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "sdk_productization",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5908,7 +5952,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "selector_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -5979,7 +6023,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "session_compaction_wiring",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6048,7 +6092,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "session_store_jsonl",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6116,7 +6160,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "shutdown_drain",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6184,7 +6228,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "sse_auth_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6252,7 +6296,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "steward_eval_harness",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6323,7 +6367,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "storage_doctor_gateway",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6391,7 +6435,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "storage_gate",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6461,7 +6505,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "storage_health_gateway",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6529,7 +6573,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "storage_layout_boot",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6601,7 +6645,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "storage_migrate_cli",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6671,7 +6715,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "storage_wire",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6739,7 +6783,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "studio_k_asks",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6807,7 +6851,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "swarm_integration",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6878,7 +6922,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "tool_event_stream_contracts",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -6946,7 +6990,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "topology_control",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7016,7 +7060,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "unified_console",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7084,7 +7128,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "wildcard_routes",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7156,7 +7200,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "workgraph_e2e",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },
@@ -7223,7 +7267,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "workgraph_rpc",
         "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
     },

--- a/meerkat-mobkit/Cargo.toml
+++ b/meerkat-mobkit/Cargo.toml
@@ -48,35 +48,35 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures = "0.3"
 fs2 = "0.4"
 object_store = { version = "0.13", features = ["fs"] }
-meerkat-core = "=0.8.18"
-meerkat-client = "=0.8.18"
-meerkat-comms = "=0.8.18"
-meerkat-contracts = "=0.8.18"
-meerkat-mob = "=0.8.18"
-meerkat-mob-mcp = "=0.8.18"
-meerkat-mcp = "=0.8.18"
-meerkat-models = "=0.8.18"
+meerkat-core = "=0.8.20"
+meerkat-client = "=0.8.20"
+meerkat-comms = "=0.8.20"
+meerkat-contracts = "=0.8.20"
+meerkat-mob = "=0.8.20"
+meerkat-mob-mcp = "=0.8.20"
+meerkat-mcp = "=0.8.20"
+meerkat-models = "=0.8.20"
 # Meerkat split session memory out of `memory-store` (which now only maps
 # to meerkat-store/memory); explicit `memory` enables need `memory-store-session`.
-meerkat = { version = "=0.8.18", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
+meerkat = { version = "=0.8.20", features = ["comms", "skills", "mcp", "memory-store", "memory-store-session", "jsonl-store", "session-store", "sqlite-store", "live", "openai-realtime"] }
 # READ-ONLY host-side access to meerkat's OWN session semantic memory for the
 # Distiller's post-compaction harvest (§8.4: `MemoryStore::search` over the
 # discard range). This reads meerkat's store; the §12 bright line governs the
 # bundled agent-memory store, which stays plain B-tree SQLite.
-meerkat-memory = "=0.8.18"
+meerkat-memory = "=0.8.20"
 # Live (realtime) member sessions: `live_wiring` hosts the projection sink,
 # the WS transport state, and the mobkit/live/* handlers on top of this crate.
-meerkat-live = "=0.8.18"
-meerkat-runtime = { version = "=0.8.18", features = ["sqlite-store", "live"] }
-meerkat-session = { version = "=0.8.18", features = ["session-store"] }
+meerkat-live = "=0.8.20"
+meerkat-runtime = { version = "=0.8.20", features = ["sqlite-store", "live"] }
+meerkat-session = { version = "=0.8.20", features = ["session-store"] }
 # Shared SQLite mechanics (storage-unification): named connection profiles,
 # the per-file migration ledger, per-operation maintenance fence guards
 # (every in-crate opener, M3), and the doctor's read-only ledger reads (M1).
-meerkat-sqlite = "=0.8.18"
+meerkat-sqlite = "=0.8.20"
 # `memory` is the parked-delta backend for pre-registration incremental
 # writes in the continuity adapter (nothing parked is ever durable).
-meerkat-store = { version = "=0.8.18", features = ["sqlite", "memory"] }
-meerkat-tools = "=0.8.18"
+meerkat-store = { version = "=0.8.20", features = ["sqlite", "memory"] }
+meerkat-tools = "=0.8.20"
 tempfile = "3"
 async-trait = "0.1"
 rusqlite = { version = "0.37", features = ["bundled"] }
@@ -133,14 +133,14 @@ futures = "0.3"
 tower = { version = "0.5", features = ["util"] }
 jsonwebtoken = "9"
 async-trait = "0.1"
-meerkat-schedule = "=0.8.18"
+meerkat-schedule = "=0.8.20"
 # `schema` feature (test-only) exposes `meerkat_mob::adaptive::layer_decision_schema()`
 # so a parity guard can assert the bundled adaptive layer-decision schema stays
 # Value-equal to meerkat's canonical one. Dev-dependency: not enabled in release
 # builds, so the production binary keeps the lean (no-schemars) meerkat-mob.
-meerkat-mob = { version = "=0.8.18", features = ["schema"] }
+meerkat-mob = { version = "=0.8.20", features = ["schema"] }
 # `test-realtime-fixtures` (test-only) exposes meerkat's shared
 # ScriptedRealtimeSessionFactory so the live-open cross-provider regression
 # tests (tests/gateway_live.rs) can observe the exact channel identity handed
 # to the provider lane without a provider socket or credential.
-meerkat = { version = "=0.8.18", features = ["test-realtime-fixtures"] }
+meerkat = { version = "=0.8.20", features = ["test-realtime-fixtures"] }

--- a/meerkat-mobkit/src/bin/mobkit_repair.rs
+++ b/meerkat-mobkit/src/bin/mobkit_repair.rs
@@ -183,7 +183,7 @@ async fn run() -> Result<i32, Box<dyn std::error::Error>> {
         std::fs::write(&path, &rendered)?;
         eprintln!("mobkit-repair: report written to {path}");
     }
-    Ok(if refused == 0 { 0 } else { 1 })
+    Ok(i32::from(refused != 0))
 }
 
 /// Repair one session through the typed rewrite door. Every failure is a

--- a/meerkat-mobkit/src/bin/mobkit_repair.rs
+++ b/meerkat-mobkit/src/bin/mobkit_repair.rs
@@ -1,0 +1,378 @@
+//! Supported operator repair for mob-member durable transcripts (task #63):
+//! drop superseded System rows from a session's durable transcript through
+//! the typed rewrite door - one full-range audited rewrite commit composed
+//! onto the retained graph, never a hand edit of store rows.
+//!
+//! Selection modes:
+//! - DEFAULT: content-equality dedup - group System rows by
+//!   (content, identity), keep the FIRST occurrence of each distinct group,
+//!   drop the rest. Compares the system CONTENT, never the serialized
+//!   envelope: each materialized copy carries its own `created_at`
+//!   (verified in the field: 12 differing bytes, all inside the timestamp),
+//!   so envelope hashing sees every copy as distinct.
+//! - `--keep-newest <N>`: recency pruning - keep only the LAST N System
+//!   rows by position, drop every earlier one. Strictly more destructive
+//!   (discards genuinely different superseded prompt versions); an explicit
+//!   operator lever, never the default.
+//!
+//! Procedure (single-writer discipline, unchanged from the field-proven
+//! window-4/5 runs):
+//!   1. STOP the gateway.
+//!   2. Back up continuity.db (byte copy).
+//!   3. Dry run:  mobkit-repair --db /path/to/continuity.db --all-sessions
+//!   4. Apply:    ... --apply
+//!   5. Remove the runtime scratch store (runtime.db file set) so the next
+//!      boot mints runtime authority from the healed durable rows (the
+//!      fleet-proven reset-reseed lane).
+//!   6. Start the gateway.
+//!
+//! Fleet passes commit PER SESSION atomically: a typed refusal on one
+//! session is recorded in the report and the pass continues, so a refusal
+//! on member 7 never strands members 8-15 in an unknown state.
+//!
+//! Output: one JSON report document on stdout (and to `--report <path>` if
+//! given); human progress goes to stderr. Exit code is 0 when every
+//! selected session ended in a non-refused outcome, 1 otherwise.
+
+use std::sync::Arc;
+
+use meerkat_mobkit::identity_first::{
+    ContinuitySessionStoreAdapter, ContinuityStore, LocalContinuityStore, SessionRuntimeState,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectionMode {
+    ContentDedup,
+    KeepNewest(usize),
+}
+
+#[derive(Debug, serde::Serialize)]
+struct SessionReport {
+    session_id: String,
+    identity: Option<String>,
+    outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    rows_before: Option<usize>,
+    rows_after: Option<usize>,
+    bytes_before: Option<usize>,
+    bytes_after: Option<usize>,
+    system_rows_before: Option<usize>,
+    system_rows_after: Option<usize>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct RepairReport {
+    mode: String,
+    applied: bool,
+    sessions: Vec<SessionReport>,
+    refused: usize,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    match run().await {
+        Ok(exit) => std::process::exit(exit),
+        Err(error) => {
+            eprintln!("mobkit-repair: {error}");
+            std::process::exit(2);
+        }
+    }
+}
+
+async fn run() -> Result<i32, Box<dyn std::error::Error>> {
+    let mut db: Option<String> = None;
+    let mut sessions: Vec<String> = Vec::new();
+    let mut all_sessions = false;
+    let mut keep_newest: Option<usize> = None;
+    let mut apply = false;
+    let mut report_path: Option<String> = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--db" => db = args.next(),
+            "--session" => {
+                sessions.push(args.next().ok_or("--session requires a value")?);
+            }
+            "--all-sessions" => all_sessions = true,
+            "--keep-newest" => {
+                let value = args.next().ok_or("--keep-newest requires a value")?;
+                let n: usize = value
+                    .parse()
+                    .map_err(|_| format!("--keep-newest must be a number: {value}"))?;
+                if n == 0 {
+                    return Err("--keep-newest must be >= 1 (a session keeps at least \
+                                its newest System row)"
+                        .into());
+                }
+                keep_newest = Some(n);
+            }
+            "--apply" => apply = true,
+            "--report" => report_path = args.next(),
+            other => return Err(format!("unknown argument: {other}").into()),
+        }
+    }
+    let db = db.ok_or("--db <continuity.db> is required")?;
+    if all_sessions && !sessions.is_empty() {
+        return Err("--all-sessions and --session are mutually exclusive".into());
+    }
+    if !all_sessions && sessions.is_empty() {
+        return Err("select sessions with --session <uuid> (repeatable) or --all-sessions".into());
+    }
+    let mode = keep_newest.map_or(SelectionMode::ContentDedup, SelectionMode::KeepNewest);
+
+    let local = Arc::new(LocalContinuityStore::open(&db)?);
+    let targets: Vec<(Option<String>, meerkat_core::types::SessionId)> = if all_sessions {
+        local
+            .list_session_bindings()
+            .await?
+            .into_iter()
+            .map(|(identity, session_id)| (Some(identity.to_string()), session_id))
+            .collect()
+    } else {
+        let mut targets = Vec::new();
+        for raw in &sessions {
+            let session_id = meerkat_core::types::SessionId::parse(raw)
+                .map_err(|e| format!("--session must be a session UUID: {e}"))?;
+            targets.push((None, session_id));
+        }
+        targets
+    };
+    if targets.is_empty() {
+        return Err("the continuity store holds no session bindings".into());
+    }
+
+    let continuity: Arc<dyn ContinuityStore> = local;
+    let mut reports = Vec::with_capacity(targets.len());
+    let mut refused = 0usize;
+    for (identity_hint, session_id) in targets {
+        eprintln!("mobkit-repair: session {session_id} ...");
+        match repair_session(&continuity, &session_id, mode, apply).await {
+            Ok(report) => reports.push(report),
+            Err(error) => {
+                refused += 1;
+                eprintln!("mobkit-repair: session {session_id} REFUSED: {error}");
+                reports.push(SessionReport {
+                    session_id: session_id.to_string(),
+                    identity: identity_hint,
+                    outcome: "refused".to_string(),
+                    detail: Some(error.to_string()),
+                    rows_before: None,
+                    rows_after: None,
+                    bytes_before: None,
+                    bytes_after: None,
+                    system_rows_before: None,
+                    system_rows_after: None,
+                });
+            }
+        }
+    }
+
+    let report = RepairReport {
+        mode: match mode {
+            SelectionMode::ContentDedup => "content_dedup".to_string(),
+            SelectionMode::KeepNewest(n) => format!("keep_newest_{n}"),
+        },
+        applied: apply,
+        sessions: reports,
+        refused,
+    };
+    let rendered = serde_json::to_string_pretty(&report)?;
+    println!("{rendered}");
+    if let Some(path) = report_path {
+        std::fs::write(&path, &rendered)?;
+        eprintln!("mobkit-repair: report written to {path}");
+    }
+    Ok(if refused == 0 { 0 } else { 1 })
+}
+
+/// Repair one session through the typed rewrite door. Every failure is a
+/// typed refusal returned to the fleet loop; the durable row is preserved
+/// by the door's own guards on every refused path.
+async fn repair_session(
+    continuity: &Arc<dyn ContinuityStore>,
+    session_id: &meerkat_core::types::SessionId,
+    mode: SelectionMode,
+    apply: bool,
+) -> Result<SessionReport, Box<dyn std::error::Error>> {
+    let adapter = Arc::new(ContinuitySessionStoreAdapter::new(Arc::clone(continuity)));
+
+    // Write authority = the durable continuity record, exactly the facts a
+    // registered resume would carry (the parked-repair contract).
+    let (record, fencing_token, fence_current) = continuity
+        .resolve_record_by_session(session_id)
+        .await?
+        .ok_or("no continuity record binds this session")?;
+    adapter
+        .register_session(
+            session_id,
+            SessionRuntimeState {
+                identity: record.identity.clone(),
+                generation: record.generation,
+                fencing_token,
+                checkpoint_version: fence_current,
+            },
+        )
+        .await?;
+
+    // Load the durable session (slim: content only), then HYDRATE the
+    // out-of-line rewrite graph from the store's own rewrite rows onto it.
+    // Slim materializations drop the compact graph by design - a rewrite
+    // committed on one composes at generation 1 and the store refuses it
+    // against the retained chain. With the store-proved graph installed the
+    // rewrite composes at the correct next generation.
+    let mut session = meerkat::SessionStore::load(adapter.as_ref(), session_id)
+        .await?
+        .ok_or("no durable row for this session")?;
+    let channel = continuity
+        .as_incremental_sessions()
+        .ok_or("the continuity store provides no incremental channel")?;
+    let rewrite_records = channel.load_rewrites(session_id).await?;
+    if let Some(validated) =
+        meerkat_core::ValidatedTranscriptHistory::from_rewrite_records_with_proved(
+            rewrite_records,
+            None,
+        )?
+    {
+        session.install_validated_audited_transcript_history_preserving_live(validated)?;
+    }
+
+    let messages = session.messages();
+    let serialized: Vec<Vec<u8>> = messages
+        .iter()
+        .map(serde_json::to_vec)
+        .collect::<Result<_, _>>()?;
+    let values: Vec<serde_json::Value> = serialized
+        .iter()
+        .map(|bytes| serde_json::from_slice(bytes))
+        .collect::<Result<_, _>>()?;
+    let is_system = |value: &serde_json::Value| -> bool {
+        value
+            .get("role")
+            .and_then(|r| r.as_str())
+            .map(|r| r == "system")
+            .unwrap_or(false)
+    };
+    let system_positions: Vec<usize> = values
+        .iter()
+        .enumerate()
+        .filter(|(_, value)| is_system(value))
+        .map(|(index, _)| index)
+        .collect();
+
+    let duplicate_indices: Vec<usize> = match mode {
+        SelectionMode::ContentDedup => {
+            // Group System rows by (content, identity), ignoring only the
+            // envelope timestamp; keep the FIRST occurrence per group.
+            let mut seen_groups: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::new();
+            let mut duplicates = Vec::new();
+            for &index in &system_positions {
+                let value = &values[index];
+                let key = serde_json::to_string(&serde_json::json!({
+                    "content": value.get("content"),
+                    "identity": value.get("identity"),
+                }))?;
+                match seen_groups.entry(key) {
+                    std::collections::hash_map::Entry::Vacant(slot) => {
+                        slot.insert(index);
+                    }
+                    std::collections::hash_map::Entry::Occupied(_) => duplicates.push(index),
+                }
+            }
+            duplicates
+        }
+        SelectionMode::KeepNewest(n) => {
+            let cut = system_positions.len().saturating_sub(n);
+            system_positions[..cut].to_vec()
+        }
+    };
+
+    let rows_before = messages.len();
+    let bytes_before: usize = serialized.iter().map(Vec::len).sum();
+    let system_before = system_positions.len();
+    if duplicate_indices.is_empty() {
+        eprintln!(
+            "mobkit-repair: session {session_id}: {system_before} System row(s), \
+             nothing to drop"
+        );
+        return Ok(SessionReport {
+            session_id: session_id.to_string(),
+            identity: Some(record.identity.to_string()),
+            outcome: "nothing_to_do".to_string(),
+            detail: None,
+            rows_before: Some(rows_before),
+            rows_after: Some(rows_before),
+            bytes_before: Some(bytes_before),
+            bytes_after: Some(bytes_before),
+            system_rows_before: Some(system_before),
+            system_rows_after: Some(system_before),
+        });
+    }
+
+    let cleaned: Vec<meerkat_core::Message> = messages
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !duplicate_indices.contains(index))
+        .map(|(_, message)| message.clone())
+        .collect();
+    let rows_after = cleaned.len();
+    let bytes_after: usize = cleaned
+        .iter()
+        .map(|m| serde_json::to_vec(m).map(|v| v.len()).unwrap_or(0))
+        .sum();
+    let system_after = system_before - duplicate_indices.len();
+    eprintln!(
+        "mobkit-repair: session {session_id}: plan {rows_before} -> {rows_after} rows, \
+         ~{bytes_before} -> ~{bytes_after} bytes, System {system_before} -> {system_after}"
+    );
+
+    if !apply {
+        return Ok(SessionReport {
+            session_id: session_id.to_string(),
+            identity: Some(record.identity.to_string()),
+            outcome: "dry_run".to_string(),
+            detail: None,
+            rows_before: Some(rows_before),
+            rows_after: Some(rows_after),
+            bytes_before: Some(bytes_before),
+            bytes_after: Some(bytes_after),
+            system_rows_before: Some(system_before),
+            system_rows_after: Some(system_after),
+        });
+    }
+
+    let parent_revision = session.transcript_revision()?;
+    let selection_end = messages.len();
+    let mut rewritten = session.clone();
+    let commit = rewritten.commit_transcript_rewrite(
+        meerkat_core::TranscriptRewriteSelection::MessageRange {
+            start: 0,
+            end: selection_end,
+        },
+        cleaned,
+        meerkat_core::TranscriptRewriteReason::new(
+            "operator prune of superseded System rows (mobkit-repair)",
+        ),
+        Some("mobkit-repair/system-rows".to_string()),
+        Some(parent_revision),
+    )?;
+    meerkat::SessionStore::save_transcript_rewrite(adapter.as_ref(), &rewritten, &commit).await?;
+    meerkat::SessionStore::save_authoritative_projection(adapter.as_ref(), &rewritten).await?;
+    eprintln!(
+        "mobkit-repair: session {session_id}: APPLIED at rewrite generation {}",
+        commit.rewrite_generation
+    );
+    Ok(SessionReport {
+        session_id: session_id.to_string(),
+        identity: Some(record.identity.to_string()),
+        outcome: "applied".to_string(),
+        detail: None,
+        rows_before: Some(rows_before),
+        rows_after: Some(rows_after),
+        bytes_before: Some(bytes_before),
+        bytes_after: Some(bytes_after),
+        system_rows_before: Some(system_before),
+        system_rows_after: Some(system_after),
+    })
+}

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -6574,19 +6574,24 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                         .get("resume_session_id")
                         .and_then(|v| v.as_str())
                         .is_some();
-                // Apply additional_instructions as system prompt extension -
-                // on MINT builds only. Folding them into an explicit
-                // SystemPromptOverride::Set on a RESUMED build made the
-                // runtime record one assembled System row per boot (the
-                // HomeCore accretion: parent-1 reached 1,294,962 tokens
-                // against a 922,000 ceiling), because an explicit Set at
-                // resume IS new transcript intent by contract. Standing
-                // instructions are per-session build state baked at mint;
-                // a deliberate mid-life change must use the typed
-                // transcript admission, not a build-time fold.
+                // Apply additional_instructions through meerkat's NATIVE
+                // standing-instructions carrier
+                // (SessionBuildOptions.additional_instructions) - on MINT
+                // builds only. The old translation folded them into an
+                // explicit SystemPromptOverride::Set, a transcript-authoring
+                // ruling this layer does not own: an explicit Set at resume
+                // IS new transcript intent by contract, so the runtime
+                // recorded one assembled System row per boot (the HomeCore
+                // accretion: parent-1 reached 1,294,962 tokens against a
+                // 922,000 ceiling). Standing instructions are per-session
+                // build state baked at mint; a deliberate mid-life change
+                // must use the typed transcript admission.
                 if let Some(instructions) = result.get("additional_instructions") {
                     if let Some(arr) = instructions.as_array() {
-                        let combined: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+                        let combined: Vec<String> = arr
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
                         if !combined.is_empty() {
                             if resumed {
                                 tracing::warn!(
@@ -6596,26 +6601,15 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                                      admission instead)"
                                 );
                             } else {
-                                let extra = combined.join("\n");
-                                use meerkat_core::config::SystemPromptOverride;
-                                modified_req.system_prompt = match &modified_req.system_prompt {
-                                    SystemPromptOverride::Set(existing) => {
-                                        SystemPromptOverride::Set(format!("{existing}\n{extra}"))
-                                    }
-                                    SystemPromptOverride::Inherit => {
-                                        SystemPromptOverride::Set(extra)
-                                    }
-                                    // An explicit Disable suppresses every prompt
-                                    // source; honor it rather than resurrecting a
-                                    // prompt from hook-supplied instructions.
-                                    SystemPromptOverride::Disable => {
-                                        tracing::warn!(
-                                            "callback/build_agent: additional_instructions \
-                                             ignored because system prompt is explicitly disabled"
-                                        );
-                                        SystemPromptOverride::Disable
-                                    }
-                                };
+                                let build = modified_req.build.get_or_insert_with(|| {
+                                    meerkat_core::service::SessionBuildOptions::default()
+                                });
+                                // Merge, preserving instructions another
+                                // customizer already installed.
+                                build
+                                    .additional_instructions
+                                    .get_or_insert_with(Vec::new)
+                                    .extend(combined);
                             }
                         }
                     }

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -1310,6 +1310,60 @@ actions = ["agent.view"]
         assert_eq!(options.max_sessions, 320);
     }
 
+    /// Task #62 (HomeCore field ask): the build callback must carry the
+    /// mint-vs-resume signal so a host can append standing instructions on
+    /// MINT and inherit on RESUME. Measured field gap: both boots printed
+    /// session_id=None resume_session_id=None, so every host composing
+    /// instructions in build_agent silently accreted one durable System row
+    /// per boot.
+    #[test]
+    fn callback_build_agent_options_carry_resume_session_identity() {
+        let resumed_session = meerkat_core::Session::new();
+        let resumed_id = resumed_session.id().to_string();
+        let build = meerkat_core::service::SessionBuildOptions {
+            resume_session: Some(resumed_session),
+            ..Default::default()
+        };
+        let req = CreateSessionRequest {
+            model: "m".to_string(),
+            prompt: meerkat_core::ContentInput::Text("noop".to_string()),
+            system_prompt: meerkat_core::config::SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            build: Some(build),
+            labels: None,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
+        };
+
+        let options = callback_build_agent_options(&req, "build-test");
+        assert_eq!(options["resume_session_id"], resumed_id.as_str());
+        assert_eq!(
+            options["session_id"],
+            resumed_id.as_str(),
+            "session identity falls back to the resumed session when labels lack it"
+        );
+
+        let mint_req = CreateSessionRequest {
+            model: "m".to_string(),
+            prompt: meerkat_core::ContentInput::Text("noop".to_string()),
+            system_prompt: meerkat_core::config::SystemPromptOverride::Inherit,
+            max_tokens: None,
+            event_tx: None,
+            initial_turn: meerkat_core::service::InitialTurnPolicy::Defer,
+            build: None,
+            labels: None,
+            deferred_prompt_policy: meerkat_core::service::DeferredPromptPolicy::default(),
+            injected_context: Vec::new(),
+        };
+        let mint_options = callback_build_agent_options(&mint_req, "build-test");
+        assert!(
+            mint_options["resume_session_id"].is_null(),
+            "a mint build carries no resume identity"
+        );
+    }
+
     #[test]
     fn callback_build_agent_options_include_profile_name_from_spawn_labels() {
         let build = meerkat_core::service::SessionBuildOptions {
@@ -6408,15 +6462,31 @@ fn callback_build_agent_options(req: &CreateSessionRequest, scope_id: &str) -> V
             request_labels
                 .and_then(|labels| labels.get("profile_name").or_else(|| labels.get("role")))
         });
+    // Mint-vs-resume signal (task #62, HomeCore field ask 2026-08-06): a
+    // spawn-level resume is known here via `build.resume_session`, so the
+    // host can honor the System-message contract (append standing
+    // instructions on MINT, inherit on RESUME) instead of inferring
+    // platform state from its own continuity store. `session_id` keeps its
+    // label-sourced semantics but falls back to the resumed session's id,
+    // which is the identity the older restore-path complaint was missing.
+    let resume_session_id = req
+        .build
+        .as_ref()
+        .and_then(|b| b.resume_session.as_ref())
+        .map(|s| s.id().to_string());
     json!({
         "scope_id": scope_id,
-        "session_id": labels.as_ref().and_then(|l| l.get("session_id")),
+        "session_id": labels
+            .as_ref()
+            .and_then(|l| l.get("session_id").cloned())
+            .or_else(|| resume_session_id.clone()),
         "profile_name": profile_name,
         "model": &req.model,
         "prompt": &req.prompt,
         "labels": &labels,
         "app_context": req.build.as_ref()
             .and_then(|b| b.app_context.as_ref()),
+        "resume_session_id": resume_session_id,
     })
 }
 
@@ -6490,29 +6560,63 @@ impl SessionAgentBuilder for StdioCallbackAgentBuilder {
                     deferred_prompt_policy: req.deferred_prompt_policy,
                     injected_context: req.injected_context.clone(),
                 };
-                // Apply additional_instructions as system prompt extension
+                // Resume-ness decides the instruction fold below, so resolve
+                // it FIRST: a resume can arrive spawn-level
+                // (build.resume_session already loaded) or be requested by
+                // the Python response (resume_session_id, applied further
+                // down) - both shapes must suppress the fold.
+                let resumed = modified_req
+                    .build
+                    .as_ref()
+                    .and_then(|b| b.resume_session.as_ref())
+                    .is_some()
+                    || result
+                        .get("resume_session_id")
+                        .and_then(|v| v.as_str())
+                        .is_some();
+                // Apply additional_instructions as system prompt extension -
+                // on MINT builds only. Folding them into an explicit
+                // SystemPromptOverride::Set on a RESUMED build made the
+                // runtime record one assembled System row per boot (the
+                // HomeCore accretion: parent-1 reached 1,294,962 tokens
+                // against a 922,000 ceiling), because an explicit Set at
+                // resume IS new transcript intent by contract. Standing
+                // instructions are per-session build state baked at mint;
+                // a deliberate mid-life change must use the typed
+                // transcript admission, not a build-time fold.
                 if let Some(instructions) = result.get("additional_instructions") {
                     if let Some(arr) = instructions.as_array() {
                         let combined: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
                         if !combined.is_empty() {
-                            let extra = combined.join("\n");
-                            use meerkat_core::config::SystemPromptOverride;
-                            modified_req.system_prompt = match &modified_req.system_prompt {
-                                SystemPromptOverride::Set(existing) => {
-                                    SystemPromptOverride::Set(format!("{existing}\n{extra}"))
-                                }
-                                SystemPromptOverride::Inherit => SystemPromptOverride::Set(extra),
-                                // An explicit Disable suppresses every prompt
-                                // source; honor it rather than resurrecting a
-                                // prompt from hook-supplied instructions.
-                                SystemPromptOverride::Disable => {
-                                    tracing::warn!(
-                                        "callback/build_agent: additional_instructions ignored \
-                                         because system prompt is explicitly disabled"
-                                    );
-                                    SystemPromptOverride::Disable
-                                }
-                            };
+                            if resumed {
+                                tracing::warn!(
+                                    "callback/build_agent: additional_instructions ignored on a \
+                                     RESUMED build (resume inherits persisted prompt state; \
+                                     append deliberate System content through the typed \
+                                     admission instead)"
+                                );
+                            } else {
+                                let extra = combined.join("\n");
+                                use meerkat_core::config::SystemPromptOverride;
+                                modified_req.system_prompt = match &modified_req.system_prompt {
+                                    SystemPromptOverride::Set(existing) => {
+                                        SystemPromptOverride::Set(format!("{existing}\n{extra}"))
+                                    }
+                                    SystemPromptOverride::Inherit => {
+                                        SystemPromptOverride::Set(extra)
+                                    }
+                                    // An explicit Disable suppresses every prompt
+                                    // source; honor it rather than resurrecting a
+                                    // prompt from hook-supplied instructions.
+                                    SystemPromptOverride::Disable => {
+                                        tracing::warn!(
+                                            "callback/build_agent: additional_instructions \
+                                             ignored because system prompt is explicitly disabled"
+                                        );
+                                        SystemPromptOverride::Disable
+                                    }
+                                };
+                            }
                         }
                     }
                 }

--- a/meerkat-mobkit/src/identity_first/local_store.rs
+++ b/meerkat-mobkit/src/identity_first/local_store.rs
@@ -2719,6 +2719,50 @@ impl ContinuityStore for LocalContinuityStore {
 // ---------------------------------------------------------------------------
 
 impl LocalContinuityStore {
+    /// Read-only enumeration of every durable identity → session binding.
+    ///
+    /// Operator-maintenance surface (task #63): the repair binary's
+    /// `--all-sessions` pass needs the fleet's bindings without knowing
+    /// identities up front; each binding then goes through the ordinary
+    /// per-session [`ContinuityStore::resolve_record_by_session`] path, so
+    /// this adds no new write or trust surface.
+    pub async fn list_session_bindings(
+        &self,
+    ) -> Result<Vec<(AgentIdentity, meerkat_core::types::SessionId)>, ContinuityStoreError> {
+        self.run_blocking("list_session_bindings", move |inner| {
+            inner.with_reader(|connection| {
+                let mut stmt = connection
+                    .prepare_cached(
+                        "SELECT identity, session_id FROM continuity_records ORDER BY identity",
+                    )
+                    .map_err(|e| sqlite_err("prepare", e))?;
+                let rows = stmt
+                    .query_map([], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    })
+                    .map_err(|e| sqlite_err("query", e))?;
+                let mut bindings = Vec::new();
+                for row in rows {
+                    let (identity, session_id) = row.map_err(|e| sqlite_err("row", e))?;
+                    bindings.push((
+                        AgentIdentity::parse(&identity).map_err(|e| {
+                            ContinuityStoreError::Corruption(format!(
+                                "invalid identity in store: {e}"
+                            ))
+                        })?,
+                        meerkat_core::types::SessionId::parse(&session_id).map_err(|e| {
+                            ContinuityStoreError::Corruption(format!(
+                                "invalid session id in store: {e}"
+                            ))
+                        })?,
+                    ));
+                }
+                Ok(bindings)
+            })
+        })
+        .await
+    }
+
     /// Run one delta mutation inside ONE writer transaction that enforces
     /// and advances the continuity cursor — and, on a file that does not
     /// carry the head-canonical channel yet, converges the schema and arms

--- a/meerkat-mobkit/tests/identity_first_lazy_recall_continuity.rs
+++ b/meerkat-mobkit/tests/identity_first_lazy_recall_continuity.rs
@@ -383,6 +383,50 @@ fn continuity_db(state: &Path) -> std::path::PathBuf {
         .path
 }
 
+/// The lazy-recall mob with a PROFILE-declared system prompt - the one
+/// configuration shape proven (HomeCore/OB3 field contrast, 2026-08-06) to
+/// re-author one assembled System row per automatic revival on the
+/// 0.8.16-0.8.18 line: the assembled prompt lands in persisted spawn state
+/// at original spawn and the mob-resume AppendExplicit branches re-lower it
+/// as fresh explicit intent on every boot.
+const PROFILE_PROMPT_MOB_TOML: &str = r#"
+[mob]
+id = "lazy-recall-continuity"
+
+[profiles.personal]
+model = "gpt-5.5"
+external_addressable = true
+runtime_mode = "turn_driven"
+system_prompt = "PROFILE-PROMPT-MARKER-16-YANKEE: you are alice."
+
+[profiles.personal.tools]
+comms = true
+"#;
+
+/// `boot` with an explicit definition and NO agent customizer, so a
+/// profile-declared prompt is the only prompt source in play.
+async fn boot_with_definition_no_customizer(
+    state: &Path,
+    capture: CaptureClient,
+    mode: IdentityBootstrapMode,
+    definition: MobDefinition,
+) -> meerkat_mobkit::UnifiedRuntime {
+    let builder = UnifiedRuntimeBuilder::default()
+        .definition(definition)
+        .persistent_state(state)
+        .continuity_from_state_dir(state)
+        .await
+        .expect("open the state-dir identity substrate")
+        .roster_provider(Arc::new(OneMemberRoster))
+        .identity_bootstrap_mode(mode)
+        .identity_runtime_instance_id(RUNTIME_INSTANCE)
+        .comms(true)
+        .default_llm_client(Arc::new(capture));
+    Box::pin(builder.build())
+        .await
+        .expect("build the gateway-shaped UnifiedRuntime")
+}
+
 // ---------------------------------------------------------------------------
 // Precondition probe
 // ---------------------------------------------------------------------------
@@ -2819,6 +2863,156 @@ async fn steer_into_non_resident_member_delivers_content() {
              (identity persisted, content empty); request: {last}"
         );
         runtime.shutdown().await;
+    }
+}
+
+/// Profile-prompt revival hygiene (0.8.19 pairing prep, 2026-08-06): a
+/// member whose PROFILE declares a system_prompt, booted repeatedly with a
+/// turn each - automatic rematerialization must author NOTHING beyond each
+/// turn's own messages. MEASURED FINDING: this is ALREADY GREEN on the
+/// 0.8.18 pairing - the identity-first lazy revival and the cold-mint
+/// recovery lane both take PreservePersisted paths (host_materialize) and
+/// do not mint. The field defect (HomeCore parent-1: one assembled row per
+/// boot, 263 copies) therefore lives in resume paths this harness does not
+/// traverse (the mob actor resume AppendExplicit branches, reached through
+/// the gateway's bridge session lanes). This test pins the clean lanes as
+/// STAYING clean across the 0.8.19 contract change (resumed builds force
+/// Inherit); the minting lane needs its own regression at the call site
+/// the meerkat lead's inspection confirms.
+#[tokio::test(flavor = "multi_thread")]
+async fn profile_prompt_revival_authors_no_system_rows() {
+    if proxied_to_memo_free_child("profile_prompt_revival_authors_no_system_rows") {
+        return;
+    }
+    let _serial = SERIAL_WINDOW.lock().await;
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let state = temp.path().join("state");
+    let member = id(MEMBER);
+    let definition = || {
+        MobDefinition::from_toml(PROFILE_PROMPT_MOB_TOML)
+            .expect("parse profile-prompt mob definition")
+    };
+
+    // Boot 1: original spawn (the assembled prompt lands in persisted
+    // spawn state here) plus one turn.
+    let session_id;
+    let mut durable_count;
+    {
+        let capture = CaptureClient::default();
+        let runtime = boot_with_definition_no_customizer(
+            &state,
+            capture.clone(),
+            IdentityBootstrapMode::LazyMaterialize,
+            definition(),
+        )
+        .await;
+        let identity_runtime = runtime
+            .identity_runtime()
+            .expect("identity runtime")
+            .clone();
+        identity_runtime
+            .send(
+                &member,
+                &meerkat_core::ContentInput::Text("boot 1 turn".to_string()),
+            )
+            .await
+            .expect("boot 1's turn");
+        wait_for_turn(&capture, 1, "boot 1's turn").await;
+        runtime.shutdown().await;
+        let (head, count) = wait_for_durable_document_at_least(&state, 2, "boot 1's commit").await;
+        session_id = head;
+        durable_count = count;
+    }
+
+    // Boots 2 and 3: pure revivals. Any durable growth beyond the turn's
+    // own two messages is revival-authored configuration - the defect.
+    for boot_no in 2i64..=3 {
+        let capture = CaptureClient::default();
+        let runtime = boot_with_definition_no_customizer(
+            &state,
+            capture.clone(),
+            IdentityBootstrapMode::LazyMaterialize,
+            definition(),
+        )
+        .await;
+        let identity_runtime = runtime
+            .identity_runtime()
+            .expect("identity runtime")
+            .clone();
+        identity_runtime
+            .send(
+                &member,
+                &meerkat_core::ContentInput::Text(format!("boot {boot_no} turn")),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("boot {boot_no}'s turn must not be refused: {e}"));
+        wait_for_turn(&capture, 1, "a revival boot's turn").await;
+        wait_for_durable_document_at_least(
+            &state,
+            durable_count + 2,
+            "a revival boot's boundary commit",
+        )
+        .await;
+        runtime.shutdown().await;
+        let (head, count) =
+            wait_for_durable_document_at_least(&state, 0, "the quiescent post-boot document").await;
+        assert_eq!(head, session_id, "revivals must extend the same session");
+        assert_eq!(
+            count,
+            durable_count + 2,
+            "boot {boot_no} authored {} extra durable row(s): automatic rematerialization \
+             re-authored persisted prompt configuration as fresh System input",
+            count - durable_count - 2
+        );
+        durable_count = count;
+    }
+
+    // Sanctioned recovery lane under the same contract: runtime-store
+    // reset, cold mint, one more turn.
+    let mut removed = 0;
+    for suffix in ["", "-wal", "-shm", ".mfence"] {
+        let path = state.join(format!(
+            "{}{suffix}",
+            meerkat_mobkit::storage_layout::RUNTIME_DB_FILE_NAME
+        ));
+        if path.exists() {
+            std::fs::remove_file(&path).expect("reset runtime store");
+            removed += 1;
+        }
+    }
+    assert!(
+        removed > 0,
+        "the persistent shape must have written runtime.sqlite"
+    );
+    {
+        let capture = CaptureClient::default();
+        let runtime = boot_with_definition_no_customizer(
+            &state,
+            capture.clone(),
+            IdentityBootstrapMode::LazyMaterialize,
+            definition(),
+        )
+        .await;
+        let identity_runtime = runtime
+            .identity_runtime()
+            .expect("identity runtime")
+            .clone();
+        identity_runtime
+            .send(
+                &member,
+                &meerkat_core::ContentInput::Text("post-reset turn".to_string()),
+            )
+            .await
+            .expect("the cold-mint turn must not be refused");
+        wait_for_turn(&capture, 1, "the cold-mint turn").await;
+        runtime.shutdown().await;
+        let (_, count) =
+            wait_for_durable_document_at_least(&state, 0, "the post-reset document").await;
+        assert_eq!(
+            count,
+            durable_count + 2,
+            "the cold-mint boot must extend the head exactly, authoring nothing"
+        );
     }
 }
 

--- a/meerkat-mobkit/tests/identity_first_lazy_recall_continuity.rs
+++ b/meerkat-mobkit/tests/identity_first_lazy_recall_continuity.rs
@@ -2866,6 +2866,192 @@ async fn steer_into_non_resident_member_delivers_content() {
     }
 }
 
+/// THE SHIPPED REPAIR BINARY end to end (task #63): seed field-shape
+/// duplicate System rows, run `mobkit-repair` dry-run then `--apply`
+/// against the stopped store, reset the runtime scratch, and prove the
+/// member resumes with the healed head and its conversation intact - the
+/// window-4/5 operator procedure, driven through the supported binary
+/// instead of the example.
+#[tokio::test(flavor = "multi_thread")]
+async fn mobkit_repair_binary_prunes_duplicates_and_member_resumes() {
+    const TOKEN: &str = "MARKER-REPAIR-BIN-17-ZULU";
+    if proxied_to_memo_free_child("mobkit_repair_binary_prunes_duplicates_and_member_resumes") {
+        return;
+    }
+    let _serial = SERIAL_WINDOW.lock().await;
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let state = temp.path().join("state");
+    let member = id(MEMBER);
+
+    // Boot 1: one turn with the recall marker, then shut down.
+    let session_id;
+    {
+        let capture = CaptureClient::default();
+        let runtime = boot(
+            &state,
+            capture.clone(),
+            IdentityBootstrapMode::LazyMaterialize,
+        )
+        .await;
+        let identity_runtime = runtime
+            .identity_runtime()
+            .expect("identity runtime")
+            .clone();
+        identity_runtime
+            .send(
+                &member,
+                &meerkat_core::ContentInput::Text(format!("Please note this token: {TOKEN}")),
+            )
+            .await
+            .expect("boot 1's turn");
+        wait_for_turn(&capture, 1, "boot 1's turn").await;
+        runtime.shutdown().await;
+        let (head, _) = wait_for_durable_document_at_least(&state, 2, "boot 1's commit").await;
+        session_id = head;
+    }
+
+    // Seed 12 field-shape duplicate System rows through the typed door.
+    {
+        let continuity: Arc<dyn ContinuityStore> =
+            Arc::new(LocalContinuityStore::open(continuity_db(&state)).expect("open continuity"));
+        let adapter = Arc::new(ContinuitySessionStoreAdapter::new(Arc::clone(&continuity)));
+        let sid = meerkat_core::types::SessionId::parse(&session_id).expect("session id");
+        let (record, fencing_token, fence_current) = continuity
+            .resolve_record_by_session(&sid)
+            .await
+            .expect("resolve record")
+            .expect("record binds session");
+        adapter
+            .register_session(
+                &sid,
+                meerkat_mobkit::identity_first::SessionRuntimeState {
+                    identity: record.identity.clone(),
+                    generation: record.generation,
+                    fencing_token,
+                    checkpoint_version: fence_current,
+                },
+            )
+            .await
+            .expect("register seed writer");
+        let mut with_dups = meerkat::SessionStore::load(adapter.as_ref(), &sid)
+            .await
+            .expect("load")
+            .expect("durable session");
+        for _ in 0..12 {
+            with_dups.push(meerkat_core::Message::System(
+                meerkat_core::types::SystemMessage::new(CUSTOMIZER_PROMPT),
+            ));
+        }
+        meerkat::SessionStore::save(adapter.as_ref(), &with_dups)
+            .await
+            .expect("seed duplicates");
+    }
+    let (_, seeded_count) =
+        wait_for_durable_document_at_least(&state, 0, "the seeded document").await;
+
+    // Dry run through the SHIPPED binary: plan only, durable untouched.
+    let bin = env!("CARGO_BIN_EXE_mobkit_repair");
+    let db = continuity_db(&state);
+    let dry = std::process::Command::new(bin)
+        .args(["--db", db.to_str().expect("db path"), "--all-sessions"])
+        .output()
+        .expect("run mobkit-repair dry-run");
+    assert!(dry.status.success(), "dry-run must exit 0: {dry:?}");
+    let dry_report: serde_json::Value =
+        serde_json::from_slice(&dry.stdout).expect("dry-run emits JSON");
+    assert_eq!(dry_report["mode"], "content_dedup");
+    assert_eq!(dry_report["applied"], false);
+    assert_eq!(dry_report["sessions"][0]["outcome"], "dry_run");
+    assert_eq!(
+        dry_report["sessions"][0]["system_rows_after"],
+        dry_report["sessions"][0]["system_rows_before"]
+            .as_u64()
+            .expect("count")
+            - 11,
+        "12 identical copies collapse to one kept occurrence"
+    );
+    let (_, after_dry) =
+        wait_for_durable_document_at_least(&state, 0, "the document after dry-run").await;
+    assert_eq!(
+        after_dry, seeded_count,
+        "a dry run must not touch the durable row"
+    );
+
+    // Apply through the binary, then the reset-reseed lane.
+    let applied = std::process::Command::new(bin)
+        .args([
+            "--db",
+            db.to_str().expect("db path"),
+            "--all-sessions",
+            "--apply",
+        ])
+        .output()
+        .expect("run mobkit-repair apply");
+    assert!(applied.status.success(), "apply must exit 0: {applied:?}");
+    let applied_report: serde_json::Value =
+        serde_json::from_slice(&applied.stdout).expect("apply emits JSON");
+    assert_eq!(applied_report["sessions"][0]["outcome"], "applied");
+    assert_eq!(applied_report["refused"], 0);
+    let expected_after = seeded_count - 11;
+    let (_, healed) = wait_for_durable_document_at_least(&state, 0, "the healed document").await;
+    assert_eq!(
+        healed, expected_after,
+        "the durable head reflects the applied plan"
+    );
+
+    let mut removed = 0;
+    for suffix in ["", "-wal", "-shm", ".mfence"] {
+        let path = state.join(format!(
+            "{}{suffix}",
+            meerkat_mobkit::storage_layout::RUNTIME_DB_FILE_NAME
+        ));
+        if path.exists() {
+            std::fs::remove_file(&path).expect("reset runtime store");
+            removed += 1;
+        }
+    }
+    assert!(
+        removed > 0,
+        "the persistent shape must have written runtime.sqlite"
+    );
+
+    // Boot 2: cold mint over the healed rewritten head, one real turn.
+    {
+        let capture = CaptureClient::default();
+        let runtime = boot(
+            &state,
+            capture.clone(),
+            IdentityBootstrapMode::LazyMaterialize,
+        )
+        .await;
+        let identity_runtime = runtime
+            .identity_runtime()
+            .expect("identity runtime")
+            .clone();
+        identity_runtime
+            .send(
+                &member,
+                &meerkat_core::ContentInput::Text("What token did I give you earlier?".to_string()),
+            )
+            .await
+            .expect("the post-repair cold-mint turn must not be refused");
+        wait_for_turn(&capture, 1, "the post-repair turn").await;
+        let last = capture.last().expect("request captured");
+        assert!(
+            last.contains(TOKEN),
+            "the conversation survives the repair (token {TOKEN})"
+        );
+        runtime.shutdown().await;
+        let (_, post) =
+            wait_for_durable_document_at_least(&state, 0, "the post-repair document").await;
+        assert_eq!(
+            post,
+            expected_after + 2,
+            "the turn extends the healed head exactly"
+        );
+    }
+}
+
 /// Profile-prompt revival hygiene (0.8.19 pairing prep, 2026-08-06): a
 /// member whose PROFILE declares a system_prompt, booted repeatedly with a
 /// turn each - automatic rematerialization must author NOTHING beyond each

--- a/mobkit-store-conformance/BUILD.bazel
+++ b/mobkit-store-conformance/BUILD.bazel
@@ -41,7 +41,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_MANIFEST_DIR": "./mobkit-store-conformance",
     },
     proc_macro_deps = all_crate_deps(
@@ -75,7 +75,7 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_MANIFEST_DIR": "./mobkit-store-conformance",
     },
     tags = [
@@ -124,7 +124,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "conformance",
         "CARGO_MANIFEST_DIR": "./mobkit-store-conformance",
     },
@@ -172,7 +172,7 @@ rust_test(
     ],
     visibility = ["//visibility:public"],
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.8.13",
+        "CARGO_PKG_VERSION": "0.8.14",
         "CARGO_BIN_NAME": "one_remote_bundle",
         "CARGO_MANIFEST_DIR": "./mobkit-store-conformance",
     },

--- a/mobkit-store-conformance/Cargo.toml
+++ b/mobkit-store-conformance/Cargo.toml
@@ -19,14 +19,14 @@ workspace = true
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
-meerkat-core = "=0.8.18"
+meerkat-core = "=0.8.20"
 # The one-remote-bundle reference provider (M4b) implements both levels of
 # the composite seam: meerkat's RealmStorageProvider (facade storage_provider
 # module + in-memory store implementations) next to MobKit's realm store set.
-meerkat = { version = "=0.8.18", features = ["session-store", "memory-store"] }
-meerkat-runtime = "=0.8.18"
-meerkat-store = { version = "=0.8.18", features = ["memory"] }
-meerkat-store-conformance = "=0.8.18"
+meerkat = { version = "=0.8.20", features = ["session-store", "memory-store"] }
+meerkat-runtime = "=0.8.20"
+meerkat-store = { version = "=0.8.20", features = ["memory"] }
+meerkat-store-conformance = "=0.8.20"
 meerkat-mobkit = { path = "../meerkat-mobkit" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meerkat-mobkit"
-version = "0.8.13"
+version = "0.8.14"
 description = "Python SDK for MobKit — companion orchestration platform for the Meerkat multi-agent runtime"
 requires-python = ">=3.10"
 license = {text = "MIT OR Apache-2.0"}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rkat/mobkit-sdk",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "devDependencies": {
         "@types/node": "^22.19.15",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rkat/mobkit-sdk",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "MobKit TypeScript SDK — companion orchestration for the Meerkat agent runtime",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Paired directly on meerkat 0.8.20 per the owner's decision (no 0.8.19 artifact). Field evidence on the exact pair: 17-member real-corpus restore gate PASS, three-boot accretion drill flat (17 rows, max 1/identity, real PluginAgentBuilder), and mobkit_repair exercised against a production copy - 31->5 System rows per member, all 17 under the provider ceiling, conversation preserved exactly, and a real resurrection turn (domain:network answered in 8.3s after being mute through a 906s production probe).

- #62: build callback carries resume_session_id; resumed builds never author prompt state; mint instructions ride meerkat's native additional_instructions carrier (the Set translation is deleted - it was the mobkit half of the HomeCore accretion).
- #63: mobkit-repair maintenance binary (content-equality default, --keep-newest N, fleet passes with per-session atomic commits, JSON reports, dry-run default, release-asset packaging on all five targets).
- Regressions: first-wake steer guard, both cold-mint count guards, window-5 operator-rewrite mirror, profile-prompt revival hygiene, repair-binary end-to-end.
- Owner-requested seam assessment (docs/proposals/seam-assessment-mobkit.md) with the committed 0.8.15 queue.

Shipping under the owner's standing release order and the explicit field clearance ("Tag it", hold lifted at 00:08Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)