### PR TITLE
feat(cross-mob): two-process operation + authenticated control channel (P0 continuation)

### DIFF
--- a/meerkat-mobkit/BUILD.bazel
+++ b/meerkat-mobkit/BUILD.bazel
@@ -1573,6 +1573,76 @@ rust_test(
 )
 
 rust_test(
+    name = "cross_mob_two_process_test",
+    aliases = aliases(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    crate_name = "cross_mob_two_process",
+    crate_root = "tests/cross_mob_two_process.rs",
+    crate_features = [],
+    edition = "2024",
+    compile_data = [
+        "Cargo.toml",
+        "assets/release-targets.json",
+        "console-dist/console-app.css",
+        "console-dist/console-app.js",
+        "console-dist/index.html",
+        "examples/library_mode_reference.rs",
+        "flow-editor-dist/flow-editor.css",
+        "flow-editor-dist/flow-editor.js",
+        "flow-editor-dist/index.html",
+        "flow-editor-dist/react-globals.js",
+        "src/adaptive_layer_decision.schema.json",
+        "src/memory/distiller_prompt_v0.md",
+        "src/memory/hygienist_prompt_v0.md",
+        "src/memory/selector_prompt_v0.md",
+        "src/memory/steward_prompt_v0.md",
+        "src/unified_runtime/http.rs",
+        "src/unified_runtime/lifecycle.rs",
+        "tests/fixtures/homecore_ledgerv1_closure/calendar-continuity-closure.json",
+        "tests/fixtures/homecore_ledgerv1_closure/continuity-schema.sql",
+        "tests/fixtures/homecore_security_idempotency/security-head-evolution.json",
+        "tests/fixtures/v0_8_10_released_session.json",
+        "tests/fixtures/v0_8_10_zero_rewrite_supervisor_session.json",
+    ],
+    srcs = [
+        "tests/cross_mob_two_process.rs",
+    ],
+    visibility = ["//visibility:public"],
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.8.15",
+        "CARGO_BIN_NAME": "cross_mob_two_process",
+        "CARGO_MANIFEST_DIR": "./meerkat-mobkit",
+    },
+    tags = [
+        "fast",
+    ],
+    size = "small",
+    data = [
+        ":package_runfiles",
+    ],
+    env = {
+        "RUST_MIN_STACK": "16777216",
+    },
+    proc_macro_deps = all_crate_deps(
+        package_name = "meerkat-mobkit",
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [
+        "//meerkat-mobkit:meerkat_mobkit",
+    ] + all_crate_deps(
+        package_name = "meerkat-mobkit",
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test(
     name = "cross_mob_uds_test",
     aliases = aliases(
         package_name = "meerkat-mobkit",
@@ -7379,6 +7449,7 @@ test_suite(
         ":cross_mob_control_round_trip_test",
         ":cross_mob_signed_test",
         ":cross_mob_tcp_test",
+        ":cross_mob_two_process_test",
         ":cross_mob_uds_test",
         ":discovery_bootstrap_test",
         ":distiller_eval_harness_test",

--- a/meerkat-mobkit/src/bin/mobkit_gateway.rs
+++ b/meerkat-mobkit/src/bin/mobkit_gateway.rs
@@ -107,6 +107,11 @@ struct RuntimeRegistryEntry {
     http_base_url: String,
     pid: u32,
     updated_at_ms: u64,
+    /// Dialable cross-mob control-listener address of the live gateway, so
+    /// a resumed launch can still report it. Serde-defaulted: registries
+    /// written by older gateways simply resume with no control address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    control_listen_address: Option<String>,
 }
 
 fn current_time_ms() -> u64 {
@@ -693,6 +698,7 @@ fn init_response(
     runtime_id: &str,
     http_base_url: &str,
     launch_state: &str,
+    control_listen_address: Option<&str>,
 ) -> Value {
     json!({
         "jsonrpc": "2.0",
@@ -702,6 +708,11 @@ fn init_response(
             "runtime_id": runtime_id,
             "http_base_url": http_base_url,
             "launch_state": launch_state,
+            // Dialable address of the cross-mob control listener when the
+            // gateway was launched with --control-listen (real bound port
+            // for tcp://host:0); null otherwise. Peers put this address in
+            // their contact directories. Wire-additive optional field.
+            "control_listen_address": control_listen_address,
         }
     })
 }
@@ -1184,6 +1195,7 @@ async fn run(control_listen: Option<ControlListenAddr>) -> anyhow::Result<()> {
             &entry.runtime_id,
             &entry.http_base_url,
             "resumed",
+            entry.control_listen_address.as_deref(),
         ));
         return Ok(());
     }
@@ -1597,6 +1609,7 @@ async fn run(control_listen: Option<ControlListenAddr>) -> anyhow::Result<()> {
         listener.local_addr().context("missing local addr")?.port()
     );
 
+    let control_listen_address = runtime.control_listener_advertised_address();
     registry.entries.retain(|entry| entry.key != key);
     registry.entries.push(RuntimeRegistryEntry {
         key: key.clone(),
@@ -1604,6 +1617,7 @@ async fn run(control_listen: Option<ControlListenAddr>) -> anyhow::Result<()> {
         http_base_url: http_base_url.clone(),
         pid: std::process::id(),
         updated_at_ms: current_time_ms(),
+        control_listen_address: control_listen_address.clone(),
     });
     save_registry(&registry_file, &registry)?;
 
@@ -1612,6 +1626,7 @@ async fn run(control_listen: Option<ControlListenAddr>) -> anyhow::Result<()> {
         &runtime_id,
         &http_base_url,
         "created",
+        control_listen_address.as_deref(),
     ));
 
     let decisions = runtime_decision_state(&runtime_id, console_ui, console_read_only);

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -8905,12 +8905,32 @@ external_addressable = true
     };
 
     // Cross-mob surfaces: install the inline contact directory (while the
-    // runtime is still exclusively owned) and bind the control listener.
-    // The listener starts after identity-first attachment above, but its
-    // handler re-reads the identity authority per request either way.
+    // runtime is still exclusively owned), the gateway signing identity,
+    // and the control listener. The listener starts after identity-first
+    // attachment above, but its handler re-reads the identity authority
+    // per request either way.
     if let Some(directory) = gateway_options.contacts.clone() {
         runtime.set_contact_directory(directory);
     }
+    // The gateway keypair signs cross-mob control responses (peers with
+    // this gateway's pubkey pinned verify them) and backs mobkit/peer_pubkey.
+    // Persistent boots keep it stable across restarts in the state dir;
+    // ephemeral boots mint a per-process key.
+    let gateway_peer_keys = match persistent_state.as_ref() {
+        Some(state_path) => match meerkat_mobkit::GatewayPeerKeys::load_or_create(state_path) {
+            Ok(keys) => keys,
+            Err(error) => fail_init(
+                &request_id,
+                -32603,
+                format!(
+                    "failed to load or mint the gateway peer key under {}: {error}",
+                    state_path.display()
+                ),
+            ),
+        },
+        None => meerkat_mobkit::GatewayPeerKeys::ephemeral(),
+    };
+    runtime.set_gateway_peer_keys(gateway_peer_keys);
     let control_listen_address = match control_listen.as_ref() {
         Some(addr) => match runtime.start_control_listener(addr).await {
             Ok(advertised) => {

--- a/meerkat-mobkit/src/bin/rpc_gateway.rs
+++ b/meerkat-mobkit/src/bin/rpc_gateway.rs
@@ -34,6 +34,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use base64::Engine;
+use meerkat_mobkit::contact_directory::ContactDirectory;
+use meerkat_mobkit::runtime::cross_mob_control::ControlListenAddr;
 use meerkat_mobkit::unified_runtime::EventLogError;
 use meerkat_mobkit::{
     AuthPolicy, AuthProvider, Base64BlobStoreAdapter, BigQueryNaming, BinaryBlobStore,
@@ -96,6 +98,12 @@ struct GatewayRuntimeOptions {
     /// Bind each locally hosted member to a signed loopback TCP endpoint so
     /// peer-only external members in another process can return traffic.
     member_comms_address: Option<String>,
+    /// `runtime_options.contacts_toml`: the cross-mob contact directory as
+    /// inline TOML (same format as `config/contacts.toml` on
+    /// mobkit_gateway). Inline because SDK-driven gateways receive all
+    /// launch config through init params, and cross-process tests must
+    /// write a peer's bound address into the directory at spawn time.
+    contacts: Option<ContactDirectory>,
     agent_memory: Option<GatewayAgentMemoryOptions>,
     /// WorkGraph service construction switch (default on). `false` disables
     /// the store, member tools, overlays, and the mobkit/workgraph/* RPCs.
@@ -219,6 +227,7 @@ impl Default for GatewayRuntimeOptions {
             access: None,
             demo_llm: false,
             member_comms_address: None,
+            contacts: None,
             agent_memory: None,
             workgraph: GatewayWorkgraphOption::Enabled,
             live: GatewayLiveOption::Disabled,
@@ -2784,6 +2793,7 @@ fn parse_gateway_runtime_options(
         "console_fetch_timeout_ms",
         "demo_llm",
         "member_comms_address",
+        "contacts_toml",
         "max_sessions",
         "event_log",
         "agent_memory",
@@ -2983,6 +2993,15 @@ fn parse_gateway_runtime_options(
             );
         }
         parsed.member_comms_address = Some(address.to_string());
+    }
+    if let Some(value) = runtime_options.get("contacts_toml") {
+        let text = value
+            .as_str()
+            .ok_or_else(|| "runtime_options.contacts_toml must be a TOML string".to_string())?;
+        parsed.contacts = Some(
+            ContactDirectory::from_toml(text)
+                .map_err(|error| format!("runtime_options.contacts_toml is invalid: {error}"))?,
+        );
     }
     if let Some(value) = runtime_options.get("max_sessions") {
         let max_sessions = value
@@ -6758,7 +6777,7 @@ fn agent_tool_error(message: String) -> AgentError {
 }
 
 /// Persistent mode: reads JSON-RPC over stdin, bootstraps unified runtime, serves HTTP.
-fn run_persistent() {
+fn run_persistent(control_listen: Option<ControlListenAddr>) {
     // Meerkat 0.7's generated machine-authority apply path needs deep worker
     // stacks (mirrors meerkat-rpc's explicit 16 MiB tokio worker sizing).
     match tokio::runtime::Builder::new_multi_thread()
@@ -6766,7 +6785,7 @@ fn run_persistent() {
         .thread_stack_size(16 * 1024 * 1024)
         .build()
     {
-        Ok(runtime) => runtime.block_on(run_persistent_inner()),
+        Ok(runtime) => runtime.block_on(run_persistent_inner(control_listen)),
         Err(error) => {
             eprintln!("failed to build tokio runtime: {error}");
             std::process::exit(1);
@@ -6774,7 +6793,7 @@ fn run_persistent() {
     }
 }
 
-async fn run_persistent_inner() {
+async fn run_persistent_inner(control_listen: Option<ControlListenAddr>) {
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     // Initialize tracing subscriber so meerkat-mob/meerkat-runtime errors
@@ -8885,6 +8904,28 @@ external_addressable = true
         (None, None)
     };
 
+    // Cross-mob surfaces: install the inline contact directory (while the
+    // runtime is still exclusively owned) and bind the control listener.
+    // The listener starts after identity-first attachment above, but its
+    // handler re-reads the identity authority per request either way.
+    if let Some(directory) = gateway_options.contacts.clone() {
+        runtime.set_contact_directory(directory);
+    }
+    let control_listen_address = match control_listen.as_ref() {
+        Some(addr) => match runtime.start_control_listener(addr).await {
+            Ok(advertised) => {
+                tracing::info!(%advertised, "cross-mob control listener bound");
+                Some(advertised)
+            }
+            Err(error) => fail_init(
+                &request_id,
+                -32603,
+                format!("--control-listen {addr}: {error}"),
+            ),
+        },
+        None => None,
+    };
+
     let runtime = Arc::new(runtime);
     if let Some(detached_jobs) = gateway_detached_jobs.as_ref() {
         match detached_jobs.health_projection().await {
@@ -9013,6 +9054,13 @@ external_addressable = true
             // Complete, bounded host wait for the private shutdown request.
             // SDKs keep callback admission and stdin alive for this horizon.
             "stdio_shutdown_horizon_ms": GATEWAY_SHUTDOWN_HORIZON_MS,
+            // Dialable address of the cross-mob control listener when the
+            // gateway was launched with --control-listen (`tcp://ip:port`
+            // with the real kernel-assigned port for host:0 binds, or
+            // `uds:///path`); null otherwise. Peers put this address in
+            // their contact directories. Wire-additive: older SDKs ignore
+            // unknown result fields.
+            "control_listen_address": control_listen_address,
         }
     });
     let _ = stdout_tx
@@ -9197,11 +9245,45 @@ fn main() {
         );
         return;
     }
+    // --control-listen <tcp://host:port | uds:///path>: bind the cross-mob
+    // control listener so remote gateways can wire/unwire/inject/lookup
+    // members of this runtime. Mirrors the mobkit_gateway flag; validated
+    // here so a typo is a launch error, not a silently ignored flag. The
+    // bound address is reported back in the mobkit/init response as
+    // `control_listen_address` (important for tcp://host:0 ephemeral ports).
+    let control_listen = match parse_control_listen_arg(&args[1..]) {
+        Ok(value) => value,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(2);
+        }
+    };
     if args.iter().any(|a| a == "--persistent") {
-        run_persistent();
+        run_persistent(control_listen);
     } else {
+        if control_listen.is_some() {
+            eprintln!(
+                "--control-listen requires --persistent (the single-shot gateway hosts no long-lived runtime to serve control RPC)"
+            );
+            std::process::exit(2);
+        }
         run_single_shot();
     }
+}
+
+/// Extract and validate the optional `--control-listen <addr>` flag.
+fn parse_control_listen_arg(args: &[String]) -> Result<Option<ControlListenAddr>, String> {
+    let Some(position) = args.iter().position(|arg| arg == "--control-listen") else {
+        return Ok(None);
+    };
+    let Some(value) = args.get(position + 1) else {
+        return Err(
+            "--control-listen requires an address (tcp://host:port or uds:///path)".to_string(),
+        );
+    };
+    ControlListenAddr::parse(value)
+        .map(Some)
+        .map_err(|error| format!("--control-listen: {error}"))
 }
 
 // ---------------------------------------------------------------------------

--- a/meerkat-mobkit/src/contact_directory.rs
+++ b/meerkat-mobkit/src/contact_directory.rs
@@ -34,6 +34,14 @@ pub struct ContactEntry {
     /// is `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pubkey: Option<[u8; 32]>,
+    /// Whether control responses from this peer must be signed by the
+    /// pinned `pubkey`. `None` (the default) means STRICT WHEN PINNED: a
+    /// contact that pins a pubkey requires signed control responses, a
+    /// contact without one performs no verification. Set to `false` only
+    /// to keep talking to a pre-0.8.16 gateway that pins a key but cannot
+    /// sign control responses yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_signed_control: Option<bool>,
 }
 
 /// Error loading or parsing a contact directory.
@@ -133,6 +141,7 @@ fn parse_entry(mob_id: &str, value: &toml::Value) -> Result<ContactEntry, Contac
             mob_id: mob_id.to_string(),
             transport,
             pubkey: None,
+            require_signed_control: None,
         });
     }
 
@@ -160,10 +169,21 @@ fn parse_entry(mob_id: &str, value: &toml::Value) -> Result<ContactEntry, Contac
                 })?),
                 None => None,
             };
+        let require_signed_control =
+            match tbl.get("require_signed_control") {
+                None => None,
+                Some(value) => Some(value.as_bool().ok_or_else(|| {
+                    ContactDirectoryError::InvalidTransport {
+                        mob_id: mob_id.to_string(),
+                        value: format!("require_signed_control must be a boolean, got {value}"),
+                    }
+                })?),
+            };
         return Ok(ContactEntry {
             mob_id: mob_id.to_string(),
             transport,
             pubkey,
+            require_signed_control,
         });
     }
 

--- a/meerkat-mobkit/src/runtime/cross_mob_control.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_control.rs
@@ -32,6 +32,7 @@
 
 use std::time::Duration;
 
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -140,12 +141,18 @@ impl BoundControlListener {
         }
     }
 
-    /// Serve control requests until the owning task is aborted.
-    pub async fn serve(self, handler: std::sync::Arc<dyn ControlHandler>) {
+    /// Serve control requests until the owning task is aborted. Responses
+    /// are signed with the gateway key when `signer` holds one (re-read
+    /// per request, so late-installed keys take effect).
+    pub async fn serve(
+        self,
+        handler: std::sync::Arc<dyn ControlHandler>,
+        signer: ControlSignerSlot,
+    ) {
         match self {
-            Self::Tcp { listener, .. } => serve_tcp_control(listener, handler).await,
+            Self::Tcp { listener, .. } => serve_tcp_control(listener, handler, signer).await,
             #[cfg(unix)]
-            Self::Uds { listener, .. } => serve_uds_control(listener, handler).await,
+            Self::Uds { listener, .. } => serve_uds_control(listener, handler, signer).await,
         }
     }
 }
@@ -172,11 +179,17 @@ pub enum ControlRequest {
         local_peer_spec_address: String,
         local_comms_name: String,
         local_peer_id: String,
-        /// Optional Ed25519 pubkey of the calling gateway. When present,
+        /// Ed25519 transport pubkey of the calling MEMBER. When present,
         /// the receiving gateway builds a signed `TrustedPeerDescriptor`
         /// so meerkat-comms can verify envelope signatures.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         local_pubkey_b64: Option<String>,
+        /// Client-minted freshness nonce. It rides inside the request
+        /// bytes, so the response signature (which covers the request
+        /// digest) cannot be replayed for a later request. Old servers
+        /// ignore it; old clients omit it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        nonce: Option<String>,
     },
     /// Unwire a previously-wired peer.
     Unwire {
@@ -186,6 +199,8 @@ pub enum ControlRequest {
         local_peer_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         local_pubkey_b64: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        nonce: Option<String>,
     },
     /// Inject an external-turn message into a remote member's session.
     /// Used by `send_cross_mob` for app-level injection.
@@ -193,11 +208,17 @@ pub enum ControlRequest {
         remote_member: String,
         /// JSON-encoded `meerkat_core::ContentInput`.
         content: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        nonce: Option<String>,
     },
     /// Look up a member's comms info on the remote side. Used during
     /// `wire_cross_mob` to discover the remote member's peer_id and
     /// derived comms_name without requiring caller-supplied bookkeeping.
-    LookupMember { remote_member: String },
+    LookupMember {
+        remote_member: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        nonce: Option<String>,
+    },
 }
 
 /// Cross-mob control response.
@@ -205,7 +226,13 @@ pub enum ControlRequest {
 #[serde(tag = "result", rename_all = "snake_case")]
 pub enum ControlResponse {
     /// Operation succeeded (no payload).
-    Ok,
+    Ok {
+        /// Gateway signature over this response bound to the exact request
+        /// bytes - see [`control_response_signing_payload`]. Absent when
+        /// the serving gateway has no signing keys installed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sig_b64: Option<String>,
+    },
     /// Inject succeeded - the far side admitted the dispatch and returns
     /// the bridge session id that accepted it, so the caller can correlate
     /// downstream events.
@@ -218,7 +245,11 @@ pub enum ControlResponse {
     /// durable admission over remote paths reconcile by idempotent
     /// re-submit with WorkRef dedup - the protocol deliberately has no
     /// resend verb.
-    Injected { session_id: String },
+    Injected {
+        session_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sig_b64: Option<String>,
+    },
     /// LookupMember succeeded - return the remote member's comms facts so
     /// the caller can build a signed `TrustedPeerDescriptor` pointing at
     /// it.
@@ -239,11 +270,138 @@ pub enum ControlResponse {
         /// control handler has no session-service access.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         advertised_address: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sig_b64: Option<String>,
     },
     /// Operation failed. `code` is a stable short string for machine
     /// dispatch (`unknown_member`, `mob_error`, `decode`, ...); `message`
     /// is human-readable.
     Err { code: String, message: String },
+}
+
+/// Domain-separation context for control-response signatures. Versioned so
+/// a future payload change cannot be confused with this one.
+pub const CONTROL_SIG_CONTEXT: &str = "mobkit-cross-mob-control-v1";
+
+/// Live signing authority for control responses: the gateway keypair,
+/// late-bound because hosts install keys after the runtime (and possibly
+/// after the listener) exists. `None` serves unsigned responses, which
+/// clients with a pinned peer pubkey reject.
+pub type ControlSignerSlot = std::sync::Arc<
+    std::sync::RwLock<Option<std::sync::Arc<crate::auth::peer_keys::GatewayPeerKeys>>>,
+>;
+
+/// A signer slot that never signs (tests, deployments without keys).
+pub fn unsigned_control_signer() -> ControlSignerSlot {
+    std::sync::Arc::new(std::sync::RwLock::new(None))
+}
+
+fn control_request_digest_hex(request_bytes: &[u8]) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(request_bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// The deterministic byte string a control-response signature covers.
+///
+/// Built from the semantic response fields plus the SHA-256 of the exact
+/// request bytes the server read off the wire - never from re-serialized
+/// JSON, so there is no canonicalization to get wrong. Binding the request
+/// digest means a signature is only valid for the one request (including
+/// its client-minted nonce) that elicited it: a MITM can neither
+/// substitute member facts in a `Member` response nor replay a previous
+/// response for a fresh request. `Err` responses are not trusted material
+/// and are never signed.
+pub fn control_response_signing_payload(
+    request_bytes: &[u8],
+    response: &ControlResponse,
+) -> Option<String> {
+    let facts = match response {
+        ControlResponse::Ok { .. } => "ok".to_string(),
+        ControlResponse::Injected { session_id, .. } => format!("injected\n{session_id}"),
+        ControlResponse::Member {
+            peer_id,
+            comms_name,
+            pubkey_b64,
+            advertised_address,
+            ..
+        } => format!(
+            "member\n{peer_id}\n{comms_name}\n{}\n{}",
+            pubkey_b64.as_deref().unwrap_or(""),
+            advertised_address.as_deref().unwrap_or("")
+        ),
+        ControlResponse::Err { .. } => return None,
+    };
+    Some(format!(
+        "{CONTROL_SIG_CONTEXT}\n{}\n{facts}",
+        control_request_digest_hex(request_bytes)
+    ))
+}
+
+/// Sign `response` in place with the gateway key. No-op for `Err`.
+fn sign_control_response(
+    signer: &crate::auth::peer_keys::GatewayPeerKeys,
+    request_bytes: &[u8],
+    response: &mut ControlResponse,
+) {
+    use ed25519_dalek::Signer;
+    let Some(payload) = control_response_signing_payload(request_bytes, response) else {
+        return;
+    };
+    let signature = signer.signing_key().sign(payload.as_bytes());
+    let encoded = base64::engine::general_purpose::STANDARD.encode(signature.to_bytes());
+    match response {
+        ControlResponse::Ok { sig_b64 }
+        | ControlResponse::Injected { sig_b64, .. }
+        | ControlResponse::Member { sig_b64, .. } => *sig_b64 = Some(encoded),
+        ControlResponse::Err { .. } => {}
+    }
+}
+
+/// Verify a control response against the pinned gateway pubkey and the
+/// exact request bytes that were sent. `Err` responses pass unverified:
+/// they are failure reports, not trusted material, and rejecting them
+/// would only change WHICH error the caller sees.
+pub fn verify_control_response(
+    pinned_pubkey: &[u8; 32],
+    request_bytes: &[u8],
+    response: &ControlResponse,
+) -> Result<(), String> {
+    let Some(payload) = control_response_signing_payload(request_bytes, response) else {
+        return Ok(());
+    };
+    let sig_b64 = match response {
+        ControlResponse::Ok { sig_b64 }
+        | ControlResponse::Injected { sig_b64, .. }
+        | ControlResponse::Member { sig_b64, .. } => sig_b64.as_deref(),
+        ControlResponse::Err { .. } => None,
+    };
+    let Some(sig_b64) = sig_b64 else {
+        return Err(
+            "response is unsigned; the peer gateway has no signing keys installed or predates \
+             signed control responses"
+                .to_string(),
+        );
+    };
+    let sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(sig_b64)
+        .map_err(|err| format!("signature is not valid base64: {err}"))?;
+    let sig_bytes: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| "signature must be 64 bytes".to_string())?;
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+    let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(pinned_pubkey)
+        .map_err(|err| format!("pinned pubkey is not a valid Ed25519 key: {err}"))?;
+    verifying_key
+        .verify_strict(payload.as_bytes(), &signature)
+        .map_err(|_| "signature does not verify against the pinned gateway pubkey".to_string())
 }
 
 /// Open a control connection to a remote endpoint.
@@ -317,7 +475,20 @@ impl RemoteControlClient {
         request: &ControlRequest,
         timeout: Duration,
     ) -> Result<ControlResponse, RemoteMobError> {
-        tokio::time::timeout(timeout, Self::send_inner(endpoint, request))
+        let payload =
+            serde_json::to_vec(request).map_err(|err| encode_error(endpoint, err.to_string()))?;
+        Self::send_payload(endpoint, &payload, timeout).await
+    }
+
+    /// Send pre-serialized request bytes. Callers that verify signed
+    /// responses use this form so the exact bytes on the wire (the input
+    /// to the response's request digest) are in their hands.
+    pub async fn send_payload(
+        endpoint: &RemoteEndpoint,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> Result<ControlResponse, RemoteMobError> {
+        tokio::time::timeout(timeout, Self::send_inner(endpoint, payload))
             .await
             .map_err(|_| RemoteMobError::ControlChannelUnavailable {
                 mob_id: String::new(),
@@ -328,7 +499,7 @@ impl RemoteControlClient {
 
     async fn send_inner(
         endpoint: &RemoteEndpoint,
-        request: &ControlRequest,
+        payload: &[u8],
     ) -> Result<ControlResponse, RemoteMobError> {
         let mut stream = match endpoint {
             RemoteEndpoint::Tcp(addr) => ControlStream::Tcp(
@@ -350,10 +521,8 @@ impl RemoteControlClient {
                 });
             }
         };
-        let payload =
-            serde_json::to_vec(request).map_err(|err| encode_error(endpoint, err.to_string()))?;
         stream
-            .write_frame(&payload)
+            .write_frame(payload)
             .await
             .map_err(|err| io_error("write", endpoint, err))?;
         let response_payload = stream
@@ -518,6 +687,7 @@ impl ControlHandler for MobHandleControlHandler {
                     local_comms_name,
                     local_peer_id,
                     local_pubkey_b64,
+                    nonce: _,
                 } => {
                     handle_wire(
                         &handle,
@@ -539,6 +709,7 @@ impl ControlHandler for MobHandleControlHandler {
                     local_comms_name,
                     local_peer_id,
                     local_pubkey_b64,
+                    nonce: _,
                 } => {
                     handle_wire(
                         &handle,
@@ -557,10 +728,14 @@ impl ControlHandler for MobHandleControlHandler {
                 ControlRequest::Inject {
                     remote_member,
                     content,
+                    nonce: _,
                 } => {
                     handle_inject(&handle, &remote_member, content, identity_runtime.as_ref()).await
                 }
-                ControlRequest::LookupMember { remote_member } => {
+                ControlRequest::LookupMember {
+                    remote_member,
+                    nonce: _,
+                } => {
                     handle_lookup_member(
                         &handle,
                         session_service.as_ref(),
@@ -725,7 +900,7 @@ async fn handle_wire(
         })
         .await;
     match result {
-        Ok(()) => ControlResponse::Ok,
+        Ok(()) => ControlResponse::Ok { sig_b64: None },
         Err((code, message)) => ControlResponse::Err { code, message },
     }
 }
@@ -769,7 +944,10 @@ async fn handle_inject(
     })
     .await
     {
-        Ok(session_id) => ControlResponse::Injected { session_id },
+        Ok(session_id) => ControlResponse::Injected {
+            session_id,
+            sig_b64: None,
+        },
         Err((code, message)) => ControlResponse::Err { code, message },
     }
 }
@@ -863,6 +1041,7 @@ async fn handle_lookup_member_raw(
         comms_name,
         pubkey_b64,
         advertised_address,
+        sig_b64: None,
     })
 }
 
@@ -871,7 +1050,11 @@ async fn handle_lookup_member_raw(
 /// Each accepted connection is read-frame, dispatched to the handler,
 /// response-written, then closed. The listener accepts indefinitely; cancel
 /// via `tokio::select!` against your shutdown signal.
-pub async fn serve_tcp_control(listener: TcpListener, handler: std::sync::Arc<dyn ControlHandler>) {
+pub async fn serve_tcp_control(
+    listener: TcpListener,
+    handler: std::sync::Arc<dyn ControlHandler>,
+    signer: ControlSignerSlot,
+) {
     loop {
         let (stream, _peer_addr) = match listener.accept().await {
             Ok(pair) => pair,
@@ -881,7 +1064,8 @@ pub async fn serve_tcp_control(listener: TcpListener, handler: std::sync::Arc<dy
             }
         };
         let handler = handler.clone();
-        tokio::spawn(serve_one_tcp(stream, handler));
+        let signer = std::sync::Arc::clone(&signer);
+        tokio::spawn(serve_one_tcp(stream, handler, signer));
     }
 }
 
@@ -890,6 +1074,7 @@ pub async fn serve_tcp_control(listener: TcpListener, handler: std::sync::Arc<dy
 pub async fn serve_uds_control(
     listener: UnixListener,
     handler: std::sync::Arc<dyn ControlHandler>,
+    signer: ControlSignerSlot,
 ) {
     loop {
         let (stream, _peer_addr) = match listener.accept().await {
@@ -900,22 +1085,35 @@ pub async fn serve_uds_control(
             }
         };
         let handler = handler.clone();
-        tokio::spawn(serve_one_uds(stream, handler));
+        let signer = std::sync::Arc::clone(&signer);
+        tokio::spawn(serve_one_uds(stream, handler, signer));
     }
 }
 
-async fn serve_one_tcp(stream: TcpStream, handler: std::sync::Arc<dyn ControlHandler>) {
+async fn serve_one_tcp(
+    stream: TcpStream,
+    handler: std::sync::Arc<dyn ControlHandler>,
+    signer: ControlSignerSlot,
+) {
     let mut s = ControlStream::Tcp(stream);
-    serve_one(&mut s, handler).await;
+    serve_one(&mut s, handler, signer).await;
 }
 
 #[cfg(unix)]
-async fn serve_one_uds(stream: UnixStream, handler: std::sync::Arc<dyn ControlHandler>) {
+async fn serve_one_uds(
+    stream: UnixStream,
+    handler: std::sync::Arc<dyn ControlHandler>,
+    signer: ControlSignerSlot,
+) {
     let mut s = ControlStream::Uds(stream);
-    serve_one(&mut s, handler).await;
+    serve_one(&mut s, handler, signer).await;
 }
 
-async fn serve_one(stream: &mut ControlStream, handler: std::sync::Arc<dyn ControlHandler>) {
+async fn serve_one(
+    stream: &mut ControlStream,
+    handler: std::sync::Arc<dyn ControlHandler>,
+    signer: ControlSignerSlot,
+) {
     let payload = match stream.read_frame().await {
         Ok(buf) => buf,
         Err(err) => {
@@ -935,7 +1133,17 @@ async fn serve_one(stream: &mut ControlStream, handler: std::sync::Arc<dyn Contr
             return;
         }
     };
-    let response = handler.handle(request).await;
+    let mut response = handler.handle(request).await;
+    // Bind the response to this gateway's pinned identity and to the exact
+    // request bytes. Re-read per request: hosts install keys after the
+    // listener exists.
+    let keys = signer
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    if let Some(keys) = keys {
+        sign_control_response(&keys, &payload, &mut response);
+    }
     let response_payload = serde_json::to_vec(&response).unwrap_or_default();
     let _ = stream.write_frame(&response_payload).await;
 }
@@ -1011,16 +1219,18 @@ mod tests {
             Box::pin(async move {
                 match request {
                     ControlRequest::Wire { .. } | ControlRequest::Unwire { .. } => {
-                        ControlResponse::Ok
+                        ControlResponse::Ok { sig_b64: None }
                     }
                     ControlRequest::Inject { remote_member, .. } => ControlResponse::Injected {
                         session_id: format!("session-for-{remote_member}"),
+                        sig_b64: None,
                     },
-                    ControlRequest::LookupMember { remote_member } => ControlResponse::Member {
+                    ControlRequest::LookupMember { remote_member, .. } => ControlResponse::Member {
                         peer_id: format!("peer-id-for-{remote_member}"),
                         comms_name: format!("mob/role/{remote_member}"),
                         pubkey_b64: None,
                         advertised_address: None,
+                        sig_b64: None,
                     },
                 }
             })
@@ -1103,6 +1313,164 @@ mod tests {
         assert_eq!(code, "peer_spec");
     }
 
+    fn signer_with(keys: crate::auth::peer_keys::GatewayPeerKeys) -> ControlSignerSlot {
+        Arc::new(std::sync::RwLock::new(Some(Arc::new(keys))))
+    }
+
+    /// A signed response verifies against the pinned key and the exact
+    /// request bytes - and against nothing else: different request bytes
+    /// (a replay for a fresh nonce) and a different pinned key both fail.
+    #[tokio::test]
+    async fn signed_responses_verify_against_pinned_gateway_key() {
+        let keys = crate::auth::peer_keys::GatewayPeerKeys::ephemeral();
+        let pinned = keys.pubkey_bytes();
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(serve_tcp_control(listener, handler, signer_with(keys)));
+
+        let request = ControlRequest::LookupMember {
+            remote_member: "alice".to_string(),
+            nonce: Some("nonce-1".to_string()),
+        };
+        let payload = serde_json::to_vec(&request).expect("encode");
+        let endpoint = RemoteEndpoint::Tcp(addr.to_string());
+        let response =
+            RemoteControlClient::send_payload(&endpoint, &payload, DEFAULT_CONTROL_TIMEOUT)
+                .await
+                .expect("control rpc");
+        verify_control_response(&pinned, &payload, &response).expect("signature verifies");
+
+        let replayed_request = ControlRequest::LookupMember {
+            remote_member: "alice".to_string(),
+            nonce: Some("nonce-2".to_string()),
+        };
+        let replayed_payload = serde_json::to_vec(&replayed_request).expect("encode");
+        assert!(
+            verify_control_response(&pinned, &replayed_payload, &response).is_err(),
+            "a response must not verify for different request bytes (replay)"
+        );
+        let other_key = crate::auth::peer_keys::GatewayPeerKeys::ephemeral().pubkey_bytes();
+        assert!(
+            verify_control_response(&other_key, &payload, &response).is_err(),
+            "a response must not verify against a different pinned key"
+        );
+        server.abort();
+    }
+
+    #[test]
+    fn unsigned_response_fails_verification_when_pinned() {
+        let pinned = crate::auth::peer_keys::GatewayPeerKeys::ephemeral().pubkey_bytes();
+        let response = ControlResponse::Ok { sig_b64: None };
+        let err =
+            verify_control_response(&pinned, b"{}", &response).expect_err("unsigned must fail");
+        assert!(err.contains("unsigned"), "got: {err}");
+    }
+
+    /// `Err` responses are failure reports, not trusted material: they
+    /// carry no signature and pass verification unchanged (rejecting them
+    /// would only swap WHICH error the caller sees).
+    #[test]
+    fn error_responses_skip_verification() {
+        let pinned = crate::auth::peer_keys::GatewayPeerKeys::ephemeral().pubkey_bytes();
+        let response = ControlResponse::Err {
+            code: "unknown_member".to_string(),
+            message: "nope".to_string(),
+        };
+        verify_control_response(&pinned, b"{}", &response).expect("Err passes through");
+    }
+
+    /// Strict-when-pinned at the proxy: a contact that pins a gateway
+    /// pubkey rejects unsigned responses typed; the explicit
+    /// `require_signed_control = false` opt-out accepts them.
+    #[tokio::test]
+    async fn pinned_contact_requires_signed_control_responses() {
+        use crate::contact_directory::{ContactEntry, MobTransport};
+        use crate::runtime::cross_mob_remote::RemoteMobProxy;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(serve_tcp_control(
+            listener,
+            handler,
+            unsigned_control_signer(),
+        ));
+        let pinned = crate::auth::peer_keys::GatewayPeerKeys::ephemeral().pubkey_bytes();
+
+        let strict_entry = ContactEntry {
+            mob_id: "remote".to_string(),
+            transport: MobTransport::Tcp(addr.to_string()),
+            pubkey: Some(pinned),
+            require_signed_control: None,
+        };
+        let proxy = RemoteMobProxy::from_entry(&strict_entry)
+            .expect("tcp ok")
+            .expect("some");
+        let err = proxy
+            .lookup_member("alice")
+            .await
+            .expect_err("unsigned response must fail a pinned contact");
+        assert!(
+            matches!(err, RemoteMobError::ControlResponseUnauthenticated { .. }),
+            "got {err:?}"
+        );
+
+        let opt_out_entry = ContactEntry {
+            require_signed_control: Some(false),
+            ..strict_entry
+        };
+        let proxy = RemoteMobProxy::from_entry(&opt_out_entry)
+            .expect("tcp ok")
+            .expect("some");
+        proxy
+            .lookup_member("alice")
+            .await
+            .expect("explicit opt-out accepts unsigned responses");
+        server.abort();
+    }
+
+    /// End-to-end signed exchange through the proxy: a pinned contact
+    /// talking to a gateway that signs with the matching key succeeds.
+    #[tokio::test]
+    async fn pinned_contact_accepts_signed_responses() {
+        use crate::contact_directory::{ContactEntry, MobTransport};
+        use crate::runtime::cross_mob_remote::RemoteMobProxy;
+
+        let keys = crate::auth::peer_keys::GatewayPeerKeys::ephemeral();
+        let pinned = keys.pubkey_bytes();
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
+        let server = tokio::spawn(serve_tcp_control(listener, handler, signer_with(keys)));
+
+        let entry = ContactEntry {
+            mob_id: "remote".to_string(),
+            transport: MobTransport::Tcp(addr.to_string()),
+            pubkey: Some(pinned),
+            require_signed_control: None,
+        };
+        let proxy = RemoteMobProxy::from_entry(&entry)
+            .expect("tcp ok")
+            .expect("some");
+        let info = proxy
+            .lookup_member("alice")
+            .await
+            .expect("signed lookup verifies");
+        assert_eq!(info.peer_id, "peer-id-for-alice");
+        proxy
+            .wire_remote(
+                "alice",
+                "tcp://127.0.0.1:9001",
+                "demo/role/alice",
+                "00000000-0000-4000-8000-000000000001",
+                None,
+            )
+            .await
+            .expect("signed wire ack verifies");
+        server.abort();
+    }
+
     #[test]
     fn control_listen_addr_parses_contact_directory_spellings() {
         assert_eq!(
@@ -1139,11 +1507,12 @@ mod tests {
             "advertised address must carry the kernel-assigned port: {advertised}"
         );
         let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
-        let server = tokio::spawn(bound.serve(handler));
+        let server = tokio::spawn(bound.serve(handler, unsigned_control_signer()));
 
         let endpoint = RemoteEndpoint::Tcp(dial.to_string());
         let request = ControlRequest::LookupMember {
             remote_member: "alice".to_string(),
+            nonce: None,
         };
         let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
             .await
@@ -1164,12 +1533,13 @@ mod tests {
             format!("uds://{}", path.display())
         );
         let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
-        let server = tokio::spawn(bound.serve(handler));
+        let server = tokio::spawn(bound.serve(handler, unsigned_control_signer()));
 
         let endpoint = RemoteEndpoint::Uds(path.display().to_string());
         let request = ControlRequest::Inject {
             remote_member: "bob".to_string(),
             content: serde_json::json!({"text": "hi"}),
+            nonce: None,
         };
         let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
             .await
@@ -1178,6 +1548,7 @@ mod tests {
             response,
             ControlResponse::Injected {
                 session_id: "session-for-bob".to_string(),
+                sig_b64: None,
             },
         );
         server.abort();
@@ -1188,12 +1559,17 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("addr");
         let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
-        let server = tokio::spawn(serve_tcp_control(listener, handler));
+        let server = tokio::spawn(serve_tcp_control(
+            listener,
+            handler,
+            unsigned_control_signer(),
+        ));
 
         let endpoint = RemoteEndpoint::Tcp(addr.to_string());
         let request = ControlRequest::Inject {
             remote_member: "alice".to_string(),
             content: serde_json::json!({"text": "hello"}),
+            nonce: None,
         };
         let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
             .await
@@ -1202,6 +1578,7 @@ mod tests {
             response,
             ControlResponse::Injected {
                 session_id: "session-for-alice".to_string(),
+                sig_b64: None,
             },
         );
         server.abort();
@@ -1212,7 +1589,11 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("addr");
         let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
-        let server = tokio::spawn(serve_tcp_control(listener, handler));
+        let server = tokio::spawn(serve_tcp_control(
+            listener,
+            handler,
+            unsigned_control_signer(),
+        ));
 
         let endpoint = RemoteEndpoint::Tcp(addr.to_string());
         let request = ControlRequest::Wire {
@@ -1221,11 +1602,12 @@ mod tests {
             local_comms_name: "demo/role/alice".to_string(),
             local_peer_id: "00000000-0000-4000-8000-000000000001".to_string(),
             local_pubkey_b64: None,
+            nonce: None,
         };
         let response = RemoteControlClient::send(&endpoint, &request, DEFAULT_CONTROL_TIMEOUT)
             .await
             .expect("control rpc");
-        assert_eq!(response, ControlResponse::Ok);
+        assert_eq!(response, ControlResponse::Ok { sig_b64: None });
         server.abort();
     }
 
@@ -1234,7 +1616,11 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("addr");
         let handler: Arc<dyn ControlHandler> = Arc::new(EchoHandler);
-        let _server = tokio::spawn(serve_tcp_control(listener, handler));
+        let _server = tokio::spawn(serve_tcp_control(
+            listener,
+            handler,
+            unsigned_control_signer(),
+        ));
 
         // Send raw garbage bytes as a "control request" — server should
         // respond with a `decode` error instead of dropping the connection

--- a/meerkat-mobkit/src/runtime/cross_mob_remote.rs
+++ b/meerkat-mobkit/src/runtime/cross_mob_remote.rs
@@ -59,6 +59,16 @@ pub enum RemoteMobError {
     /// We received a response we couldn't decode — peer is speaking a
     /// different protocol or sent corrupted data.
     Decode { endpoint: String, message: String },
+    /// The contact directory pins this gateway's pubkey and requires
+    /// signed control responses, but the response could not be
+    /// authenticated (unsigned, malformed signature, or signed by a
+    /// different key). Distinct from [`Self::Rejected`]: the peer did not
+    /// refuse the request; its ANSWER could not be trusted.
+    ControlResponseUnauthenticated {
+        mob_id: String,
+        endpoint: String,
+        reason: String,
+    },
 }
 
 impl RemoteMobError {
@@ -121,6 +131,21 @@ impl std::fmt::Display for RemoteMobError {
                 write!(
                     f,
                     "control response decode failed for {endpoint}: {message}"
+                )
+            }
+            Self::ControlResponseUnauthenticated {
+                mob_id,
+                endpoint,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "remote mob '{mob_id}' control response ({endpoint}) failed \
+                     authentication against the pinned gateway pubkey: {reason}. Upgrade the \
+                     peer gateway to one that signs control responses (0.8.16+ with gateway \
+                     keys installed), fix the pinned pubkey, or set \
+                     require_signed_control = false on this contact to accept unsigned \
+                     responses"
                 )
             }
         }
@@ -195,6 +220,13 @@ pub struct RemoteMemberInfo {
 pub struct RemoteMobProxy {
     mob_id: String,
     endpoint: RemoteEndpoint,
+    /// The peer GATEWAY's pinned Ed25519 pubkey from the contact
+    /// directory, used to authenticate control responses.
+    pinned_pubkey: Option<[u8; 32]>,
+    /// Strict-when-pinned: a pinned pubkey requires signed responses
+    /// unless the contact explicitly opted out
+    /// (`require_signed_control = false`).
+    require_signed_responses: bool,
 }
 
 impl RemoteMobProxy {
@@ -202,17 +234,19 @@ impl RemoteMobProxy {
     /// `Inproc` entries — those are served by an `Arc<MobHandle>` via
     /// `LocalOrRemote::Local` instead.
     pub fn from_entry(entry: &ContactEntry) -> Result<Option<Self>, RemoteMobError> {
-        match &entry.transport {
-            MobTransport::Inproc => Ok(None),
-            MobTransport::Tcp(addr) => Ok(Some(Self {
-                mob_id: entry.mob_id.clone(),
-                endpoint: RemoteEndpoint::Tcp(addr.clone()),
-            })),
-            MobTransport::Uds(path) => Ok(Some(Self {
-                mob_id: entry.mob_id.clone(),
-                endpoint: RemoteEndpoint::Uds(path.clone()),
-            })),
-        }
+        let endpoint = match &entry.transport {
+            MobTransport::Inproc => return Ok(None),
+            MobTransport::Tcp(addr) => RemoteEndpoint::Tcp(addr.clone()),
+            MobTransport::Uds(path) => RemoteEndpoint::Uds(path.clone()),
+        };
+        let require_signed_responses =
+            entry.pubkey.is_some() && entry.require_signed_control.unwrap_or(true);
+        Ok(Some(Self {
+            mob_id: entry.mob_id.clone(),
+            endpoint,
+            pinned_pubkey: entry.pubkey,
+            require_signed_responses,
+        }))
     }
 
     /// The peer mob's identifier.
@@ -223,6 +257,44 @@ impl RemoteMobProxy {
     /// The peer mob's control endpoint.
     pub fn endpoint(&self) -> &RemoteEndpoint {
         &self.endpoint
+    }
+
+    /// Fresh per-request nonce. It rides inside the request bytes, and the
+    /// response signature covers the digest of those bytes, so a signed
+    /// response can never be replayed for a later request.
+    fn mint_nonce() -> Option<String> {
+        Some(uuid::Uuid::new_v4().simple().to_string())
+    }
+
+    /// Serialize, send, and (when this contact pins a gateway pubkey and
+    /// requires it) authenticate one control request/response exchange.
+    async fn dispatch(
+        &self,
+        request: &super::cross_mob_control::ControlRequest,
+    ) -> Result<super::cross_mob_control::ControlResponse, RemoteMobError> {
+        let payload = serde_json::to_vec(request).map_err(|err| RemoteMobError::Encode {
+            endpoint: self.endpoint.comms_address(),
+            message: err.to_string(),
+        })?;
+        let response = super::cross_mob_control::RemoteControlClient::send_payload(
+            &self.endpoint,
+            &payload,
+            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
+        )
+        .await
+        .map_err(|err| self.attach_mob_id(err))?;
+        if self.require_signed_responses
+            && let Some(pinned) = self.pinned_pubkey.as_ref()
+            && let Err(reason) =
+                super::cross_mob_control::verify_control_response(pinned, &payload, &response)
+        {
+            return Err(RemoteMobError::ControlResponseUnauthenticated {
+                mob_id: self.mob_id.clone(),
+                endpoint: self.endpoint.comms_address(),
+                reason,
+            });
+        }
+        Ok(response)
     }
 
     /// Wire a peer on the remote side.
@@ -245,6 +317,7 @@ impl RemoteMobProxy {
             local_comms_name: local_comms_name.to_string(),
             local_peer_id: local_peer_id.to_string(),
             local_pubkey_b64,
+            nonce: Self::mint_nonce(),
         };
         self.dispatch_no_payload(request, "wire").await
     }
@@ -264,6 +337,7 @@ impl RemoteMobProxy {
             local_comms_name: local_comms_name.to_string(),
             local_peer_id: local_peer_id.to_string(),
             local_pubkey_b64,
+            nonce: Self::mint_nonce(),
         };
         self.dispatch_no_payload(request, "unwire").await
     }
@@ -281,16 +355,13 @@ impl RemoteMobProxy {
         let request = super::cross_mob_control::ControlRequest::Inject {
             remote_member: remote_member.to_string(),
             content: content_json,
+            nonce: Self::mint_nonce(),
         };
-        let response = super::cross_mob_control::RemoteControlClient::send(
-            &self.endpoint,
-            &request,
-            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
-        )
-        .await
-        .map_err(|err| self.attach_mob_id(err))?;
+        let response = self.dispatch(&request).await?;
         match response {
-            super::cross_mob_control::ControlResponse::Injected { session_id } => Ok(session_id),
+            super::cross_mob_control::ControlResponse::Injected { session_id, .. } => {
+                Ok(session_id)
+            }
             super::cross_mob_control::ControlResponse::Err { code, message } => {
                 Err(RemoteMobError::Rejected {
                     mob_id: self.mob_id.clone(),
@@ -311,15 +382,9 @@ impl RemoteMobProxy {
         request: super::cross_mob_control::ControlRequest,
         operation: &'static str,
     ) -> Result<(), RemoteMobError> {
-        let response = super::cross_mob_control::RemoteControlClient::send(
-            &self.endpoint,
-            &request,
-            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
-        )
-        .await
-        .map_err(|err| self.attach_mob_id(err))?;
+        let response = self.dispatch(&request).await?;
         match response {
-            super::cross_mob_control::ControlResponse::Ok => Ok(()),
+            super::cross_mob_control::ControlResponse::Ok { .. } => Ok(()),
             super::cross_mob_control::ControlResponse::Err { code, message } => {
                 Err(RemoteMobError::Rejected {
                     mob_id: self.mob_id.clone(),
@@ -344,20 +409,16 @@ impl RemoteMobProxy {
     ) -> Result<RemoteMemberInfo, RemoteMobError> {
         let request = super::cross_mob_control::ControlRequest::LookupMember {
             remote_member: remote_member.to_string(),
+            nonce: Self::mint_nonce(),
         };
-        let response = super::cross_mob_control::RemoteControlClient::send(
-            &self.endpoint,
-            &request,
-            super::cross_mob_control::DEFAULT_CONTROL_TIMEOUT,
-        )
-        .await
-        .map_err(|err| self.attach_mob_id(err))?;
+        let response = self.dispatch(&request).await?;
         match response {
             super::cross_mob_control::ControlResponse::Member {
                 peer_id,
                 comms_name,
                 pubkey_b64,
                 advertised_address,
+                sig_b64: _,
             } => Ok(RemoteMemberInfo {
                 peer_id,
                 comms_name,
@@ -408,6 +469,7 @@ mod tests {
             mob_id: "demo".to_string(),
             transport: MobTransport::Inproc,
             pubkey: None,
+            require_signed_control: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry).expect("inproc is supported");
         assert!(proxy.is_none());
@@ -419,6 +481,7 @@ mod tests {
             mob_id: "remote".to_string(),
             transport: MobTransport::Tcp("127.0.0.1:9001".to_string()),
             pubkey: None,
+            require_signed_control: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry)
             .expect("tcp is supported")
@@ -435,6 +498,7 @@ mod tests {
             mob_id: "remote-uds".to_string(),
             transport: MobTransport::Uds("/tmp/cross-mob.sock".to_string()),
             pubkey: None,
+            require_signed_control: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry)
             .expect("uds is supported")
@@ -457,6 +521,7 @@ mod tests {
             mob_id: "remote".to_string(),
             transport: MobTransport::Tcp("127.0.0.1:1".to_string()),
             pubkey: None,
+            require_signed_control: None,
         };
         let proxy = RemoteMobProxy::from_entry(&entry)
             .expect("tcp ok")

--- a/meerkat-mobkit/src/unified_runtime/cross_mob.rs
+++ b/meerkat-mobkit/src/unified_runtime/cross_mob.rs
@@ -1435,7 +1435,9 @@ impl UnifiedRuntime {
         }
         let handler: std::sync::Arc<dyn crate::runtime::cross_mob_control::ControlHandler> =
             std::sync::Arc::new(handler);
-        *task_slot = Some(tokio::spawn(bound.serve(handler)));
+        *task_slot = Some(tokio::spawn(
+            bound.serve(handler, std::sync::Arc::clone(&self.gateway_peer_keys)),
+        ));
         *self
             .cross_mob_control_advertised
             .write()
@@ -1454,20 +1456,27 @@ impl UnifiedRuntime {
     }
 
     /// Install the long-lived Ed25519 keypair this gateway advertises via
-    /// `mobkit/peer_pubkey` and (when meerkat-comms grows out-of-process
-    /// transports) signs outbound envelopes with.
+    /// `mobkit/peer_pubkey` and signs cross-mob control responses with.
     ///
     /// Inproc-only deployments and most tests skip this — the in-process
     /// router authorises by identity map and signature verification is
     /// moot. Production gateways and any cross-process integration test
-    /// must call this.
+    /// must call this. Takes effect immediately for a control listener
+    /// that is already serving (the serve task re-reads the slot per
+    /// request).
     pub fn set_gateway_peer_keys(&mut self, keys: GatewayPeerKeys) {
-        self.gateway_peer_keys = Some(keys);
+        *self
+            .gateway_peer_keys
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(std::sync::Arc::new(keys));
     }
 
-    /// Borrow the local gateway keypair if one was installed.
-    pub fn gateway_peer_keys(&self) -> Option<&GatewayPeerKeys> {
-        self.gateway_peer_keys.as_ref()
+    /// The local gateway keypair if one was installed.
+    pub fn gateway_peer_keys(&self) -> Option<std::sync::Arc<GatewayPeerKeys>> {
+        self.gateway_peer_keys
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     /// Wire a local member to a member in an external mob.

--- a/meerkat-mobkit/src/unified_runtime/http.rs
+++ b/meerkat-mobkit/src/unified_runtime/http.rs
@@ -207,7 +207,7 @@ impl UnifiedRuntime {
             Some(self.module_runtime_handle()),
             self.contact_directory.clone(),
             self.event_log_store(),
-            self.gateway_peer_keys().cloned(),
+            self.gateway_peer_keys().map(|keys| (*keys).clone()),
             Some(self.console_events()),
             Some(self.console_log_store()),
             Some(self.mob_events_store()),

--- a/meerkat-mobkit/src/unified_runtime/mod.rs
+++ b/meerkat-mobkit/src/unified_runtime/mod.rs
@@ -174,9 +174,12 @@ pub struct UnifiedRuntime {
     /// `None` is the default for inproc-only deployments and tests;
     /// production gateways set this via
     /// [`UnifiedRuntime::set_gateway_peer_keys`] during bootstrap so the
-    /// `mobkit/peer_pubkey` RPC and non-inproc `wire_*` paths can stamp
-    /// a real pubkey on outbound descriptors.
-    gateway_peer_keys: Option<crate::auth::peer_keys::GatewayPeerKeys>,
+    /// `mobkit/peer_pubkey` RPC can advertise it and the cross-mob control
+    /// listener can sign its responses. A shared late-bound slot (the same
+    /// pattern as the identity authority): the control listener may start
+    /// before the host installs keys, and its serve task re-reads this
+    /// slot per request.
+    gateway_peer_keys: crate::runtime::cross_mob_control::ControlSignerSlot,
 
     // Identity-first session bridge
     session_bridge: Option<Arc<dyn crate::identity_first::bridge::SessionBridge>>,
@@ -314,7 +317,7 @@ impl UnifiedRuntime {
             peer_mob_handles: tokio::sync::RwLock::new(BTreeMap::new()),
             cross_mob_control_task: tokio::sync::Mutex::new(None),
             cross_mob_control_advertised: std::sync::RwLock::new(None),
-            gateway_peer_keys: None,
+            gateway_peer_keys: crate::runtime::cross_mob_control::unsigned_control_signer(),
             session_bridge: None,
             identity_first_context: None,
             access_controller: None,

--- a/meerkat-mobkit/tests/cross_mob_two_process.rs
+++ b/meerkat-mobkit/tests/cross_mob_two_process.rs
@@ -1,0 +1,542 @@
+//! TWO-PROCESS cross-mob round trip: the full-fidelity proof that two real
+//! `rpc_gateway --persistent` OS processes can wire members over the
+//! cross-mob control channel and deliver messages in both directions with
+//! nothing shared but TCP sockets.
+//!
+//! Two children are spawned from the shipped binary (the
+//! `identity_first_subprocess_reboot.rs` harness idiom), each with:
+//!
+//! * `--control-listen tcp://127.0.0.1:<port>` - the cross-mob control
+//!   listener, with the port probed up front so BOTH contact directories
+//!   can be written at init time (A needs B's address and B needs A's; an
+//!   ephemeral `:0` bind on both sides would be circular). The init
+//!   response's new `control_listen_address` field is asserted against the
+//!   requested address.
+//! * `runtime_options.member_comms_address = "127.0.0.1:0"` - every member
+//!   binds its own signed envelope listener, so the descriptors installed
+//!   by the wire are dialable across the process boundary.
+//! * `runtime_options.contacts_toml` - the inline contact directory
+//!   pointing at the OTHER process's control listener.
+//! * `runtime_options.demo_llm` - deterministic `TestClient`, no network.
+//!
+//! Proven across the process boundary:
+//!
+//! 1. `mobkit/cross_mob/wire` from A reaches B's control listener over real
+//!    TCP, installs signed descriptors on BOTH sides (asserted via each
+//!    gateway's own `mobkit/get_member` `wired_to` projection - the far
+//!    side's row is the reverse leg).
+//! 2. `mobkit/cross_mob/send` delivers A -> B and B -> A: each send returns
+//!    the receiving member's bridge session id from the OTHER process, the
+//!    injection triggers a turn on the receiver, and the marker text
+//!    minted in the SENDING process becomes durable in the RECEIVING
+//!    process's state directory - polled while the child is alive, then
+//!    asserted again from disk after the child exited.
+//! 3. `mobkit/cross_mob/unwire` from A clears the peering on BOTH sides.
+//!
+//! # What is deliberately NOT here
+//!
+//! A member-driven signed PeerMessage between the two processes. Members
+//! only emit peer messages from inside an agent turn (the comms `send`
+//! tool); `demo_llm` makes no tool calls, and no RPC surface invokes a
+//! member's session tools directly (`mobkit/call_tool` routes to modules).
+//! Driving it would need a live LLM (the e2e-live lane) or a test-only
+//! RPC. The signed envelope plane itself - real TCP dial, ingress trust
+//! check against the wired descriptor, ack signed by the addressed
+//! member's keypair - is already proven socket-for-socket by
+//! `tests/cross_mob_control_round_trip.rs`; what THIS file adds is the
+//! process boundary, which the control plane and both wire legs do cross.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::uninlined_format_args
+)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+const INIT_TIMEOUT: Duration = Duration::from_mins(3);
+const RPC_TIMEOUT: Duration = Duration::from_mins(1);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_mins(3);
+const EXIT_TIMEOUT: Duration = Duration::from_mins(1);
+
+const MOB_A: &str = r#"
+[mob]
+id = "two-proc-a"
+
+[profiles.worker]
+model = "gpt-5.5"
+external_addressable = true
+runtime_mode = "turn_driven"
+
+[profiles.worker.tools]
+comms = true
+"#;
+
+const MOB_B: &str = r#"
+[mob]
+id = "two-proc-b"
+
+[profiles.worker]
+model = "gpt-5.5"
+external_addressable = true
+runtime_mode = "turn_driven"
+
+[profiles.worker.tools]
+comms = true
+"#;
+
+const MARKER_A_TO_B: &str = "cross-mob-marker-alpha-to-bravo-7f3c";
+const MARKER_B_TO_A: &str = "cross-mob-marker-bravo-to-alpha-2e91";
+
+/// Probe a free loopback port. The port is released before the gateway
+/// binds it, so another process could race onto it; the same accepted
+/// caveat as `cross_mob_tcp.rs::ephemeral_port` (both directories must be
+/// written before either child boots, so `:0` cannot be used here).
+fn probe_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("probe port")
+        .local_addr()
+        .expect("probe addr")
+        .port()
+}
+
+struct Gateway {
+    label: String,
+    child: Child,
+    stdin: Option<ChildStdin>,
+    lines: mpsc::Receiver<String>,
+    stderr: Arc<Mutex<Vec<String>>>,
+}
+
+impl Gateway {
+    fn start(label: &str, control_listen: &str) -> Self {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rpc_gateway"));
+        command
+            .arg("--persistent")
+            .arg("--control-listen")
+            .arg(control_listen)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = command.spawn().expect("spawn rpc_gateway --persistent");
+
+        let stdin = child.stdin.take().expect("gateway stdin");
+        let stdout = child.stdout.take().expect("gateway stdout");
+        let child_stderr = child.stderr.take().expect("gateway stderr");
+
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        let stderr_sink = stderr.clone();
+        thread::spawn(move || {
+            for line in BufReader::new(child_stderr).lines() {
+                let Ok(line) = line else { break };
+                let Ok(mut sink) = stderr_sink.lock() else {
+                    break;
+                };
+                if sink.len() < 500 {
+                    sink.push(line);
+                }
+            }
+        });
+
+        Self {
+            label: label.to_string(),
+            child,
+            stdin: Some(stdin),
+            lines: rx,
+            stderr,
+        }
+    }
+
+    fn send(&mut self, value: &Value) {
+        let stdin = self.stdin.as_mut().expect("gateway stdin remains open");
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::to_string(value).expect("serialize request")
+        )
+        .expect("write request to gateway stdin");
+        stdin.flush().expect("flush gateway stdin");
+    }
+
+    fn close_stdin(&mut self) {
+        drop(self.stdin.take());
+    }
+
+    fn stderr_tail(&self) -> String {
+        let Ok(sink) = self.stderr.lock() else {
+            return "[gateway stderr unavailable: poisoned lock]".to_string();
+        };
+        let start = sink.len().saturating_sub(40);
+        format!(
+            "--- [{}] gateway stderr (last {} of {} lines) ---\n{}",
+            self.label,
+            sink.len() - start,
+            sink.len(),
+            sink[start..].join("\n")
+        )
+    }
+
+    /// Send one request and return its response. This harness declares no
+    /// host providers, so any `callback/*` arriving is a composition bug
+    /// the test must fail on, not stub around.
+    fn call(&mut self, id: &str, method: &str, params: Value, deadline: Duration) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }));
+        let start = Instant::now();
+        loop {
+            let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
+                panic!(
+                    "[{}] no response to {method} within {:?}\n{}",
+                    self.label,
+                    deadline,
+                    self.stderr_tail()
+                );
+            };
+            let Ok(line) = self.lines.recv_timeout(remaining) else {
+                panic!(
+                    "[{}] gateway stdout closed while waiting for {method}\n{}",
+                    self.label,
+                    self.stderr_tail()
+                );
+            };
+            let Ok(message) = serde_json::from_str::<Value>(line.trim()) else {
+                continue;
+            };
+            if let Some(callback) = message.get("method").and_then(Value::as_str) {
+                assert!(
+                    !callback.starts_with("callback/"),
+                    "[{}] unexpected host callback {callback}: this harness declares no \
+                     providers, so a stub answer would invalidate the run",
+                    self.label
+                );
+                continue; // notification
+            }
+            if message.get("id").and_then(Value::as_str) == Some(id) {
+                assert!(
+                    message.get("error").is_none(),
+                    "[{}] {method} failed: {message}\n{}",
+                    self.label,
+                    self.stderr_tail()
+                );
+                return message;
+            }
+        }
+    }
+
+    fn shutdown_and_reap(&mut self) {
+        let response = self.call("shutdown", "mobkit/shutdown", json!({}), SHUTDOWN_TIMEOUT);
+        assert_eq!(
+            response["result"]["shutdown"],
+            json!(true),
+            "[{}] shutdown completed without cleanup attestation (wedge): {response}\n{}",
+            self.label,
+            self.stderr_tail()
+        );
+        self.close_stdin();
+        let status = self.wait_for_exit(EXIT_TIMEOUT);
+        assert!(
+            status.success(),
+            "[{}] rpc_gateway exited with {status}\n{}",
+            self.label,
+            self.stderr_tail()
+        );
+    }
+
+    fn wait_for_exit(&mut self, deadline: Duration) -> ExitStatus {
+        let start = Instant::now();
+        loop {
+            if let Some(status) = self.child.try_wait().expect("poll gateway exit") {
+                return status;
+            }
+            if start.elapsed() >= deadline {
+                let tail = self.stderr_tail();
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+                panic!(
+                    "[{}] rpc_gateway did not exit within {:?}\n{}",
+                    self.label, deadline, tail
+                );
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+}
+
+impl Drop for Gateway {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Boot one gateway: spawn with `--control-listen`, init with the inline
+/// contact directory pointing at the peer, and assert the init response
+/// reports the requested control address back.
+fn boot(
+    label: &str,
+    state: &Path,
+    mob_config: &str,
+    control_listen: &str,
+    contacts_toml: &str,
+) -> Gateway {
+    let mut gateway = Gateway::start(label, control_listen);
+    let response = gateway.call(
+        "init",
+        "mobkit/init",
+        json!({
+            "persistent_state": state,
+            "mob_config": mob_config,
+            "runtime_options": {
+                "demo_llm": true,
+                "member_comms_address": "127.0.0.1:0",
+                "contacts_toml": contacts_toml,
+            }
+        }),
+        INIT_TIMEOUT,
+    );
+    assert_eq!(
+        response["result"]["control_listen_address"],
+        json!(control_listen),
+        "[{label}] init response must report the bound control-listener address: {response}"
+    );
+    gateway
+}
+
+fn spawn_member(gateway: &mut Gateway, member: &str) {
+    let response = gateway.call(
+        "spawn",
+        "mobkit/spawn_member",
+        json!({ "profile": "worker", "meerkat_id": member }),
+        RPC_TIMEOUT,
+    );
+    assert_eq!(
+        response["result"]["accepted"],
+        json!(true),
+        "[{}] spawn_member {member} not accepted: {response}",
+        gateway.label
+    );
+}
+
+fn wired_to(gateway: &mut Gateway, member: &str) -> Vec<String> {
+    let response = gateway.call(
+        "get-member",
+        "mobkit/get_member",
+        json!({ "member_id": member }),
+        RPC_TIMEOUT,
+    );
+    response["result"]["wired_to"]
+        .as_array()
+        .map(|peers| {
+            peers
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Scan every regular file under a state
+/// directory for `marker` bytes. Schema-agnostic on purpose - the claim is
+/// exactly "text minted in the OTHER process reached this process's
+/// durable storage", not any particular table layout.
+fn state_dir_contains_marker(state: &Path, marker: &str) -> bool {
+    fn scan(path: &Path, needle: &[u8], hit: &mut bool) {
+        if *hit {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.is_dir() {
+                scan(&entry_path, needle, hit);
+            } else if let Ok(bytes) = std::fs::read(&entry_path)
+                && bytes.windows(needle.len()).any(|window| window == needle)
+            {
+                *hit = true;
+            }
+            if *hit {
+                return;
+            }
+        }
+    }
+    let mut hit = false;
+    scan(state, marker.as_bytes(), &mut hit);
+    hit
+}
+
+/// Wait for `marker` to become durable in `state` while the child is still
+/// alive. The injected turn runs asynchronously in the receiving process;
+/// polling the durable bytes (WAL included) is the deterministic
+/// completion signal that does not depend on any schema or event surface.
+fn wait_for_durable_marker(label: &str, state: &Path, marker: &str, deadline: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if state_dir_contains_marker(state, marker) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("[{label}] marker '{marker}' did not become durable within {deadline:?}");
+}
+
+#[test]
+fn two_process_cross_mob_wire_and_delivery_round_trip() {
+    let state_a = tempfile::tempdir().expect("state dir a");
+    let state_b = tempfile::tempdir().expect("state dir b");
+    let port_a = probe_port();
+    let port_b = probe_port();
+    let control_a = format!("tcp://127.0.0.1:{port_a}");
+    let control_b = format!("tcp://127.0.0.1:{port_b}");
+    let contacts_a = format!("[mobs]\n\"two-proc-b\" = \"{control_b}\"\n");
+    let contacts_b = format!("[mobs]\n\"two-proc-a\" = \"{control_a}\"\n");
+
+    let mut gateway_a = boot("A", state_a.path(), MOB_A, &control_a, &contacts_a);
+    let mut gateway_b = boot("B", state_b.path(), MOB_B, &control_b, &contacts_b);
+
+    spawn_member(&mut gateway_a, "alice");
+    spawn_member(&mut gateway_b, "bob");
+
+    // Wire across the process boundary: A's runtime talks to B's control
+    // listener over real TCP (LookupMember for bob's facts, then the Wire
+    // request carrying alice's member address + pubkey).
+    let response = gateway_a.call(
+        "wire",
+        "mobkit/cross_mob/wire",
+        json!({
+            "local_member_id": "alice",
+            "remote_member_id": "bob",
+            "remote_mob_id": "two-proc-b",
+        }),
+        RPC_TIMEOUT,
+    );
+    assert_eq!(response["result"]["accepted"], json!(true));
+
+    // Both rosters project the peering - B's row is the reverse leg,
+    // installed by a request that crossed the process boundary.
+    let alice_peers = wired_to(&mut gateway_a, "alice");
+    assert!(
+        alice_peers.iter().any(|peer| peer.contains("bob")),
+        "[A] alice must be wired to bob, got {alice_peers:?}"
+    );
+    let bob_peers = wired_to(&mut gateway_b, "bob");
+    assert!(
+        bob_peers.iter().any(|peer| peer.contains("alice")),
+        "[B] bob must be wired to alice (reverse leg across processes), got {bob_peers:?}"
+    );
+
+    // Delivery A -> B: the response's session id is minted in B's process.
+    let response = gateway_a.call(
+        "send-a-to-b",
+        "mobkit/cross_mob/send",
+        json!({
+            "from_member_id": "alice",
+            "remote_member_id": "bob",
+            "remote_mob_id": "two-proc-b",
+            "content": MARKER_A_TO_B,
+        }),
+        RPC_TIMEOUT,
+    );
+    assert!(
+        response["result"]["session_id"].is_string(),
+        "[A] cross_mob/send returned no remote session id: {response}"
+    );
+
+    // Delivery B -> A, over B's own contact directory and A's listener.
+    let response = gateway_b.call(
+        "send-b-to-a",
+        "mobkit/cross_mob/send",
+        json!({
+            "from_member_id": "bob",
+            "remote_member_id": "alice",
+            "remote_mob_id": "two-proc-a",
+            "content": MARKER_B_TO_A,
+        }),
+        RPC_TIMEOUT,
+    );
+    assert!(
+        response["result"]["session_id"].is_string(),
+        "[B] cross_mob/send returned no remote session id: {response}"
+    );
+
+    // The injections trigger a turn on each receiving member (same
+    // member-door as a direct send); wait for the marker bytes to become
+    // durable in each receiver's state directory before shutting down, so
+    // shutdown quiescing cannot race an unstarted turn.
+    wait_for_durable_marker("B", state_b.path(), MARKER_A_TO_B, RPC_TIMEOUT);
+    wait_for_durable_marker("A", state_a.path(), MARKER_B_TO_A, RPC_TIMEOUT);
+
+    // Unwire across the boundary and confirm both projections drop it.
+    let response = gateway_a.call(
+        "unwire",
+        "mobkit/cross_mob/unwire",
+        json!({
+            "local_member_id": "alice",
+            "remote_member_id": "bob",
+            "remote_mob_id": "two-proc-b",
+        }),
+        RPC_TIMEOUT,
+    );
+    assert_eq!(response["result"]["accepted"], json!(true));
+    let alice_peers = wired_to(&mut gateway_a, "alice");
+    assert!(
+        !alice_peers.iter().any(|peer| peer.contains("bob")),
+        "[A] alice must no longer be wired to bob after unwire, got {alice_peers:?}"
+    );
+    let bob_peers = wired_to(&mut gateway_b, "bob");
+    assert!(
+        !bob_peers.iter().any(|peer| peer.contains("alice")),
+        "[B] bob must no longer be wired to alice after remote unwire, got {bob_peers:?}"
+    );
+
+    // Clean shutdown, then read the durable proof from disk: the marker
+    // minted in the OTHER process must be present in each receiver's state
+    // directory, and must NOT appear in the sender's own durable state
+    // (guards against a false positive from some shared path).
+    gateway_a.shutdown_and_reap();
+    gateway_b.shutdown_and_reap();
+
+    assert!(
+        state_dir_contains_marker(state_b.path(), MARKER_A_TO_B),
+        "marker sent A -> B not found in B's durable state directory"
+    );
+    assert!(
+        state_dir_contains_marker(state_a.path(), MARKER_B_TO_A),
+        "marker sent B -> A not found in A's durable state directory"
+    );
+    assert!(
+        !state_dir_contains_marker(state_a.path(), MARKER_A_TO_B),
+        "A -> B marker unexpectedly present in A's own durable state; the delivery assert \
+         would be meaningless"
+    );
+    assert!(
+        !state_dir_contains_marker(state_b.path(), MARKER_B_TO_A),
+        "B -> A marker unexpectedly present in B's own durable state; the delivery assert \
+         would be meaningless"
+    );
+}


### PR DESCRIPTION
## Summary

Continuation of #314 under the owner P0 order (remote mobs + cross-mob comms, item 1 of the ratified 0.8.16 list). Two slices:

- **Two-process enablement** (46c64fdb): `rpc_gateway --control-listen` (persistent mode; typed rejection in single-shot), `runtime_options.contacts_toml` (inline TOML, wire-additive, fail-closed at init with the TOML error surfaced), `mobkit/init` response field `control_listen_address` on both gateways (serde-defaulted; created and resumed paths). New `tests/cross_mob_two_process.rs`: two real `rpc_gateway` processes, wire across the process boundary, `cross_mob/send` both directions with the marker polled to durability in the receiver's state dir and re-asserted from disk after clean shutdown, unwire clears both sides. Documented limitation in the test header: the member-driven signed PeerMessage across the boundary has no deterministic driver, so the signed envelope plane's proof remains the in-process round-trip test; this file proves the control plane and both wire legs across processes.
- **Authenticated control channel** (dc87c84c): Ed25519 signatures over `context || SHA256(exact request bytes) || semantic response fields` - no JSON canonicalization anywhere; client-minted nonce inside the signed-over bytes prevents replay; `Err` responses are unsigned failure reports, never trusted material. Strict-when-pinned: a contact with a pinned pubkey requires signed responses (typed `ControlResponseUnauthenticated`, distinguishable from `Rejected`, remedy in the message); `require_signed_control = false` is the per-contact opt-out for pre-0.8.16 peers. `rpc_gateway` installs gateway keys (persistent boots reuse the state-dir key, ephemeral boots mint per-process); the signer is late-bound so the existing round-trip tests exercise the verified path end to end.

## Remaining item-1 work (next PRs)

Scoped grants (caller authorization on the control channel) and two-host verification (004-pack GCP harness) - ledgered on task #69.

## Test evidence

- Full crate suite on this branch: **2228/2228 passed** (150 skipped, 2 leaky), exit 0.
- Targeted cross-mob set: 34/34 including the two-process round trip (7.9s).
- Clippy `--all-targets -D warnings`: exit 0 per slice.
- Bazel metadata freshness verified pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)