### PR TITLE
fix(release): asset verifier inventory includes mobkit-repair (v0.8.14 unblock)

### DIFF
--- a/scripts/test_verify_release_assets.py
+++ b/scripts/test_verify_release_assets.py
@@ -31,6 +31,17 @@ class ReleaseAssetContractTests(unittest.TestCase):
             artifact_dir.mkdir()
             (artifact_dir / name).write_bytes(f"artifact-{index}".encode())
 
+    def test_expected_inventory_includes_the_repair_binary_on_all_targets(self):
+        # Release-blocker regression (v0.8.14 attempt 1): mobkit-repair
+        # archives were built but rejected as unexpected because the
+        # inventory constant was never taught about the new binary. The
+        # repair tool ships as a release asset by explicit consumer
+        # requirement - building a maintenance tool from source inside a
+        # repair window is how deployment defects are born.
+        names = release_assets.expected_archive_names("0.8.0")
+        for target, ext in release_assets.TARGET_ARCHIVES:
+            self.assertIn(f"mobkit-repair-0.8.0-{target}.{ext}", names)
+
     def test_prepare_emits_exact_flat_manifest_and_verified_checksums(self):
         self.write_complete_source()
 

--- a/scripts/verify-release-assets.py
+++ b/scripts/verify-release-assets.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 
-ARCHIVE_PREFIXES = ("mobkit-gateway", "mobkit-rpc-gateway")
+ARCHIVE_PREFIXES = ("mobkit-gateway", "mobkit-rpc-gateway", "mobkit-repair")
 TARGET_ARCHIVES = (
     ("x86_64-unknown-linux-gnu", "tar.gz"),
     ("aarch64-unknown-linux-gnu", "tar.gz"),


### PR DESCRIPTION
One-constant fix for the v0.8.14 release blocker: ARCHIVE_PREFIXES gains mobkit-repair (5 green builds were rejected as unexpected assets), plus a regression test pinning the repair archives on all five targets. Verifier suite: 5/5. Tag moves to the new release commit after merge (crates unpublished, tag-move is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)