### PR TITLE
feat(cross-mob): complete the remote path - control listener, member-fact descriptors, signed round-trip proof

### DIFF
--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -1369,6 +1369,74 @@ rust_test(
 )
 
 rust_test(
+    name = "cross_mob_control_round_trip_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "cross_mob_control_round_trip",
+    crate_root = "tests/cross_mob_control_round_trip.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+        "tests/fixtures/homecore_ledgerv1_closure/calendar-continuity-closure.json",
+        "tests/fixtures/homecore_ledgerv1_closure/continuity-schema.sql",
+        "tests/fixtures/homecore_security_idempotency/security-head-evolution.json",
+        "tests/fixtures/v0_8_10_released_session.json",
+        "tests/fixtures/v0_8_10_zero_rewrite_supervisor_session.json",
+    ],
+    srcs = [
+        "tests/cross_mob_control_round_trip.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.8.15",
+        "CARGO_BIN_NAME": "cross_mob_control_round_trip",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "cross_mob_signed_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -7308,6 +7376,7 @@ test_suite(
         ":console_experience_test",
         ":console_route_auth_test",
         ":core_types_and_rpc_test",
+        ":cross_mob_control_round_trip_test",
         ":cross_mob_signed_test",
         ":cross_mob_tcp_test",
         ":cross_mob_uds_test",

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -10,6 +10,7 @@ use meerkat::{AgentFactory, Config, FactoryAgentBuilder, PersistentSessionServic
 use meerkat_mob::ids::AgentIdentity;
 use meerkat_mob::{MobDefinition, MobStorage, ProfileName, SpawnMemberSpec};
 use meerkat_mobkit::contact_directory::ContactDirectory;
+use meerkat_mobkit::runtime::cross_mob_control::ControlListenAddr;
 use meerkat_mobkit::{
     AuthPolicy, Base64BlobStoreAdapter, BigQueryNaming, BinaryBlobStore, ConsolePolicy,
     ConsoleUiConfig, ConventionalPaths, GatewayPeerKeys, MOBKIT_CONTRACT_VERSION,
@@ -187,6 +188,7 @@ fn config_fingerprint(
     project_root: &Path,
     context_root: Option<&Path>,
     compaction: Option<&meerkat_core::config::CompactionRuntimeConfig>,
+    control_listen: Option<&ControlListenAddr>,
     paths: &ConventionalPaths,
 ) -> anyhow::Result<String> {
     let mut hasher = Sha256::new();
@@ -228,6 +230,13 @@ fn config_fingerprint(
         hasher.update(policy.recent_turn_budget.to_le_bytes());
         hasher.update(policy.max_summary_tokens.to_le_bytes());
         hasher.update(policy.min_turns_between_compactions.to_le_bytes());
+    }
+    hasher.update(b"\n");
+    // The control listener binds at launch; resuming a live gateway that was
+    // launched without (or with a different) --control-listen would silently
+    // drop the flag, so the address participates in the resume key.
+    if let Some(addr) = control_listen {
+        hasher.update(addr.to_string().as_bytes());
     }
     hasher.update(b"\n");
     hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
@@ -1015,6 +1024,17 @@ fn main() {
     if args.first().map(String::as_str) == Some("storage-prune") {
         std::process::exit(run_storage_prune(&args[1..]));
     }
+    // --control-listen <tcp://host:port | uds:///path>: bind the cross-mob
+    // control listener so remote gateways can wire/unwire/inject/lookup
+    // members of this runtime. Validated here so a typo is a launch error,
+    // not a silently ignored flag.
+    let control_listen = match parse_control_listen_arg(&args) {
+        Ok(value) => value,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(2);
+        }
+    };
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         "mobkit_gateway starting (console/HTTP gateway)"
@@ -1033,14 +1053,29 @@ fn main() {
             std::process::exit(1);
         }
     };
-    if let Err(error) = runtime.block_on(Box::pin(run())) {
+    if let Err(error) = runtime.block_on(Box::pin(run(control_listen))) {
         let response = init_error(Value::Null, -32603, error.to_string());
         print_json_line(&response);
         std::process::exit(1);
     }
 }
 
-async fn run() -> anyhow::Result<()> {
+/// Extract and validate the optional `--control-listen <addr>` flag.
+fn parse_control_listen_arg(args: &[String]) -> Result<Option<ControlListenAddr>, String> {
+    let Some(position) = args.iter().position(|arg| arg == "--control-listen") else {
+        return Ok(None);
+    };
+    let Some(value) = args.get(position + 1) else {
+        return Err(
+            "--control-listen requires an address (tcp://host:port or uds:///path)".to_string(),
+        );
+    };
+    ControlListenAddr::parse(value)
+        .map(Some)
+        .map_err(|error| format!("--control-listen: {error}"))
+}
+
+async fn run(control_listen: Option<ControlListenAddr>) -> anyhow::Result<()> {
     let stdin = tokio::io::stdin();
     let mut reader = BufReader::new(stdin);
     let mut init_line = String::new();
@@ -1122,6 +1157,7 @@ async fn run() -> anyhow::Result<()> {
         &project_root,
         context_root.as_deref(),
         compaction_policy.as_ref(),
+        control_listen.as_ref(),
         &paths,
     )?;
     let registry_file = layout
@@ -1471,6 +1507,17 @@ async fn run() -> anyhow::Result<()> {
         None
     };
 
+    // Bind the cross-mob control listener after identity-first attachment so
+    // its startup log reflects the final authority posture (the handler
+    // re-reads the identity slot per request either way).
+    if let Some(addr) = control_listen.as_ref() {
+        let advertised = runtime
+            .start_control_listener(addr)
+            .await
+            .map_err(|error| anyhow!("--control-listen {addr}: {error}"))?;
+        tracing::info!(%advertised, "cross-mob control listener bound");
+    }
+
     // Start schedule delivery only after identity-first attachment. The host
     // owns a snapshot of the authority Arc, so starting it before this point
     // would permanently reject every generated `rt:*` target.
@@ -1703,6 +1750,7 @@ mod tests {
             temp.path(),
             None,
             None,
+            None,
             &paths,
         )?;
         let read_only = config_fingerprint(
@@ -1715,6 +1763,7 @@ mod tests {
             temp.path(),
             temp.path(),
             temp.path(),
+            None,
             None,
             None,
             &paths,
@@ -1752,6 +1801,7 @@ mod tests {
             temp.path(),
             None,
             None,
+            None,
             &paths,
         )?;
         let pinned_key = config_fingerprint(
@@ -1766,6 +1816,7 @@ mod tests {
             temp.path(),
             None,
             Some(&pinned),
+            None,
             &paths,
         )?;
         let lower_key = config_fingerprint(
@@ -1780,6 +1831,7 @@ mod tests {
             temp.path(),
             None,
             Some(&lower),
+            None,
             &paths,
         )?;
 

--- a/meerkat-mobkit/src/contact_directory.rs
+++ b/meerkat-mobkit/src/contact_directory.rs
@@ -173,7 +173,10 @@ fn parse_entry(mob_id: &str, value: &toml::Value) -> Result<ContactEntry, Contac
     })
 }
 
-fn parse_transport(s: &str) -> Option<MobTransport> {
+/// Parse a transport string (`inproc`, `tcp://host:port`, `uds:///path`).
+/// Shared with the control-listen address parser so the two surfaces never
+/// drift on address spelling.
+pub(crate) fn parse_transport(s: &str) -> Option<MobTransport> {
     if s == "inproc" {
         return Some(MobTransport::Inproc);
     }

--- a/meerkat-mobkit/src/rpc.rs
+++ b/meerkat-mobkit/src/rpc.rs
@@ -134,7 +134,9 @@ async fn mobpack_runtime_catalog_state(
     if runtime.has_contact_directory() {
         runtime_methods.push("mobkit/cross_mob/directory".to_string());
     }
-    if runtime.has_peer_mob_handles().await && runtime.has_inproc_contacts() {
+    if (runtime.has_peer_mob_handles().await && runtime.has_inproc_contacts())
+        || runtime.has_remote_contacts()
+    {
         runtime_methods.extend([
             "mobkit/cross_mob/wire".to_string(),
             "mobkit/cross_mob/unwire".to_string(),
@@ -1821,10 +1823,13 @@ async fn handle_unified_rpc_json_inner(
             if runtime.has_contact_directory() {
                 methods.push("mobkit/cross_mob/directory");
             }
-            // High-level wire/unwire/send require peer mob handles AND inproc contacts.
-            // resolve_contact() rejects non-Inproc transports at execution time, so
-            // advertising these methods for TCP/UDS-only deployments guarantees failures.
-            if runtime.has_peer_mob_handles().await && runtime.has_inproc_contacts() {
+            // High-level wire/unwire/send are reachable through two shapes:
+            // same-process peers (registered handles + inproc contacts) and
+            // cross-process peers (TCP/UDS contact entries served by the
+            // remote gateway's control listener).
+            if (runtime.has_peer_mob_handles().await && runtime.has_inproc_contacts())
+                || runtime.has_remote_contacts()
+            {
                 methods.extend_from_slice(&[
                     "mobkit/cross_mob/wire",
                     "mobkit/cross_mob/unwire",

--- a/meerkat-mobkit/src/runtime/cross_mob_control.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_control.rs
@@ -206,12 +206,40 @@ pub enum ControlRequest {
 pub enum ControlResponse {
     /// Operation succeeded (no payload).
     Ok,
-    /// Inject succeeded — return the bridge session id that accepted the
-    /// injection so the caller can correlate downstream events.
+    /// Inject succeeded - the far side admitted the dispatch and returns
+    /// the bridge session id that accepted it, so the caller can correlate
+    /// downstream events.
+    ///
+    /// This is NOT a durability receipt. It classifies as dispatch
+    /// admission only: the receiving runtime accepted the turn into the
+    /// named session, and whether that turn commits durably is the
+    /// receiving runtime's business. Coarse transport ACKs (this response
+    /// included) must never be inferred as durable=true. Callers that need
+    /// durable admission over remote paths reconcile by idempotent
+    /// re-submit with WorkRef dedup - the protocol deliberately has no
+    /// resend verb.
     Injected { session_id: String },
-    /// LookupMember succeeded — return the remote member's peer info so
-    /// the caller can build a `TrustedPeerDescriptor` pointing at it.
-    Member { peer_id: String, comms_name: String },
+    /// LookupMember succeeded - return the remote member's comms facts so
+    /// the caller can build a signed `TrustedPeerDescriptor` pointing at
+    /// it.
+    Member {
+        peer_id: String,
+        comms_name: String,
+        /// The member's transport pubkey as the roster carries it (base64,
+        /// optional `ed25519:` prefix). `None` when the member has no
+        /// comms runtime. Descriptors for this member MUST use this key:
+        /// the peer-id/pubkey consistency check rejects any other (the
+        /// gateway key included).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pubkey_b64: Option<String>,
+        /// The member's dialable envelope-listener address as its live
+        /// comms runtime advertises it (`tcp://host:port` with the real
+        /// bound port, `uds:///path`, or `inproc://name` for members
+        /// without a socket transport). `None` when the serving gateway's
+        /// control handler has no session-service access.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        advertised_address: Option<String>,
+    },
     /// Operation failed. `code` is a stable short string for machine
     /// dispatch (`unknown_member`, `mob_error`, `decode`, ...); `message`
     /// is human-readable.
@@ -385,6 +413,12 @@ pub trait ControlHandler: Send + Sync + 'static {
 pub struct MobHandleControlHandler {
     handle: meerkat_mob::MobHandle,
     identity_authority: ControlIdentityAuthority,
+    /// Session-service access for member-fact resolution: `LookupMember`
+    /// reaches through it to the member's live comms runtime for the
+    /// advertised envelope-listener address (the roster does not persist
+    /// transport addresses). `None` degrades LookupMember to roster facts
+    /// only, which remote wire callers reject fail-closed.
+    session_service: Option<std::sync::Arc<dyn meerkat_mob::MobSessionService>>,
 }
 
 /// How the handler resolves the durable identity authority for generated
@@ -422,6 +456,7 @@ impl MobHandleControlHandler {
         Self {
             handle,
             identity_authority: ControlIdentityAuthority::None,
+            session_service: None,
         }
     }
 
@@ -434,6 +469,7 @@ impl MobHandleControlHandler {
         Self {
             handle,
             identity_authority: ControlIdentityAuthority::Fixed(identity_runtime),
+            session_service: None,
         }
     }
 
@@ -449,7 +485,20 @@ impl MobHandleControlHandler {
         Self {
             handle,
             identity_authority: ControlIdentityAuthority::Shared(identity_slot),
+            session_service: None,
         }
+    }
+
+    /// Attach the session service that owns member comms runtimes, so
+    /// `LookupMember` can report each member's advertised envelope-listener
+    /// address alongside its roster facts.
+    #[must_use]
+    pub fn with_session_service(
+        mut self,
+        session_service: std::sync::Arc<dyn meerkat_mob::MobSessionService>,
+    ) -> Self {
+        self.session_service = Some(session_service);
+        self
     }
 }
 
@@ -460,6 +509,7 @@ impl ControlHandler for MobHandleControlHandler {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ControlResponse> + Send + '_>> {
         let handle = self.handle.clone();
         let identity_runtime = self.identity_authority.current();
+        let session_service = self.session_service.clone();
         Box::pin(async move {
             match request {
                 ControlRequest::Wire {
@@ -511,7 +561,13 @@ impl ControlHandler for MobHandleControlHandler {
                     handle_inject(&handle, &remote_member, content, identity_runtime.as_ref()).await
                 }
                 ControlRequest::LookupMember { remote_member } => {
-                    handle_lookup_member(&handle, &remote_member, identity_runtime.as_ref()).await
+                    handle_lookup_member(
+                        &handle,
+                        session_service.as_ref(),
+                        &remote_member,
+                        identity_runtime.as_ref(),
+                    )
+                    .await
                 }
             }
         })
@@ -593,44 +649,58 @@ struct WireControlParams<'a> {
     wire: bool,
 }
 
+/// Build the `TrustedPeerDescriptor` a remote Wire/Unwire request installs
+/// on this side.
+///
+/// Requests arriving over the remote control channel must carry a peer
+/// address that is dialable from THIS process and the calling MEMBER's own
+/// transport pubkey. `inproc://` fails closed: it used to slip through the
+/// relaxed unsigned branch and install a descriptor that could never
+/// deliver an envelope across processes. A missing pubkey also fails
+/// closed: meerkat-comms keys its trust store by pubkey, so an unsigned
+/// row would admit any sender at ingress. The gateway key is not accepted
+/// either - `unsigned_with_pubkey` enforces peer_id == UUIDv5(pubkey), and
+/// only the member's transport key satisfies that.
+fn build_remote_wire_descriptor(
+    params: &WireControlParams<'_>,
+) -> Result<meerkat_core::comms::TrustedPeerDescriptor, (String, String)> {
+    if params.local_peer_spec_address.starts_with("inproc://") {
+        return Err((
+            "inproc_address_rejected".to_string(),
+            format!(
+                "peer address '{}' is inproc:// and unreachable from another process; the \
+                 calling gateway must advertise a tcp:// or uds:// member comms address",
+                params.local_peer_spec_address
+            ),
+        ));
+    }
+    let Some(pubkey_b64) = params.local_pubkey_b64.filter(|value| !value.is_empty()) else {
+        return Err((
+            "missing_pubkey".to_string(),
+            "remote wire requests must carry the calling member's Ed25519 transport pubkey; \
+             an unsigned descriptor would admit any sender at comms ingress"
+                .to_string(),
+        ));
+    };
+    let pubkey = crate::auth::peer_keys::decode_pubkey_b64(pubkey_b64)
+        .map_err(|err| ("decode".to_string(), format!("local_pubkey_b64: {err}")))?;
+    meerkat_core::comms::TrustedPeerDescriptor::unsigned_with_pubkey(
+        params.local_comms_name,
+        params.local_peer_id,
+        pubkey,
+        params.local_peer_spec_address,
+    )
+    .map_err(|err| ("peer_spec".to_string(), err))
+}
+
 async fn handle_wire(
     handle: &meerkat_mob::MobHandle,
     params: WireControlParams<'_>,
     identity_runtime: Option<&std::sync::Arc<crate::identity_first::IdentityRuntime>>,
 ) -> ControlResponse {
-    let pubkey = match params.local_pubkey_b64 {
-        Some(s) if !s.is_empty() => match crate::auth::peer_keys::decode_pubkey_b64(s) {
-            Ok(bytes) => Some(bytes),
-            Err(err) => {
-                return ControlResponse::Err {
-                    code: "decode".to_string(),
-                    message: format!("local_pubkey_b64: {err}"),
-                };
-            }
-        },
-        _ => None,
-    };
-    let spec_result = match pubkey {
-        Some(bytes) => meerkat_core::comms::TrustedPeerDescriptor::unsigned_with_pubkey(
-            params.local_comms_name,
-            params.local_peer_id,
-            bytes,
-            params.local_peer_spec_address,
-        ),
-        None => meerkat_core::comms::TrustedPeerDescriptor::test_only_unsigned(
-            params.local_comms_name,
-            params.local_peer_id,
-            params.local_peer_spec_address,
-        ),
-    };
-    let spec = match spec_result {
+    let spec = match build_remote_wire_descriptor(&params) {
         Ok(spec) => spec,
-        Err(err) => {
-            return ControlResponse::Err {
-                code: "peer_spec".to_string(),
-                message: err,
-            };
-        }
+        Err((code, message)) => return ControlResponse::Err { code, message },
     };
     // The control plane speaks the public alias space; the local roster
     // holds comms-safe encoded ids (meerkat 0.7 MemberCommsName), so encode
@@ -706,13 +776,20 @@ async fn handle_inject(
 
 async fn handle_lookup_member(
     handle: &meerkat_mob::MobHandle,
+    session_service: Option<&std::sync::Arc<dyn meerkat_mob::MobSessionService>>,
     remote_member: &str,
     identity_runtime: Option<&std::sync::Arc<crate::identity_first::IdentityRuntime>>,
 ) -> ControlResponse {
     let operation_handle = handle.clone();
+    let operation_service = session_service.cloned();
     let operation_member = crate::member_comms_id::runtime_alias_str(remote_member).into_owned();
     match run_control_member_operation(identity_runtime, remote_member, move || async move {
-        handle_lookup_member_raw(&operation_handle, &operation_member).await
+        handle_lookup_member_raw(
+            &operation_handle,
+            operation_service.as_ref(),
+            &operation_member,
+        )
+        .await
     })
     .await
     {
@@ -723,6 +800,7 @@ async fn handle_lookup_member(
 
 async fn handle_lookup_member_raw(
     handle: &meerkat_mob::MobHandle,
+    session_service: Option<&std::sync::Arc<dyn meerkat_mob::MobSessionService>>,
     remote_member: &str,
 ) -> Result<ControlResponse, (String, String)> {
     let mid = crate::member_comms_id::mob_member_id(remote_member);
@@ -769,9 +847,22 @@ async fn handle_lookup_member_raw(
             ));
         }
     };
+    let pubkey_b64 = entry.transport_public_key().map(str::to_string);
+    // The member's dialable envelope-listener address lives on its live
+    // comms runtime, not in the roster; resolve it through the session
+    // service when the control handler was given one.
+    let mut advertised_address = None;
+    if let Some(service) = session_service
+        && let Some(session_id) = handle.resolve_bridge_session_id(&mid).await
+        && let Some(comms) = service.comms_runtime(&session_id).await
+    {
+        advertised_address = comms.advertised_address();
+    }
     Ok(ControlResponse::Member {
         peer_id,
         comms_name,
+        pubkey_b64,
+        advertised_address,
     })
 }
 
@@ -928,10 +1019,88 @@ mod tests {
                     ControlRequest::LookupMember { remote_member } => ControlResponse::Member {
                         peer_id: format!("peer-id-for-{remote_member}"),
                         comms_name: format!("mob/role/{remote_member}"),
+                        pubkey_b64: None,
+                        advertised_address: None,
                     },
                 }
             })
         }
+    }
+
+    /// Base64 of the 32-byte pubkey `[42u8; 32]` (same constant the
+    /// contact-directory tests use).
+    const TEST_PUBKEY_B64: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio=";
+
+    fn wire_params<'a>(
+        address: &'a str,
+        peer_id: &'a str,
+        pubkey_b64: Option<&'a str>,
+    ) -> WireControlParams<'a> {
+        WireControlParams {
+            remote_member: "bob",
+            local_peer_spec_address: address,
+            local_comms_name: "mob-a/worker/alice",
+            local_peer_id: peer_id,
+            local_pubkey_b64: pubkey_b64,
+            wire: true,
+        }
+    }
+
+    /// Regression: the remote Wire handler used to route inproc:// through
+    /// the relaxed unsigned branch, silently installing a descriptor that
+    /// could never deliver across processes.
+    #[test]
+    fn remote_wire_descriptor_rejects_inproc_addresses() {
+        let params = wire_params(
+            "inproc://mob-a/worker/alice",
+            "00000000-0000-4000-8000-000000000001",
+            Some(TEST_PUBKEY_B64),
+        );
+        let (code, _) = build_remote_wire_descriptor(&params).expect_err("inproc must fail");
+        assert_eq!(code, "inproc_address_rejected");
+    }
+
+    #[test]
+    fn remote_wire_descriptor_requires_pubkey() {
+        for pubkey in [None, Some("")] {
+            let params = wire_params(
+                "tcp://127.0.0.1:9001",
+                "00000000-0000-4000-8000-000000000001",
+                pubkey,
+            );
+            let (code, _) =
+                build_remote_wire_descriptor(&params).expect_err("missing pubkey must fail");
+            assert_eq!(code, "missing_pubkey");
+        }
+    }
+
+    #[test]
+    fn remote_wire_descriptor_builds_signed_descriptor() {
+        let derived_peer_id =
+            meerkat_core::comms::PeerId::from_ed25519_pubkey(&[42u8; 32]).to_string();
+        let params = wire_params(
+            "tcp://127.0.0.1:9001",
+            &derived_peer_id,
+            Some(TEST_PUBKEY_B64),
+        );
+        let spec = build_remote_wire_descriptor(&params).expect("descriptor");
+        assert_eq!(spec.pubkey, [42u8; 32]);
+        assert_eq!(spec.address.endpoint(), "127.0.0.1:9001");
+    }
+
+    /// The peer-id/pubkey consistency check is what forces the MEMBER
+    /// transport key onto this path: a mismatched key (e.g. the gateway
+    /// key) must be rejected, not installed.
+    #[test]
+    fn remote_wire_descriptor_rejects_mismatched_pubkey() {
+        let params = wire_params(
+            "tcp://127.0.0.1:9001",
+            "00000000-0000-4000-8000-000000000001",
+            Some(TEST_PUBKEY_B64),
+        );
+        let (code, _) =
+            build_remote_wire_descriptor(&params).expect_err("mismatched pubkey must fail");
+        assert_eq!(code, "peer_spec");
     }
 
     #[test]

--- a/meerkat-mobkit/src/runtime/cross_mob_control.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_control.rs
@@ -1,16 +1,15 @@
-//! Cross-mob control protocol — Phase 2 of the cross-mob transport story.
+//! Cross-mob control protocol: the control-plane RPC that crosses
+//! processes.
 //!
-//! Phase 1 (sibling commit) wired the structural seam (`RemoteMobProxy`,
-//! `LocalOrRemote` dispatch, contact-directory transport awareness). Phase
-//! 2 (this module) ships the actual control-plane RPC that crosses
-//! processes:
-//!
-//! * `ControlRequest` / `ControlResponse` — the on-the-wire types.
-//! * [`serve_control_listener`] — accepts TCP/UDS connections on a gateway,
-//!   reads framed requests, dispatches them against a local
-//!   [`MobHandle`] / [`MobSessionService`], and writes back framed responses.
-//! * [`RemoteControlClient`] — opens a connection lazily, sends a single
-//!   request, reads the response. Used by [`super::cross_mob_remote::RemoteMobProxy`].
+//! * `ControlRequest` / `ControlResponse` - the on-the-wire types.
+//! * [`serve_tcp_control`] / [`serve_uds_control`] - accept connections on
+//!   a gateway's control listener, read framed requests, dispatch them
+//!   against a local mob via a [`ControlHandler`], and write back framed
+//!   responses. `UnifiedRuntime::start_control_listener` binds the
+//!   listener and spawns the serve task.
+//! * [`RemoteControlClient`] - opens a connection per request, sends a
+//!   single frame, reads the response. Used by
+//!   [`super::cross_mob_remote::RemoteMobProxy`].
 //!
 //! # Wire shape
 //!
@@ -171,10 +170,10 @@ pub struct RemoteControlClient;
 impl RemoteControlClient {
     /// Send `request` to `endpoint`, await one response, and return it.
     ///
-    /// Opens a fresh connection per request — control RPC frequency is
+    /// Opens a fresh connection per request - control RPC frequency is
     /// low (one message per wire/unwire/inject call) and lazy-reconnect
-    /// keeps the implementation simple. Phase 3 (post-this-PR) can pool
-    /// connections if profiling shows it matters.
+    /// keeps the implementation simple. Connection pooling can come later
+    /// if profiling ever shows it matters.
     pub async fn send(
         endpoint: &RemoteEndpoint,
         request: &ControlRequest,
@@ -270,8 +269,9 @@ pub trait ControlHandler: Send + Sync + 'static {
 }
 
 /// Real `ControlHandler` that dispatches requests against a local
-/// `MobHandle`. Constructed by `UnifiedRuntime::from_parts` when the
-/// contact directory advertises a TCP/UDS endpoint for this gateway.
+/// `MobHandle`. Constructed by `UnifiedRuntime::start_control_listener`
+/// when a control listener is configured (builder `control_listen()` or
+/// the mobkit_gateway `--control-listen` flag).
 pub struct MobHandleControlHandler {
     handle: meerkat_mob::MobHandle,
     identity_runtime: Option<std::sync::Arc<crate::identity_first::IdentityRuntime>>,

--- a/meerkat-mobkit/src/runtime/cross_mob_control.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_control.rs
@@ -40,6 +40,116 @@ use tokio::net::{UnixListener, UnixStream};
 
 use super::cross_mob_remote::{RemoteEndpoint, RemoteMobError};
 
+/// Address a gateway binds its cross-mob control listener on.
+///
+/// Accepts the same spelling the contact directory uses for remote peers
+/// (`tcp://host:port`, `uds:///path`), parsed through the same
+/// [`crate::contact_directory`] transport parser so the two surfaces never
+/// drift. `inproc` is rejected: a control listener only makes sense across
+/// processes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlListenAddr {
+    /// TCP `host:port`. Port 0 binds an ephemeral port; the bound port is
+    /// reported by [`BoundControlListener::advertised_address`].
+    Tcp(String),
+    /// Unix-domain-socket path.
+    Uds(String),
+}
+
+impl ControlListenAddr {
+    /// Parse `tcp://host:port` or `uds:///path`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match crate::contact_directory::parse_transport(s) {
+            Some(crate::contact_directory::MobTransport::Tcp(addr)) => Ok(Self::Tcp(addr)),
+            Some(crate::contact_directory::MobTransport::Uds(path)) => Ok(Self::Uds(path)),
+            Some(crate::contact_directory::MobTransport::Inproc) => Err(
+                "control listener requires a cross-process address (tcp://host:port or \
+                 uds:///path); 'inproc' has no listener"
+                    .to_string(),
+            ),
+            None => Err(format!(
+                "invalid control listen address '{s}': expected tcp://host:port or uds:///path"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for ControlListenAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(addr) => write!(f, "tcp://{addr}"),
+            Self::Uds(path) => write!(f, "uds://{path}"),
+        }
+    }
+}
+
+/// A control listener that has been bound but not yet served.
+///
+/// Binding is split from serving so callers learn the concrete local
+/// address (the real port for `tcp://host:0`) before the accept loop
+/// starts, and can surface it to tests and peer configuration.
+pub enum BoundControlListener {
+    Tcp {
+        listener: TcpListener,
+        advertised: String,
+    },
+    #[cfg(unix)]
+    Uds {
+        listener: UnixListener,
+        advertised: String,
+    },
+}
+
+impl BoundControlListener {
+    /// Bind `addr`. For TCP the advertised address carries the kernel-
+    /// assigned port when the caller bound port 0. For UDS the advertised
+    /// address is `uds://{path}`.
+    pub async fn bind(addr: &ControlListenAddr) -> Result<Self, std::io::Error> {
+        match addr {
+            ControlListenAddr::Tcp(spec) => {
+                let listener = TcpListener::bind(spec).await?;
+                let local = listener.local_addr()?;
+                Ok(Self::Tcp {
+                    listener,
+                    advertised: format!("tcp://{local}"),
+                })
+            }
+            #[cfg(unix)]
+            ControlListenAddr::Uds(path) => {
+                let listener = UnixListener::bind(std::path::Path::new(path))?;
+                Ok(Self::Uds {
+                    listener,
+                    advertised: format!("uds://{path}"),
+                })
+            }
+            #[cfg(not(unix))]
+            ControlListenAddr::Uds(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "unix domain sockets are not supported on this platform",
+            )),
+        }
+    }
+
+    /// The dialable address of this listener (`tcp://ip:port` with the
+    /// real bound port, or `uds:///path`).
+    pub fn advertised_address(&self) -> &str {
+        match self {
+            Self::Tcp { advertised, .. } => advertised,
+            #[cfg(unix)]
+            Self::Uds { advertised, .. } => advertised,
+        }
+    }
+
+    /// Serve control requests until the owning task is aborted.
+    pub async fn serve(self, handler: std::sync::Arc<dyn ControlHandler>) {
+        match self {
+            Self::Tcp { listener, .. } => serve_tcp_control(listener, handler).await,
+            #[cfg(unix)]
+            Self::Uds { listener, .. } => serve_uds_control(listener, handler).await,
+        }
+    }
+}
+
 /// Maximum control payload size. Control messages are tiny (a few hundred
 /// bytes typical, ~1 KiB max for an injected text turn) — we cap well below
 /// that so a misbehaving peer can't tie up reads.
@@ -274,7 +384,35 @@ pub trait ControlHandler: Send + Sync + 'static {
 /// the mobkit_gateway `--control-listen` flag).
 pub struct MobHandleControlHandler {
     handle: meerkat_mob::MobHandle,
-    identity_runtime: Option<std::sync::Arc<crate::identity_first::IdentityRuntime>>,
+    identity_authority: ControlIdentityAuthority,
+}
+
+/// How the handler resolves the durable identity authority for generated
+/// member aliases. `Shared` re-reads a host-owned slot on every request:
+/// gateways attach identity-first AFTER the base runtime (and thus after
+/// the control listener) exists, so capturing `identity_runtime()` at
+/// listener start would permanently capture `None`.
+enum ControlIdentityAuthority {
+    None,
+    Fixed(std::sync::Arc<crate::identity_first::IdentityRuntime>),
+    Shared(
+        std::sync::Arc<
+            std::sync::RwLock<Option<std::sync::Arc<crate::identity_first::IdentityRuntime>>>,
+        >,
+    ),
+}
+
+impl ControlIdentityAuthority {
+    fn current(&self) -> Option<std::sync::Arc<crate::identity_first::IdentityRuntime>> {
+        match self {
+            Self::None => None,
+            Self::Fixed(runtime) => Some(std::sync::Arc::clone(runtime)),
+            Self::Shared(slot) => slot
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+        }
+    }
 }
 
 impl MobHandleControlHandler {
@@ -283,7 +421,7 @@ impl MobHandleControlHandler {
     pub fn new(handle: meerkat_mob::MobHandle) -> Self {
         Self {
             handle,
-            identity_runtime: None,
+            identity_authority: ControlIdentityAuthority::None,
         }
     }
 
@@ -295,7 +433,22 @@ impl MobHandleControlHandler {
     ) -> Self {
         Self {
             handle,
-            identity_runtime: Some(identity_runtime),
+            identity_authority: ControlIdentityAuthority::Fixed(identity_runtime),
+        }
+    }
+
+    /// Construct a handler whose identity authority is re-read from a
+    /// host-owned slot on every request, so identity-first attachment that
+    /// happens after the listener starts is still honored.
+    pub fn with_shared_identity_authority(
+        handle: meerkat_mob::MobHandle,
+        identity_slot: std::sync::Arc<
+            std::sync::RwLock<Option<std::sync::Arc<crate::identity_first::IdentityRuntime>>>,
+        >,
+    ) -> Self {
+        Self {
+            handle,
+            identity_authority: ControlIdentityAuthority::Shared(identity_slot),
         }
     }
 }
@@ -306,7 +459,7 @@ impl ControlHandler for MobHandleControlHandler {
         request: ControlRequest,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ControlResponse> + Send + '_>> {
         let handle = self.handle.clone();
-        let identity_runtime = self.identity_runtime.clone();
+        let identity_runtime = self.identity_authority.current();
         Box::pin(async move {
             match request {
                 ControlRequest::Wire {
@@ -779,6 +932,86 @@ mod tests {
                 }
             })
         }
+    }
+
+    #[test]
+    fn control_listen_addr_parses_contact_directory_spellings() {
+        assert_eq!(
+            ControlListenAddr::parse("tcp://127.0.0.1:9001"),
+            Ok(ControlListenAddr::Tcp("127.0.0.1:9001".to_string())),
+        );
+        assert_eq!(
+            ControlListenAddr::parse("uds:///var/run/mob.sock"),
+            Ok(ControlListenAddr::Uds("/var/run/mob.sock".to_string())),
+        );
+        assert!(ControlListenAddr::parse("inproc").is_err());
+        assert!(ControlListenAddr::parse("ftp://nope").is_err());
+        assert!(ControlListenAddr::parse("127.0.0.1:9001").is_err());
+    }
+
+    #[test]
+    fn control_listen_addr_display_round_trips() {
+        for spec in ["tcp://127.0.0.1:9001", "uds:///var/run/mob.sock"] {
+            let addr = ControlListenAddr::parse(spec).expect("parse");
+            assert_eq!(addr.to_string(), spec);
+        }
+    }
+
+    /// `tcp://host:0` binds an ephemeral port and the bound listener reports
+    /// the real dialable address; a control request round-trips through it.
+    #[tokio::test]
+    async fn bound_listener_reports_real_port_and_serves() {
+        let addr = ControlListenAddr::parse("tcp://127.0.0.1:0").expect("parse");
+        let bound = BoundControlListener::bind(&addr).await.expect("bind");
+        let advertised = bound.advertised_address().to_string();
+        let dial = advertised.strip_prefix("tcp://").expect("tcp scheme");
+        assert!(
+            !dial.ends_with(":0"),
+            "advertised address must carry the kernel-assigned port: {advertised}"
+        );
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(bound.serve(handler));
+
+        let endpoint = RemoteEndpoint::Tcp(dial.to_string());
+        let request = ControlRequest::LookupMember {
+            remote_member: "alice".to_string(),
+        };
+        let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
+            .await
+            .expect("control rpc");
+        assert!(matches!(response, ControlResponse::Member { .. }));
+        server.abort();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bound_uds_listener_serves() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("control.sock");
+        let addr = ControlListenAddr::Uds(path.display().to_string());
+        let bound = BoundControlListener::bind(&addr).await.expect("bind");
+        assert_eq!(
+            bound.advertised_address(),
+            format!("uds://{}", path.display())
+        );
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(bound.serve(handler));
+
+        let endpoint = RemoteEndpoint::Uds(path.display().to_string());
+        let request = ControlRequest::Inject {
+            remote_member: "bob".to_string(),
+            content: serde_json::json!({"text": "hi"}),
+        };
+        let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
+            .await
+            .expect("control rpc");
+        assert_eq!(
+            response,
+            ControlResponse::Injected {
+                session_id: "session-for-bob".to_string(),
+            },
+        );
+        server.abort();
     }
 
     #[tokio::test]

--- a/meerkat-mobkit/src/runtime/cross_mob_remote.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_remote.rs
@@ -1,53 +1,33 @@
-//! Cross-mob remote-handle proxy.
+//! Cross-mob remote-mob proxy: the client side of cross-process cross-mob
+//! operations.
 //!
-//! `cross_mob.rs` historically dispatched all wire/unwire/send operations
-//! against an `Arc<MobHandle>` registered via `register_peer_mob`, which
-//! only works for peers living in the *same* process (inproc transport).
-//! This module introduces the seam for **remote** peers — mobs that live
-//! in a different process or on a different host, reachable over TCP or
-//! UDS.
+//! `cross_mob.rs` dispatches wire/unwire/send operations as
+//! `LocalOrRemote`: same-process peers registered via `register_peer_mob`
+//! use their `MobHandle` directly; peers whose contact-directory entry
+//! names a `tcp://host:port` or `uds:///path` transport are reached through
+//! [`RemoteMobProxy`], which speaks the control protocol defined in
+//! [`super::cross_mob_control`] (length-prefixed JSON frames, one
+//! request/response pair per connection).
 //!
-//! # Design (Phase 1)
+//! [`RemoteMobProxy`] carries four operations against the peer gateway's
+//! control listener:
 //!
-//! Per the 0.6 cross-mob plan we picked design **(A)** — a `LocalOrRemote`
-//! enum at the cross-mob dispatch site (`cross_mob.rs`). The local arm
-//! uses the existing `MobHandle` path; the remote arm uses [`RemoteMobProxy`]
-//! to talk to the peer mob's admin endpoint over TCP/UDS.
+//! * [`RemoteMobProxy::wire_remote`] / [`RemoteMobProxy::unwire_remote`]
+//!   install or remove a `TrustedPeerDescriptor` for one of OUR members on
+//!   a member of the remote mob.
+//! * [`RemoteMobProxy::inject_message`] performs an app-level external-turn
+//!   injection into a remote member's session (`send_cross_mob`).
+//! * [`RemoteMobProxy::lookup_member`] discovers a remote member's comms
+//!   facts (peer id, comms name, transport pubkey, advertised address) so
+//!   the local side can build a signed descriptor without caller-supplied
+//!   bookkeeping.
 //!
-//! Phase 1 lands the **structural seam**: the `RemoteMobProxy` type, the
-//! `LocalOrRemote` enum, and the contact-directory scheme (`tcp://host:port`,
-//! `uds:///path`) flowing all the way through. Wire setup at the comms
-//! layer already supports those addresses — outbound message routing uses
-//! `meerkat_comms::Router`, which dispatches by `PeerAddr` scheme. The
-//! per-member transport just works once peer specs carry the correct
-//! address.
-//!
-//! What this module does **not** ship in Phase 1:
-//!
-//! 1. **Cross-process control RPC.** A real `RemoteMobProxy::wire` would
-//!    open a TCP/UDS connection to the peer mob's admin endpoint, send a
-//!    `WIRE` request, and await acknowledgment. Today the methods on
-//!    `RemoteMobProxy` return [`RemoteMobError::ControlChannelUnavailable`]
-//!    so callers learn the seam exists but is not yet wired.
-//! 2. **Ed25519-signed peer descriptors.** Sibling Unit 4 lands signed
-//!    descriptor authoring; this unit keeps using
-//!    `TrustedPeerSpec::new(...)` (which is structurally `test_only_unsigned`
-//!    in the 0.5.x core seam). The seam where Unit 4 will plug in is the
-//!    helpers `build_tcp_peer_spec` / `build_uds_peer_spec` in
-//!    `cross_mob.rs`.
-//!
-//! # Phase 2 plan (out of scope here)
-//!
-//! - Add a small JSON-over-CBOR control protocol with three operations:
-//!   `WireRequest { local_member, peer_spec }`,
-//!   `UnwireRequest { local_member, peer_spec }`,
-//!   `InjectRequest { remote_member, content, handling_mode }`.
-//!   Frame with `meerkat_comms::transport::codec::TransportCodec` (length-prefix
-//!   CBOR) — same wire shape as agent envelopes, distinct payload type.
-//! - Bind a control listener on each `UnifiedRuntime` startup when the
-//!   contact directory advertises a TCP/UDS endpoint for *this* mob.
-//! - `RemoteMobProxy` opens the connection lazily and reuses it for
-//!   subsequent calls; reconnect on drop.
+//! The server side is [`super::cross_mob_control::MobHandleControlHandler`],
+//! bound by `UnifiedRuntime::start_control_listener` (builder
+//! `control_listen()` or the gateway `--control-listen` flag). Each request
+//! opens a fresh connection; control RPC frequency is low (one message per
+//! wire/unwire/inject call), so connection pooling is deliberately not
+//! implemented.
 
 use crate::contact_directory::{ContactEntry, MobTransport};
 
@@ -186,10 +166,11 @@ impl RemoteEndpoint {
 
 /// A proxy for a mob that lives in a different process.
 ///
-/// Phase 1: a structural placeholder. The methods are stubs that return
-/// [`RemoteMobError::ControlChannelUnavailable`] so call sites can be
-/// written against the final shape; Phase 2 will replace these with a
-/// real control-channel client.
+/// Every method opens a control connection to the peer gateway's
+/// TCP/UDS control listener, sends one framed request, and awaits the
+/// framed response. [`RemoteMobError::ControlChannelUnavailable`] means
+/// the peer gateway is unreachable or has no control listener bound at
+/// the configured endpoint.
 #[derive(Debug, Clone)]
 pub struct RemoteMobProxy {
     mob_id: String,

--- a/meerkat-mobkit/src/runtime/cross_mob_remote.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_remote.rs
@@ -164,6 +164,26 @@ impl RemoteEndpoint {
     }
 }
 
+/// Comms facts for a remote member, as returned by the peer gateway's
+/// `LookupMember` control operation.
+///
+/// `pubkey_b64` and `advertised_address` are `None` when the peer gateway
+/// could not resolve them (member without a comms runtime, or a control
+/// handler running without session-service access). Remote wiring fails
+/// closed on either absence: a descriptor without the member's own
+/// transport key or a dialable socket address can never deliver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteMemberInfo {
+    pub peer_id: String,
+    pub comms_name: String,
+    /// The member's transport pubkey (base64, optional `ed25519:` prefix).
+    pub pubkey_b64: Option<String>,
+    /// The member's dialable envelope-listener address (`tcp://host:port`,
+    /// `uds:///path`) or `inproc://name` for members without a socket
+    /// transport.
+    pub advertised_address: Option<String>,
+}
+
 /// A proxy for a mob that lives in a different process.
 ///
 /// Every method opens a control connection to the peer gateway's
@@ -315,13 +335,13 @@ impl RemoteMobProxy {
         }
     }
 
-    /// Look up a remote member's peer info via the control channel.
+    /// Look up a remote member's comms facts via the control channel.
     /// Used during `wire_cross_mob` to discover what `TrustedPeerDescriptor`
     /// to build for the local-side wire without caller-supplied bookkeeping.
     pub async fn lookup_member(
         &self,
         remote_member: &str,
-    ) -> Result<(String, String), RemoteMobError> {
+    ) -> Result<RemoteMemberInfo, RemoteMobError> {
         let request = super::cross_mob_control::ControlRequest::LookupMember {
             remote_member: remote_member.to_string(),
         };
@@ -336,7 +356,14 @@ impl RemoteMobProxy {
             super::cross_mob_control::ControlResponse::Member {
                 peer_id,
                 comms_name,
-            } => Ok((peer_id, comms_name)),
+                pubkey_b64,
+                advertised_address,
+            } => Ok(RemoteMemberInfo {
+                peer_id,
+                comms_name,
+                pubkey_b64,
+                advertised_address,
+            }),
             super::cross_mob_control::ControlResponse::Err { code, message } => {
                 Err(RemoteMobError::Rejected {
                     mob_id: self.mob_id.clone(),

--- a/meerkat-mobkit/src/unified_runtime/builder.rs
+++ b/meerkat-mobkit/src/unified_runtime/builder.rs
@@ -120,6 +120,7 @@ pub struct UnifiedRuntimeBuilder {
     pre_spawn_hook: Option<PreSpawnHook>,
     edge_discovery: Option<Box<dyn EdgeDiscovery>>,
     contact_directory: Option<ContactDirectory>,
+    control_listen: Option<String>,
     persistent_metadata: Option<Arc<dyn PersistentMetadataStore>>,
     access_controller: Option<crate::access::AccessController>,
     topology_control_policy: crate::topology_control::TopologyControlPolicy,
@@ -642,6 +643,18 @@ impl UnifiedRuntimeBuilder {
         self
     }
 
+    /// Bind a cross-mob control listener on startup so remote gateways can
+    /// wire/unwire/inject/lookup members of this runtime.
+    ///
+    /// Accepts the contact-directory address spelling: `tcp://host:port`
+    /// (port 0 binds an ephemeral port) or `uds:///path`. The concrete
+    /// bound address is queryable after build via
+    /// [`UnifiedRuntime::control_listener_advertised_address`].
+    pub fn control_listen(mut self, addr: impl Into<String>) -> Self {
+        self.control_listen = Some(addr.into());
+        self
+    }
+
     /// Install a persistent metadata store. Used for the structural-events
     /// subscription cursor — see `runtime::metadata::PersistentMetadataStore`.
     /// When unset, the builder defaults to an `InMemoryMetadataStore`, which
@@ -696,6 +709,20 @@ impl UnifiedRuntimeBuilder {
         self.identity_bootstrap_mode
             .validate()
             .map_err(UnifiedRuntimeBuilderError::ConflictingConfiguration)?;
+
+        // Validate the control-listen address up front so a typo fails the
+        // build before any expensive bootstrap; the actual bind happens
+        // after the runtime exists (near the end of build()).
+        let control_listen = self
+            .control_listen
+            .as_deref()
+            .map(crate::runtime::cross_mob_control::ControlListenAddr::parse)
+            .transpose()
+            .map_err(|error| {
+                UnifiedRuntimeBuilderError::ConflictingConfiguration(format!(
+                    "control_listen(): {error}"
+                ))
+            })?;
 
         let has_persistent_state = self.persistent_state_path.is_some();
         // Same-root pairing is a documented requirement of
@@ -1398,6 +1425,18 @@ impl UnifiedRuntimeBuilder {
         {
             let report = runtime.reconcile_edges().await;
             *runtime.bootstrap_edges_report.write().await = Some(report);
+        }
+
+        // Bind the cross-mob control listener last among the fallible
+        // steps: the fully assembled runtime owns the serve task, so a bind
+        // failure follows the same cooperative shutdown path as the other
+        // late bootstrap errors above.
+        if let Some(addr) = control_listen.as_ref()
+            && let Err(error) = runtime.start_control_listener(addr).await
+        {
+            let build_error = UnifiedRuntimeBuilderError::Io(format!("control_listen(): {error}"));
+            runtime.shutdown().await;
+            return Err(build_error);
         }
 
         // Start event log ingestion if configured

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -16,8 +16,9 @@ use super::UnifiedRuntime;
 /// (registered via `register_peer_mob`) or a [`RemoteMobProxy`] for
 /// peers reachable over TCP/UDS.
 ///
-/// Phase 1 wires the structural seam — see `runtime/cross_mob_remote.rs`
-/// for the Phase 2 plan that fills in real cross-process control RPC.
+/// The remote arm speaks the cross-process control protocol; see
+/// `runtime/cross_mob_remote.rs` for the client and
+/// `runtime/cross_mob_control.rs` for the wire shape and the listener.
 enum LocalOrRemote {
     /// Same-process peer with its member plane and optional identity authority.
     Local(Box<PeerMobAuthority>),
@@ -150,10 +151,10 @@ pub enum CrossMobError {
     /// are part of the physical edge: without them a structurally wired peer
     /// cannot receive messages across isolated mob realms.
     InprocAlias(String),
-    /// A cross-process control-channel call failed. Phase 1 returns this
-    /// for any TCP/UDS contact entry that does not also have an
-    /// in-process `MobHandle` registered — the seam is laid out, the
-    /// real client lands in Phase 2.
+    /// A cross-process control-channel call failed: the peer gateway is
+    /// unreachable, has no control listener bound, or rejected the
+    /// request. The inner error carries the endpoint and the peer's
+    /// rejection code when one was returned.
     Remote(RemoteMobError),
 }
 
@@ -1290,8 +1291,8 @@ impl UnifiedRuntime {
     /// The destination mob is dispatched as either [`LocalOrRemote::Local`]
     /// (when an `Arc<MobHandle>` was registered via [`Self::register_peer_mob`])
     /// or [`LocalOrRemote::Remote`] (when only a contact-directory TCP/UDS
-    /// entry exists). Phase 1 ships the structural seam; Phase 2 wires the
-    /// real cross-process control RPC — see
+    /// entry exists). The remote arm performs real cross-process control
+    /// RPC against the peer gateway's control listener - see
     /// `runtime::cross_mob_remote::RemoteMobProxy`.
     pub async fn wire_cross_mob(
         &self,
@@ -1987,12 +1988,14 @@ fn build_external_peer_spec(
     }
 }
 
-/// Build a TCP peer descriptor.
+/// Build an UNSIGNED TCP peer descriptor (test/fixture helper).
 ///
-/// Uses the comms-layer address scheme `tcp://host:port`. **Phase-1 seam**:
-/// goes through [`TrustedPeerDescriptor::test_only_unsigned`]. Callers
-/// that need a real signed descriptor (Ed25519-stamped) should construct
-/// it via [`build_external_peer_spec`] with an explicit pubkey instead.
+/// Uses the comms-layer address scheme `tcp://host:port` and goes through
+/// [`TrustedPeerDescriptor::test_only_unsigned`], so the result carries no
+/// pubkey and is rejected by every fail-closed wire path in this module.
+/// Production callers get signed descriptors from the wire/lookup flow
+/// (which routes through [`build_external_peer_spec`] with a real pubkey);
+/// this helper exists for tests that assert address canonicalization.
 pub fn build_tcp_peer_spec(
     comms_name: &str,
     peer_id: &str,
@@ -2002,11 +2005,11 @@ pub fn build_tcp_peer_spec(
         .map_err(CrossMobError::PeerSpec)
 }
 
-/// Build a UDS peer descriptor.
+/// Build an UNSIGNED UDS peer descriptor (test/fixture helper).
 ///
-/// Uses the comms-layer address scheme `uds:///path` (triple slash —
-/// `uds://` + absolute path). See [`build_tcp_peer_spec`] for the
-/// Phase-1 vs signed-descriptor seam note.
+/// Uses the comms-layer address scheme `uds:///path` (triple slash -
+/// `uds://` + absolute path). See [`build_tcp_peer_spec`] for why this
+/// stays unsigned and what production callers use instead.
 pub fn build_uds_peer_spec(
     comms_name: &str,
     peer_id: &str,

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -8,7 +8,7 @@ use meerkat_mob::{MobHandle, PeerTarget};
 
 use crate::auth::peer_keys::GatewayPeerKeys;
 use crate::contact_directory::{ContactDirectory, ContactEntry, MobTransport};
-use crate::runtime::cross_mob_remote::{RemoteMobError, RemoteMobProxy};
+use crate::runtime::cross_mob_remote::{RemoteMemberInfo, RemoteMobError, RemoteMobProxy};
 
 use super::UnifiedRuntime;
 
@@ -39,6 +39,10 @@ struct MemberPeerInfo {
     peer_id: String,
     comms_name: String,
     pubkey: [u8; 32],
+    /// Raw roster transport-pubkey string (base64, optional `ed25519:`
+    /// prefix), forwarded verbatim on remote wire requests so the far side
+    /// can build a signed descriptor for this member.
+    pubkey_b64: String,
 }
 
 struct BilateralAliasRollback<'a> {
@@ -159,6 +163,28 @@ pub enum CrossMobError {
     /// The local cross-mob control listener could not be started (bind
     /// failure, double start, unsupported transport on this platform).
     ControlListener(String),
+    /// Remote cross-mob wiring requires the LOCAL member to be reachable
+    /// over a real transport: the descriptor shipped to the peer gateway
+    /// must carry an address its comms router can dial. Members default to
+    /// inproc comms; give them a socket listener (rpc_gateway
+    /// `runtime_options.member_comms_address`, or `comms.mode = "tcp"`
+    /// plus `comms.address` in the meerkat config) and bind the control
+    /// listener (`control_listen` / `--control-listen`) on both gateways.
+    LocalMemberNotRemotelyAddressable {
+        member_id: String,
+        mob_id: String,
+        /// What the member's comms runtime advertised (`None` when the
+        /// member has no comms runtime at all).
+        advertised: Option<String>,
+    },
+    /// The remote gateway answered `LookupMember` without a dialable comms
+    /// address or transport pubkey for the target member, so no routable
+    /// signed descriptor can be built for it.
+    RemoteMemberNotRemotelyAddressable {
+        member_id: String,
+        mob_id: String,
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for CrossMobError {
@@ -191,6 +217,32 @@ impl std::fmt::Display for CrossMobError {
             Self::ControlListener(reason) => {
                 write!(f, "cross-mob control listener error: {reason}")
             }
+            Self::LocalMemberNotRemotelyAddressable {
+                member_id,
+                mob_id,
+                advertised,
+            } => write!(
+                f,
+                "local member '{member_id}' in mob '{mob_id}' is not remotely addressable \
+                 (its comms runtime advertises {}); remote cross-mob wiring needs a member \
+                 socket transport - set runtime_options.member_comms_address (rpc_gateway) or \
+                 comms.mode=\"tcp\" with comms.address in the meerkat config, and bind \
+                 control_listen / --control-listen on the peer gateways",
+                match advertised {
+                    Some(address) => format!("'{address}'"),
+                    None => "no address (no comms runtime)".to_string(),
+                }
+            ),
+            Self::RemoteMemberNotRemotelyAddressable {
+                member_id,
+                mob_id,
+                detail,
+            } => write!(
+                f,
+                "remote member '{member_id}' in mob '{mob_id}' is not remotely addressable: \
+                 {detail}; the peer gateway must run its members with a socket comms transport \
+                 and serve LookupMember with session-service access"
+            ),
             Self::MissingPeerPubkey { mob_id } => match mob_id {
                 Some(id) => write!(
                     f,
@@ -468,7 +520,64 @@ async fn member_peer_info(
         peer_id,
         comms_name,
         pubkey,
+        pubkey_b64: pubkey_b64.to_string(),
     })
+}
+
+/// The member's live comms-listener address as its runtime advertises it
+/// (`tcp://host:port` with the real bound port when configured with port
+/// 0), or `None` when the member has no comms runtime. `inproc://...`
+/// comes back as-is; remote-wire callers reject it fail-closed.
+async fn member_comms_advertised_address(
+    mob_runtime: &crate::MobRuntime,
+    handle: &MobHandle,
+    member: &AgentIdentity,
+) -> Option<String> {
+    let session_id = handle.resolve_bridge_session_id(member).await?;
+    let service = mob_runtime.session_service()?;
+    let comms = service.comms_runtime(&session_id).await?;
+    comms.advertised_address()
+}
+
+/// Build the descriptor for a remote member from the facts its gateway
+/// returned via `LookupMember`. Fails closed when the remote member is not
+/// remotely addressable: a descriptor must carry an address the local
+/// comms router can dial and the MEMBER's own transport pubkey (the
+/// peer-id/pubkey consistency check rejects any other key, the contact
+/// directory's gateway key included).
+fn build_remote_member_spec(
+    info: &RemoteMemberInfo,
+    remote_member_id: &str,
+    remote_mob_id: &str,
+) -> Result<TrustedPeerDescriptor, CrossMobError> {
+    let not_addressable = |detail: String| CrossMobError::RemoteMemberNotRemotelyAddressable {
+        member_id: remote_member_id.to_string(),
+        mob_id: remote_mob_id.to_string(),
+        detail,
+    };
+    let address = info
+        .advertised_address
+        .as_deref()
+        .filter(|address| !address.starts_with("inproc://"))
+        .ok_or_else(|| {
+            not_addressable(match &info.advertised_address {
+                Some(address) => {
+                    format!("advertised address '{address}' is not dialable across processes")
+                }
+                None => "the peer gateway reported no advertised comms address for this member"
+                    .to_string(),
+            })
+        })?;
+    let pubkey_b64 = info.pubkey_b64.as_deref().ok_or_else(|| {
+        not_addressable("the peer gateway reported no transport pubkey for this member".to_string())
+    })?;
+    let pubkey = crate::auth::peer_keys::decode_pubkey_b64(pubkey_b64).map_err(|err| {
+        CrossMobError::PeerSpec(format!(
+            "remote member '{remote_member_id}' in mob '{remote_mob_id}' has an invalid \
+             transport pubkey: {err}"
+        ))
+    })?;
+    build_external_peer_spec(&info.comms_name, &info.peer_id, address, Some(pubkey))
 }
 
 async fn member_can_address_peer(
@@ -836,14 +945,14 @@ async fn unwire_bilateral_transaction(
 async fn wire_cross_mob_transaction(
     entry: ContactEntry,
     remote: LocalOrRemote,
-    local_handle: MobHandle,
+    local_runtime: crate::MobRuntime,
     local_mid: AgentIdentity,
     local_mob_id: String,
     local_member_id: String,
     remote_member_id: String,
     remote_mob_id: String,
-    pubkey_b64: Option<String>,
 ) -> Result<(), CrossMobError> {
+    let local_handle = local_runtime.handle();
     let local_info = member_peer_info(&local_handle, &local_mid, &local_mob_id).await?;
     match remote {
         LocalOrRemote::Local(remote_authority) => {
@@ -896,16 +1005,29 @@ async fn wire_cross_mob_transaction(
             Ok(())
         }
         LocalOrRemote::Remote(proxy) => {
-            let (remote_peer_id, remote_comms_name) = proxy
+            // Resolve the LOCAL member's dialable comms address before
+            // mutating anything: the far side installs it as the reply
+            // route, and an inproc:// (or absent) address can never
+            // deliver an envelope across processes. Failing here leaves
+            // both rosters untouched.
+            let local_address =
+                member_comms_advertised_address(&local_runtime, &local_handle, &local_mid).await;
+            let local_address = match local_address {
+                Some(address) if !address.starts_with("inproc://") => address,
+                other => {
+                    return Err(CrossMobError::LocalMemberNotRemotelyAddressable {
+                        member_id: local_member_id.clone(),
+                        mob_id: local_mob_id.clone(),
+                        advertised: other,
+                    });
+                }
+            };
+            let remote_info = proxy
                 .lookup_member(&remote_member_id)
                 .await
                 .map_err(CrossMobError::Remote)?;
-            let remote_spec = build_peer_spec(
-                &remote_comms_name,
-                &remote_peer_id,
-                &entry.transport,
-                entry.pubkey,
-            )?;
+            let remote_spec =
+                build_remote_member_spec(&remote_info, &remote_member_id, &remote_mob_id)?;
             mutate_member_unchecked(
                 local_handle.clone(),
                 &local_member_id,
@@ -913,23 +1035,19 @@ async fn wire_cross_mob_transaction(
                 true,
             )
             .await?;
-            let local_spec_address = format!("inproc://{}", local_info.comms_name);
             if let Err(remote_error) = proxy
                 .wire_remote(
                     &remote_member_id,
-                    &local_spec_address,
+                    &local_address,
                     &local_info.comms_name,
                     &local_info.peer_id,
-                    pubkey_b64,
+                    Some(local_info.pubkey_b64.clone()),
                 )
                 .await
             {
-                if let Ok(spec) = build_peer_spec(
-                    &remote_comms_name,
-                    &remote_peer_id,
-                    &entry.transport,
-                    entry.pubkey,
-                ) {
+                if let Ok(spec) =
+                    build_remote_member_spec(&remote_info, &remote_member_id, &remote_mob_id)
+                {
                     let _ = mutate_member_unchecked(
                         local_handle,
                         &local_member_id,
@@ -949,14 +1067,14 @@ async fn wire_cross_mob_transaction(
 async fn unwire_cross_mob_transaction(
     entry: ContactEntry,
     remote: LocalOrRemote,
-    local_handle: MobHandle,
+    local_runtime: crate::MobRuntime,
     local_mid: AgentIdentity,
     local_mob_id: String,
     local_member_id: String,
     remote_member_id: String,
     remote_mob_id: String,
-    pubkey_b64: Option<String>,
 ) -> Result<(), CrossMobError> {
+    let local_handle = local_runtime.handle();
     let mut first_error = None;
     let local_info = member_peer_info(&local_handle, &local_mid, &local_mob_id)
         .await
@@ -1003,16 +1121,11 @@ async fn unwire_cross_mob_transaction(
             }
         }
         LocalOrRemote::Remote(proxy) => {
-            if let Ok((remote_peer_id, remote_comms_name)) =
-                proxy.lookup_member(&remote_member_id).await
-                && let Ok(spec) = build_peer_spec(
-                    &remote_comms_name,
-                    &remote_peer_id,
-                    &entry.transport,
-                    entry.pubkey,
-                )
+            if let Ok(remote_info) = proxy.lookup_member(&remote_member_id).await
+                && let Ok(spec) =
+                    build_remote_member_spec(&remote_info, &remote_member_id, &remote_mob_id)
                 && let Err(error) = mutate_member_unchecked(
-                    local_handle,
+                    local_handle.clone(),
                     &local_member_id,
                     PeerTarget::External(spec),
                     false,
@@ -1022,19 +1135,37 @@ async fn unwire_cross_mob_transaction(
                 first_error = Some(error);
             }
             if let Some(local_info) = &local_info {
-                let local_spec_address = format!("inproc://{}", local_info.comms_name);
-                if let Err(error) = proxy
-                    .unwire_remote(
-                        &remote_member_id,
-                        &local_spec_address,
-                        &local_info.comms_name,
-                        &local_info.peer_id,
-                        pubkey_b64,
-                    )
+                // The far side removes trust rows by descriptor, so the
+                // unwire request needs the same dialable address + member
+                // pubkey the wire installed; its strict handler rejects
+                // inproc:// either way.
+                match member_comms_advertised_address(&local_runtime, &local_handle, &local_mid)
                     .await
-                    && first_error.is_none()
                 {
-                    first_error = Some(CrossMobError::Remote(error));
+                    Some(local_address) if !local_address.starts_with("inproc://") => {
+                        if let Err(error) = proxy
+                            .unwire_remote(
+                                &remote_member_id,
+                                &local_address,
+                                &local_info.comms_name,
+                                &local_info.peer_id,
+                                Some(local_info.pubkey_b64.clone()),
+                            )
+                            .await
+                            && first_error.is_none()
+                        {
+                            first_error = Some(CrossMobError::Remote(error));
+                        }
+                    }
+                    other => {
+                        if first_error.is_none() {
+                            first_error = Some(CrossMobError::LocalMemberNotRemotelyAddressable {
+                                member_id: local_member_id.clone(),
+                                mob_id: local_mob_id.clone(),
+                                advertised: other,
+                            });
+                        }
+                    }
                 }
             }
         }
@@ -1294,13 +1425,16 @@ impl UnifiedRuntime {
             .await
             .map_err(|error| CrossMobError::ControlListener(format!("bind {addr}: {error}")))?;
         let advertised = bound.advertised_address().to_string();
-        let handler: std::sync::Arc<dyn crate::runtime::cross_mob_control::ControlHandler> =
-            std::sync::Arc::new(
-                crate::runtime::cross_mob_control::MobHandleControlHandler::with_shared_identity_authority(
-                    self.mob_handle(),
-                    std::sync::Arc::clone(&self.implicit_delegate_identity_runtime),
-                ),
+        let mut handler =
+            crate::runtime::cross_mob_control::MobHandleControlHandler::with_shared_identity_authority(
+                self.mob_handle(),
+                std::sync::Arc::clone(&self.implicit_delegate_identity_runtime),
             );
+        if let Some(service) = self.mob_runtime.session_service() {
+            handler = handler.with_session_service(std::sync::Arc::clone(service));
+        }
+        let handler: std::sync::Arc<dyn crate::runtime::cross_mob_control::ControlHandler> =
+            std::sync::Arc::new(handler);
         *task_slot = Some(tokio::spawn(bound.serve(handler)));
         *self
             .cross_mob_control_advertised
@@ -1402,11 +1536,8 @@ impl UnifiedRuntime {
             LocalOrRemote::Remote(_) => None,
         };
         let remote_identity_authoritative = remote_target.is_some();
-        let pubkey_b64 = self
-            .gateway_peer_keys
-            .as_ref()
-            .map(crate::auth::peer_keys::GatewayPeerKeys::pubkey_b64);
         let remote_mob_id = remote_mob_id.to_string();
+        let local_runtime = self.mob_runtime.clone();
         run_member_authority_transaction(
             [local_target, remote_target],
             format!("{local_member_id} <-> {remote_member_id}"),
@@ -1437,13 +1568,12 @@ impl UnifiedRuntime {
                 wire_cross_mob_transaction(
                     entry,
                     remote,
-                    local_handle,
+                    local_runtime,
                     local_mid,
                     local_mob_id,
                     local_member_id,
                     remote_member_id,
                     remote_mob_id,
-                    pubkey_b64,
                 )
                 .await
             },
@@ -1506,11 +1636,8 @@ impl UnifiedRuntime {
             LocalOrRemote::Remote(_) => None,
         };
         let remote_identity_authoritative = remote_target.is_some();
-        let pubkey_b64 = self
-            .gateway_peer_keys
-            .as_ref()
-            .map(crate::auth::peer_keys::GatewayPeerKeys::pubkey_b64);
         let remote_mob_id = remote_mob_id.to_string();
+        let local_runtime = self.mob_runtime.clone();
         run_member_authority_transaction(
             [local_target, remote_target],
             format!("{local_member_id} <-> {remote_member_id}"),
@@ -1541,13 +1668,12 @@ impl UnifiedRuntime {
                 unwire_cross_mob_transaction(
                     entry,
                     remote,
-                    local_handle,
+                    local_runtime,
                     local_mid,
                     local_mob_id,
                     local_member_id,
                     remote_member_id,
                     remote_mob_id,
-                    pubkey_b64,
                 )
                 .await
             },
@@ -1942,6 +2068,7 @@ impl UnifiedRuntime {
             peer_id,
             comms_name,
             pubkey,
+            pubkey_b64: pubkey_b64.to_string(),
         })
     }
 

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -156,6 +156,9 @@ pub enum CrossMobError {
     /// request. The inner error carries the endpoint and the peer's
     /// rejection code when one was returned.
     Remote(RemoteMobError),
+    /// The local cross-mob control listener could not be started (bind
+    /// failure, double start, unsupported transport on this platform).
+    ControlListener(String),
 }
 
 impl std::fmt::Display for CrossMobError {
@@ -185,6 +188,9 @@ impl std::fmt::Display for CrossMobError {
             ),
             Self::PeerSpec(reason) => write!(f, "peer spec error: {reason}"),
             Self::InprocAlias(reason) => write!(f, "inproc alias error: {reason}"),
+            Self::ControlListener(reason) => {
+                write!(f, "cross-mob control listener error: {reason}")
+            }
             Self::MissingPeerPubkey { mob_id } => match mob_id {
                 Some(id) => write!(
                     f,
@@ -1260,6 +1266,57 @@ impl UnifiedRuntime {
     /// Set the contact directory for cross-mob address resolution.
     pub fn set_contact_directory(&mut self, directory: ContactDirectory) {
         self.contact_directory = Some(directory);
+    }
+
+    /// Bind the cross-mob control listener and start serving control RPC
+    /// (wire/unwire/inject/lookup) from remote gateways.
+    ///
+    /// Returns the dialable bound address (`tcp://ip:port` with the real
+    /// kernel-assigned port for `tcp://host:0`, or `uds:///path`) - this is
+    /// what peers put in their contact directories. The serve task is owned
+    /// by the runtime and aborted on [`UnifiedRuntime::shutdown`].
+    ///
+    /// The handler re-reads the identity authority per request, so calling
+    /// this before `attach_identity_first_context` is safe: generated
+    /// `rt:*` aliases fail closed until the authority is attached and are
+    /// admitted afterwards.
+    pub async fn start_control_listener(
+        &self,
+        addr: &crate::runtime::cross_mob_control::ControlListenAddr,
+    ) -> Result<String, CrossMobError> {
+        let mut task_slot = self.cross_mob_control_task.lock().await;
+        if task_slot.is_some() {
+            return Err(CrossMobError::ControlListener(
+                "control listener already running".to_string(),
+            ));
+        }
+        let bound = crate::runtime::cross_mob_control::BoundControlListener::bind(addr)
+            .await
+            .map_err(|error| CrossMobError::ControlListener(format!("bind {addr}: {error}")))?;
+        let advertised = bound.advertised_address().to_string();
+        let handler: std::sync::Arc<dyn crate::runtime::cross_mob_control::ControlHandler> =
+            std::sync::Arc::new(
+                crate::runtime::cross_mob_control::MobHandleControlHandler::with_shared_identity_authority(
+                    self.mob_handle(),
+                    std::sync::Arc::clone(&self.implicit_delegate_identity_runtime),
+                ),
+            );
+        *task_slot = Some(tokio::spawn(bound.serve(handler)));
+        *self
+            .cross_mob_control_advertised
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(advertised.clone());
+        Ok(advertised)
+    }
+
+    /// The dialable address of the running cross-mob control listener, or
+    /// `None` when no listener was started. For `tcp://host:0` binds this
+    /// carries the real kernel-assigned port.
+    pub fn control_listener_advertised_address(&self) -> Option<String> {
+        self.cross_mob_control_advertised
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     /// Install the long-lived Ed25519 keypair this gateway advertises via

--- a/meerkat-mobkit/src/unified_runtime/lifecycle.rs
+++ b/meerkat-mobkit/src/unified_runtime/lifecycle.rs
@@ -169,6 +169,12 @@ impl UnifiedRuntime {
             task.abort();
             let _ = task.await;
         }
+        // Stop accepting cross-mob control RPC before the mob quiesces so a
+        // late inbound wire/inject cannot race member teardown.
+        if let Some(task) = self.cross_mob_control_task.lock().await.take() {
+            task.abort();
+            let _ = task.await;
+        }
         let identity_runtime = self.identity_runtime().cloned();
         if let Some(identity_runtime) = identity_runtime.as_ref() {
             // Close request admission before any supervisor is drained. A

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -160,6 +160,16 @@ pub struct UnifiedRuntime {
     // Cross-mob communication
     contact_directory: Option<crate::contact_directory::ContactDirectory>,
     peer_mob_handles: tokio::sync::RwLock<BTreeMap<String, cross_mob::PeerMobAuthority>>,
+    /// Serve task of the cross-mob control listener, when one was started
+    /// via [`UnifiedRuntime::start_control_listener`]. Aborted on shutdown
+    /// like the other runtime-owned background tasks.
+    cross_mob_control_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
+    /// The dialable address the control listener actually bound
+    /// (`tcp://ip:port` with the real port for `host:0` binds, or
+    /// `uds:///path`). This is the address remote peers are told to put in
+    /// their contact directories, and the address stamped into outbound
+    /// remote wire requests as this gateway's control endpoint.
+    cross_mob_control_advertised: std::sync::RwLock<Option<String>>,
     /// Long-lived Ed25519 signing identity for cross-process peering.
     /// `None` is the default for inproc-only deployments and tests;
     /// production gateways set this via
@@ -302,6 +312,8 @@ impl UnifiedRuntime {
             agent_memory_steward_task: tokio::sync::Mutex::new(None),
             contact_directory: None,
             peer_mob_handles: tokio::sync::RwLock::new(BTreeMap::new()),
+            cross_mob_control_task: tokio::sync::Mutex::new(None),
+            cross_mob_control_advertised: std::sync::RwLock::new(None),
             gateway_peer_keys: None,
             session_bridge: None,
             identity_first_context: None,

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -596,7 +596,7 @@ impl UnifiedRuntime {
         if self.has_contact_directory() {
             runtime_methods.push("mobkit/cross_mob/directory".to_string());
         }
-        if has_peer_mob_handles && self.has_inproc_contacts() {
+        if (has_peer_mob_handles && self.has_inproc_contacts()) || self.has_remote_contacts() {
             runtime_methods.extend([
                 "mobkit/cross_mob/wire".to_string(),
                 "mobkit/cross_mob/unwire".to_string(),

--- a/meerkat-mobkit/tests/cross_mob_control_round_trip.rs
+++ b/meerkat-mobkit/tests/cross_mob_control_round_trip.rs
@@ -1,0 +1,355 @@
+//! Cross-mob control round trip - the end-to-end proof that two
+//! `UnifiedRuntime`s can wire members across a real TCP/UDS control channel
+//! and then exchange agent-plane comms envelopes in BOTH directions.
+//! (This is the file promised by `tests/cross_mob_tcp.rs`.)
+//!
+//! Topology per test: two UnifiedRuntimes in one process, each with its own
+//! mob and its own cross-mob control listener bound on an ephemeral port
+//! (`control_listen("tcp://127.0.0.1:0")`). Members run their comms
+//! runtimes in TCP mode (`comms.mode = tcp`, `127.0.0.1:0`), so every
+//! member has a real dialable envelope listener with a kernel-assigned
+//! port. Runtime A's contact directory points at B's *bound* control
+//! address, so `wire_cross_mob` flows A -> control channel -> B and
+//! installs signed `TrustedPeerDescriptor`s on both sides:
+//!
+//! * on A: bob's member facts (peer id, comms name, transport pubkey,
+//!   advertised tcp address) discovered via `LookupMember`;
+//! * on B: alice's member facts carried by the `Wire` request - the
+//!   reverse leg. Before the reverse-address fix this carried
+//!   `inproc://...` and the gateway pubkey, which was both unreachable
+//!   from another process and rejected by the peer-id/pubkey consistency
+//!   check; the descriptor could never deliver.
+//!
+//! Delivery proof:
+//! 1. control plane A->B: `send_cross_mob` (Inject) returns bob's bridge
+//!    session id.
+//! 2. agent plane A->B: alice's comms runtime sends a `PeerMessage` to the
+//!    bob entry in HER trust directory; the router dials bob's member
+//!    listener over real TCP and requires an ack signed by bob's keypair.
+//! 3. agent plane B->A (the reply leg): bob sends a `PeerMessage` to the
+//!    alice entry the REMOTE Wire request installed. A successful, acked
+//!    send is cryptographic proof that the reverse descriptor carries a
+//!    dialable address and alice's real member pubkey.
+//!
+//! # Two-process variant
+//!
+//! Deliberately not implemented here. The subprocess harness
+//! (`tests/identity_first_subprocess_reboot.rs`) drives the `rpc_gateway`
+//! binary over stdin JSON-RPC, and that binary has no control-listen
+//! surface at all today; `--control-listen` exists on `mobkit_gateway`,
+//! which surfaces its bound control address only in tracing, not in the
+//! init response. A two-process round trip needs BOTH processes to hand
+//! their bound control address and gateway pubkey back to the test before
+//! either contact directory can be written, so it requires a gateway
+//! protocol change (an init-response field, plus the flag on rpc_gateway),
+//! not just a test. That is a small follow-up, out of scope for this
+//! lane. Everything transport-level that a second process would exercise
+//! (real TCP sockets for control AND envelope planes, signed descriptor
+//! verification at ingress, ack signing by the addressed keypair) is
+//! already crossed by the in-process pair below - nothing here shares
+//! memory except the test harness itself.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::uninlined_format_args
+)]
+
+use std::sync::Arc;
+
+use meerkat_client::TestClient;
+use meerkat_core::comms::{CommsCommand, PeerRoute, PeerSendability};
+use meerkat_core::types::HandlingMode;
+use meerkat_mob::{MobDefinition, SpawnMemberSpec};
+use meerkat_mobkit::contact_directory::ContactDirectory;
+use meerkat_mobkit::{GatewayPeerKeys, UnifiedRuntime, UnifiedRuntimeBuilder};
+
+const MOB_TOML_A: &str = r#"
+[mob]
+id = "mob-a"
+
+[profiles.worker]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.worker.tools]
+comms = true
+"#;
+
+const MOB_TOML_B: &str = r#"
+[mob]
+id = "mob-b"
+
+[profiles.worker]
+model = "gpt-5.5"
+external_addressable = true
+
+[profiles.worker.tools]
+comms = true
+"#;
+
+/// Every member binds its own signed comms listener on an ephemeral
+/// loopback port, so cross-process envelope delivery is real TCP.
+fn tcp_member_comms_config() -> meerkat::Config {
+    let mut config = meerkat::Config::default();
+    config.comms.mode = meerkat_core::CommsRuntimeMode::Tcp;
+    config.comms.address = Some("127.0.0.1:0".to_string());
+    config
+}
+
+async fn build_runtime(mob_toml: &str, control_listen: &str) -> UnifiedRuntime {
+    let definition = MobDefinition::from_toml(mob_toml).expect("parse mob definition");
+    let mut runtime = Box::pin(
+        UnifiedRuntimeBuilder::default()
+            .definition(definition)
+            .default_llm_client(Arc::new(TestClient::default()))
+            .meerkat_config(tcp_member_comms_config())
+            .control_listen(control_listen)
+            .build(),
+    )
+    .await
+    .expect("build runtime");
+    runtime.set_gateway_peer_keys(GatewayPeerKeys::ephemeral());
+    runtime
+}
+
+async fn spawn_member(runtime: &UnifiedRuntime, member: &str) {
+    runtime
+        .mob_handle()
+        .ensure_member(SpawnMemberSpec::new(
+            meerkat_mob::ProfileName::from("worker"),
+            meerkat_mob::ids::AgentIdentity::from(member),
+        ))
+        .await
+        .expect("ensure member");
+}
+
+/// The live comms runtime backing a member's bridge session.
+async fn member_comms(
+    runtime: &UnifiedRuntime,
+    member: &str,
+) -> Arc<dyn meerkat_core::agent::CommsRuntime> {
+    let handle = runtime.mob_handle();
+    let session_id = handle
+        .resolve_bridge_session_id(&meerkat_mob::ids::AgentIdentity::from(member))
+        .await
+        .expect("member has a bridge session");
+    runtime
+        .mob_runtime()
+        .session_service()
+        .expect("session service")
+        .comms_runtime(&session_id)
+        .await
+        .expect("member comms runtime")
+}
+
+fn comms_name(mob_id: &str, member: &str) -> String {
+    meerkat_core::MemberCommsName::new(mob_id, "worker", member)
+        .expect("comms name")
+        .to_string()
+}
+
+/// Find `peer_name` in the runtime-visible peer directory of a member's
+/// comms runtime, requiring PeerMessage sendability.
+async fn sendable_peer(
+    comms: &Arc<dyn meerkat_core::agent::CommsRuntime>,
+    peer_name: &str,
+) -> Option<meerkat_core::comms::PeerDirectoryEntry> {
+    comms.peers().await.into_iter().find(|peer| {
+        peer.name.as_str() == peer_name
+            && peer.sendable_kinds.contains(&PeerSendability::PeerMessage)
+    })
+}
+
+fn peer_message(to: &meerkat_core::comms::PeerDirectoryEntry, body: &str) -> CommsCommand {
+    CommsCommand::PeerMessage {
+        to: PeerRoute::new(to.peer_id),
+        body: body.to_string(),
+        blocks: None,
+        content_taint: None,
+        handling_mode: HandlingMode::Queue,
+        objective_id: None,
+    }
+}
+
+/// A peer-message send is only a delivery proof when the receipt carries a
+/// verified signed ack from the addressed member's keypair (the TCP path);
+/// anything else would mean the envelope took a route this test is not
+/// trying to prove.
+fn assert_acked(receipt: meerkat_core::comms::SendReceipt, leg: &str) {
+    match receipt {
+        meerkat_core::comms::SendReceipt::PeerMessageSent { delivery, .. } => {
+            assert_eq!(
+                delivery,
+                meerkat_core::comms::PeerDeliveryOutcome::Acked,
+                "{leg}: delivery must be a verified signed ack over the socket transport"
+            );
+        }
+        other => panic!("{leg}: expected PeerMessageSent, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tcp_control_round_trip_wires_and_delivers_both_ways() {
+    // B first: its bound control address feeds A's contact directory.
+    let rt_b = build_runtime(MOB_TOML_B, "tcp://127.0.0.1:0").await;
+    let control_b = rt_b
+        .control_listener_advertised_address()
+        .expect("B bound a control listener");
+    assert!(
+        control_b.starts_with("tcp://127.0.0.1:") && !control_b.ends_with(":0"),
+        "bound control address must carry the real port: {control_b}"
+    );
+
+    let mut rt_a = build_runtime(MOB_TOML_A, "tcp://127.0.0.1:0").await;
+    let pubkey_b = rt_b.gateway_peer_keys().expect("keys").pubkey_b64();
+    let dir_a = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-b = {{ transport = "{control_b}", pubkey = "{pubkey_b}" }}
+        "#,
+    ))
+    .expect("contact directory for mob-a");
+    rt_a.set_contact_directory(dir_a);
+
+    spawn_member(&rt_a, "alice").await;
+    spawn_member(&rt_b, "bob").await;
+
+    // Wire A -> B across the real control channel.
+    Box::pin(rt_a.wire_cross_mob("alice", "bob", "mob-b"))
+        .await
+        .expect("wire alice <-> bob across processes");
+
+    let alice_comms = member_comms(&rt_a, "alice").await;
+    let bob_comms = member_comms(&rt_b, "bob").await;
+    let bob_name = comms_name("mob-b", "bob");
+    let alice_name = comms_name("mob-a", "alice");
+
+    let bob_entry = sendable_peer(&alice_comms, &bob_name)
+        .await
+        .expect("alice's directory lists bob as a sendable peer");
+    let alice_entry = sendable_peer(&bob_comms, &alice_name)
+        .await
+        .expect("bob's directory lists alice as a sendable peer (reverse wire leg)");
+    // The reverse-address fix in one assertion: the descriptor the Wire
+    // request installed on B must carry a dialable socket address for
+    // alice, not inproc://.
+    assert_eq!(
+        alice_entry.address.transport().as_scheme(),
+        "tcp",
+        "reverse descriptor must carry alice's tcp comms address, got {}",
+        alice_entry.address
+    );
+    assert_eq!(
+        bob_entry.address.transport().as_scheme(),
+        "tcp",
+        "forward descriptor must carry bob's tcp comms address, got {}",
+        bob_entry.address
+    );
+
+    // Control plane A->B: app-level injection into bob's session.
+    let injected_session =
+        Box::pin(rt_a.send_cross_mob("alice", "bob", "mob-b", "hello bob (control plane)"))
+            .await
+            .expect("send_cross_mob injects into bob's session");
+    let bob_session = rt_b
+        .mob_handle()
+        .resolve_bridge_session_id(&meerkat_mob::ids::AgentIdentity::from("bob"))
+        .await
+        .expect("bob session");
+    assert_eq!(injected_session, bob_session.to_string());
+
+    // Agent plane A->B: alice's router dials bob's member listener over
+    // real TCP; success requires an ack signed by bob's keypair. This is
+    // the forward-descriptor proof (LookupMember-supplied member pubkey +
+    // advertised address), exercised from the direction that was broken.
+    let receipt = alice_comms
+        .send(peer_message(&bob_entry, "hello bob (agent plane)"))
+        .await
+        .expect("alice delivers a signed envelope to bob over TCP");
+    assert_acked(receipt, "alice -> bob");
+
+    // Agent plane B->A: THE reply leg. This send only exists if the Wire
+    // request carried alice's dialable address and real member pubkey.
+    let receipt = bob_comms
+        .send(peer_message(&alice_entry, "hello alice (reply leg)"))
+        .await
+        .expect("bob delivers a signed envelope back to alice over TCP");
+    assert_acked(receipt, "bob -> alice (reply leg)");
+
+    // Unwire across the control channel and verify both directories drop
+    // the peering.
+    Box::pin(rt_a.unwire_cross_mob("alice", "bob", "mob-b"))
+        .await
+        .expect("unwire alice <-> bob");
+    assert!(
+        sendable_peer(&alice_comms, &bob_name).await.is_none(),
+        "alice must no longer list bob after unwire"
+    );
+    assert!(
+        sendable_peer(&bob_comms, &alice_name).await.is_none(),
+        "bob must no longer list alice after remote unwire"
+    );
+
+    rt_a.shutdown().await;
+    rt_b.shutdown().await;
+}
+
+/// UDS variant of the control channel: same wire flow with the peer's
+/// control listener on a unix socket. Member envelope transport stays TCP
+/// (each member has its own listener), so this pins exactly the control
+/// transport difference.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn uds_control_round_trip_wires_both_sides() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("mob-b-control.sock");
+    let rt_b = build_runtime(MOB_TOML_B, &format!("uds://{}", socket.display())).await;
+    let control_b = rt_b
+        .control_listener_advertised_address()
+        .expect("B bound a control listener");
+    assert_eq!(control_b, format!("uds://{}", socket.display()));
+
+    let mut rt_a = build_runtime(MOB_TOML_A, "tcp://127.0.0.1:0").await;
+    let pubkey_b = rt_b.gateway_peer_keys().expect("keys").pubkey_b64();
+    let dir_a = ContactDirectory::from_toml(&format!(
+        r#"
+        [mobs]
+        mob-b = {{ transport = "{control_b}", pubkey = "{pubkey_b}" }}
+        "#,
+    ))
+    .expect("contact directory for mob-a");
+    rt_a.set_contact_directory(dir_a);
+
+    spawn_member(&rt_a, "alice").await;
+    spawn_member(&rt_b, "bob").await;
+
+    Box::pin(rt_a.wire_cross_mob("alice", "bob", "mob-b"))
+        .await
+        .expect("wire alice <-> bob over the UDS control channel");
+
+    let alice_comms = member_comms(&rt_a, "alice").await;
+    let bob_comms = member_comms(&rt_b, "bob").await;
+    let bob_entry = sendable_peer(&alice_comms, &comms_name("mob-b", "bob"))
+        .await
+        .expect("alice lists bob");
+    let alice_entry = sendable_peer(&bob_comms, &comms_name("mob-a", "alice"))
+        .await
+        .expect("bob lists alice (reverse leg over UDS control)");
+
+    // One delivery each way proves the descriptors are live, not just rows.
+    let receipt = alice_comms
+        .send(peer_message(&bob_entry, "hello bob (uds-wired)"))
+        .await
+        .expect("alice -> bob");
+    assert_acked(receipt, "alice -> bob (uds-wired)");
+    let receipt = bob_comms
+        .send(peer_message(&alice_entry, "hello alice (uds-wired reply)"))
+        .await
+        .expect("bob -> alice");
+    assert_acked(receipt, "bob -> alice (uds-wired reply)");
+
+    rt_a.shutdown().await;
+    rt_b.shutdown().await;
+}

--- a/meerkat-mobkit/tests/cross_mob_tcp.rs
+++ b/meerkat-mobkit/tests/cross_mob_tcp.rs
@@ -1,26 +1,21 @@
-//! Cross-mob TCP transport plumbing — Phase 1 surface tests.
+//! Cross-mob TCP transport plumbing - surface tests.
 //!
-//! These tests pin the structural contract delivered by Unit 3 of the
-//! 0.6.x cross-mob work:
+//! These tests pin the structural contract of the TCP contact path:
 //!
 //! 1. `ContactDirectory::from_toml` accepts `tcp://host:port` entries.
 //! 2. `UnifiedRuntime::has_remote_contacts()` flips on for TCP entries.
 //! 3. The peer-spec helpers `build_tcp_peer_spec` produce valid
 //!    comms-layer addresses.
-//! 4. `wire_cross_mob` no longer returns the legacy
-//!    `TransportNotSupported` early-reject — it goes through the new
-//!    `LocalOrRemote` dispatcher and surfaces the
-//!    `Remote(ControlChannelUnavailable)` seam for cross-process peers.
+//! 4. `wire_cross_mob` routes TCP contacts through the `LocalOrRemote`
+//!    dispatcher (local roster checks first, then the real cross-process
+//!    control client).
 //! 5. `wire_local` / `unwire_local` accept `tcp://` addresses and
 //!    pass them through to the comms-layer trust store unchanged
 //!    (no early scheme rejection in mobkit).
 //!
-//! Phase 2 (cross-process control RPC) replaces the
-//! `ControlChannelUnavailable` stub with a real client; that work lands
-//! in a sibling unit and an updated test will assert end-to-end delivery.
-//!
-//! Two-runtime ephemeral-port / TempDir scaffolding is in place so the
-//! Phase-2 update is a pure additive edit — no test-rebuild required.
+//! The end-to-end proof (two runtimes, real control listeners, signed
+//! envelope delivery both ways) lives in
+//! `tests/cross_mob_control_round_trip.rs`.
 
 #![allow(
     clippy::expect_used,
@@ -151,11 +146,8 @@ async fn unified_runtime_with_tcp_contact_reports_remote_contacts() {
 
 #[tokio::test]
 async fn wire_cross_mob_over_tcp_surfaces_remote_seam() {
-    // Phase 1: with no `register_peer_mob`, a TCP contact entry routes
-    // through the `RemoteMobProxy`. The Phase 1 stub returns
-    // `ControlChannelUnavailable` so callers see the seam without a
-    // silent misroute. Phase 2 replaces this with a real control-channel
-    // client.
+    // With no `register_peer_mob`, a TCP contact entry routes through the
+    // `RemoteMobProxy` (the real control-channel client).
     let port_b = ephemeral_port().await;
     let dir_a = ContactDirectory::from_toml(&format!(
         r#"


### PR DESCRIPTION
## Summary

0.8.16 program head item (owner-ratified list, item 1): complete remote mobs / cross-mob. The cross-mob control protocol had a finished client and a server with zero construction sites; every remote dispatch died at ControlChannelUnavailable, and the wire/unwire reverse path sent unroutable inproc:// addresses that failed open. This wave binds the listener, fixes the descriptor facts, and proves delivery both ways over real TCP and UDS with signed acks.

- **Slice 0 - docs honesty** (6796a4e7): the Phase-1/Phase-2 fiction in cross_mob_remote.rs / cross_mob_control.rs / unified_runtime/cross_mob.rs is gone; comments describe what ships.
- **Slice 1 - bind the listener** (70944ef8): `ControlListenAddr::parse` (tcp://host:port, uds:///path, shared contact-directory parser, inproc rejected), `BoundControlListener` (bind/serve split so `tcp://host:0` reports the real port), `UnifiedRuntime::start_control_listener` + advertised-address accessor, `UnifiedRuntimeBuilder::control_listen()`, `mobkit_gateway --control-listen` (hashed into the resume fingerprint). Identity authority resolves late, per request, so gateways attaching identity-first after boot serve generated rt:* aliases correctly. Serve task aborts on shutdown.
- **Slice 2 - descriptors carry member facts** (58e372ef): Wire/Unwire send the local member's advertised comms address + member transport pubkey (satisfies UUIDv5(pubkey) peer-id consistency); members without a socket transport fail closed with `LocalMemberNotRemotelyAddressable` naming the remedy knobs. `ControlResponse::Member` gains wire-additive pubkey_b64/advertised_address; forward descriptors are built from member facts too. The remote Wire handler rejects inproc:// addresses and missing pubkeys with typed codes distinct from unknown_member. Local/in-process paths byte-identical (all pre-existing cross_mob suites pass unchanged). `ControlResponse::Injected` documented as dispatch admission, not a durability receipt (agreed with the meerkat 0.8.22 peer-admission contract). Capability advertisement now admits remote-contact deployments at all three sites.
- **Slice 3 - proof** (62174195): `tests/cross_mob_control_round_trip.rs` - the test promised by a stale comment but never written. Two runtimes, real listeners on ephemeral ports, wire from the previously-broken direction, agent-plane PeerMessage delivery asserted `Acked` in BOTH directions (the reply leg could not exist before slice 2), TCP and UDS variants, unwire clears both directories.

## Test evidence

- Full crate suite: **2222/2222 passed** (150 skipped, 2 leaky) after fixing a worktree-environment issue (untracked `.rct/` not present in a fresh worktree - not a product failure).
- Targeted: slice 1 9/9, slice 2 28/28, slice 3 7/7.
- Clippy `--all-targets -D warnings`: exit 0 on every slice.

## Deferred (ledgered on the 0.8.16 program, task #69)

- True two-process round trip: needs a gateway protocol addition (init-response field carrying the bound control address; `--control-listen` on rpc_gateway).
- Control responses are not gateway-signed: member-key substitution by an on-path attacker remains possible on the control channel (pre-existing documented posture, now load-bearing) - queued as a security follow-up.
- Pairing/TOFU bootstrap verb for contacts.toml pubkeys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)